### PR TITLE
Freifunk: correct bbsid in Potsdam on channel 5

### DIFF
--- a/contrib/package/community-profiles/files/etc/config/profile_potsdam
+++ b/contrib/package/community-profiles/files/etc/config/profile_potsdam
@@ -11,3 +11,5 @@ config 'community' 'profile'
 config 'defaults' 'wifi_device'
 	option 'channel' '5'
 
+config 'defaults' 'bssidscheme'
+	option '5' '02:CA:FF:EE:BA:BE'


### PR DESCRIPTION
weirdly enough the default bssid is 12:CA:FF:EE:BA:BE or similiar in Freifunk Potsdam instances, we have to change this manually every time.
