### PR TITLE
openconnect proto: added missing makefile

### DIFF
--- a/protocols/openconnect/Makefile
+++ b/protocols/openconnect/Makefile
@@ -1,0 +1,2 @@
+include ../../build/config.mk
+include ../../build/module.mk


### PR DESCRIPTION
Not sure if that Makefile is needed, but all other protocols have it.

Signed-off-by: Nikos Mavrogiannopoulos nmav@gnutls.org
