### PR TITLE
themes/bootstrap: make theme usable on touchscreen

### DIFF
--- a/themes/bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -154,7 +154,7 @@ You may obtain a copy of the License at
                 if #grandchildren > 0 then
 	%>
         <li class="dropdown">
-            <a class="menu" href="<%=pcdata(href)%>"><%=pcdata(striptags(translate(nnode.title)))%></a>
+            <a class="menu" href="#"><%=pcdata(striptags(translate(nnode.title)))%></a>
             <%- submenu("/" .. category .. "/" .. r .. "/", nnode) %>
         </li>
 	<%          else %>


### PR DESCRIPTION
When using this theme on touchscreen, after selecting menu it won't
allow me select submenu selection. It directly start loading menu
section (unnecessary, because it's always first link in subsection).
It work only at moment, when you are really fast, which is annoying.

Signed-off-by: David Heidelberger david.heidelberger@ixit.cz
