### PR TITLE
fixes missing imports for gwcheck

### DIFF
--- a/contrib/package/freifunk-gwcheck/files/usr/sbin/ff_olsr_test_gw.sh
+++ b/contrib/package/freifunk-gwcheck/files/usr/sbin/ff_olsr_test_gw.sh
@@ -5,6 +5,7 @@
 
 . /lib/functions.sh
 . /lib/functions/network.sh
+. /usr/share/libubox/jshn.sh
 
 # exit if dyngw_plain is not enabled or RtTable is not (254 or unset)
 config_load olsrd


### PR DESCRIPTION
since r41281 (83e9122) network.sh depends on jsonfilter instead of jshn.
Therefor jshn is missing for gwcheck and needs to be sourced manually.
