### PR TITLE
build/mkversion.sh: detect git branch and show that in Luci

### DIFF
--- a/build/mkversion.sh
+++ b/build/mkversion.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
-if [ "${4%%/*}" = "branches" ]; then
-	variant="LuCI ${4##*[-/]} Branch"
-elif [ "${4%%/*}" = "tags" ]; then
-	variant="LuCI ${4##*[-/]} Release"
+GITBRANCH=`git symbolic-ref --short -q HEAD`
+if [ $GITBRANCH != "master" ]; then
+	variant="LuCI branch: $GITBRANCH"
 else
 	variant="LuCI Trunk"
 fi


### PR DESCRIPTION
Detect the current git branch and use that as the branch name in Luci.

Previous logic was based on the old svn repo structure & functionality
and showed all git branches as "LuCI Trunk".

This should be committed also to LuCI Trunk, but is more critical for private builds from luci-0.12, so I am filing this against the 0.12 branch. The core issue is also discussed in #239. 

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
