### PR TITLE
luci-app-ddns: update/rebuild to support ddns-scripts V 2.x

### DIFF
--- a/applications/luci-ddns/Makefile
+++ b/applications/luci-ddns/Makefile
@@ -1,3 +1,8 @@
+# supports ddns-scripts 1.0.0-23 and ddns-scripts starting
+# PKG_VERSION:=2.0.1
+# PKG_RELEASE:=8
+# PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
+
 PO = ddns
 
 include ../../build/config.mk

--- a/applications/luci-ddns/ipkg/postinst
+++ b/applications/luci-ddns/ipkg/postinst
@@ -1,0 +1,5 @@
+#!/bin/sh
+[ -n "${IPKG_INSTROOT}" ] || {
+	( . /etc/uci-defaults/luci-ddns ) && rm -f /etc/uci-defaults/luci-ddns
+	exit 0
+}

--- a/applications/luci-ddns/luasrc/controller/ddns.lua
+++ b/applications/luci-ddns/luasrc/controller/ddns.lua
@@ -3,6 +3,7 @@ LuCI - Lua Configuration Interface
 
 Copyright 2008 Steven Barth <steven@midlink.org>
 Copyright 2008 Jo-Philipp Wich <xm@leipzig.freifunk.net>
+Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,16 +16,238 @@ $Id$
 
 module("luci.controller.ddns", package.seeall)
 
+require "nixio"
+require "nixio.fs"
+require "luci.sys"
+require "luci.http"
+require "luci.model.uci"
+require "luci.dispatcher"
+require "luci.tools.ddns"
+
 function index()
+	-- no configuration file, don't start
 	if not nixio.fs.access("/etc/config/ddns") then
 		return
 	end
-	
-	local page
+	-- ddns-scripts 1.0.0 installed, run old luci app
+	if not nixio.fs.access("/usr/lib/ddns/services_ipv6")
+	    or nixio.fs.access("/usr/lib/ddns/url_escape.sed") then
+		local page
+		page = entry({"admin", "services", "ddns"}, cbi("ddns/ddns"), _("Dynamic DNS"), 60)
+		page.dependent = true
+		page = entry({"mini", "network", "ddns"}, cbi("ddns/ddns", {autoapply=true}), _("Dynamic DNS"), 60)
+		page.dependent = true
+	-- it looks like ddns-scripts 2.x.x are installed
+	else
+		entry( {"admin", "services", "ddns"}, cbi("ddns/overview"), _("Dynamic DNS"), 59)
+		entry( {"admin", "services", "ddns", "detail"}, cbi("ddns/detail"), nil ).leaf = true
+		entry( {"admin", "services", "ddns", "hints"}, cbi("ddns/hints", 
+			{hideapplybtn=true, hidesavebtn=true, hideresetbtn=true}), nil ).leaf = true
+		entry( {"admin", "services", "ddns", "logview"}, call("logread") ).leaf = true
+		entry( {"admin", "services", "ddns", "status"}, call("status") ).leaf = true
+		entry( {"admin", "services", "ddns", "startstop"}, call("startstop") ).leaf = true
+	end
+end
 
-	page = entry({"admin", "services", "ddns"}, cbi("ddns/ddns"), _("Dynamic DNS"), 60)
-	page.dependent = true
+-- function to read all sections status and return data array
+function _get_status()
+	local uci	= luci.model.uci.cursor()
+	local service	= luci.sys.init.enabled("ddns") and 1 or 0
+	local url_start	= luci.dispatcher.build_url("admin", "system", "startup")
+	local data	= {}	-- Array to transfer data to javascript
 
-	page = entry({"mini", "network", "ddns"}, cbi("ddns/ddns", {autoapply=true}), _("Dynamic DNS"), 60)
-	page.dependent = true
+	-- read application settings
+	local date_format = uci:get("ddns", "global", "date_format") or "%F %R"
+	local run_dir	  = uci:get("ddns", "global", "run_dir") or "/var/run/ddns"
+
+	data[#data+1] 	= {
+		enabled	= service,	-- service enabled
+		url_up	= url_start	-- link to enable DDS (System-Startup)
+	}
+
+	uci:foreach("ddns", "service", function (s)
+
+		-- Get section we are looking at
+		-- and enabled state
+		local section	= s[".name"]
+		local enabled	= tonumber(s["enabled"]) or 0
+		local datelast	= "_empty_"	-- formated date of last update 
+		local datenext	= "_empty_"	-- formated date of next update
+
+		-- get force seconds
+		local force_seconds = luci.tools.ddns.calc_seconds(
+				tonumber(s["force_interval"]) or 72 ,
+				s["force_unit"] or "hours" )
+		-- get/validate pid and last update 
+		local pid      = luci.tools.ddns.get_pid(section, run_dir)
+		local uptime   = luci.sys.uptime()
+		local lasttime = tonumber(nixio.fs.readfile("%s/%s.update" % { run_dir, section } ) or 0 )
+		if lasttime > uptime then 	-- /var might not be linked to /tmp
+			lasttime = 0 		-- and/or not cleared on reboot
+		end
+
+		-- no last update happen
+		if lasttime == 0 then
+			datelast = "_never_"
+
+		-- we read last update
+		else
+			-- calc last update
+			--             sys.epoch - sys uptime   + lastupdate(uptime)
+			local epoch = os.time() - uptime + lasttime
+			-- use linux date to convert epoch
+			datelast = luci.sys.exec([[/bin/date -d @]] .. epoch .. [[ +']] .. date_format .. [[']])
+			-- calc and fill next update
+			datenext = luci.sys.exec([[/bin/date -d @]] .. (epoch + force_seconds) .. 
+						[[ +']] .. date_format .. [[']])
+		end
+
+		-- process running but update needs to happen
+		-- problems it force_seconds > uptime
+		force_seconds = (force_seconds > uptime) and uptime or force_seconds
+		if pid > 0 and ( lasttime + force_seconds - uptime ) <= 0 then
+			datenext = "_verify_"
+
+		-- run once 
+		elseif force_seconds == 0 then
+			datenext = "_runonce_"
+
+		-- no process running and NOT enabled
+		elseif pid == 0 and enabled == 0 then
+			datenext  = "_disabled_"
+
+		-- no process running and NOT 
+		elseif pid == 0 and enabled ~= 0 then
+			datenext = "_stopped_"
+		end
+		
+		-- get/set monitored interface and IP version
+		local iface	= s["interface"] or "_nonet_"
+		local use_ipv6	= tonumber(s["use_ipv6"]) or 0
+		if iface ~= "_nonet_" then
+			local ipv = (use_ipv6 == 1) and "IPv6" or "IPv4"
+			iface = ipv .. " / " .. iface
+		end
+
+		-- try to get registered IP
+		local domain	= s["domain"] or "_nodomain_"
+		local dnsserver	= s["dns_server"] or ""
+		local force_ipversion = tonumber(s["force_ipversion"] or 0)
+		local force_dnstcp = tonumber(s["force_dnstcp"] or 0)
+		local command = [[/usr/lib/ddns/dynamic_dns_lucihelper.sh]]
+		command = command .. [[ get_registered_ip ]] .. domain .. [[ ]] .. use_ipv6 .. 
+			[[ ]] .. force_ipversion .. [[ ]] .. force_dnstcp .. [[ ]] .. dnsserver
+		local reg_ip = luci.sys.exec(command)
+		if reg_ip == "" then 
+			reg_ip = "_nodata_"
+		end
+
+		-- fill transfer array
+		data[#data+1]	= {
+			section  = section,
+			enabled  = enabled,
+			iface    = iface,
+			domain   = domain,
+			reg_ip   = reg_ip,
+			pid      = pid,
+			datelast = datelast,
+			datenext = datenext
+		}
+	end)
+
+	uci:unload("ddns")
+
+	return data
+end
+
+-- called by XHR.get from detail_logview.htm
+function logread(section)
+	-- read application settings
+	local uci	  = luci.model.uci.cursor()
+	local log_dir	  = uci:get("ddns", "global", "log_dir") or "/var/log/ddns"
+	local lfile=log_dir .. "/" .. section .. ".log"
+
+	local ldata=nixio.fs.readfile(lfile)
+	if not ldata or #ldata == 0 then
+		ldata="_nodata_"
+	end 
+	luci.http.write(ldata)
+end
+
+-- called by XHR.get from overview_status.htm
+function startstop(section, enabled)
+	-- Array to transfer data to javascript
+	local data	= {}
+	-- read application settings
+	local uci	  = luci.model.uci.cursor()
+	local run_dir	  = uci:get("ddns", "global", "run_dir") or "/var/run/ddns"
+
+	-- if process running we want to stop and return
+	local pid = luci.tools.ddns.get_pid(section, run_dir)
+	if pid > 0 then
+		os.execute ([[kill -9 %s]] % pid)
+		nixio.nanosleep(2)	-- 2 second "show time"
+		-- status changed so return full status
+		data = _get_status()
+		luci.http.prepare_content("application/json")
+		luci.http.write_json(data)
+		return
+	end
+
+	-- read uncommited changes
+	-- we don't save and commit data from other section or other options
+	-- only enabled will be done
+	local exec	  = true
+	local changed     = uci:changes("ddns")
+	for k_config, v_section in pairs(changed) do
+		-- security check because uci.changes only gets our config
+		if k_config ~= "ddns" then
+			exec = false
+			break
+		end
+		for k_section, v_option in pairs(v_section) do
+			-- check if only section of button was changed
+			if k_section ~= section then
+				exec = false
+				break
+			end
+			for k_option, v_value in pairs(v_option) do
+				-- check if only enabled was changed
+				if k_option ~= "enabled" then
+					exec = false
+					break
+				end
+			end
+		end
+
+	end
+
+	-- we can not execute because other 
+	-- uncommited changes pending, so exit here
+	if not exec then
+		luci.http.write("_uncommited_")
+		return
+	end
+
+	-- save enable state
+	uci:set("ddns", section, "enabled", ( (enabled == "true") and "1" or "0") )
+	uci:save("ddns") 
+	uci:commit("ddns")
+	uci:unload("ddns")
+
+	-- start dynamic_dns_updater.sh script
+	os.execute ([[/usr/lib/ddns/dynamic_dns_updater.sh %s 0 > /dev/null 2>&1 &]] % section)
+	nixio.nanosleep(3)	-- 3 seconds "show time"
+
+	-- status changed so return full status
+	data = _get_status()
+	luci.http.prepare_content("application/json")
+	luci.http.write_json(data)
+end
+
+-- called by XHR.poll from overview_status.htm
+function status()
+	local data = _get_status()
+	luci.http.prepare_content("application/json")
+	luci.http.write_json(data)
 end

--- a/applications/luci-ddns/luasrc/model/cbi/ddns/ddns.lua
+++ b/applications/luci-ddns/luasrc/model/cbi/ddns/ddns.lua
@@ -26,6 +26,10 @@ s.anonymous = false
 
 s:option(Flag, "enabled", translate("Enable"))
 
+interface = s:option(ListValue, "interface", translate("Event interface"), translate("Network on which the ddns-updater scripts will be started"))
+luci.tools.webadmin.cbi_add_networks(interface)
+interface.default = "wan"
+
 svc = s:option(ListValue, "service_name", translate("Service"))
 svc.rmempty = false
 svc.default = "dyndns.org"

