### PR TITLE
[for-0.12] luci-app-ddns: fix OpenWrt Ticket #18018 in BB release

### DIFF
--- a/applications/luci-ddns/luasrc/model/cbi/ddns/ddns.lua
+++ b/applications/luci-ddns/luasrc/model/cbi/ddns/ddns.lua
@@ -26,6 +26,10 @@ s.anonymous = false
 
 s:option(Flag, "enabled", translate("Enable"))
 
+interface = s:option(ListValue, "interface", translate("Event interface"), translate("Network on which the ddns-updater scripts will be started"))
+luci.tools.webadmin.cbi_add_networks(interface)
+interface.default = "wan"
+
 svc = s:option(ListValue, "service_name", translate("Service"))
 svc.rmempty = false
 svc.default = "dyndns.org"


### PR DESCRIPTION
fix for OpenWrt Ticket #18018 in BB 14.07 release.
Without fix the application writes a config without event interface
which causes ddns-scripts to NEVER start.

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