--- a/applications/luci-ddns/luasrc/model/cbi/ddns/detail.lua
+++ b/applications/luci-ddns/luasrc/model/cbi/ddns/detail.lua
@@ -1,0 +1,1198 @@
+--[[
+LuCI - Lua Configuration Interface
+
+A lot of code taken from original ddns.lua cbi-model made by
+Copyright 2008 Steven Barth <steven@midlink.org>
+Copyright 2008 Jo-Philipp Wich <xm@leipzig.freifunk.net>
+Copyright 2013 Manuel Munz <freifunk at somakoma dot de>
+
+modified to use as detail page together with new overview page and
+extensions for IPv6, HTTPS settings, syslog and log settings,
+optional Proxy-Support, optional DNS-Server, optional use of TCP requests to DNS server,
+optional force of IP protocol version usage
+Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+require "luci.dispatcher"
+require "nixio.fs"
+require "luci.sys"
+require "luci.tools.webadmin"
+require "luci.cbi.datatypes"
+require "luci.tools.ddns"	-- ddns multiused functions
+
+-- takeover arguments
+section = arg[1]
+
+-- check supported options
+-- saved to local vars here because doing multiple os calls slow down the system
+has_ipv6   = luci.tools.ddns.check_ipv6()	-- IPv6 support
+has_ssl    = luci.tools.ddns.check_ssl()	-- HTTPS support
+has_proxy  = luci.tools.ddns.check_proxy()	-- Proxy support
+has_dnstcp = luci.tools.ddns.check_bind_host()	-- DNS TCP support
+has_force  = has_ssl and has_dnstcp		-- Force IP Protocoll
+
+-- html constants
+font_red = "<font color='red'>"
+font_off = "</font>"
+bold_on  = "<strong>"
+bold_off = "</strong>"
+
+-- error text constants
+err_ipv6_plain = translate("IPv6 not supported") .. " - " ..
+		translate("please select 'IPv4' address version")
+err_ipv6_basic = bold_on .. 
+			font_red ..
+				translate("IPv6 not supported") .. 
+			font_off .. 
+			"<br />" .. translate("please select 'IPv4' address version") .. 
+		 bold_off
+err_ipv6_other = bold_on .. 
+			font_red .. 
+				translate("IPv6 not supported") .. 
+			font_off .. 
+			"<br />" .. translate("please select 'IPv4' address version in") .. " " .. 
+			[[<a href="]] .. 
+					luci.dispatcher.build_url("admin", "services", "ddns", "detail", section) .. 
+					"?tab.dns." .. section .. "=basic" ..
+				[[">]] .. 
+				translate("Basic Settings") .. 
+			[[</a>]] .. 
+		 bold_off
+
+function err_tab_basic(self)
+	return translate("Basic Settings") .. " - " .. self.title .. ": "
+end
+function err_tab_adv(self)
+	return translate("Advanced Settings") .. " - " .. self.title .. ": "
+end
+function err_tab_timer(self)
+	return translate("Timer Settings") .. " - " .. self.title .. ": "
+end
+
+-- function to verify settings around ip_source
+-- will use dynamic_dns_lucihelper to check if
+-- local IP can be read
+local function _verify_ip_source()
+	-- section is globally defined here be calling agrument (see above)
+	local _network   = "-"
+	local _url       = "-"
+	local _interface = "-"
+	local _script    = "-"
+	local _proxy     = ""
+
+	local _ipv6   = usev6:formvalue(section)
+	local _source = (_ipv6 == "1")
+			and src6:formvalue(section)
+			or  src4:formvalue(section)
+	if _source == "network" then
+		_network = (_ipv6 == "1")
+			and ipn6:formvalue(section)
+			or  ipn4:formvalue(section)
+	elseif _source == "web" then
+		_url = (_ipv6 == "1")
+			and iurl6:formvalue(section)
+			or  iurl4:formvalue(section)
+		-- proxy only needed for checking url
+		_proxy = (pxy) and pxy:formvalue(section) or ""
+	elseif _source == "interface" then
+		_interface = ipi:formvalue(section)
+	elseif _source == "script" then
+		_script = ips:formvalue(section)
+	end
+
+	local command = [[/usr/lib/ddns/dynamic_dns_lucihelper.sh get_local_ip ]] .. 
+		_ipv6 .. [[ ]] .. _source .. [[ ]] .. _network .. [[ ]] .. 
+		_url .. [[ ]] .. _interface .. [[ ]] .. _script.. [[ ]] .. _proxy
+	local ret = luci.sys.call(command)
+
+	if ret == 0 then
+		return true	-- valid
+	else
+		return nil	-- invalid
+	end
+end
+
+-- cbi-map definition
+m = Map("ddns")
+
+m.title = [[<a href="]] .. luci.dispatcher.build_url("admin", "services", "ddns") .. [[">]] .. 
+		translate("Dynamic DNS") .. [[</a>]]
+
+m.description = translate("Dynamic DNS allows that your router can be reached with " ..
+			"a fixed hostname while having a dynamically changing " ..
+			"IP address.")
+
+m.redirect = luci.dispatcher.build_url("admin", "services", "ddns")
+
+-- read application settings
+-- date format; if not set use ISO format
+date_format = m.uci:get(m.config, "global", "date_format") or "%F %R"
+-- log directory
+log_dir = m.uci:get(m.config, "global", "log_dir") or "/var/log/ddns"
+
+-- cbi-section definition
+ns = m:section( NamedSection, section, "service", 
+	translate("Details for") .. ([[: <strong>%s</strong>]] % section),
+	translate("Configure here the details for selected Dynamic DNS service") )
+ns.instance = section	-- arg [1]
+ns:tab("basic", translate("Basic Settings"), nil )
+ns:tab("advanced", translate("Advanced Settings"), nil )
+ns:tab("timer", translate("Timer Settings"), nil )
+ns:tab("logview", translate("Log File Viewer"), nil )
+
+-- TAB: Basic ##################################################################
+-- enabled  
+en = ns:taboption("basic", Flag, "enabled", 
+	translate("Enabled"),
+	translate("If this service section is disabled it could not be started." .. "<br />" ..
+		"Neither from LuCI interface nor from console") )
+en.orientation = "horizontal"
+
+-- use_ipv6 (NEW)
+usev6 = ns:taboption("basic", ListValue, "use_ipv6", 
+	translate("IP address version"),
+	translate("Defines which IP address 'IPv4/IPv6' is send to the DDNS provider") )
+usev6.widget  = "radio"
+usev6.default = "0"
+usev6:value("0", translate("IPv4-Address") )
+function usev6.cfgvalue(self, section)
+	local value = AbstractValue.cfgvalue(self, section)
+	if has_ipv6 or (value == "1" and not has_ipv6) then
+		self:value("1", translate("IPv6-Address") )
+	end
+	if value == "1" and not has_ipv6 then
+		self.description = err_ipv6_basic
+	end
+	return value
+end
+function usev6.validate(self, value)
+	if (value == "1" and has_ipv6) or value == "0" then 
+		return value
+	end
+	return nil, err_tab_basic(self) .. err_ipv6_plain
+end
+function usev6.write(self, section, value)
+	if value == "0" then	-- force rmempty 
+		return self.map:del(section, self.option)
+	else
+		return self.map:set(section, self.option, value)
+	end
+end
+
+-- IPv4 - service_name
+svc4 = ns:taboption("basic", ListValue, "ipv4_service_name", 
+	translate("DDNS Service provider") .. " [IPv4]" )
+svc4.default	= "-"
+svc4:depends("use_ipv6", "0")	-- only show on IPv4
+
+local services4 = { }
+local fd4 = io.open("/usr/lib/ddns/services", "r")
+
+if fd4 then
+	local ln
+	repeat
+		ln = fd4:read("*l")
+		local s = ln and ln:match('^%s*"([^"]+)"')
+		if s then services4[#services4+1] = s end
+	until not ln
+	fd4:close()
+end
+
+for _, v in luci.util.vspairs(services4) do svc4:value(v) end
+svc4:value("-", translate("-- custom --") )
+
+function svc4.cfgvalue(self, section)
+	local v =  luci.tools.ddns.read_value(self, section, "service_name")
+	if not v or #v == 0 then
+		return "-"
+	else
+		return v
+	end
+end
+function svc4.validate(self, value)
+	if usev6:formvalue(section) == "0" then	-- do only on IPv4
+		return value
+	else
+		return ""	-- supress validate error
+	end
+end
+function svc4.write(self, section, value)
+	if usev6:formvalue(section) == "0" then	-- do only IPv4 here
+		self.map:del(section, self.option)	-- to be shure
+		if value ~= "-" then			-- and write "service_name
+			self.map:del(section, "update_url")	-- delete update_url
+			return self.map:set(section, "service_name", value)
+		else
+			return self.map:del(section, "service_name")
+		end
+	end
+end
+
+-- IPv6 - service_name
+svc6 = ns:taboption("basic", ListValue, "ipv6_service_name", 
+	translate("DDNS Service provider") .. " [IPv6]" )
+svc6.default	= "-"
+svc6:depends("use_ipv6", "1")	-- only show on IPv6
+if not has_ipv6 then 
+	svc6.description = err_ipv6_basic 
+end
+
+local services6 = { }
+local fd6 = io.open("/usr/lib/ddns/services_ipv6", "r")
+
+if fd6 then
+	local ln
+	repeat
+		ln = fd6:read("*l")
+		local s = ln and ln:match('^%s*"([^"]+)"')
+		if s then services6[#services6+1] = s end
+	until not ln
+	fd6:close()
+end
+
+for _, v in luci.util.vspairs(services6) do svc6:value(v) end
+svc6:value("-", translate("-- custom --") )
+
+function svc6.cfgvalue(self, section)
+	local v =  luci.tools.ddns.read_value(self, section, "service_name")
+	if not v or #v == 0 then
+		return "-"
+	else
+		return v
+	end
+end
+function svc6.validate(self, value)
+	if usev6:formvalue(section) == "1" then	-- do only on IPv6
+		if has_ipv6 then return value end
+		return nil, err_tab_basic(self) .. err_ipv6_plain
+	else
+		return ""	-- supress validate error
+	end
+end
+function svc6.write(self, section, value)
+	if usev6:formvalue(section) == "1" then	-- do only when IPv6
+		self.map:del(section, self.option)	-- delete "ipv6_service_name" helper
+		if value ~= "-" then			-- and write "service_name
+			self.map:del(section, "update_url")	-- delete update_url
+			return self.map:set(section, "service_name", value)
+		else
+			return self.map:del(section, "service_name")
+		end
+	end
+end
+
+-- IPv4/IPv6 - update_url
+uurl = ns:taboption("basic", Value, "update_url", 
+	translate("Custom update-URL"),
+	translate("Update URL to be used for updating your DDNS Provider." .. "<br />" ..
+		"Follow instructions you will find on their WEB page.") )
+uurl:depends("ipv4_service_name", "-")
+uurl:depends("ipv6_service_name", "-")
+function uurl.validate(self, value)
+	local script = ush:formvalue(section)
+
+	if (usev6:formvalue(section) == "0" and svc4:formvalue(section) ~= "-") or
+	   (usev6:formvalue(section) == "1" and svc6:formvalue(section) ~= "-") then
+		return ""	-- suppress validate error
+	elseif not value then
+		if not script or not (#script > 0) then
+			return nil, err_tab_basic(self) .. translate("missing / required")
+		else
+			return ""	-- suppress validate error / update_script is given
+		end
+	elseif (#script > 0) then
+		return nil, err_tab_basic(self) .. translate("either url or script could be set")
+	end
+
+	local url = luci.tools.ddns.parse_url(value)
+	if not url.scheme == "http" then
+		return nil, err_tab_basic(self) .. translate("must start with 'http://'")
+	elseif not url.query then
+		return nil, err_tab_basic(self) .. "<QUERY> " .. translate("missing / required")
+	elseif not url.host then
+		return nil, err_tab_basic(self) .. "<HOST> " .. translate("missing / required")
+	elseif luci.sys.call([[nslookup ]] .. url.host .. [[ >/dev/null 2>&1]]) ~= 0 then
+		return nil, err_tab_basic(self) .. translate("can not resolve host: ") .. url.host
+	end
+
+	return value
+end
+
+-- IPv4/IPv6 - update_script
+ush = ns:taboption("basic", Value, "update_script", 
+	translate("Custom update-script"),
+	translate("Custom update script to be used for updating your DDNS Provider.") )
+ush:depends("ipv4_service_name", "-")
+ush:depends("ipv6_service_name", "-")
+function ush.validate(self, value)
+	local url = uurl:formvalue(section)
+
+	if (usev6:formvalue(section) == "0" and svc4:formvalue(section) ~= "-") or
+	   (usev6:formvalue(section) == "1" and svc6:formvalue(section) ~= "-") then
+		return ""	-- suppress validate error
+	elseif not value then
+		if not url or not (#url > 0) then
+			return nil, err_tab_basic(self) .. translate("missing / required")
+		else
+			return ""	-- suppress validate error / update_url is given
+		end
+	elseif (#url > 0) then
+		return nil, err_tab_basic(self) .. translate("either url or script could be set")
+	elseif not nixio.fs.access(value) then
+		return nil, err_tab_basic(self) .. translate("File not found")
+	end
+	return value
+end
+
+-- IPv4/IPv6 - domain
+dom = ns:taboption("basic", Value, "domain", 
+		translate("Hostname/Domain"),
+		translate("Replaces [DOMAIN] in Update-URL") )
+dom.rmempty	= false
+dom.placeholder	= "mypersonaldomain.dyndns.org"
+function dom.validate(self, value)
+	if not value 
+	or not (#value > 0)
+	or not luci.cbi.datatypes.hostname(value) then
+		return nil, err_tab_basic(self) ..	translate("invalid - Sample") .. ": 'mypersonaldomain.dyndns.org'"
+	else
+		return value
+	end
+end
+
+-- IPv4/IPv6 - username
+user = ns:taboption("basic", Value, "username",
+		translate("Username"),
+		translate("Replaces [USERNAME] in Update-URL") )
+user.rmempty = false
+function user.validate(self, value)
+	if not value then
+		return nil, err_tab_basic(self) .. translate("missing / required")
+	end
+	return value
+end
+
+-- IPv4/IPv6 - password
+pw = ns:taboption("basic", Value, "password",
+		translate("Password"),
+		translate("Replaces [PASSWORD] in Update-URL") )
+pw.rmempty  = false
+pw.password = true
+function pw.validate(self, value)
+	if not value then
+		return nil, err_tab_basic(self) .. translate("missing / required")
+	end
+	return value
+end
+
+-- IPv4/IPv6 - use_https (NEW)
+if has_ssl or ( ( m:get(section, "use_https") or "0" ) == "1" ) then
+	https = ns:taboption("basic", Flag, "use_https", 
+		translate("Use HTTP Secure") )
+	https.orientation = "horizontal"
+	https.rmempty = false -- force validate function
+	function https.cfgvalue(self, section)
+		local value = AbstractValue.cfgvalue(self, section)
+		if not has_ssl and value == "1" then
+			self.description = bold_on .. font_red ..
+				translate("HTTPS not supported") .. font_off .. "<br />" ..
+				translate("please disable") .. " !" .. bold_off
+		else
+			self.description = translate("Enable secure communication with DDNS provider")
+		end
+		return value
+	end
+	function https.validate(self, value)
+		if (value == "1" and has_ssl ) or value == "0" then return value end
+		return nil, err_tab_basic(self) .. translate("HTTPS not supported") .. " !"
+	end
+	function https.write(self, section, value)
+		if value == "1" then
+			return self.map:set(section, self.option, value)
+		else
+			self.map:del(section, "cacert")
+			return self.map:del(section, self.option)
+		end
+	end
+end
+
+-- IPv4/IPv6 - cacert (NEW)
+if has_ssl then
+	cert = ns:taboption("basic", Value, "cacert", 
+		translate("Path to CA-Certificate"), 
+		translate("directory or path/file") .. "<br />" ..
+		translate("or") .. bold_on .. " IGNORE " .. bold_off ..
+		translate("to run HTTPS without verification of server certificates (insecure)") )
+	cert:depends("use_https", "1")
+	cert.rmempty = false -- force validate function
+	cert.default = "/etc/ssl/certs"
+	function cert.validate(self, value)
+		if https:formvalue(section) == "0" then 
+			return ""	-- supress validate error if NOT https
+		end
+		if value then	-- otherwise errors in datatype check
+			if luci.cbi.datatypes.directory(value)
+			or luci.cbi.datatypes.file(value)
+			or value == "IGNORE" then
+				return value
+			end
+		end
+		return nil, err_tab_basic(self) ..
+			translate("file or directory not found or not 'IGNORE'") .. " !"
+	end
+end
+
+-- use_syslog
+slog = ns:taboption("basic", ListValue, "use_syslog", 
+	translate("Log to syslog"),
+	translate("Writes log messages to syslog. Critical Errors will always be written to syslog.") )
+slog.default = "0"
+slog:value("0", translate("No logging"))
+slog:value("1", translate("Info"))
+slog:value("2", translate("Notice"))
+slog:value("3", translate("Warning"))
+slog:value("4", translate("Error"))
+
+-- use_logfile (NEW)
+logf = ns:taboption("basic", Flag, "use_logfile", 
+	translate("Log to file"),
+	translate("Writes detailed messages to log file. File will be truncated automatically.") .. "<br />" ..
+	translate("File") .. [[: "]] .. log_dir .. [[/]] .. section .. [[.log"]] )
+logf.orientation = "horizontal"
+logf.rmempty = false	-- we want to save in /etc/config/ddns file on "0" because
+logf.default = "1"	-- if not defined write to log by default
+
+-- TAB: Advanced  ##############################################################
+-- IPv4 - ip_source
+src4 = ns:taboption("advanced", ListValue, "ipv4_source", 
+	translate("IP address source") .. " [IPv4]",
+	translate("Defines the source to read systems IPv4-Address from, that will be send to the DDNS provider") )
+src4:depends("use_ipv6", "0")	-- IPv4 selected
+src4.default = "network"
+src4:value("network", translate("Network"))
+src4:value("web", translate("URL"))
+src4:value("interface", translate("Interface"))
+src4:value("script", translate("Script"))
+function src4.cfgvalue(self, section) 
+	return luci.tools.ddns.read_value(self, section, "ip_source") 
+end
+function src4.validate(self, value)
+	if usev6:formvalue(section) == "1" then 
+		return ""	-- ignore on IPv6 selected
+	elseif not _verify_ip_source() then
+		return nil, err_tab_adv(self) ..
+			translate("can not detect local IP. Please select a different Source combination")
+	else
+		return value
+	end
+end
+function src4.write(self, section, value)
+	if usev6:formvalue(section) == "1" then 
+		return true	-- ignore on IPv6 selected
+	elseif value == "network" then
+		self.map:del(section, "ip_url")		-- delete not need parameters
+		self.map:del(section, "ip_interface")
+		self.map:del(section, "ip_script")
+	elseif value == "web" then
+		self.map:del(section, "ip_network")	-- delete not need parameters
+		self.map:del(section, "ip_interface")
+		self.map:del(section, "ip_script")
+	elseif value == "interface" then
+		self.map:del(section, "ip_network")	-- delete not need parameters
+		self.map:del(section, "ip_url")
+		self.map:del(section, "ip_script")
+	elseif value == "script" then
+		self.map:del(section, "ip_network")
+		self.map:del(section, "ip_url")		-- delete not need parameters
+		self.map:del(section, "ip_interface")
+	end
+	self.map:del(section, self.option)		-- delete "ipv4_source" helper
+	return self.map:set(section, "ip_source", value) -- and write "ip_source
+end
+
+-- IPv6 - ip_source
+src6 = ns:taboption("advanced", ListValue, "ipv6_source", 
+	translate("IP address source") .. " [IPv6]",
+	translate("Defines the source to read systems IPv6-Address from, that will be send to the DDNS provider") )
+src6:depends("use_ipv6", 1)	-- IPv6 selected
+src6.default = "network"
+src6:value("network", translate("Network"))
+src6:value("web", translate("URL"))
+src6:value("interface", translate("Interface"))
+src6:value("script", translate("Script"))
+if not has_ipv6 then 
+	src6.description = err_ipv6_other 
+end
+function src6.cfgvalue(self, section)
+	return luci.tools.ddns.read_value(self, section, "ip_source")
+end
+function src6.validate(self, value)
+	if usev6:formvalue(section) == "0" then 
+		return ""	-- ignore on IPv4 selected
+	elseif not has_ipv6 then
+		return nil, err_tab_adv(self) .. err_ipv6_plain
+	elseif not _verify_ip_source() then
+		return nil, err_tab_adv(self) ..
+			translate("can not detect local IP. Please select a different Source combination")
+	else
+		return value
+	end
+end
+function src6.write(self, section, value)
+	if usev6:formvalue(section) == "0" then 
+		return true	-- ignore on IPv4 selected
+	elseif value == "network" then
+		self.map:del(section, "ip_url")		-- delete not need parameters
+		self.map:del(section, "ip_interface")
+		self.map:del(section, "ip_script")
+	elseif value == "web" then
+		self.map:del(section, "ip_network")	-- delete not need parameters
+		self.map:del(section, "ip_interface")
+		self.map:del(section, "ip_script")
+	elseif value == "interface" then
+		self.map:del(section, "ip_network")	-- delete not need parameters
+		self.map:del(section, "ip_url")
+		self.map:del(section, "ip_script")
+	elseif value == "script" then
+		self.map:del(section, "ip_network")
+		self.map:del(section, "ip_url")		-- delete not need parameters
+		self.map:del(section, "ip_interface")
+	end
+	self.map:del(section, self.option)		-- delete "ipv4_source" helper
+	return self.map:set(section, "ip_source", value) -- and write "ip_source
+end
+
+-- IPv4 - ip_network (default "wan")
+ipn4 = ns:taboption("advanced", ListValue, "ipv4_network", 
+	translate("Network") .. " [IPv4]",
+	translate("Defines the network to read systems IPv4-Address from") )
+ipn4:depends("ipv4_source", "network")
+ipn4.default = "wan"
+luci.tools.webadmin.cbi_add_networks(ipn4)
+function ipn4.cfgvalue(self, section) 
+	return luci.tools.ddns.read_value(self, section, "ip_network") 
+end
+function ipn4.validate(self, value)
+	if usev6:formvalue(section) == "1"
+	 or src4:formvalue(section) ~= "network" then
+		-- ignore if IPv6 selected OR
+		-- ignore everything except "network"
+		return ""
+	else
+		return value
+	end
+end
+function ipn4.write(self, section, value)
+	if usev6:formvalue(section) == "1"
+	 or src4:formvalue(section) ~= "network" then
+		-- ignore if IPv6 selected OR
+		-- ignore everything except "network"
+		return true
+	else
+		-- set also as "interface" for monitoring events changes/hot-plug
+		self.map:set(section, "interface", value)
+		self.map:del(section, self.option)		 -- delete "ipv4_network" helper
+		return self.map:set(section, "ip_network", value) -- and write "ip_network"
+	end
+end
+
+-- IPv6 - ip_network (default "wan6")
+ipn6 = ns:taboption("advanced", ListValue, "ipv6_network", 
+	translate("Network") .. " [IPv6]" )
+ipn6:depends("ipv6_source", "network")
+ipn6.default = "wan6"
+luci.tools.webadmin.cbi_add_networks(ipn6)
+if has_ipv6 then
+	ipn6.description = translate("Defines the network to read systems IPv6-Address from")
+else
+	ipn6.description = err_ipv6_other
+end
+function ipn6.cfgvalue(self, section)
+	return luci.tools.ddns.read_value(self, section, "ip_network")
+end
+function ipn6.validate(self, value)
+	if usev6:formvalue(section) == "0"
+	 or src6:formvalue(section) ~= "network" then
+		-- ignore if IPv4 selected OR
+		-- ignore everything except "network"
+		return ""	
+	elseif has_ipv6 then 
+		return value
+	else
+		return nil, err_tab_adv(self) .. err_ipv6_plain
+	end
+end
+function ipn6.write(self, section, value)
+	if usev6:formvalue(section) == "0"
+	 or src6:formvalue(section) ~= "network" then
+		-- ignore if IPv4 selected OR
+		-- ignore everything except "network"
+		return true
+	else
+		-- set also as "interface" for monitoring events changes/hotplug
+		self.map:set(section, "interface", value)
+		self.map:del(section, self.option)		 -- delete "ipv6_network" helper
+		return self.map:set(section, "ip_network", value) -- and write "ip_network"
+	end
+end
+
+-- IPv4 - ip_url (default "checkip.dyndns.com")
+iurl4 = ns:taboption("advanced", Value, "ipv4_url", 
+	translate("URL to detect") .. " [IPv4]",
+	translate("Defines the Web page to read systems IPv4-Address from") )
+iurl4:depends("ipv4_source", "web")
+iurl4.default = "http://checkip.dyndns.com"
+function iurl4.cfgvalue(self, section)
+	return luci.tools.ddns.read_value(self, section, "ip_url")
+end
+function iurl4.validate(self, value)
+	if usev6:formvalue(section) == "1"
+	 or src4:formvalue(section) ~= "web" then
+		-- ignore if IPv6 selected OR
+		-- ignore everything except "web"
+		return ""
+	elseif not value or #value == 0 then
+		return nil, err_tab_adv(self) .. translate("missing / required")
+	end
+
+	local url = luci.tools.ddns.parse_url(value)
+	if not (url.scheme == "http" or url.scheme == "https") then
+		return nil, err_tab_adv(self) .. translate("must start with 'http://'")
+	elseif not url.host then
+		return nil, err_tab_adv(self) .. "<HOST> " .. translate("missing / required")
+	elseif luci.sys.call([[nslookup ]] .. 
+		url.host .. 
+		[[>/dev/null 2>&1]]) ~= 0 then
+		return nil, err_tab_adv(self) .. translate("can not resolve host: ") .. url.host
+	else
+		return value
+	end
+end
+function iurl4.write(self, section, value)
+	if usev6:formvalue(section) == "1"
+	 or src4:formvalue(section) ~= "web" then
+		-- ignore if IPv6 selected OR
+		-- ignore everything except "web"
+		return true
+	else
+		self.map:del(section, self.option)		-- delete "ipv4_url" helper
+		return self.map:set(section, "ip_url", value)	-- and write "ip_url"
+	end
+end
+
+-- IPv6 - ip_url (default "checkipv6.dyndns.com")
+iurl6 = ns:taboption("advanced", Value, "ipv6_url", 
+	translate("URL to detect") .. " [IPv6]" )
+iurl6:depends("ipv6_source", "web")
+iurl6.default = "http://checkipv6.dyndns.com"
+if has_ipv6 then 
+	iurl6.description = translate("Defines the Web page to read systems IPv6-Address from")
+else
+	iurl6.description = err_ipv6_other
+end
+function iurl6.cfgvalue(self, section)
+	return luci.tools.ddns.read_value(self, section, "ip_url")
+end
+function iurl6.validate(self, value)
+	if usev6:formvalue(section) == "0"
+	 or src6:formvalue(section) ~= "web" then
+		-- ignore if IPv4 selected OR
+		-- ignore everything except "web"
+		return ""
+	elseif not has_ipv6 then
+		return nil, err_tab_adv(self) .. err_ipv6_plain
+	elseif not value or #value == 0 then
+		return nil, err_tab_adv(self) .. translate("missing / required")
+	end
+
+	local url = luci.tools.ddns.parse_url(value)
+	if not (url.scheme == "http" or url.scheme == "https") then
+		return nil, err_tab_adv(self) .. translate("must start with 'http://'")
+	elseif not url.host then
+		return nil, err_tab_adv(self) .. "<HOST> " .. translate("missing / required")
+	elseif luci.sys.call([[nslookup ]] .. 
+		url.host .. 
+		[[>/dev/null 2>&1]]) ~= 0 then
+		return nil, err_tab_adv(self) .. translate("can not resolve host: ") .. url.host
+	else
+		return value
+	end
+end
+function iurl6.write(self, section, value)
+	if usev6:formvalue(section) == "0"
+	 or src6:formvalue(section) ~= "web" then
+		-- ignore if IPv4 selected OR
+		-- ignore everything except "web"
+		return true
+	else
+		self.map:del(section, self.option)		-- delete "ipv6_url" helper
+		return self.map:set(section, "ip_url", value)	-- and write "ip_url"
+	end
+end
+
+-- IPv4 + IPv6 - ip_interface
+ipi = ns:taboption("advanced", ListValue, "ip_interface", 
+	translate("Interface"),
+	translate("Defines the interface to read systems IP-Address from") )
+ipi:depends("ipv4_source", "interface")	-- IPv4
+ipi:depends("ipv6_source", "interface")	-- or IPv6
+for _, v in pairs(luci.sys.net.devices()) do
+	-- show only interface set to a network
+	-- and ignore loopback
+	net = luci.tools.webadmin.iface_get_network(v)
+	if net and net ~= "loopback" then 
+		ipi:value(v)
+	end
+end
+function ipi.validate(self, value)
+	if (usev6:formvalue(section) == "0" and src4:formvalue(section) ~= "interface")
+	or (usev6:formvalue(section) == "1" and src6:formvalue(section) ~= "interface") then
+		return ""
+	else
+		return value
+	end
+end
+function ipi.write(self, section, value)
+	if (usev6:formvalue(section) == "0" and src4:formvalue(section) ~= "interface")
+	or (usev6:formvalue(section) == "1" and src6:formvalue(section) ~= "interface") then
+		return true
+	else
+		-- get network from device to
+		-- set also as "interface" for monitoring events changes/hotplug
+		local net = luci.tools.webadmin.iface_get_network(value)
+		self.map:set(section, "interface", net)
+		return self.map:set(section, self.option, value)
+	end
+end
+
+-- IPv4 + IPv6 - ip_script (NEW)
+ips = ns:taboption("advanced", Value, "ip_script", 
+	translate("Script"),
+	translate("User defined script to read systems IP-Address") )
+ips:depends("ipv4_source", "script")	-- IPv4
+ips:depends("ipv6_source", "script")	-- or IPv6
+ips.placeholder = "/path/to/script.sh"
+function ips.validate(self, value)
+	if (usev6:formvalue(section) == "0" and src4:formvalue(section) ~= "script")
+	or (usev6:formvalue(section) == "1" and src6:formvalue(section) ~= "script") then
+		return ""
+	elseif not value or not nixio.fs.access(value, "x") then 
+		return nil, err_tab_adv(self) .. 
+			translate("not found or not executable - Sample: '/path/to/script.sh'")
+	else
+		return value
+	end
+end
+function ips.write(self, section, value)
+	if (usev6:formvalue(section) == "0" and src4:formvalue(section) ~= "script")
+	or (usev6:formvalue(section) == "1" and src6:formvalue(section) ~= "script") then
+		return true
+	else
+		return self.map:set(section, self.option, value)
+	end
+end
+
+-- IPv4 - interface - default "wan"
+-- event network to monitor changes/hotplug/dynamic_dns_updater.sh
+-- only needs to be set if "ip_source"="web" or "script"
+-- if "ip_source"="network" or "interface" we use their network 
+eif4 = ns:taboption("advanced", ListValue, "ipv4_interface", 
+	translate("Event Network") .. " [IPv4]", 
+	translate("Network on which the ddns-updater scripts will be started") )
+eif4:depends("ipv4_source", "web")
+eif4:depends("ipv4_source", "script")
+eif4.default = "wan"
+luci.tools.webadmin.cbi_add_networks(eif4)
+function eif4.cfgvalue(self, section)
+	return luci.tools.ddns.read_value(self, section, "interface")
+end
+function eif4.validate(self, value)
+	if usev6:formvalue(section) == "1"
+	 or src4:formvalue(section) == "network"
+	 or src4:formvalue(section) == "interface" then
+		return ""	-- ignore IPv6, network, interface
+	else
+		return value
+	end
+end
+function eif4.write(self, section, value)
+	if usev6:formvalue(section) == "1"
+	 or src4:formvalue(section) == "network"
+	 or src4:formvalue(section) == "interface" then
+		return true	-- ignore IPv6, network, interface
+	else
+		self.map:del(section, self.option)		-- delete "ipv4_interface" helper
+		return self.map:set(section, "interface", value) -- and write "interface"
+	end
+end
+
+-- IPv6 - interface (NEW) - default "wan6"
+-- event network to monitor changes/hotplug (NEW)
+-- only needs to be set if "ip_source"="web" or "script"
+-- if "ip_source"="network" or "interface" we use their network 
+eif6 = ns:taboption("advanced", ListValue, "ipv6_interface", 
+	translate("Event Network") .. " [IPv6]" )
+eif6:depends("ipv6_source", "web")
+eif6:depends("ipv6_source", "script")
+eif6.default = "wan6"
+luci.tools.webadmin.cbi_add_networks(eif6)
+if not has_ipv6 then 
+	eif6.description = err_ipv6_other
+else
+	eif6.description = translate("Network on which the ddns-updater scripts will be started")
+end
+function eif6.cfgvalue(self, section)
+	return luci.tools.ddns.read_value(self, section, "interface")
+end
+function eif6.validate(self, value)
+	if usev6:formvalue(section) == "0"
+	 or src4:formvalue(section) == "network"
+	 or src4:formvalue(section) == "interface" then
+		return ""	-- ignore IPv4, network, interface
+	elseif not has_ipv6 then 
+		return nil, err_tab_adv(self) .. err_ipv6_plain
+	else
+		return value
+	end
+end
+function eif6.write(self, section, value)
+	if usev6:formvalue(section) == "0"
+	 or src4:formvalue(section) == "network"
+	 or src4:formvalue(section) == "interface" then
+		return true	-- ignore IPv4, network, interface
+	else
+		self.map:del(section, self.option)		-- delete "ipv6_interface" helper
+		return self.map:set(section, "interface", value) -- and write "interface"
+	end
+end
+
+-- IPv4 + IPv6 - force_ipversion (NEW)
+-- optional to force wget/curl and host to use only selected IP version
+-- command parameter "-4" or "-6"
+if has_force or ( ( m:get(section, "force_ipversion") or "0" ) ~= "0" ) then
+	fipv = ns:taboption("advanced", Flag, "force_ipversion",
+		translate("Force IP Version") )
+	fipv.orientation = "horizontal"
+	function fipv.cfgvalue(self, section)
+		local value = AbstractValue.cfgvalue(self, section)
+		if not has_force and value ~= "0" then
+			self.description = bold_on .. font_red ..
+				translate("Force IP Version not supported") .. font_off .. "<br />" ..
+				translate("please disable") .. " !" .. bold_off
+		else
+			self.description = translate("OPTIONAL: Force the usage of pure IPv4/IPv6 only communication.")
+		end
+		return value
+	end
+	function fipv.validate(self, value)
+		if (value == "1" and has_force) or value == "0" then return value end
+		return nil, err_tab_adv(self) .. translate("Force IP Version not supported")
+	end
+	function fipv.write(self, section, value)
+		if value == "1" then
+			return self.map:set(section, self.option, value)
+		else
+			return self.map:del(section, self.option)
+		end
+	end
+end
+
+-- IPv4 + IPv6 - dns_server (NEW)
+-- optional DNS Server to use resolving my IP if "ip_source"="web"
+dns = ns:taboption("advanced", Value, "dns_server", 
+	translate("DNS-Server"),
+	translate("OPTIONAL: Use non-default DNS-Server to detect 'Registered IP'.") .. "<br />" ..
+	translate("Format: IP or FQDN"))
+dns.placeholder = "mydns.lan"
+function dns.validate(self, value)
+	-- if .datatype is set, then it is checked before calling this function
+	if not value then
+		return ""	-- ignore on empty
+	elseif not luci.cbi.datatypes.hostname(value) then
+		return nil, err .. translate("use hostname, FQDN, IPv4- or IPv6-Address")
+	else
+		local ipv6  = usev6:formvalue(section)
+		local force = (fipv) and fipv:formvalue(section) or "0"
+		local command = [[/usr/lib/ddns/dynamic_dns_lucihelper.sh verify_dns ]] .. 
+			value .. [[ ]] .. ipv6 .. [[ ]] .. force
+		local ret = luci.sys.call(command)
+		if     ret == 0 then return value	-- everything OK
+		elseif ret == 2 then return nil, err_tab_adv(self) .. translate("nslookup can not resolve host")
+		elseif ret == 3 then return nil, err_tab_adv(self) .. translate("nc (netcat) can not connect")
+		elseif ret == 4 then return nil, err_tab_adv(self) .. translate("Forced IP Version don't matched")
+		else                 return nil, err_tab_adv(self) .. translate("unspecific error")
+		end
+	end
+end
+
+-- IPv4 + IPv6 - force_dnstcp (NEW)
+if has_dnstcp or ( ( m:get(section, "force_dnstcp") or "0" ) ~= "0" ) then
+	tcp = ns:taboption("advanced", Flag, "force_dnstcp",
+		translate("Force TCP on DNS") )
+	tcp.orientation = "horizontal"
+	function tcp.cfgvalue(self, section)
+		local value = AbstractValue.cfgvalue(self, section)
+		if not has_dnstcp and value ~= "0" then
+			self.description = bold_on .. font_red ..
+				translate("DNS requests via TCP not supported") .. font_off .. "<br />" ..
+				translate("please disable") .. " !" .. bold_off
+		else
+			self.description = translate("OPTIONAL: Force the use of TCP instead of default UDP on DNS requests.")
+		end
+		return value
+	end
+	function tcp.validate(self, value)
+		if (value == "1" and has_dnstcp ) or value == "0" then 
+			return value
+		end
+		return nil, err_tab_adv(self) .. translate("DNS requests via TCP not supported")
+	end
+end
+
+-- IPv4 + IPv6 - proxy (NEW)
+-- optional Proxy to use for http/https requests  [user:password@]proxyhost[:port]
+if has_proxy or ( ( m:get(section, "proxy") or "" ) ~= "" ) then
+	pxy = ns:taboption("advanced", Value, "proxy", 
+		translate("PROXY-Server") )
+	pxy.placeholder="user:password@myproxy.lan:8080"
+	function pxy.cfgvalue(self, section)
+		local value = AbstractValue.cfgvalue(self, section)
+		if not has_proxy and value ~= "" then
+			self.description = bold_on .. font_red ..
+				translate("PROXY-Server not supported") .. font_off .. "<br />" ..
+				translate("please remove entry") .. "!" .. bold_off
+		else
+			self.description = translate("OPTIONAL: Proxy-Server for detection and updates.") .. "<br />" ..
+				translate("Format") .. ": " .. bold_on .. "[user:password@]proxyhost:port" .. bold_off .. "<br />" ..
+				translate("IPv6 address must be given in square brackets") .. ": " .. 
+				bold_on .. " [2001:db8::1]:8080" .. bold_off 
+		end
+		return value
+	end
+	function pxy.validate(self, value)
+		-- if .datatype is set, then it is checked before calling this function
+		if not value then
+			return ""	-- ignore on empty
+		elseif has_proxy then 
+			local ipv6  = usev6:formvalue(section) or "0"
+			local force = (fipv) and fipv:formvalue(section) or "0"
+			local command = [[/usr/lib/ddns/dynamic_dns_lucihelper.sh verify_proxy ]] .. 
+				value .. [[ ]] .. ipv6 .. [[ ]] .. force
+			local ret = luci.sys.call(command)
+			if     ret == 0 then return value
+			elseif ret == 2 then return nil, err_tab_adv(self) .. translate("nslookup can not resolve host")
+			elseif ret == 3 then return nil, err_tab_adv(self) .. translate("nc (netcat) can not connect")
+			elseif ret == 4 then return nil, err_tab_adv(self) .. translate("Forced IP Version don't matched")
+			elseif ret == 5 then return nil, err_tab_adv(self) .. translate("proxy port missing")
+			else                 return nil, err_tab_adv(self) .. translate("unspecific error")
+			end
+		else
+			return nil, err .. translate("PROXY-Server not supported")
+		end
+	end
+end
+
+-- TAB: Timer  #################################################################
+-- check_interval
+ci = ns:taboption("timer", Value, "check_interval", 
+	translate("Check Interval") )
+ci.template = "ddns/detail_value"
+ci.default  = 10 
+ci.rmempty = false	-- validate ourselves for translatable error messages
+function ci.validate(self, value)
+	if not luci.cbi.datatypes.uinteger(value) 
+	or tonumber(value) < 1 then
+		return nil, err_tab_timer(self) .. translate("minimum value 5 minutes == 300 seconds")
+	end
+
+	local secs = luci.tools.ddns.calc_seconds(value, cu:formvalue(section))
+	if secs >= 300 then 
+		return value
+	else
+		return nil, err_tab_timer(self) .. translate("minimum value 5 minutes == 300 seconds")
+	end
+end
+function ci.write(self, section, value)
+	-- simulate rmempty=true remove default
+	local secs = luci.tools.ddns.calc_seconds(value, cu:formvalue(section))
+	if secs ~= 600 then	--default 10 minutes
+		return self.map:set(section, self.option, value)
+	else
+		self.map:del(section, "check_unit")
+		return self.map:del(section, self.option)
+	end
+end
+
+-- check_unit
+cu = ns:taboption("timer", ListValue, "check_unit", "not displayed, but needed otherwise error",
+	translate("Interval to check for changed IP" .. "<br />" .. 
+		"Values below 5 minutes == 300 seconds are not supported") )
+cu.template = "ddns/detail_lvalue"
+cu.default  = "minutes"
+cu.rmempty  = false	-- want to control write process
+cu:value("seconds", translate("seconds"))
+cu:value("minutes", translate("minutes"))
+cu:value("hours", translate("hours"))
+--cu:value("days", translate("days"))
+function cu.write(self, section, value)
+	-- simulate rmempty=true remove default
+	local secs = luci.tools.ddns.calc_seconds(ci:formvalue(section), value)
+	if secs ~= 600 then	--default 10 minutes
+		return self.map:set(section, self.option, value)
+	else
+		return true
+	end
+end
+
+-- force_interval (modified)
+fi = ns:taboption("timer", Value, "force_interval", 
+	translate("Force Interval") )
+fi.template = "ddns/detail_value"
+fi.default  = 72 	-- see dynamic_dns_updater.sh script
+fi.rmempty = false	-- validate ourselves for translatable error messages
+function fi.validate(self, value)
+	if not luci.cbi.datatypes.uinteger(value) 
+	or tonumber(value) < 0 then
+		return nil, err_tab_timer(self) .. translate("minimum value '0'")
+	end
+
+	local force_s = luci.tools.ddns.calc_seconds(value, fu:formvalue(section))
+	if force_s == 0 then 
+		return value
+	end
+
+	local ci_value = ci:formvalue(section)
+	if not luci.cbi.datatypes.uinteger(ci_value) then
+		return ""	-- ignore because error in check_interval above
+	end
+
+	local check_s = luci.tools.ddns.calc_seconds(ci_value, cu:formvalue(section))
+	if force_s >= check_s then
+		return value
+	end
+
+	return nil, err_tab_timer(self) .. translate("must be greater or equal 'Check Interval'")
+end
+function fi.write(self, section, value)
+	-- simulate rmempty=true remove default
+	local secs = luci.tools.ddns.calc_seconds(value, fu:formvalue(section))
+	if secs ~= 259200 then	--default 72 hours == 3 days
+		return self.map:set(section, self.option, value)
+	else
+		self.map:del(section, "force_unit")
+		return self.map:del(section, self.option)
+	end
+end
+
+-- force_unit
+fu = ns:taboption("timer", ListValue, "force_unit", "not displayed, but needed otherwise error",
+	translate("Interval to force updates send to DDNS Provider" .. "<br />" ..
+		"Setting this parameter to 0 will force the script to only run once" .. "<br />" ..
+		"Values lower 'Check Interval' except '0' are not supported") )
+fu.template = "ddns/detail_lvalue"
+fu.default  = "hours"
+fu.rmempty  = false	-- want to control write process
+--fu:value("seconds", translate("seconds"))
+fu:value("minutes", translate("minutes"))
+fu:value("hours", translate("hours"))
+fu:value("days", translate("days"))
+function fu.write(self, section, value)
+	-- simulate rmempty=true remove default
+	local secs = luci.tools.ddns.calc_seconds(fi:formvalue(section), value)
+	if secs ~= 259200 and secs ~= 0 then	--default 72 hours == 3 days
+		return self.map:set(section, self.option, value)
+	else
+		return true
+	end
+end
+
+-- retry_count (NEW)
+rc = ns:taboption("timer", Value, "retry_count", 
+	translate("Error Retry Counter"),
+	translate("On Error the script will stop execution after given number of retrys") )
+rc.default = 5
+rc.rmempty = false	-- validate ourselves for translatable error messages
+function rc.validate(self, value)
+	if not luci.cbi.datatypes.uinteger(value) 
+	or tonumber(value) < 1 then
+		return nil, err_tab_timer(self) .. translate("minimum value '1'")
+	else
+		return value
+	end
+end
+function rc.write(self, section, value)
+	-- simulate rmempty=true remove default
+	if tonumber(value) ~= self.default then
+		return self.map:set(section, self.option, value)
+	else
+		return self.map:del(section, self.option)
+	end
+end
+
+-- retry_interval
+ri = ns:taboption("timer", Value, "retry_interval", 
+	translate("Error Retry Interval") ) 
+ri.template = "ddns/detail_value"
+ri.default  = 60
+ri.rmempty  = false	-- validate ourselves for translatable error messages
+function ri.validate(self, value)
+	if not luci.cbi.datatypes.uinteger(value) 
+	or tonumber(value) < 1 then
+		return nil, err_tab_timer(self) .. translate("minimum value '1'")
+	else
+		return value
+	end
+end
+function ri.write(self, section, value)
+	-- simulate rmempty=true remove default
+	local secs = luci.tools.ddns.calc_seconds(value, ru:formvalue(section))
+	if secs ~= 60 then	--default 60seconds
+		return self.map:set(section, self.option, value)
+	else
+		self.map:del(section, "retry_unit")
+		return self.map:del(section, self.option)
+	end
+end
+
+-- retry_unit
+ru = ns:taboption("timer", ListValue, "retry_unit", "not displayed, but needed otherwise error",
+	translate("On Error the script will retry the failed action after given time") )
+ru.template = "ddns/detail_lvalue"
+ru.default  = "seconds"
+ru.rmempty  = false	-- want to control write process
+ru:value("seconds", translate("seconds"))
+ru:value("minutes", translate("minutes"))
+--ru:value("hours", translate("hours"))
+--ru:value("days", translate("days"))
+function ru.write(self, section, value)
+	-- simulate rmempty=true remove default
+	local secs = luci.tools.ddns.calc_seconds(ri:formvalue(section), value)
+	if secs ~= 60 then	--default 60seconds
+		return self.map:set(section, self.option, value)
+	else
+		return true -- will be deleted by retry_interval
+	end
+end
+
+-- TAB: LogView  (NEW) #############################################################################
+lv = ns:taboption("logview", DummyValue, "_logview")
+lv.template = "ddns/detail_logview"
+lv.inputtitle = translate("Read / Reread log file")
+lv.rows = 50
+function lv.cfgvalue(self, section)
+	local lfile=log_dir .. "/" .. section .. ".log"
+	if nixio.fs.access(lfile) then
+		return lfile .. "\n" .. translate("Please press [Read] button")
+	end
+	return lfile .. "\n" .. translate("File not found or empty")
+end
+
+return m

--- a/applications/luci-ddns/luasrc/model/cbi/ddns/hints.lua
+++ b/applications/luci-ddns/luasrc/model/cbi/ddns/hints.lua
@@ -1,0 +1,129 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+require "luci.sys"
+require "luci.dispatcher"
+require "luci.tools.ddns"
+
+-- check supported options
+-- saved to local vars here because doing multiple os calls slow down the system
+has_ssl    = luci.tools.ddns.check_ssl()	-- HTTPS support
+has_proxy  = luci.tools.ddns.check_proxy()	-- Proxy support
+has_dnstcp = luci.tools.ddns.check_bind_host()	-- DNS TCP support
+
+-- html constants
+bold_on  = [[<strong>]]
+bold_off = [[</strong>]]
+
+-- cbi-map definition
+m = Map("ddns")
+
+m.title = [[<a href="]] .. luci.dispatcher.build_url("admin", "services", "ddns") .. [[">]] .. 
+		translate("Dynamic DNS") .. [[</a>]]
+
+m.description = translate("Dynamic DNS allows that your router can be reached with " ..
+			"a fixed hostname while having a dynamically changing " ..
+			"IP address.")
+
+m.redirect = luci.dispatcher.build_url("admin", "services", "ddns")
+
+-- SimpleSection definition
+-- show Hints to optimize installation and script usage
+s = m:section( SimpleSection, 
+	translate("Hints"), 
+	translate("Below a list of configuration tips for your system to run Dynamic DNS updates without limitations") )
+-- DDNS Service disabled
+if not luci.sys.init.enabled("ddns") then
+	local dv = s:option(DummyValue, "_not_enabled")
+	dv.titleref = luci.dispatcher.build_url("admin", "system", "startup")
+	dv.rawhtml  = true
+	dv.title = bold_on .. 
+		translate("DDNS Autostart disabled") .. bold_off
+	dv.value = translate("Currently DDNS updates are not started at boot or on interface events." .. "<br />" .. 
+			"This is the default if you run DDNS scripts by yourself (i.e. via cron with force_interval set to '0')" )
+end
+
+-- No IPv6 support
+if not luci.tools.ddns.check_ipv6() then
+	local dv = s:option(DummyValue, "_no_ipv6")
+	dv.titleref = 'http://www.openwrt.org" target="_blank'
+	dv.rawhtml  = true
+	dv.title = bold_on .. 
+		translate("IPv6 not supported") .. bold_off
+	dv.value = translate("IPv6 is currently not (fully) supported by this system" .. "<br />" .. 
+			"Please follow the instructions on OpenWrt's homepage to enable IPv6 support" .. "<br />" ..
+			"or update your system to the latest OpenWrt Release")
+end
+
+-- No HTTPS support
+if not has_ssl then
+	local dv = s:option(DummyValue, "_no_https")
+	dv.titleref = luci.dispatcher.build_url("admin", "system", "packages")
+	dv.rawhtml  = true
+	dv.title = bold_on .. 
+		translate("HTTPS not supported") .. bold_off
+	dv.value = translate("Neither GNU Wget with SSL nor cURL installed to support updates via HTTPS protocol.") .. 
+			"<br />- " .. 
+			translate("You should install GNU Wget with SSL (prefered) or cURL package.") .. 
+			"<br />- " ..
+			translate("In some versions cURL/libcurl in OpenWrt is compiled without proxy support.")
+end
+
+-- cURL without proxy support
+if has_ssl and not has_proxy then
+	local dv = s:option(DummyValue, "_no_proxy")
+	dv.titleref = luci.dispatcher.build_url("admin", "system", "packages")
+	dv.rawhtml  = true
+	dv.title = bold_on .. 
+		translate("cURL without Proxy Support") .. bold_off
+	dv.value = translate("cURL is installed, but libcurl was compiled without proxy support.") .. 
+			"<br />- " .. 
+			translate("You should install GNU Wget with SSL or replace libcurl.") .. 
+			"<br />- " ..
+			translate("In some versions cURL/libcurl in OpenWrt is compiled without proxy support.")
+end
+
+-- "Force IP Version not supported"
+if not (has_ssl and has_dnstcp) then
+	local dv = s:option(DummyValue, "_no_force_ip")
+	dv.titleref = luci.dispatcher.build_url("admin", "system", "packages")
+	dv.rawhtml  = true
+	dv.title = bold_on .. 
+		translate("Force IP Version not supported") .. bold_off
+	local value = translate("BusyBox's nslookup and Wget do not support to specify " ..
+			"the IP version to use for communication with DDNS Provider.") 
+	if not has_ssl then
+		value = value .. "<br />- " ..
+			translate("You should install GNU Wget with SSL (prefered) or cURL package.")
+	end
+	if not has_dnstcp then
+		value = value .. "<br />- " ..
+			translate("You should install BIND host package for DNS requests.")
+	end
+	dv.value = value
+end
+
+-- "DNS requests via TCP not supported"
+if not has_dnstcp then
+	local dv = s:option(DummyValue, "_no_dnstcp")
+	dv.titleref = luci.dispatcher.build_url("admin", "system", "packages")
+	dv.rawhtml  = true
+	dv.title = bold_on .. 
+		translate("DNS requests via TCP not supported") .. bold_off
+	dv.value = translate("BusyBox's nslookup does not support to specify to use TCP instead of default UDP when requesting DNS server") .. 
+			"<br />- " ..
+			translate("You should install BIND host package for DNS requests.")
+end
+
+return m

--- a/applications/luci-ddns/luasrc/model/cbi/ddns/overview.lua
+++ b/applications/luci-ddns/luasrc/model/cbi/ddns/overview.lua
@@ -1,0 +1,224 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+require "nixio.fs"
+require "luci.sys"
+require "luci.dispatcher"
+require "luci.tools.ddns"
+
+-- show hints ?
+show_hints = not (luci.tools.ddns.check_ipv6()		-- IPv6 support
+		and luci.tools.ddns.check_ssl()		-- HTTPS support
+		and luci.tools.ddns.check_proxy()	-- Proxy support
+		and luci.tools.ddns.check_bind_host()	-- DNS TCP support
+		)
+
+-- html constants
+font_red = [[<font color="red">]]
+font_off = [[</font>]]
+bold_on  = [[<strong>]]
+bold_off = [[</strong>]]
+
+-- cbi-map definition
+m = Map("ddns", 
+	translate("Dynamic DNS"),
+	translate("Dynamic DNS allows that your router can be reached with " ..
+		"a fixed hostname while having a dynamically changing " ..
+		"IP address."))
+
+-- read application settings
+date_format = m.uci:get(m.config, "global", "date_format") or "%F %R"
+run_dir	    = m.uci:get(m.config, "global", "run_dir") or "/var/run/ddns"
+
+-- SimpleSection definition
+-- show Hints to optimize installation and script usage
+-- only show if 	service not enabled
+--		or	no IPv6 support
+--		or	not GNU Wget and not cURL	(for https support)
+--		or	not GNU Wget but cURL without proxy support
+--		or	not BIND's host
+if show_hints or not luci.sys.init.enabled("ddns") then
+	s = m:section( SimpleSection, translate("Hints") )
+	-- DDNS Service disabled
+	if not luci.sys.init.enabled("ddns") then
+		local dv = s:option(DummyValue, "_not_enabled")
+		dv.titleref = luci.dispatcher.build_url("admin", "system", "startup")
+		dv.rawhtml  = true
+		dv.title = bold_on .. 
+			translate("DDNS Autostart disabled") .. bold_off
+		dv.value = translate("Currently DDNS updates are not started at boot or on interface events." .. "<br />" .. 
+				"You can start/stop each configuration here. It will run until next reboot.")
+	end
+
+	-- Show more hints on a separate page
+	if show_hints then
+		local dv = s:option(DummyValue, "_separate")
+		dv.titleref = luci.dispatcher.build_url("admin", "services", "ddns", "hints")
+		dv.rawhtml  = true
+		dv.title = bold_on .. 
+			translate("Show more") .. bold_off
+		dv.value = translate("Follow this link" .. "<br />" ..
+				"You will find more hints to optimize your system to run DDNS scripts with all options")
+	end
+end
+
+-- SimpleSection definiton
+-- with all the JavaScripts we need for "a good Show"
+a = m:section( SimpleSection )
+a.template = "ddns/overview_status"
+
+-- TableSection definition
+ts = m:section( TypedSection, "service", 
+	translate("Overview"), 
+	translate("Below is a list of configured DDNS configurations and their current state." .. "<br />" ..
+		"If you want to send updates for IPv4 and IPv6 you need to define two separate Configurations " ..
+		"i.e. 'myddns_ipv4' and 'myddns_ipv6'") )
+ts.sectionhead = translate("Configuration")
+ts.template = "cbi/tblsection"
+ts.addremove = true
+ts.extedit = luci.dispatcher.build_url("admin", "services", "ddns", "detail", "%s")
+function ts.create(self, name)
+	AbstractSection.create(self, name)
+	luci.http.redirect( self.extedit:format(name) )
+end
+
+-- Domain and registered IP
+dom = ts:option(DummyValue, "_domainIP",
+	translate("Hostname/Domain") .. "<br />" .. translate("Registered IP") )
+dom.template = "ddns/overview_doubleline"
+function dom.set_one(self, section)
+	local domain = self.map:get(section, "domain") or ""
+	if domain ~= "" then
+		return domain
+	else
+		return [[<em>]] .. translate("config error") .. [[</em>]]
+	end
+end
+function dom.set_two(self, section)
+	local domain = self.map:get(section, "domain") or ""
+	if domain == "" then return "" end
+	local dnsserver = self.map:get(section, "dnsserver") or ""
+	local use_ipv6 = tonumber(self.map:get(section, "use_ipv6") or 0)
+	local force_ipversion = tonumber(self.map:get(section, "force_ipversion") or 0)
+	local force_dnstcp = tonumber(self.map:get(section, "force_dnstcp") or 0)
+	local command = [[/usr/lib/ddns/dynamic_dns_lucihelper.sh]]
+	if not nixio.fs.access(command, "rwx", "rx", "rx") then
+		nixio.fs.chmod(command, 755)
+	end
+	command = command .. [[ get_registered_ip ]] .. domain .. [[ ]] .. use_ipv6 .. 
+		[[ ]] .. force_ipversion .. [[ ]] .. force_dnstcp .. [[ ]] .. dnsserver
+	local ip = luci.sys.exec(command)
+	if ip == "" then ip = translate("no data") end
+	return ip
+end
+
+-- enabled 
+ena = ts:option( Flag, "enabled", 
+	translate("Enabled"))
+ena.template = "ddns/overview_enabled"
+ena.rmempty = false
+
+-- show PID and next update
+upd = ts:option( DummyValue, "_update", 
+	translate("Last Update") .. "<br />" .. translate("Next Update"))
+upd.template = "ddns/overview_doubleline"
+function upd.set_one(self, section)	-- fill Last Update
+	-- get/validate last update
+	local uptime   = luci.sys.uptime()
+	local lasttime = tonumber(nixio.fs.readfile("%s/%s.update" % { run_dir, section } ) or 0 )
+	if lasttime > uptime then 	-- /var might not be linked to /tmp and cleared on reboot
+		lasttime = 0 
+	end
+
+	-- no last update happen
+	if lasttime == 0 then
+		return translate("never")
+
+	-- we read last update
+	else
+		-- calc last update
+		--            os.epoch  - sys.uptime + lastupdate(uptime)
+		local epoch = os.time() - uptime + lasttime
+		-- use linux date to convert epoch
+		return luci.sys.exec([[/bin/date -d @]] .. epoch .. [[ +']] .. date_format .. [[']])
+	end
+end
+function upd.set_two(self, section)	-- fill Next Update
+	-- get enabled state
+	local enabled	= tonumber(self.map:get(section, "enabled") or 0)
+	local datenext	= translate("unknown error")	-- formatted date of next update
+
+	-- get force seconds
+	local force_interval = tonumber(self.map:get(section, "force_interval") or 72)
+	local force_unit = self.map:get(section, "force_unit") or "hours"
+	local force_seconds = luci.tools.ddns.calc_seconds(force_interval, force_unit)
+
+	-- get last update and get/validate PID
+	local uptime   = luci.sys.uptime()
+	local lasttime = tonumber(nixio.fs.readfile("%s/%s.update" % { run_dir, section } ) or 0 )
+	if lasttime > uptime then 	-- /var might not be linked to /tmp and cleared on reboot
+		lasttime = 0 
+	end
+	local pid      = luci.tools.ddns.get_pid(section, run_dir)
+
+	-- calc next update
+	if lasttime > 0 then
+		local epoch = os.time() - uptime + lasttime + force_seconds
+		-- use linux date to convert epoch
+		datelast = luci.sys.exec([[/bin/date -d @]] .. epoch .. [[ +']] .. date_format .. [[']])
+	end		
+
+	-- process running but update needs to happen 
+	if pid > 0 and ( lasttime + force_seconds - uptime ) < 0 then
+		datenext = translate("Verify")
+
+	-- run once 
+	elseif force_seconds == 0 then
+		datenext = translate("Run once")
+
+	-- no process running and NOT enabled
+	elseif pid == 0 and enabled == 0 then
+		datenext  = translate("Disabled")
+
+	-- no process running and NOT 
+	elseif pid == 0 and enabled ~= 0 then
+		datenext = translate("Stopped")
+	end
+
+	return datenext
+end
+
+-- start/stop button
+btn = ts:option( Button, "_startstop", 
+	translate("Process ID") .. "<br />" .. translate("Start / Stop") )
+btn.template = "ddns/overview_startstop"
+function btn.cfgvalue(self, section)
+	local pid = luci.tools.ddns.get_pid(section, run_dir)
+	if pid > 0 then
+		btn.inputtitle	= "PID: " .. pid
+		btn.inputstyle	= "reset"
+		btn.disabled	= false
+	elseif (self.map:get(section, "enabled") or "0") ~= "0" then
+		btn.inputtitle	= translate("Start")
+		btn.inputstyle	= "apply"
+		btn.disabled	= false
+	else
+		btn.inputtitle	= "----------"
+		btn.inputstyle	= "button"
+		btn.disabled	= true
+	end
+	return true
+end
+
+return m

--- a/applications/luci-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-ddns/luasrc/tools/ddns.lua
@@ -1,0 +1,212 @@
+--[[
+LuCI - Lua Configuration Interface
+
+shared module for luci-app-ddns-v2
+Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+
+function parse_url copied from https://svn.nmap.org/nmap/nselib/url.lua
+Parses a URL and returns a table with all its parts according to RFC 2396.
+@author Diego Nehab	@author Eddie Bell <ejlbell@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+]]--
+
+module("luci.tools.ddns", package.seeall)
+
+require "luci.sys"
+require "nixio.fs"
+
+function check_ipv6()
+	return nixio.fs.access("/proc/net/ipv6_route") 
+	   and nixio.fs.access("/usr/sbin/ip6tables")
+end
+
+function check_ssl()
+	if (luci.sys.call([[ grep -iq "\+ssl" /usr/bin/wget 2>/dev/null ]]) == 0) then
+		return true
+	else
+		return nixio.fs.access("/usr/bin/curl")
+	end
+end
+
+function check_proxy()
+	-- we prefere GNU Wget for communication
+	if (luci.sys.call([[ grep -iq "\+ssl" /usr/bin/wget 2>/dev/null ]]) == 0) then
+		return true
+
+	-- if not installed cURL must support proxy
+	elseif nixio.fs.access("/usr/bin/curl") then
+		return (luci.sys.call([[ grep -iq all_proxy /usr/lib/libcurl.so* 2>/dev/null ]]) == 0)
+
+	-- only BusyBox Wget is installed
+	else
+		return nixio.fs.access("/usr/bin/wget")
+	end
+end
+
+function check_bind_host()
+	return nixio.fs.access("/usr/bin/host")
+end
+
+-- function to calculate seconds from given interval and unit
+function calc_seconds(interval, unit)
+	if not tonumber(interval) then
+		return nil
+	elseif unit == "days" then
+		return (tonumber(interval) * 86400)	-- 60 sec * 60 min * 24 h
+	elseif unit == "hours" then
+		return (tonumber(interval) * 3600)	-- 60 sec * 60 min
+	elseif unit == "minutes" then
+		return (tonumber(interval) * 60)	-- 60 sec
+	elseif unit == "seconds" then
+		return tonumber(interval)
+	else
+		return nil
+	end
+end
+
+-- read PID from run file and verify if still running
+function get_pid(section, run_dir)
+	local pid = tonumber(nixio.fs.readfile("%s/%s.pid" % { run_dir, section } ) or 0 )
+	if pid > 0 and not luci.sys.process.signal(pid, 0) then
+		pid = 0
+	end
+	return pid
+end
+
+-- replacement of build-in read of UCI option
+-- modified AbstractValue.cfgvalue(self, section) from cbi.lua
+-- needed to read from other option then current value definition
+function read_value(self, section, option)
+	local value
+	if self.tag_error[section] then
+		value = self:formvalue(section)
+	else
+		value = self.map:get(section, option)
+	end
+
+	if not value then
+		return nil
+	elseif not self.cast or self.cast == type(value) then
+		return value
+	elseif self.cast == "string" then
+		if type(value) == "table" then
+			return value[1]
+		end
+	elseif self.cast == "table" then
+		return { value }
+	end
+end
+
+-----------------------------------------------------------------------------
+-- copied from https://svn.nmap.org/nmap/nselib/url.lua
+-- @author Diego Nehab
+-- @author Eddie Bell <ejlbell@gmail.com>
+--[[
+    URI parsing, composition and relative URL resolution
+    LuaSocket toolkit.
+    Author: Diego Nehab
+    RCS ID: $Id: url.lua,v 1.37 2005/11/22 08:33:29 diego Exp $
+    parse_query and build_query added For nmap (Eddie Bell <ejlbell@gmail.com>)
+]]--
+---
+-- Parses a URL and returns a table with all its parts according to RFC 2396.
+--
+-- The following grammar describes the names given to the URL parts.
+-- <code>
+-- <url> ::= <scheme>://<authority>/<path>;<params>?<query>#<fragment>
+-- <authority> ::= <userinfo>@<host>:<port>
+-- <userinfo> ::= <user>[:<password>]
+-- <path> :: = {<segment>/}<segment>
+-- </code>
+--
+-- The leading <code>/</code> in <code>/<path></code> is considered part of
+-- <code><path></code>.
+-- @param url URL of request.
+-- @param default Table with default values for each field.
+-- @return A table with the following fields, where RFC naming conventions have
+--   been preserved:
+--     <code>scheme</code>, <code>authority</code>, <code>userinfo</code>,
+--     <code>user</code>, <code>password</code>, <code>host</code>,
+--     <code>port</code>, <code>path</code>, <code>params</code>,
+--     <code>query</code>, and <code>fragment</code>.
+-----------------------------------------------------------------------------
+function parse_url(url)	--, default)
+	-- initialize default parameters
+	local parsed = {}
+--	for i,v in base.pairs(default or parsed) do 
+--		parsed[i] = v
+--	end
+
+	-- remove whitespace
+--	url = string.gsub(url, "%s", "")
+	-- get fragment
+	url = string.gsub(url, "#(.*)$", 
+		function(f)
+			parsed.fragment = f
+			return ""
+		end)
+	-- get scheme. Lower-case according to RFC 3986 section 3.1.
+	url = string.gsub(url, "^([%w][%w%+%-%.]*)%:",
+		function(s)
+			parsed.scheme = string.lower(s);
+			return ""
+		end)
+	-- get authority
+	url = string.gsub(url, "^//([^/]*)",
+		function(n)
+			parsed.authority = n
+			return ""
+		end)
+	-- get query stringing
+	url = string.gsub(url, "%?(.*)",
+		function(q)
+			parsed.query = q
+			return ""
+		end)
+	-- get params
+	url = string.gsub(url, "%;(.*)",
+		function(p)
+			parsed.params = p
+			return ""
+		end)
+	-- path is whatever was left
+	parsed.path = url
+
+	local authority = parsed.authority
+	if not authority then 
+		return parsed
+	end
+	authority = string.gsub(authority,"^([^@]*)@",
+		function(u)
+			parsed.userinfo = u;
+			return ""
+		end)
+	authority = string.gsub(authority, ":([0-9]*)$",
+		function(p)
+			if p ~= "" then
+				parsed.port = p
+			end;
+			return ""
+		end)
+	if authority ~= "" then
+		parsed.host = authority
+	end
+
+	local userinfo = parsed.userinfo
+	if not userinfo then
+		return parsed
+	end
+	userinfo = string.gsub(userinfo, ":([^:]*)$",
+		function(p)
+			parsed.password = p;
+			return ""
+		end)
+	parsed.user = userinfo
+	return parsed
+end

--- a/applications/luci-ddns/luasrc/view/admin_status/index/ddns.htm
+++ b/applications/luci-ddns/luasrc/view/admin_status/index/ddns.htm
@@ -1,0 +1,1 @@
+<%+ddns/system_status%>

--- a/applications/luci-ddns/luasrc/view/ddns/detail_logview.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/detail_logview.htm
@@ -1,0 +1,56 @@
+
+<!-- ++ BEGIN ++ Dynamic DNS ++ detail_logview.htm ++ -->
+<script type="text/javascript">//<![CDATA[
+	function onclick_logview(section, bottom)  {
+		// get elements
+		var txt = document.getElementById("cbid.ddns." + section + "._logview.txt");	// TextArea
+		if ( !txt ) { return; }	// security check
+
+		XHR.get('<%=luci.dispatcher.build_url("admin", "services", "ddns", "logview")%>/' + section, null,
+			function(x) {
+				if (x.responseText == "_nodata_")
+					txt.value = "<%:File not found or empty%>";
+				else
+					txt.value = x.responseText;
+				if (bottom)
+					txt.scrollTop = txt.scrollHeight;
+				else
+					txt.scrollTop = 0;			}
+		);
+	}
+//]]></script>
+
+<%+cbi/valueheader%>
+
+<br />
+
+<%
+-- one button on top, one at the buttom
+%>
+<input class="cbi-button cbi-input-button" style="align: center; width: 100%" type="button" onclick="onclick_logview(this.name, false)"
+<%= 
+attr("name", section) .. attr("id", cbid .. ".btn1") .. attr("value", self.inputtitle) 
+%> />
+
+<br /><br />
+
+<%
+-- set a readable style taken from openwrt theme for textarea#syslog
+-- in openwrt theme there are problems with a width of 100 so we check for theme and set to lower value
+%>
+<textarea style="width: <%if media == "/luci-static/openwrt.org" then%>98.7%<%else%>100%<%end%> ; min-height: 500px; border: 3px solid #cccccc; padding: 5px; font-family: monospace; resize: none;" wrap="off" readonly="readonly"
+<%= 
+attr("name", cbid .. ".txt") .. attr("id", cbid .. ".txt") .. ifattr(self.rows, "rows") 
+%> >
+<%-=pcdata(self:cfgvalue(section))-%>
+</textarea>
+<br /><br />
+
+<% 
+-- one button on top, one at the buttom 
+%>
+<input class="cbi-button cbi-input-button" style="align: center; width: 100%" type="button" onclick="onclick_logview(this.name, true)"
+<%= attr("name", section) .. attr("id", cbid .. ".btn2") .. attr("value", self.inputtitle) %> />
+
+<%+cbi/valuefooter%>
+<!-- ++ END ++ Dynamic DNS ++ detail_logview.htm ++ -->

--- a/applications/luci-ddns/luasrc/view/ddns/detail_lvalue.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/detail_lvalue.htm
@@ -1,0 +1,22 @@
+
+<!-- ++ BEGIN ++ Dynamic DNS ++ detail_lvalue.htm ++ -->
+<!-- no value header to supress next line -->
+&#160;
+<% if self.widget == "select" then %>
+	<select class="cbi-input-select" onchange="cbi_d_update(this.id)"<%= attr("id", cbid) .. attr("name", cbid) .. ifattr(self.size, "size") %>>
+	<% for i, key in pairs(self.keylist) do -%>
+		<option id="cbi-<%=self.config.."-"..section.."-"..self.option.."-"..key%>"<%= attr("value", key) .. ifattr(tostring(self:cfgvalue(section) or self.default) == key, "selected", "selected") %>><%=striptags(self.vallist[i])%></option>
+	<%- end %>
+	</select>
+<% elseif self.widget == "radio" then
+	local c = 0
+	for i, key in pairs(self.keylist) do
+	c = c + 1
+%>
+	<input class="cbi-input-radio" onclick="cbi_d_update(this.id)" onchange="cbi_d_update(this.id)" type="radio"<%= attr("id", cbid..c) .. attr("name", cbid) .. attr("value", key) .. ifattr((self:cfgvalue(section) or self.default) == key, "checked", "checked") %> />
+	<label<%= attr("for", cbid..c) %>><%=self.vallist[i]%></label>
+<% if c == self.size then c = 0 %><% if self.orientation == "horizontal" then %>&#160;<% else %><br /><% end %>
+<% end end %>
+<% end %>
+<%+cbi/valuefooter%>
+<!-- ++ END ++ Dynamic DNS ++ detail_lvalue.htm ++ -->

--- a/applications/luci-ddns/luasrc/view/ddns/detail_value.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/detail_value.htm
@@ -1,0 +1,9 @@
+
+<!-- ++ BEGIN ++ Dynamic DNS ++ detail_value.htm ++ -->
+<%+cbi/valueheader%>
+	<input type="text" class="cbi-input-text" style="width: 10em;" onchange="cbi_d_update(this.id)"<%=
+		attr("name", cbid) .. attr("id", cbid) .. attr("value", self:cfgvalue(section) or self.default) ..
+		ifattr(self.size, "size") .. ifattr(self.placeholder, "placeholder")
+	%> />
+<!-- no value footer to supress next line -->
+<!-- ++ END ++ Dynamic DNS ++ detail_value.htm ++ -->

--- a/applications/luci-ddns/luasrc/view/ddns/overview_doubleline.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/overview_doubleline.htm
@@ -1,0 +1,10 @@
+
+<!-- ++ BEGIN ++ Dynamic DNS ++ overview_doubleline.htm ++ -->
+<%+cbi/valueheader%>
+
+<span id="<%=cbid%>.one"><%=self:set_one(section)%></span>
+<br />
+<span id="<%=cbid%>.two"><%=self:set_two(section)%></span>
+
+<%+cbi/valuefooter%>
+<!-- ++ END ++ Dynamic DNS ++ overview_doubleline.htm ++ -->

--- a/applications/luci-ddns/luasrc/view/ddns/overview_enabled.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/overview_enabled.htm
@@ -1,0 +1,15 @@
+
+<!-- ++ BEGIN ++ Dynamic DNS ++ overview_enabled.htm ++ -->
+<%+cbi/valueheader%>
+
+<input type="hidden" value="1"<%=
+	attr("name", "cbi.cbe." .. self.config .. "." .. section .. "." .. self.option)
+%> />
+                                                                 <!-- modified to call own function -->
+<input class="cbi-input-checkbox" onclick="cbi_d_update(this.id)" onchange="onchange_enabled(this.id)" type="checkbox"<%=
+	attr("id", cbid) .. attr("name", cbid) .. attr("value", self.enabled or 1) ..
+	ifattr((self:cfgvalue(section) or self.default) == self.enabled, "checked", "checked")
+%> />
+
+<%+cbi/valuefooter%>
+<!-- ++ END ++ Dynamic DNS ++ overview_enabled.htm ++ -->

--- a/applications/luci-ddns/luasrc/view/ddns/overview_startstop.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/overview_startstop.htm
@@ -1,0 +1,17 @@
+
+<!-- ++ BEGIN ++ Dynamic DNS ++ overview_startstop.htm ++ -->
+<%+cbi/valueheader%>
+
+<% if self:cfgvalue(section) ~= false then
+-- We need to garantie that function cfgvalue run first to set missing parameters 
+%>
+	<!-- style="font-size: 100%;" needed for openwrt theme to fix font size -->
+	<!-- type="button" onclick="..." enable standard onclick functionalty   -->
+	<input class="cbi-button cbi-input-<%=self.inputstyle or "button" %>" style="font-size: 100%;" type="button" onclick="onclick_startstop(this.id)"
+	<%= 
+	attr("name", section) .. attr("id", cbid) .. attr("value", self.inputtitle) .. ifattr(self.disabled, "disabled") 
+	%> />
+<% end %>
+
+<%+cbi/valuefooter%>
+<!-- ++ END ++ Dynamic DNS ++ overview_startstop.htm ++ -->

--- a/applications/luci-ddns/luasrc/view/ddns/overview_status.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/overview_status.htm
@@ -1,0 +1,178 @@
+
+<!-- ++ BEGIN ++ Dynamic DNS ++ overview_status.htm ++ -->
+<script type="text/javascript">//<![CDATA[
+
+	// helper to extract section from objects id
+	// cbi.ddns.SECTION._xyz
+	function _id2section(id) {
+		var x = id.split(".");
+		return x[2];
+	}
+
+	// helper to move status data to the relevant
+	// screen objects
+	// called by XHR.poll and onclick_startstop
+	function _data2elements(data) {
+		// DDNS Service
+		// data[0] ignored here
+
+		// Service sections
+		for( i = 1; i < data.length; i++ )
+		{
+			var section = data[i].section	// Section to handle
+			var cbx = document.getElementById("cbid.ddns." + section + ".enabled");		// Enabled
+			var btn = document.getElementById("cbid.ddns." + section + "._startstop");	// Start/Stop button
+			var rip = document.getElementById("cbid.ddns." + section + "._domainIP.two");	// Registered IP
+			var lup = document.getElementById("cbid.ddns." + section + "._update.one");	// Last Update
+			var nup = document.getElementById("cbid.ddns." + section + "._update.two");	// Next Update
+			if ( !(cbx && btn && rip && lup && nup) ) { return; }	// security check
+
+			// process id
+			if (data[i].pid > 0) {
+				// stop always possible if process running
+				btn.value = "PID: " + data[i].pid;
+				btn.className = "cbi-button cbi-input-reset";
+			} else {
+				// default Start / enabled
+				btn.value = "<%:Start%>";
+				btn.className = "cbi-button cbi-input-apply";
+			}
+			btn.disabled = false;	// button enabled
+			
+			// last update
+			switch (data[i].datelast) {
+				case "_empty_":
+					lup.innerHTML = '<em><%:Unknown error%></em>' ;
+					break;
+				case "_never_":
+					lup.innerHTML = '<em><%:Never%></em>' ;
+					break;
+				default:
+					lup.innerHTML = data[i].datelast;
+					break;
+			}
+
+			// next update
+			switch (data[i].datenext) {
+				case "_empty_":
+					nup.innerHTML = '<em><%:Unknown error%></em>' ;
+					break;
+				case "_verify_":
+					nup.innerHTML = '<em><%:Verify%></em>';
+					break;
+				case "_runonce_":
+				case "_stopped_":
+				case "_disabled_":
+					if (cbx.checked && data[i].datenext == "_runonce_") {
+						nup.innerHTML = '<em><%:Run once%></em>';
+					} else if (cbx.checked) {
+						nup.innerHTML = '<em><%:Stopped%></em>';
+					} else {
+						nup.innerHTML = '<em><%:Disabled%></em>';
+						btn.value = '----------';
+						btn.className = "cbi-button cbi-input-button";	// no image
+						btn.disabled = true;	// disabled 
+					}
+					break;
+				default:
+					nup.innerHTML = data[i].datenext;
+					break;
+			}
+
+			// domain
+			// (data[i].domain ignored here
+
+			// registered IP
+			// rip.innerHTML = "Registered IP";
+			if (data[i].domain == "_nodomain_") 
+				rip.innerHTML = '';
+			else if (data[i].reg_ip == "_nodata_")
+				rip.innerHTML = '<em><%:No data%></em>';
+			else
+				rip.innerHTML = data[i].reg_ip;
+		
+			// monitored interfacce
+			// data[i].iface ignored here
+		}
+	}
+
+	// event handler for enabled checkbox
+	function onchange_enabled(id) {
+		// run original function in cbi.js
+		// whatever is done there
+		cbi_d_update(id);
+
+		var section = _id2section(id);
+		var cbx = document.getElementById("cbid.ddns." + section + ".enabled");
+		var btn = document.getElementById("cbid.ddns." + section + "._startstop");
+		if ( !(cbx && btn) ) { return; }	// security check
+
+		var pid_txt = btn.value;
+		var pid_found = ( pid_txt.search("PID") >= 0 ) ? true : false;
+
+		if (pid_found) {
+			// btn.value = "PID: 0000";
+			btn.className = "cbi-button cbi-button-reset";
+			btn.disabled = false;
+		} else if (cbx.checked) {
+			btn.value = "<%:Start%>";
+			btn.className = "cbi-button cbi-button-apply";
+			btn.disabled = false;
+		} else {
+			btn.value = '----------';
+			btn.className = "cbi-button cbi-input-button";	// no image
+			btn.disabled = true;		// disabled 
+		}		
+	}
+
+	// event handler for start/stop button
+	function onclick_startstop(id) {
+		// extract section		
+		var section = _id2section(id);
+		// get elements
+		var cbx = document.getElementById("cbid.ddns." + section + ".enabled");		// Enabled
+		var obj = document.getElementById("cbi-ddns-overview-status-legend");		// objext defined below to make in-/visible
+		if ( !(obj && cbx) ) { return; }	// security check
+
+		// make me visible
+		obj.parentNode.style.display = "block";
+
+		// do start/stop
+		var btnXHR = new XHR();
+		btnXHR.get('<%=luci.dispatcher.build_url("admin", "services", "ddns", "startstop")%>/' + section + '/' + cbx.checked, null,
+			function(x, data) {
+				if (x.responseText == "_uncommited_") {
+					// we need a trick to display Ampersand "&" in stead of "&#38;" or "&amp;"
+					// after translation
+					txt="<%:Please [Save & Apply] your changes first%>";
+					alert( txt.replace(new RegExp("<%:&%>", "g"), "&") );
+				} else {
+					// should have data because status changed
+					// so update screen
+					if (data)
+						_data2elements(data);
+				}
+				// make me invisible
+				obj.parentNode.style.display = "none";
+			}
+		);
+	}
+
+	// define only ONE XHR.poll in a page because if one is running it blocks the other one
+	// optimum is to define on Map or Section Level from here you can reach all elements
+	// we need update every 30 seconds only
+	XHR.poll(30, '<%=luci.dispatcher.build_url("admin", "services", "ddns", "status")%>', null,
+		function(x, data)
+		{
+			_data2elements(data);
+		}			
+	);
+
+//]]></script>
+
+<fieldset class="cbi-section" style="display:none">
+	<legend id="cbi-ddns-overview-status-legend"><%:Applying changes%></legend>
+	<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle" />
+	<span id="cbi-ddns-overview-status-text"><%:Waiting for changes to be applied...%></span>
+</fieldset>
+<!-- ++ END ++ Dynamic DNS ++ overview_status.htm ++ -->

--- a/applications/luci-ddns/luasrc/view/ddns/system_status.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/system_status.htm
@@ -1,0 +1,145 @@
+
+<!-- ++ BEGIN ++ Dynamic DNS ++ system_status.htm ++ -->
+<script type="text/javascript">//<![CDATA[
+	XHR.poll(10, '<%=luci.dispatcher.build_url("admin", "services", "ddns", "status")%>', null,
+		function(x, data)
+		{
+			var tbl = document.getElementById('ddns_status_table');
+			// security check
+			if ( !(tbl) ) { return; }
+
+			// clear all rows
+			while (tbl.rows.length > 1) 
+				tbl.deleteRow(1);
+
+			// variable for Modulo-Division use to set cbi-rowstyle-? (0 or 1)
+			var x = -1;
+			var i = 1;
+
+			// no data => no ddns-scripts Version 2 installed
+			if ( !data ) {
+				var txt = '<br /><strong><font color="red"><%:Old version of ddns-scripts installed%></font>' ;
+				var url = '<a href="' ;
+				url += '<%=luci.dispatcher.build_url("admin", "system", "packages")%>' ;
+				url += '"><%:install update here%></a></strong>' ;
+				var tr = tbl.insertRow(-1);
+				tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1);
+				var td = tr.insertCell(-1);
+				td.colSpan = 2 ;
+				td.innerHTML = txt + " - " + url
+				tr.insertCell(-1).colSpan = 3 ;
+				return;
+			}
+
+			// DDNS Service disabled
+			if (data[0].enabled == 0) {
+				var txt = '<strong><font color="red"><%:DDNS Autostart disabled%></font>' ;
+				var url = '<a href="' + data[0].url_up + '"><%:enable here%></a></strong>' ;
+				var tr = tbl.insertRow(-1);
+				tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1);
+				var td = tr.insertCell(-1);
+				td.colSpan = 2 ;
+				td.innerHTML = txt + " - " + url
+				tr.insertCell(-1).colSpan = 3 ;
+				x++ ;
+			}
+
+			for( i = 1; i < data.length; i++ )
+			{
+				var tr = tbl.insertRow(-1);
+				tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1) ;
+
+				// configuration
+				tr.insertCell(-1).innerHTML = '<strong>' + data[i].section + '</strong>' ;
+
+				// pid
+				// data[i].pid ignored here
+
+				// last update
+				// data[i].datelast ignored here
+
+				// next update
+				switch (data[i].datenext) {
+					case "_empty_":
+						tr.insertCell(-1).innerHTML = '<em><%:Unknown error%></em>' ;
+						break;
+					case "_stopped_":
+						tr.insertCell(-1).innerHTML = '<em><%:Stopped%></em>' ;
+						break;
+					case "_disabled_":
+						tr.insertCell(-1).innerHTML = '<em><%:Disabled%></em>' ;
+						break;
+					case "_noupdate_":
+						tr.insertCell(-1).innerHTML = '<em><%:Update error%></em>' ;
+						break;
+					case "_runonce_":
+						tr.insertCell(-1).innerHTML = '<em><%:Run once%></em>' ;
+						break;
+					case "_verify_":
+						tr.insertCell(-1).innerHTML = '<em><%:Verify%></em>';
+						break;
+					default:
+						tr.insertCell(-1).innerHTML = data[i].datenext ;
+						break;
+				}
+
+				// domain
+				if (data[i].domain == "_nodomain_")
+					tr.insertCell(-1).innerHTML = '<em><%:config error%></em>';
+				else
+					tr.insertCell(-1).innerHTML = data[i].domain;
+
+				// registered IP
+				switch (data[i].reg_ip) {
+					case "_nodomain_":
+						tr.insertCell(-1).innerHTML = '<em><%:Config error%></em>';
+						break;
+					case "_nodata_":
+						tr.insertCell(-1).innerHTML = '<em><%:No data%></em>';
+						break;
+					case "_noipv6_":
+						tr.insertCell(-1).innerHTML = '<em><%:IPv6 not supported%></em>';
+						break;
+					default:
+						tr.insertCell(-1).innerHTML = data[i].reg_ip;
+						break;
+				}
+
+				// monitored interfacce
+				if (data[i].iface == "_nonet_")
+					tr.insertCell(-1).innerHTML = '<em><%:Config error%></em>';
+				else
+					tr.insertCell(-1).innerHTML = data[i].iface;
+			}
+
+			if (tbl.rows.length == 1 || (data[0].enabled == 0 && tbl.rows.length == 2) ) {
+				var br = '<br />';
+				if (tbl.rows.length > 1) 
+					br = '';
+				var tr = tbl.insertRow(-1);
+				tr.className = "cbi-section-table-row";
+				var td = tr.insertCell(-1);
+				td.colSpan = 5;
+				td.innerHTML = '<em>' + br + '<%:There is no service configured.%></em>' ;
+			}
+		}
+	);
+//]]></script>
+
+<fieldset class="cbi-section" id="ddns_status_section">
+	<legend><a href="<%=luci.dispatcher.build_url([[admin]], [[services]], [[ddns]])%>"><%:Dynamic DNS%></a></legend>
+
+	<table class="cbi-section-table" id="ddns_status_table">
+		<tr class="cbi-section-table-titles">
+			<th class="cbi-section-table-cell"><%:Configuration%></th>
+			<th class="cbi-section-table-cell"><%:Next Update%></th>
+			<th class="cbi-section-table-cell"><%:Hostname/Domain%></th>
+			<th class="cbi-section-table-cell"><%:Registered IP%></th>
+			<th class="cbi-section-table-cell"><%:Network%></th>
+		</tr>
+		<tr class="cbi-section-table-row">
+			<td colspan="5"><em><br /><%:Collecting data...%></em></td>
+		</tr>
+	</table>
+</fieldset>
+<!-- ++ END ++ Dynamic DNS ++ system_status.htm ++ -->

--- a/applications/luci-ddns/root/etc/uci-defaults/luci-ddns
+++ b/applications/luci-ddns/root/etc/uci-defaults/luci-ddns
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# needed for "Save and Apply" to restart ddns
+uci -q batch <<-EOF >/dev/null
+	delete ucitrack.@ddns[-1]
+	add ucitrack ddns
+	set ucitrack.@ddns[-1].init="ddns"
+	commit ucitrack
+EOF
+
+# make helper script executable
+chmod 755 /usr/lib/ddns/dynamic_dns_lucihelper.sh
+
+# update application section for luci-app-ddns
+uci -q get ddns.global > /dev/null || uci -q set ddns.global='ddns'
+uci -q get ddns.global.date_format > /dev/null || uci -q set ddns.global.date_format='%F %R'
+uci -q get ddns.global.log_lines > /dev/null || uci -q set ddns.global.log_lines='250'
+uci -q commit ddns
+
+rm -f /tmp/luci-indexcache
+exit 0

--- a/applications/luci-ddns/root/usr/lib/ddns/dynamic_dns_lucihelper.sh
+++ b/applications/luci-ddns/root/usr/lib/ddns/dynamic_dns_lucihelper.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# /usr/lib/ddns/luci_dns_helper.sh
+#
+# Written by Christian Schoenebeck in August 2014 to support:
+# this script is used by luci-app-ddns
+# - getting registered IP
+# - check if possible to get local IP
+# - verifing given DNS- or Proxy-Server
+#
+# variables in small chars are read from /etc/config/ddns
+# variables in big chars are defined inside these scripts as gloval vars
+# variables in big chars beginning with "__" are local defined inside functions only
+# set -vx  	#script debugger
+
+[ $# -lt 2 ] && exit 1
+
+. /usr/lib/ddns/dynamic_dns_functions.sh	# global vars are also defined here
+
+# set -vx  	#script debugger
+
+# preset some variables wrong or not set in dynamic_dns_functions.sh
+SECTION_ID="dynamic_dns_lucihelper"
+LOGFILE="$LOGDIR/$SECTION_ID.log"
+LUCI_HELPER="ACTIV"	# supress verbose and critical logging
+# global variables normally set by reading DDNS UCI configuration
+use_logfile=0
+use_syslog=0
+
+case "$1" in
+	get_registered_ip)
+		local IP
+		domain=$2			# Hostname/Domain
+		use_ipv6=${3:-"0"}		# Use IPv6 - default IPv4
+		force_ipversion=${4:-"0"}	# Force IP Version - default 0 - No
+		force_dnstcp=${5:-"0"}		# Force TCP on DNS - default 0 - No
+		dns_server=${6:-""}		# DNS server - default No DNS
+		get_registered_ip IP
+		[ $? -ne 0 ] && IP=""
+		echo -n "$IP"			# suppress LF
+		;;
+	verify_dns)
+		# $2 == dns-server to verify	# no need for force_dnstcp because
+						# verify with nc (netcat) uses tcp anyway
+		use_ipv6=${3:-"0"}		# Use IPv6 - default IPv4
+		force_ipversion=${4:-"0"}	# Force IP Version - default 0 - No
+		verify_dns "$2"
+		;;
+	verify_proxy)
+		# $2 == proxy string to verify
+		use_ipv6=${3:-"0"}		# Use IPv6 - default IPv4
+		force_ipversion=${4:-"0"}	# Force IP Version - default 0 - No
+		verify_proxy "$2"
+		;;
+	get_local_ip)
+		local IP
+		use_ipv6="$2"			# Use IPv6
+		ip_source="$3"			# IP source
+		ip_network="$4"			# set if source = "network" otherwise "-"
+		ip_url="$5"			# set if source = "web" otherwise "-"
+		ip_interface="$6"		# set if source = "interface" itherwiase "-"
+		ip_script="$7"			# set if source = "script" otherwise "-"
+		proxy="$8"			# proxy if set
+		force_ipversion="0"		# not needed but must be set
+		use_https="0"			# not needed but must be set
+		[ -n "$proxy" -a "$ip_source" == "web" ] && {
+			# proxy defined, used for ip_source=web
+			export HTTP_PROXY="http://$proxy"
+			export HTTPS_PROXY="http://$proxy"
+			export http_proxy="http://$proxy"
+			export https_proxy="http://$proxy"
+		}
+		# don't need IP only the return code
+		[ "$ip_source" == "web" -o  "$ip_source" == "script"] && {		
+			# we wait only 3 seconds for an 
+			# answer from "web" or "script"
+			__timeout 3 -- get_local_ip IP
+		} || get_local_ip IP
+		;;
+	*)	
+		return 1
+		;;
+esac

--- a/po/de/ddns.po
+++ b/po/de/ddns.po
@@ -1,17 +1,57 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2010-04-02 13:44+0100\n"
-"PO-Revision-Date: 2012-11-21 20:48+0200\n"
-"Last-Translator: Jo-Philipp <xm@subsignal.org>\n"
+"Project-Id-Version: luci-app-ddns\n"
+"POT-Creation-Date: 2014-10-04 16:26+1000\n"
+"PO-Revision-Date: 2014-10-04 16:27+0100\n"
+"Last-Translator: Christian Schoenebeck <christian.schoenebeck@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Pootle 2.0.6\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: .\n"
+
+msgid "&"
+msgstr "&"
+
+msgid "Basic Settings"
+msgstr "Grundlegende Einstellungen"
+
+msgid ""
+"Below a list of configuration tips for your system to run Dynamic DNS "
+"updates without limitations"
+msgstr ""
+"Liste der Konfigurationshinweise um Dynamische DNS Aktualisierungen ohne "
+"Einschränkungen zu nutzen"
+
+msgid ""
+"Below is a list of configured DDNS configurations and their current state."
+"<br />If you want to send updates for IPv4 and IPv6 you need to define two "
+"separate Configurations i.e. 'myddns_ipv4' and 'myddns_ipv6'"
+msgstr ""
+"Liste der definierten DDNS Konfigurationen und ihr aktueller Status.<br /"
+">Wenn Sie Aktualisierungen für IPv4 und IPv6 senden möchten benötigen Sie "
+"zwei Konfigurationen z.B. 'myddns_ipv4' und 'myddns_ipv6'"
+
+msgid ""
+"BusyBox's nslookup and Wget do not support to specify the IP version to use "
+"for communication with DDNS Provider."
+msgstr ""
+"BusyBox's nslookup und Wget unterstützen nicht die IP Version für die "
+"Kommunikation festzulegen."
+
+msgid ""
+"BusyBox's nslookup does not support to specify to use TCP instead of default "
+"UDP when requesting DNS server"
+msgstr ""
+"BusyBox's nslookup unterstützt es nicht das TCP-Protokoll für DNS Anfragen "
+"anstelle des standardmäßigen UDP-Protokolls."
+
+msgid "Check Interval"
+msgstr "Prüfinterval"
 
 msgid "Check for changed IP every"
 msgstr "Teste auf neue IP alle"
@@ -19,8 +59,96 @@ msgstr "Teste auf neue IP alle"
 msgid "Check-time unit"
 msgstr "Zeiteinheit"
 
+msgid "Config error"
+msgstr "Konfigurationsfehler"
+
+msgid "Configure here the details for selected Dynamic DNS service"
+msgstr "Konfiguriere hier die Details für den gewählten Dynamik DNS Dienst"
+
+msgid ""
+"Currently DDNS updates are not started at boot or on interface events.<br /"
+">This is the default if you run DDNS scripts by yourself (i.e. via cron with "
+"force_interval set to '0')"
+msgstr ""
+"Aktuell werden keine DDNS Aktualisierungen beim Systemstart oder bei "
+"Netzwerkereignissen gestartet.<br />Dieses ist der Standard, wenn Sie die "
+"DDSN Skripte über eigene Routinen (z.B. cron und Erzwungener Aktualisierung "
+"von '0')  starten."
+
+msgid ""
+"Currently DDNS updates are not started at boot or on interface events.<br /"
+">You can start/stop each configuration here. It will run until next reboot."
+msgstr ""
+"Aktuell werden DDNS Aktualisierungen nicht bei Systemstart oder bei "
+"Netzwerkereignissen gestartet.<br />Sie können jede Konfiguration hier "
+"starten und stoppen. Sie wird bis zum nächsten Neustart ausgeführt."
+
+msgid "Custom update script to be used for updating your DDNS Provider."
+msgstr "Update-Skript um Aktualisierungen an Ihren DDNS Anbieter zu senden."
+
 msgid "Custom update-URL"
 msgstr "Eigene Update-URL"
+
+msgid "Custom update-script"
+msgstr "Eigenes Update-Skript"
+
+msgid "DDNS Autostart disabled"
+msgstr "DDNS Autostart deaktiviert"
+
+msgid "DDNS Service provider"
+msgstr "DDNS-Dienstanbieter"
+
+msgid "DNS requests via TCP not supported"
+msgstr "DNS Anfragen über TCP nicht unterstützt"
+
+msgid "DNS-Server"
+msgstr "DNS-Server"
+
+msgid "Defines the Web page to read systems IPv4-Address from"
+msgstr ""
+"Definiert die Web-Seite von der die aktuelle IPv4-Adresse des System gelesen "
+"wird."
+
+msgid "Defines the Web page to read systems IPv6-Address from"
+msgstr ""
+"Definiert die Web-Seite von der die aktuelle IPv6-Adresse des System gelesen "
+"wird."
+
+msgid "Defines the interface to read systems IP-Address from"
+msgstr ""
+"Definiert die Schnittstelle von der die aktuelle IP-Adresse des System "
+"gelesen wird."
+
+msgid "Defines the network to read systems IPv4-Address from"
+msgstr ""
+"Definiert das Netzwerk von dem die aktuelle IPv4-Adresse des System gelesen "
+"wird."
+
+msgid "Defines the network to read systems IPv6-Address from"
+msgstr ""
+"Definiert das Netzwerk von dem die aktuelle IPv6-Adresse des System gelesen "
+"wird."
+
+msgid ""
+"Defines the source to read systems IPv4-Address from, that will be send to "
+"the DDNS provider"
+msgstr ""
+"Definiert die Quelle von der die aktuelle IPv4-Adresse des Systems gelesen "
+"wird, die an Ihren DDNS Anbieter gesendet wird."
+
+msgid ""
+"Defines the source to read systems IPv6-Address from, that will be send to "
+"the DDNS provider"
+msgstr ""
+"Definiert die Quelle von der die aktuelle IPv6-Adresse des Systems gelesen "
+"wird, die an Ihren DDNS Anbieter gesendet wird."
+
+msgid "Defines which IP address 'IPv4/IPv6' is send to the DDNS provider"
+msgstr ""
+"Legt fest welche IP-Adresse 'IPv4/IPv6' zum DDNS Anbieter gesendet wird"
+
+msgid "Details for"
+msgstr "Details für"
 
 msgid "Dynamic DNS"
 msgstr "Dynamisches DNS"
@@ -32,8 +160,45 @@ msgstr ""
 "Dynamisches DNS erlaubt es, den Router bei dynamischer IP-Adresse über einen "
 "festen DNS-Namen zu erreichen."
 
-msgid "Enable"
-msgstr "Aktivieren"
+msgid "Enable secure communication with DDNS provider"
+msgstr "Aktiviert sichere Kommunikation mit dem DDNS Anbieter"
+
+msgid "Error Retry Counter"
+msgstr "Wiederholungszähler bei Fehler"
+
+msgid "Error Retry Interval"
+msgstr "Wiederholungsintervall bei Fehler"
+
+msgid "Event Network"
+msgstr "Ereignis Netzwerk"
+
+msgid "Event interface"
+msgstr "Ereignis Netzwerk"
+
+msgid "File not found"
+msgstr "Datei nicht gefunden"
+
+msgid "File not found or empty"
+msgstr "Datei nicht gefunden oder leer"
+
+msgid ""
+"Follow this link<br />You will find more hints to optimize your system to "
+"run DDNS scripts with all options"
+msgstr ""
+"Folgen Sie dem Link<br />Hier finden Sie weitere Hinweise um Ihr System für "
+"die Nutzung aller Optionen der DDNS Skripte zu optimieren."
+
+msgid "Force IP Version"
+msgstr "Erzwinge IP-Version"
+
+msgid "Force IP Version not supported"
+msgstr "Erzwinge IP-Version nicht unterstützt"
+
+msgid "Force Interval"
+msgstr "Erzwungene Aktualisierung"
+
+msgid "Force TCP on DNS"
+msgstr "Erzwinge TCP bei DNS-Anfragen"
 
 msgid "Force update every"
 msgstr "Erzwinge Aktualisierung alle"
@@ -41,50 +206,369 @@ msgstr "Erzwinge Aktualisierung alle"
 msgid "Force-time unit"
 msgstr "Zeiteinheit"
 
-msgid "Hostname"
-msgstr "Hostname"
+msgid "Forced IP Version don't matched"
+msgstr "Erzwungene IP Version stimmt nicht überein"
 
-msgid "Interface"
-msgstr "Schnittstelle"
+msgid "Format"
+msgstr "Format"
 
-msgid "Network"
-msgstr "Netzwerk"
+msgid "Format: IP or FQDN"
+msgstr "Format: IP-Adresse oder FQDN"
 
-msgid "Password"
-msgstr "Passwort"
+msgid "HTTPS not supported"
+msgstr "HTTPS nicht unterstützt"
+
+msgid "Hints"
+msgstr "Hinweise"
+
+msgid "Hostname/Domain"
+msgstr "Rechnername/Domäne"
+
+msgid "IP address source"
+msgstr "IP-Adressquelle"
+
+msgid "IP address version"
+msgstr "IP-Adressversion"
+
+msgid "IPv6 address must be given in square brackets"
+msgstr "Eine IPv6 Adresse muss in eckigen Klammern angegeben werden"
+
+msgid ""
+"IPv6 is currently not (fully) supported by this system<br />Please follow "
+"the instructions on OpenWrt's homepage to enable IPv6 support<br />or update "
+"your system to the latest OpenWrt Release"
+msgstr ""
+"IPv6 wird vom System nicht (voll) unterstützt.<br /> Bitte folgen Sie den "
+"Hinweisen auf der Homepage von OpenWrt um die volle IPv6-Unterstützung zu "
+"aktivieren<br /> oder installieren Sie die aktuellste OpenWrt Version."
+
+msgid "IPv6 not supported"
+msgstr "IPv6 nicht unterstützt"
+
+msgid ""
+"If this service section is disabled it could not be started.<br />Neither "
+"from LuCI interface nor from console"
+msgstr ""
+"Wenn deaktiviert kann die Aktualisierung nicht gestartet werden.<br />Weder "
+"über das LuCI Web Interface noch von der Geräte-Konsole"
+
+msgid ""
+"In some versions cURL/libcurl in OpenWrt is compiled without proxy support."
+msgstr ""
+"In einigen Versionen von OpenWrt wurde cURL/libcurl ohne Proxy Unterstützung "
+"compiliert."
+
+msgid ""
+"Interval to check for changed IP<br />Values below 5 minutes == 300 seconds "
+"are not supported"
+msgstr ""
+"Intervall zur Prüfung auf geänderte IP-Adresse<br />Minimum Wert 5 Minuten "
+"== 300 Sekunden"
+
+msgid ""
+"Interval to force updates send to DDNS Provider<br />Setting this parameter "
+"to 0 will force the script to only run once<br />Values lower 'Check "
+"Interval' except '0' are not supported"
+msgstr ""
+"Intervall mit dem Aktualisierungen erzwungen an den DDNS Anbieter gesendet "
+"werden.<br />Ein Wert von '0' führt das Skript nur einmalig aus. <br />Der "
+"Wert muss größer als das Prüfintervall sein oder '0'."
+
+msgid "Last Update"
+msgstr "Letztes Aktualisierung"
+
+msgid "Log File Viewer"
+msgstr "Protokolldatei"
+
+msgid "Log to file"
+msgstr "Protokoll in Datei schreiben"
+
+msgid "Log to syslog"
+msgstr "Systemprotokoll verwenden"
+
+msgid ""
+"Neither GNU Wget with SSL nor cURL installed to support updates via HTTPS "
+"protocol."
+msgstr ""
+"Weder GNU Wget mit SSL noch cURL sind installiert um Aktualisierungen über "
+"HTTPS Protokoll zu unterstützen."
+
+msgid "Network on which the ddns-updater scripts will be started"
+msgstr "Netzwerk auf dem Ereignisse die ddns-updater Skripte starten"
+
+msgid "Never"
+msgstr "Nie"
+
+msgid "Next Update"
+msgstr "Nächste Aktualisierung"
+
+msgid "No data"
+msgstr "Keine Daten"
+
+msgid "No logging"
+msgstr "Keine Protokollierung"
+
+msgid "OPTIONAL: Force the usage of pure IPv4/IPv6 only communication."
+msgstr ""
+"OPTIONAL: Erzwingt die Verwendung einer reinen IPv4/IPv6 Kommunikation."
+
+msgid "OPTIONAL: Force the use of TCP instead of default UDP on DNS requests."
+msgstr ""
+"OPTIONAL: Erzwingt die Verwendung von TCP anstelle von UDP bei DNS Anfragen."
+
+msgid "OPTIONAL: Proxy-Server for detection and updates."
+msgstr "OPTIONAL: Proxy-Server für Adresserkennung und Aktualisierungen"
+
+msgid "OPTIONAL: Use non-default DNS-Server to detect 'Registered IP'."
+msgstr ""
+"OPTIONAL: Ersetzt den voreingestellten DNS-Server um die 'Registrierte IP' "
+"zu ermitteln."
+
+msgid "Old version of ddns-scripts installed"
+msgstr "Alte Version von ddns-scripts installiert"
+
+msgid "On Error the script will retry the failed action after given time"
+msgstr ""
+"Bei Fehlern wird das Skript die fehlerhafte Aktion nach der gegebenen Zeit "
+"wiederholen"
+
+msgid "On Error the script will stop execution after given number of retrys"
+msgstr "Das Skript wird nach der gegebener Anzahlt von Fehlversuchen beendet"
+
+msgid "PROXY-Server"
+msgstr "Proxy-Server"
+
+msgid "PROXY-Server not supported"
+msgstr "Proxy-Server nicht unterstützt"
+
+msgid "Please [Save & Apply] your changes first"
+msgstr "Bitte [Speichern & Anwenden] Sie Änderungen zunächst"
+
+msgid "Please press [Read] button"
+msgstr "Bitte Protokolldatei einlesen"
+
+msgid "Process ID"
+msgstr "Prozess ID"
+
+msgid "Read / Reread log file"
+msgstr "Protokolldatei (neu) einlesen"
+
+msgid "Registered IP"
+msgstr "Registrierte IP"
+
+msgid "Replaces [DOMAIN] in Update-URL"
+msgstr "Ersetzt [DOMAIN] in der Update-URL"
+
+msgid "Replaces [PASSWORD] in Update-URL"
+msgstr "Ersetzt [PASSWORD] in der Update-URL"
+
+msgid "Replaces [USERNAME] in Update-URL"
+msgstr "Ersetzt [USERNAME] in der Update-URL"
+
+msgid "Run once"
+msgstr "Einmalig ausführen"
+
+msgid "Script"
+msgstr "Skript"
 
 msgid "Service"
 msgstr "Dienst"
 
+msgid "Show more"
+msgstr "Zeige mehr"
+
 msgid "Source of IP address"
 msgstr "Quelle der IP-Adresse"
+
+msgid "Start / Stop"
+msgstr "Start / Stopp"
+
+msgid "Stopped"
+msgstr "Angehalten"
+
+msgid "There is no service configured."
+msgstr "Kein Dienst konfiguriert"
+
+msgid "Timer Settings"
+msgstr "Zeitgeber Einstellungen"
 
 msgid "URL"
 msgstr "URL"
 
-msgid "Username"
-msgstr "Benutzername"
+msgid "URL to detect"
+msgstr "URL zur Adresserkennung für"
+
+msgid "Unknown error"
+msgstr "Unbekannter Fehler"
+
+msgid ""
+"Update URL to be used for updating your DDNS Provider.<br />Follow "
+"instructions you will find on their WEB page."
+msgstr ""
+"Update-URL um Aktualisierungen an Ihren DDNS Anbieter zu senden.<br />Folgen "
+"Sie der Anleitung auf der Internet Seite des Anbieters."
+
+msgid "Update error"
+msgstr "Aktualisierungsfehler"
+
+msgid "Use HTTP Secure"
+msgstr "Verwende sicheres HTTP"
+
+msgid "User defined script to read systems IP-Address"
+msgstr ""
+"Definiert das Skript mit dem die  aktuelle IP-Adresse des System gelesen "
+"wird."
+
+msgid ""
+"Writes detailed messages to log file. File will be truncated automatically."
+msgstr ""
+"Schreibt detaillierte Meldungen in die Protokolldatei. Die Datei wird "
+"automatisch gekürzt."
+
+msgid ""
+"Writes log messages to syslog. Critical Errors will always be written to "
+"syslog."
+msgstr ""
+"Schreibt Meldungen ins Systemprotokoll. Kritische Fehler werden immer in das "
+"Systemprotokoll geschrieben."
+
+msgid "You should install BIND host package for DNS requests."
+msgstr ""
+"Sie sollten das Programmpakete BIND host for DNS Anfragen installieren."
+
+msgid "You should install GNU Wget with SSL (prefered) or cURL package."
+msgstr ""
+"Sie sollten das Programmpaket GNU Wget mit SSL (bevorzugt) oder cURL "
+"installieren."
+
+msgid "You should install GNU Wget with SSL or replace libcurl."
+msgstr ""
+"Sie sollten das Programmpaket GNU Wget mit SSL installieren oder libcurl "
+"austauschen."
+
+msgid "cURL is installed, but libcurl was compiled without proxy support."
+msgstr ""
+"cURL ist installiert, aber libcurl wurde ohne Proxy Unterstützung compiliert"
+
+msgid "cURL without Proxy Support"
+msgstr "cURL ohne Proxy Unterstützung"
+
+msgid "can not detect local IP. Please select a different Source combination"
+msgstr ""
+"kann lokale IP-Adresse nicht ermitteln. Bitte wählen Sie eine andere Quelle."
+
+msgid "can not resolve host:"
+msgstr "Konnte Server nicht finden:"
+
+msgid "config error"
+msgstr "Konfigurationsfehler"
 
 msgid "custom"
 msgstr "benutzerdefiniert"
 
-# Hours
+msgid "days"
+msgstr "Tage"
+
+msgid "directory or path/file"
+msgstr "Verzeichnis oder Pfad/zur/Datei"
+
+msgid "either url or script could be set"
+msgstr "Weder Url noch Script ist definiert"
+
+msgid "enable here"
+msgstr "hier aktivieren"
+
+msgid "file or directory not found or not 'IGNORE'"
+msgstr "Datei oder Verzeichnis nicht gefunden oder nicht 'IGNORE'"
+
 msgid "h"
 msgstr "Stunden"
+
+msgid "hours"
+msgstr "Stunden"
+
+msgid "install update here"
+msgstr "Aktualisierung hier installieren"
 
 msgid "interface"
 msgstr "Schnittstelle"
 
-# Minutes (not minimum)
+msgid "invalid - Sample"
+msgstr "ungültig - Beispiel"
+
 msgid "min"
 msgstr "Minuten"
+
+msgid "minimum value '0'"
+msgstr "Minimum Wert '0'"
+
+msgid "minimum value '1'"
+msgstr "Minimum Wert '1'"
+
+msgid "minimum value 5 minutes == 300 seconds"
+msgstr "Minimum Wert 5 Minuten == 300 Sekunden"
+
+msgid "minutes"
+msgstr "Minuten"
+
+msgid "missing / required"
+msgstr "fehlt / Pflichteingabe"
+
+msgid "must be greater or equal 'Check Interval'"
+msgstr "muss größer als das Prüfintervall sein"
+
+msgid "must start with 'http://'"
+msgstr "muss mit 'http://' beginnen"
+
+msgid "nc (netcat) can not connect"
+msgstr "nc (netcat) kann keine Verbindung herstellen"
 
 msgid "network"
 msgstr "Netzwerk"
 
-#~ msgid "Event interface"
-#~ msgstr "Ereignis-Schnittstelle"
+msgid "never"
+msgstr "nie"
 
-#~ msgid "On which interface up should start the ddns script process."
-#~ msgstr ""
-#~ "Spezifiziert die durch den DDNS-Prozess überwachte Netzwerkschnittstelle"
+msgid "no data"
+msgstr "Keine Daten"
+
+msgid "not found or not executable - Sample: '/path/to/script.sh'"
+msgstr ""
+"Skript nicht gefunden oder nicht ausführbar. - Beispiel: 'Pfad/zum/Skript.sh'"
+
+msgid "nslookup can not resolve host"
+msgstr "nslookup kann den Namen nicht auflösen"
+
+msgid "or"
+msgstr "oder"
+
+msgid "please disable"
+msgstr "Bitte deaktivieren"
+
+msgid "please remove entry"
+msgstr "Bitte Eintrag entfernen"
+
+msgid "please select 'IPv4' address version"
+msgstr "Bitte 'IPv4' Adressversion auswählen"
+
+msgid "please select 'IPv4' address version in"
+msgstr "Bitte 'IPv4' Adressversion auswählen in den"
+
+msgid "proxy port missing"
+msgstr "Proxy-Port fehlt"
+
+msgid "seconds"
+msgstr "Sekunden"
+
+msgid "to run HTTPS without verification of server certificates (insecure)"
+msgstr ""
+"um HTTPS ohne Überprüfung der Server Zertifikate auszuführen (unsicher)"
+
+msgid "unknown error"
+msgstr "Unbekannter Fehler"
+
+msgid "unspecific error"
+msgstr "Unspezifischer Fehler"
+
+msgid "use hostname, FQDN, IPv4- or IPv6-Address"
+msgstr "verwende Rechnername, FQDN, IPv4- oder IPv6-Adresse"

--- a/po/templates/ddns.pot
+++ b/po/templates/ddns.pot
@@ -1,13 +1,109 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
+msgid "&"
+msgstr ""
+
+msgid "Basic Settings"
+msgstr ""
+
+msgid ""
+"Below a list of configuration tips for your system to run Dynamic DNS "
+"updates without limitations"
+msgstr ""
+
+msgid ""
+"Below is a list of configured DDNS configurations and their current state."
+"<br />If you want to send updates for IPv4 and IPv6 you need to define two "
+"separate Configurations i.e. 'myddns_ipv4' and 'myddns_ipv6'"
+msgstr ""
+
+msgid ""
+"BusyBox's nslookup and Wget do not support to specify the IP version to use "
+"for communication with DDNS Provider."
+msgstr ""
+
+msgid ""
+"BusyBox's nslookup does not support to specify to use TCP instead of default "
+"UDP when requesting DNS server"
+msgstr ""
+
+msgid "Check Interval"
+msgstr ""
+
 msgid "Check for changed IP every"
 msgstr ""
 
 msgid "Check-time unit"
 msgstr ""
 
+msgid "Config error"
+msgstr ""
+
+msgid "Configure here the details for selected Dynamic DNS service"
+msgstr ""
+
+msgid ""
+"Currently DDNS updates are not started at boot or on interface events.<br /"
+">This is the default if you run DDNS scripts by yourself (i.e. via cron with "
+"force_interval set to '0')"
+msgstr ""
+
+msgid ""
+"Currently DDNS updates are not started at boot or on interface events.<br /"
+">You can start/stop each configuration here. It will run until next reboot."
+msgstr ""
+
+msgid "Custom update script to be used for updating your DDNS Provider."
+msgstr ""
+
 msgid "Custom update-URL"
+msgstr ""
+
+msgid "Custom update-script"
+msgstr ""
+
+msgid "DDNS Autostart disabled"
+msgstr ""
+
+msgid "DDNS Service provider"
+msgstr ""
+
+msgid "DNS requests via TCP not supported"
+msgstr ""
+
+msgid "DNS-Server"
+msgstr ""
+
+msgid "Defines the Web page to read systems IPv4-Address from"
+msgstr ""
+
+msgid "Defines the Web page to read systems IPv6-Address from"
+msgstr ""
+
+msgid "Defines the interface to read systems IP-Address from"
+msgstr ""
+
+msgid "Defines the network to read systems IPv4-Address from"
+msgstr ""
+
+msgid "Defines the network to read systems IPv6-Address from"
+msgstr ""
+
+msgid ""
+"Defines the source to read systems IPv4-Address from, that will be send to "
+"the DDNS provider"
+msgstr ""
+
+msgid ""
+"Defines the source to read systems IPv6-Address from, that will be send to "
+"the DDNS provider"
+msgstr ""
+
+msgid "Defines which IP address 'IPv4/IPv6' is send to the DDNS provider"
+msgstr ""
+
+msgid "Details for"
 msgstr ""
 
 msgid "Dynamic DNS"
@@ -18,7 +114,42 @@ msgid ""
 "while having a dynamically changing IP address."
 msgstr ""
 
-msgid "Enable"
+msgid "Enable secure communication with DDNS provider"
+msgstr ""
+
+msgid "Error Retry Counter"
+msgstr ""
+
+msgid "Error Retry Interval"
+msgstr ""
+
+msgid "Event Network"
+msgstr ""
+
+msgid "Event interface"
+msgstr ""
+
+msgid "File not found"
+msgstr ""
+
+msgid "File not found or empty"
+msgstr ""
+
+msgid ""
+"Follow this link<br />You will find more hints to optimize your system to "
+"run DDNS scripts with all options"
+msgstr ""
+
+msgid "Force IP Version"
+msgstr ""
+
+msgid "Force IP Version not supported"
+msgstr ""
+
+msgid "Force Interval"
+msgstr ""
+
+msgid "Force TCP on DNS"
 msgstr ""
 
 msgid "Force update every"
@@ -27,41 +158,332 @@ msgstr ""
 msgid "Force-time unit"
 msgstr ""
 
-msgid "Hostname"
+msgid "Forced IP Version don't matched"
 msgstr ""
 
-msgid "Interface"
+msgid "Format"
 msgstr ""
 
-msgid "Network"
+msgid "Format: IP or FQDN"
 msgstr ""
 
-msgid "Password"
+msgid "HTTPS not supported"
+msgstr ""
+
+msgid "Hints"
+msgstr ""
+
+msgid "Hostname/Domain"
+msgstr ""
+
+msgid "IP address source"
+msgstr ""
+
+msgid "IP address version"
+msgstr ""
+
+msgid "IPv6 address must be given in square brackets"
+msgstr ""
+
+msgid ""
+"IPv6 is currently not (fully) supported by this system<br />Please follow "
+"the instructions on OpenWrt's homepage to enable IPv6 support<br />or update "
+"your system to the latest OpenWrt Release"
+msgstr ""
+
+msgid "IPv6 not supported"
+msgstr ""
+
+msgid ""
+"If this service section is disabled it could not be started.<br />Neither "
+"from LuCI interface nor from console"
+msgstr ""
+
+msgid ""
+"In some versions cURL/libcurl in OpenWrt is compiled without proxy support."
+msgstr ""
+
+msgid ""
+"Interval to check for changed IP<br />Values below 5 minutes == 300 seconds "
+"are not supported"
+msgstr ""
+
+msgid ""
+"Interval to force updates send to DDNS Provider<br />Setting this parameter "
+"to 0 will force the script to only run once<br />Values lower 'Check "
+"Interval' except '0' are not supported"
+msgstr ""
+
+msgid "Last Update"
+msgstr ""
+
+msgid "Log File Viewer"
+msgstr ""
+
+msgid "Log to file"
+msgstr ""
+
+msgid "Log to syslog"
+msgstr ""
+
+msgid ""
+"Neither GNU Wget with SSL nor cURL installed to support updates via HTTPS "
+"protocol."
+msgstr ""
+
+msgid "Network on which the ddns-updater scripts will be started"
+msgstr ""
+
+msgid "Never"
+msgstr ""
+
+msgid "Next Update"
+msgstr ""
+
+msgid "No data"
+msgstr ""
+
+msgid "No logging"
+msgstr ""
+
+msgid "OPTIONAL: Force the usage of pure IPv4/IPv6 only communication."
+msgstr ""
+
+msgid "OPTIONAL: Force the use of TCP instead of default UDP on DNS requests."
+msgstr ""
+
+msgid "OPTIONAL: Proxy-Server for detection and updates."
+msgstr ""
+
+msgid "OPTIONAL: Use non-default DNS-Server to detect 'Registered IP'."
+msgstr ""
+
+msgid "Old version of ddns-scripts installed"
+msgstr ""
+
+msgid "On Error the script will retry the failed action after given time"
+msgstr ""
+
+msgid "On Error the script will stop execution after given number of retrys"
+msgstr ""
+
+msgid "PROXY-Server"
+msgstr ""
+
+msgid "PROXY-Server not supported"
+msgstr ""
+
+msgid "Please [Save & Apply] your changes first"
+msgstr ""
+
+msgid "Please press [Read] button"
+msgstr ""
+
+msgid "Process ID"
+msgstr ""
+
+msgid "Read / Reread log file"
+msgstr ""
+
+msgid "Registered IP"
+msgstr ""
+
+msgid "Replaces [DOMAIN] in Update-URL"
+msgstr ""
+
+msgid "Replaces [PASSWORD] in Update-URL"
+msgstr ""
+
+msgid "Replaces [USERNAME] in Update-URL"
+msgstr ""
+
+msgid "Run once"
+msgstr ""
+
+msgid "Script"
 msgstr ""
 
 msgid "Service"
 msgstr ""
 
+msgid "Show more"
+msgstr ""
+
 msgid "Source of IP address"
+msgstr ""
+
+msgid "Start / Stop"
+msgstr ""
+
+msgid "Stopped"
+msgstr ""
+
+msgid "There is no service configured."
+msgstr ""
+
+msgid "Timer Settings"
 msgstr ""
 
 msgid "URL"
 msgstr ""
 
-msgid "Username"
+msgid "URL to detect"
+msgstr ""
+
+msgid "Unknown error"
+msgstr ""
+
+msgid ""
+"Update URL to be used for updating your DDNS Provider.<br />Follow "
+"instructions you will find on their WEB page."
+msgstr ""
+
+msgid "Update error"
+msgstr ""
+
+msgid "Use HTTP Secure"
+msgstr ""
+
+msgid "User defined script to read systems IP-Address"
+msgstr ""
+
+msgid ""
+"Writes detailed messages to log file. File will be truncated automatically."
+msgstr ""
+
+msgid ""
+"Writes log messages to syslog. Critical Errors will always be written to "
+"syslog."
+msgstr ""
+
+msgid "You should install BIND host package for DNS requests."
+msgstr ""
+
+msgid "You should install GNU Wget with SSL (prefered) or cURL package."
+msgstr ""
+
+msgid "You should install GNU Wget with SSL or replace libcurl."
+msgstr ""
+
+msgid "cURL is installed, but libcurl was compiled without proxy support."
+msgstr ""
+
+msgid "cURL without Proxy Support"
+msgstr ""
+
+msgid "can not detect local IP. Please select a different Source combination"
+msgstr ""
+
+msgid "can not resolve host:"
+msgstr ""
+
+msgid "config error"
 msgstr ""
 
 msgid "custom"
 msgstr ""
 
+msgid "days"
+msgstr ""
+
+msgid "directory or path/file"
+msgstr ""
+
+msgid "either url or script could be set"
+msgstr ""
+
+msgid "enable here"
+msgstr ""
+
+msgid "file or directory not found or not 'IGNORE'"
+msgstr ""
+
 msgid "h"
+msgstr ""
+
+msgid "hours"
+msgstr ""
+
+msgid "install update here"
 msgstr ""
 
 msgid "interface"
 msgstr ""
 
+msgid "invalid - Sample"
+msgstr ""
+
 msgid "min"
 msgstr ""
 
+msgid "minimum value '0'"
+msgstr ""
+
+msgid "minimum value '1'"
+msgstr ""
+
+msgid "minimum value 5 minutes == 300 seconds"
+msgstr ""
+
+msgid "minutes"
+msgstr ""
+
+msgid "missing / required"
+msgstr ""
+
+msgid "must be greater or equal 'Check Interval'"
+msgstr ""
+
+msgid "must start with 'http://'"
+msgstr ""
+
+msgid "nc (netcat) can not connect"
+msgstr ""
+
 msgid "network"
+msgstr ""
+
+msgid "never"
+msgstr ""
+
+msgid "no data"
+msgstr ""
+
+msgid "not found or not executable - Sample: '/path/to/script.sh'"
+msgstr ""
+
+msgid "nslookup can not resolve host"
+msgstr ""
+
+msgid "or"
+msgstr ""
+
+msgid "please disable"
+msgstr ""
+
+msgid "please remove entry"
+msgstr ""
+
+msgid "please select 'IPv4' address version"
+msgstr ""
+
+msgid "please select 'IPv4' address version in"
+msgstr ""
+
+msgid "proxy port missing"
+msgstr ""
+
+msgid "seconds"
+msgstr ""
+
+msgid "to run HTTPS without verification of server certificates (insecure)"
+msgstr ""
+
+msgid "unknown error"
+msgstr ""
+
+msgid "unspecific error"
+msgstr ""
+
+msgid "use hostname, FQDN, IPv4- or IPv6-Address"
 msgstr ""


### PR DESCRIPTION
extends/replaces exising luci-app-ddns to support ddns-scripts starting
Version 2.0.1-8
Still supports ddns-scripts Version 1.0.0-23 with the old interface
including fix for OpenWrt Ticket #18018.

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
