### PR TITLE
luci-app-ddns: Update to support ddns-scripts 2.1.0-1

### DIFF
--- a/applications/luci-ddns/CHANGELOG
+++ b/applications/luci-ddns/CHANGELOG
@@ -1,0 +1,25 @@
+Version: 2.1.0-1
+Date: 2014-11-09
+ddns-scripts: 2.1.0-1 or greater needed
+
+fix verify of entry for DNS server Issue #244
+	https://github.com/openwrt/luci/issues/244
+add support for option 'update_script'
+add display of version information when click on "Dynamic DNS" on overview page
+add verify of installed ddns-scripts version and show as hint if not correct version
+modified epoch to date conversation
+cbi object Flag did not set section.changed state, fixed in tools.flag_parse function
+ucitrack entry no longer needed and removed
+minor fixes
+
+--------------------------------------------------------------------------------
+Version: 2.0.1-1
+Date: 2014-09-21
+ddns-scripts: 2.0.1-1 up to 2.0.1-9
+
+New DDNS status in System->Status overview
+New Overview page with option to start/stop a section
+New Detail page with tabbed view incl. logfile viewer
+Extended verify of all entries before save to config
+   incl. connect test to DNS- and Proxy-server
+Support for all available options of ddns-scripts 1.x and 2.x

--- a/applications/luci-ddns/Makefile
+++ b/applications/luci-ddns/Makefile
@@ -1,8 +1,3 @@
-# supports ddns-scripts 1.0.0-23 and ddns-scripts starting
-# PKG_VERSION:=2.0.1
-# PKG_RELEASE:=8
-# PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
-
 PO = ddns
 
 include ../../build/config.mk

--- a/applications/luci-ddns/luasrc/model/cbi/ddns/hints.lua
+++ b/applications/luci-ddns/luasrc/model/cbi/ddns/hints.lua
@@ -12,56 +12,74 @@ You may obtain a copy of the License at
 $Id$
 ]]--
 
-require "luci.sys"
-require "luci.dispatcher"
-require "luci.tools.ddns"
+local CTRL = require "luci.controller.ddns"	-- this application's controller
+local DISP = require "luci.dispatcher"
+local SYS  = require "luci.sys"
+local DDNS = require "luci.tools.ddns"		-- ddns multiused functions
 
--- check supported options
+-- check supported options -- ##################################################
 -- saved to local vars here because doing multiple os calls slow down the system
-has_ssl    = luci.tools.ddns.check_ssl()	-- HTTPS support
-has_proxy  = luci.tools.ddns.check_proxy()	-- Proxy support
-has_dnstcp = luci.tools.ddns.check_bind_host()	-- DNS TCP support
+has_ssl     = DDNS.check_ssl()		-- HTTPS support
+has_proxy   = DDNS.check_proxy()	-- Proxy support
+has_dnstcp  = DDNS.check_bind_host()	-- DNS TCP support
+need_update = CTRL.update_needed()	-- correct ddns-scripts version
 
 -- html constants
+font_red = [[<font color="red">]]
+font_off = [[</font>]]
 bold_on  = [[<strong>]]
 bold_off = [[</strong>]]
 
--- cbi-map definition
+-- cbi-map definition -- #######################################################
 m = Map("ddns")
 
-m.title = [[<a href="]] .. luci.dispatcher.build_url("admin", "services", "ddns") .. [[">]] .. 
-		translate("Dynamic DNS") .. [[</a>]]
+-- first need to close <a> from cbi map template our <a> closed by template
+m.title = [[</a><a href="]] .. DISP.build_url("admin", "services", "ddns") .. [[">]] ..
+		translate("Dynamic DNS")
 
 m.description = translate("Dynamic DNS allows that your router can be reached with " ..
 			"a fixed hostname while having a dynamically changing " ..
 			"IP address.")
 
-m.redirect = luci.dispatcher.build_url("admin", "services", "ddns")
+m.redirect = DISP.build_url("admin", "services", "ddns")
 
--- SimpleSection definition
+-- SimpleSection definition -- #################################################
 -- show Hints to optimize installation and script usage
-s = m:section( SimpleSection, 
-	translate("Hints"), 
+s = m:section( SimpleSection,
+	translate("Hints"),
 	translate("Below a list of configuration tips for your system to run Dynamic DNS updates without limitations") )
--- DDNS Service disabled
-if not luci.sys.init.enabled("ddns") then
-	local dv = s:option(DummyValue, "_not_enabled")
-	dv.titleref = luci.dispatcher.build_url("admin", "system", "startup")
+
+-- ddns_scripts needs to be updated for full functionality
+if need_update then
+	local dv = s:option(DummyValue, "_update_needed")
+	dv.titleref = DISP.build_url("admin", "system", "packages")
 	dv.rawhtml  = true
-	dv.title = bold_on .. 
+	dv.title = font_red .. bold_on ..
+		translate("Software update required") .. bold_off .. font_off
+	dv.value = translate("The currently installed 'ddns-scripts' package did not support all available settings.") ..
+			"<br />" ..
+			translate("Please update to the current version!")
+end
+
+-- DDNS Service disabled
+if not SYS.init.enabled("ddns") then
+	local dv = s:option(DummyValue, "_not_enabled")
+	dv.titleref = DISP.build_url("admin", "system", "startup")
+	dv.rawhtml  = true
+	dv.title = bold_on ..
 		translate("DDNS Autostart disabled") .. bold_off
-	dv.value = translate("Currently DDNS updates are not started at boot or on interface events." .. "<br />" .. 
+	dv.value = translate("Currently DDNS updates are not started at boot or on interface events." .. "<br />" ..
 			"This is the default if you run DDNS scripts by yourself (i.e. via cron with force_interval set to '0')" )
 end
 
 -- No IPv6 support
-if not luci.tools.ddns.check_ipv6() then
+if not DDNS.check_ipv6() then
 	local dv = s:option(DummyValue, "_no_ipv6")
 	dv.titleref = 'http://www.openwrt.org" target="_blank'
 	dv.rawhtml  = true
-	dv.title = bold_on .. 
+	dv.title = bold_on ..
 		translate("IPv6 not supported") .. bold_off
-	dv.value = translate("IPv6 is currently not (fully) supported by this system" .. "<br />" .. 
+	dv.value = translate("IPv6 is currently not (fully) supported by this system" .. "<br />" ..
 			"Please follow the instructions on OpenWrt's homepage to enable IPv6 support" .. "<br />" ..
 			"or update your system to the latest OpenWrt Release")
 end
@@ -69,13 +87,13 @@ end
 -- No HTTPS support
 if not has_ssl then
 	local dv = s:option(DummyValue, "_no_https")
-	dv.titleref = luci.dispatcher.build_url("admin", "system", "packages")
+	dv.titleref = DISP.build_url("admin", "system", "packages")
 	dv.rawhtml  = true
-	dv.title = bold_on .. 
+	dv.title = bold_on ..
 		translate("HTTPS not supported") .. bold_off
-	dv.value = translate("Neither GNU Wget with SSL nor cURL installed to support updates via HTTPS protocol.") .. 
-			"<br />- " .. 
-			translate("You should install GNU Wget with SSL (prefered) or cURL package.") .. 
+	dv.value = translate("Neither GNU Wget with SSL nor cURL installed to support updates via HTTPS protocol.") ..
+			"<br />- " ..
+			translate("You should install GNU Wget with SSL (prefered) or cURL package.") ..
 			"<br />- " ..
 			translate("In some versions cURL/libcurl in OpenWrt is compiled without proxy support.")
 end
@@ -83,13 +101,13 @@ end
 -- cURL without proxy support
 if has_ssl and not has_proxy then
 	local dv = s:option(DummyValue, "_no_proxy")
-	dv.titleref = luci.dispatcher.build_url("admin", "system", "packages")
+	dv.titleref = DISP.build_url("admin", "system", "packages")
 	dv.rawhtml  = true
-	dv.title = bold_on .. 
+	dv.title = bold_on ..
 		translate("cURL without Proxy Support") .. bold_off
-	dv.value = translate("cURL is installed, but libcurl was compiled without proxy support.") .. 
-			"<br />- " .. 
-			translate("You should install GNU Wget with SSL or replace libcurl.") .. 
+	dv.value = translate("cURL is installed, but libcurl was compiled without proxy support.") ..
+			"<br />- " ..
+			translate("You should install GNU Wget with SSL or replace libcurl.") ..
 			"<br />- " ..
 			translate("In some versions cURL/libcurl in OpenWrt is compiled without proxy support.")
 end
@@ -97,12 +115,12 @@ end
 -- "Force IP Version not supported"
 if not (has_ssl and has_dnstcp) then
 	local dv = s:option(DummyValue, "_no_force_ip")
-	dv.titleref = luci.dispatcher.build_url("admin", "system", "packages")
+	dv.titleref = DISP.build_url("admin", "system", "packages")
 	dv.rawhtml  = true
-	dv.title = bold_on .. 
+	dv.title = bold_on ..
 		translate("Force IP Version not supported") .. bold_off
 	local value = translate("BusyBox's nslookup and Wget do not support to specify " ..
-			"the IP version to use for communication with DDNS Provider.") 
+			"the IP version to use for communication with DDNS Provider.")
 	if not has_ssl then
 		value = value .. "<br />- " ..
 			translate("You should install GNU Wget with SSL (prefered) or cURL package.")
@@ -117,11 +135,11 @@ end
 -- "DNS requests via TCP not supported"
 if not has_dnstcp then
 	local dv = s:option(DummyValue, "_no_dnstcp")
-	dv.titleref = luci.dispatcher.build_url("admin", "system", "packages")
+	dv.titleref = DISP.build_url("admin", "system", "packages")
 	dv.rawhtml  = true
-	dv.title = bold_on .. 
+	dv.title = bold_on ..
 		translate("DNS requests via TCP not supported") .. bold_off
-	dv.value = translate("BusyBox's nslookup does not support to specify to use TCP instead of default UDP when requesting DNS server") .. 
+	dv.value = translate("BusyBox's nslookup does not support to specify to use TCP instead of default UDP when requesting DNS server") ..
 			"<br />- " ..
 			translate("You should install BIND host package for DNS requests.")
 end

--- a/applications/luci-ddns/luasrc/model/cbi/ddns/overview.lua
+++ b/applications/luci-ddns/luasrc/model/cbi/ddns/overview.lua
@@ -12,17 +12,20 @@ You may obtain a copy of the License at
 $Id$
 ]]--
 
-require "nixio.fs"
-require "luci.sys"
-require "luci.dispatcher"
-require "luci.tools.ddns"
+local NXFS = require "nixio.fs"
+local CTRL = require "luci.controller.ddns"	-- this application's controller
+local DISP = require "luci.dispatcher"
+local HTTP = require "luci.http"
+local SYS  = require "luci.sys"
+local DDNS = require "luci.tools.ddns"		-- ddns multiused functions
 
 -- show hints ?
-show_hints = not (luci.tools.ddns.check_ipv6()		-- IPv6 support
-		and luci.tools.ddns.check_ssl()		-- HTTPS support
-		and luci.tools.ddns.check_proxy()	-- Proxy support
-		and luci.tools.ddns.check_bind_host()	-- DNS TCP support
+show_hints = not (DDNS.check_ipv6()		-- IPv6 support
+		and DDNS.check_ssl()		-- HTTPS support
+		and DDNS.check_proxy()		-- Proxy support
+		and DDNS.check_bind_host()	-- DNS TCP support
 		)
+need_update = CTRL.update_needed()		-- correct ddns-scripts version
 
 -- html constants
 font_red = [[<font color="red">]]
@@ -30,70 +33,96 @@ font_off = [[</font>]]
 bold_on  = [[<strong>]]
 bold_off = [[</strong>]]
 
--- cbi-map definition
-m = Map("ddns", 
-	translate("Dynamic DNS"),
-	translate("Dynamic DNS allows that your router can be reached with " ..
-		"a fixed hostname while having a dynamically changing " ..
-		"IP address."))
+-- cbi-map definition -- #######################################################
+m = Map("ddns")
 
--- read application settings
-date_format = m.uci:get(m.config, "global", "date_format") or "%F %R"
-run_dir	    = m.uci:get(m.config, "global", "run_dir") or "/var/run/ddns"
+-- first need to close <a> from cbi map template our <a> closed by template
+--m.title = [[</a><a href="javascript:alert(']] .. CTRL.show_versions() ..[[')">]] ..
+--		translate("Dynamic DNS")
+m.title = [[</a><a href="#" onclick="onclick_maptitle();">]] ..
+		translate("Dynamic DNS")
 
--- SimpleSection definition
+m.description = translate("Dynamic DNS allows that your router can be reached with " ..
+			"a fixed hostname while having a dynamically changing " ..
+			"IP address.")
+
+m.on_after_commit = function(self)
+	if self.changed then	-- changes ?
+		if SYS.init.enabled("ddns") then	-- ddns service enabled, restart all
+			os.execute("/etc/init.d/ddns restart")
+		else	-- ddns service disabled, send SIGHUP to running
+			os.execute("killall -1 dynamic_dns_updater.sh")
+		end
+	end
+end
+
+-- SimpleSection definiton -- ##################################################
+-- with all the JavaScripts we need for "a good Show"
+a = m:section( SimpleSection )
+a.template = "ddns/overview_status"
+
+-- SimpleSection definition -- #################################################
 -- show Hints to optimize installation and script usage
 -- only show if 	service not enabled
 --		or	no IPv6 support
 --		or	not GNU Wget and not cURL	(for https support)
 --		or	not GNU Wget but cURL without proxy support
 --		or	not BIND's host
-if show_hints or not luci.sys.init.enabled("ddns") then
+--		or	ddns-scripts package need update
+if show_hints or need_update or not SYS.init.enabled("ddns") then
 	s = m:section( SimpleSection, translate("Hints") )
-	-- DDNS Service disabled
-	if not luci.sys.init.enabled("ddns") then
-		local dv = s:option(DummyValue, "_not_enabled")
-		dv.titleref = luci.dispatcher.build_url("admin", "system", "startup")
+
+	-- ddns_scripts needs to be updated for full functionality
+	if need_update then
+		local dv = s:option(DummyValue, "_update_needed")
+		dv.titleref = DISP.build_url("admin", "system", "packages")
 		dv.rawhtml  = true
-		dv.title = bold_on .. 
+		dv.title = font_red .. bold_on ..
+			translate("Software update required") .. bold_off .. font_off
+		dv.value = translate("The currently installed 'ddns-scripts' package did not support all available settings.") ..
+				"<br />" ..
+				translate("Please update to the current version!")
+	end
+
+	-- DDNS Service disabled
+	if not SYS.init.enabled("ddns") then
+		local dv = s:option(DummyValue, "_not_enabled")
+		dv.titleref = DISP.build_url("admin", "system", "startup")
+		dv.rawhtml  = true
+		dv.title = bold_on ..
 			translate("DDNS Autostart disabled") .. bold_off
-		dv.value = translate("Currently DDNS updates are not started at boot or on interface events." .. "<br />" .. 
+		dv.value = translate("Currently DDNS updates are not started at boot or on interface events." .. "<br />" ..
 				"You can start/stop each configuration here. It will run until next reboot.")
 	end
 
 	-- Show more hints on a separate page
 	if show_hints then
 		local dv = s:option(DummyValue, "_separate")
-		dv.titleref = luci.dispatcher.build_url("admin", "services", "ddns", "hints")
+		dv.titleref = DISP.build_url("admin", "services", "ddns", "hints")
 		dv.rawhtml  = true
-		dv.title = bold_on .. 
+		dv.title = bold_on ..
 			translate("Show more") .. bold_off
 		dv.value = translate("Follow this link" .. "<br />" ..
 				"You will find more hints to optimize your system to run DDNS scripts with all options")
 	end
 end
 
--- SimpleSection definiton
--- with all the JavaScripts we need for "a good Show"
-a = m:section( SimpleSection )
-a.template = "ddns/overview_status"
-
--- TableSection definition
-ts = m:section( TypedSection, "service", 
-	translate("Overview"), 
+-- TableSection definition -- ##################################################
+ts = m:section( TypedSection, "service",
+	translate("Overview"),
 	translate("Below is a list of configured DDNS configurations and their current state." .. "<br />" ..
 		"If you want to send updates for IPv4 and IPv6 you need to define two separate Configurations " ..
 		"i.e. 'myddns_ipv4' and 'myddns_ipv6'") )
 ts.sectionhead = translate("Configuration")
 ts.template = "cbi/tblsection"
 ts.addremove = true
-ts.extedit = luci.dispatcher.build_url("admin", "services", "ddns", "detail", "%s")
+ts.extedit = DISP.build_url("admin", "services", "ddns", "detail", "%s")
 function ts.create(self, name)
 	AbstractSection.create(self, name)
-	luci.http.redirect( self.extedit:format(name) )
+	HTTP.redirect( self.extedit:format(name) )
 end
 
--- Domain and registered IP
+-- Domain and registered IP -- #################################################
 dom = ts:option(DummyValue, "_domainIP",
 	translate("Hostname/Domain") .. "<br />" .. translate("Registered IP") )
 dom.template = "ddns/overview_doubleline"
@@ -113,32 +142,35 @@ function dom.set_two(self, section)
 	local force_ipversion = tonumber(self.map:get(section, "force_ipversion") or 0)
 	local force_dnstcp = tonumber(self.map:get(section, "force_dnstcp") or 0)
 	local command = [[/usr/lib/ddns/dynamic_dns_lucihelper.sh]]
-	if not nixio.fs.access(command, "rwx", "rx", "rx") then
-		nixio.fs.chmod(command, 755)
+	if not NXFS.access(command, "rwx", "rx", "rx") then
+		NXFS.chmod(command, 755)
 	end
-	command = command .. [[ get_registered_ip ]] .. domain .. [[ ]] .. use_ipv6 .. 
+	command = command .. [[ get_registered_ip ]] .. domain .. [[ ]] .. use_ipv6 ..
 		[[ ]] .. force_ipversion .. [[ ]] .. force_dnstcp .. [[ ]] .. dnsserver
-	local ip = luci.sys.exec(command)
+	local ip = SYS.exec(command)
 	if ip == "" then ip = translate("no data") end
 	return ip
 end
 
--- enabled 
-ena = ts:option( Flag, "enabled", 
+-- enabled
+ena = ts:option( Flag, "enabled",
 	translate("Enabled"))
 ena.template = "ddns/overview_enabled"
 ena.rmempty = false
+function ena.parse(self, section)
+	DDNS.flag_parse(self, section)
+end
 
 -- show PID and next update
-upd = ts:option( DummyValue, "_update", 
+upd = ts:option( DummyValue, "_update",
 	translate("Last Update") .. "<br />" .. translate("Next Update"))
 upd.template = "ddns/overview_doubleline"
 function upd.set_one(self, section)	-- fill Last Update
 	-- get/validate last update
-	local uptime   = luci.sys.uptime()
-	local lasttime = tonumber(nixio.fs.readfile("%s/%s.update" % { run_dir, section } ) or 0 )
+	local uptime   = SYS.uptime()
+	local lasttime = DDNS.get_lastupd(section)
 	if lasttime > uptime then 	-- /var might not be linked to /tmp and cleared on reboot
-		lasttime = 0 
+		lasttime = 0
 	end
 
 	-- no last update happen
@@ -151,7 +183,7 @@ function upd.set_one(self, section)	-- fill Last Update
 		--            os.epoch  - sys.uptime + lastupdate(uptime)
 		local epoch = os.time() - uptime + lasttime
 		-- use linux date to convert epoch
-		return luci.sys.exec([[/bin/date -d @]] .. epoch .. [[ +']] .. date_format .. [[']])
+		return DDNS.epoch2date(epoch)
 	end
 end
 function upd.set_two(self, section)	-- fill Next Update
@@ -162,28 +194,28 @@ function upd.set_two(self, section)	-- fill Next Update
 	-- get force seconds
 	local force_interval = tonumber(self.map:get(section, "force_interval") or 72)
 	local force_unit = self.map:get(section, "force_unit") or "hours"
-	local force_seconds = luci.tools.ddns.calc_seconds(force_interval, force_unit)
+	local force_seconds = DDNS.calc_seconds(force_interval, force_unit)
 
 	-- get last update and get/validate PID
-	local uptime   = luci.sys.uptime()
-	local lasttime = tonumber(nixio.fs.readfile("%s/%s.update" % { run_dir, section } ) or 0 )
+	local uptime   = SYS.uptime()
+	local lasttime = DDNS.get_lastupd(section)
 	if lasttime > uptime then 	-- /var might not be linked to /tmp and cleared on reboot
-		lasttime = 0 
+		lasttime = 0
 	end
-	local pid      = luci.tools.ddns.get_pid(section, run_dir)
+	local pid      = DDNS.get_pid(section)
 
 	-- calc next update
 	if lasttime > 0 then
 		local epoch = os.time() - uptime + lasttime + force_seconds
 		-- use linux date to convert epoch
-		datelast = luci.sys.exec([[/bin/date -d @]] .. epoch .. [[ +']] .. date_format .. [[']])
-	end		
+		datelast = DDNS.epoch2date(epoch)
+	end
 
-	-- process running but update needs to happen 
+	-- process running but update needs to happen
 	if pid > 0 and ( lasttime + force_seconds - uptime ) < 0 then
 		datenext = translate("Verify")
 
-	-- run once 
+	-- run once
 	elseif force_seconds == 0 then
 		datenext = translate("Run once")
 
@@ -191,7 +223,7 @@ function upd.set_two(self, section)	-- fill Next Update
 	elseif pid == 0 and enabled == 0 then
 		datenext  = translate("Disabled")
 
-	-- no process running and NOT 
+	-- no process running and NOT
 	elseif pid == 0 and enabled ~= 0 then
 		datenext = translate("Stopped")
 	end
@@ -200,11 +232,11 @@ function upd.set_two(self, section)	-- fill Next Update
 end
 
 -- start/stop button
-btn = ts:option( Button, "_startstop", 
+btn = ts:option( Button, "_startstop",
 	translate("Process ID") .. "<br />" .. translate("Start / Stop") )
 btn.template = "ddns/overview_startstop"
 function btn.cfgvalue(self, section)
-	local pid = luci.tools.ddns.get_pid(section, run_dir)
+	local pid = DDNS.get_pid(section)
 	if pid > 0 then
 		btn.inputtitle	= "PID: " .. pid
 		btn.inputstyle	= "reset"

--- a/applications/luci-ddns/luasrc/view/ddns/overview_status.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/overview_status.htm
@@ -2,6 +2,12 @@
 <!-- ++ BEGIN ++ Dynamic DNS ++ overview_status.htm ++ -->
 <script type="text/javascript">//<![CDATA[
 
+	// variables to store version information
+	var luci_version
+	var luci_build
+	var ddns_version
+	var ddns_required
+
 	// helper to extract section from objects id
 	// cbi.ddns.SECTION._xyz
 	function _id2section(id) {
@@ -14,7 +20,11 @@
 	// called by XHR.poll and onclick_startstop
 	function _data2elements(data) {
 		// DDNS Service
-		// data[0] ignored here
+		// fill Version informations
+		luci_version  = data[0].luci_ver
+		luci_build    = data[0].luci_build
+		ddns_version  = data[0].script_ver
+		ddns_required = data[0].script_min
 
 		// Service sections
 		for( i = 1; i < data.length; i++ )
@@ -38,7 +48,7 @@
 				btn.className = "cbi-button cbi-input-apply";
 			}
 			btn.disabled = false;	// button enabled
-			
+
 			// last update
 			switch (data[i].datelast) {
 				case "_empty_":
@@ -71,7 +81,7 @@
 						nup.innerHTML = '<em><%:Disabled%></em>';
 						btn.value = '----------';
 						btn.className = "cbi-button cbi-input-button";	// no image
-						btn.disabled = true;	// disabled 
+						btn.disabled = true;	// disabled
 					}
 					break;
 				default:
@@ -84,13 +94,13 @@
 
 			// registered IP
 			// rip.innerHTML = "Registered IP";
-			if (data[i].domain == "_nodomain_") 
+			if (data[i].domain == "_nodomain_")
 				rip.innerHTML = '';
 			else if (data[i].reg_ip == "_nodata_")
 				rip.innerHTML = '<em><%:No data%></em>';
 			else
 				rip.innerHTML = data[i].reg_ip;
-		
+
 			// monitored interfacce
 			// data[i].iface ignored here
 		}
@@ -121,13 +131,27 @@
 		} else {
 			btn.value = '----------';
 			btn.className = "cbi-button cbi-input-button";	// no image
-			btn.disabled = true;		// disabled 
-		}		
+			btn.disabled = true;		// disabled
+		}
+	}
+
+	// event handler for map.title link
+	function onclick_maptitle() {
+		var str = "<%:Version Information%>";
+		str += "\n\nluci-app-ddns:";
+		str += "\n\t<%:Version%>:\t" + luci_version;
+		str += "\n\t<%:Build%>:\t" + luci_build;
+		str += "\n\nddns-scripts <%:installed%>:";
+		str += "\n\t<%:Version%>:\t" + ddns_version;
+		str += "\n\nddns-scripts <%:required%>:";
+		str += "\n\t<%:Version%>:\t" + ddns_required + " <%:or greater%>";
+		str += "\n\n"
+		alert(str);
 	}
 
 	// event handler for start/stop button
 	function onclick_startstop(id) {
-		// extract section		
+		// extract section
 		var section = _id2section(id);
 		// get elements
 		var cbx = document.getElementById("cbid.ddns." + section + ".enabled");		// Enabled
@@ -158,14 +182,20 @@
 		);
 	}
 
+	// force to immediate show status on page load (not waiting for XHR.poll)
+	XHR.get('<%=luci.dispatcher.build_url("admin", "services", "ddns", "status")%>', null,
+		function(x, data) {
+			_data2elements(data);
+		}
+	);
+
 	// define only ONE XHR.poll in a page because if one is running it blocks the other one
 	// optimum is to define on Map or Section Level from here you can reach all elements
-	// we need update every 30 seconds only
-	XHR.poll(30, '<%=luci.dispatcher.build_url("admin", "services", "ddns", "status")%>', null,
-		function(x, data)
-		{
+	// we need update every 15 seconds only
+	XHR.poll(15, '<%=luci.dispatcher.build_url("admin", "services", "ddns", "status")%>', null,
+		function(x, data) {
 			_data2elements(data);
-		}			
+		}
 	);
 
 //]]></script>

--- a/applications/luci-ddns/luasrc/view/ddns/system_status.htm
+++ b/applications/luci-ddns/luasrc/view/ddns/system_status.htm
@@ -1,127 +1,140 @@
 
 <!-- ++ BEGIN ++ Dynamic DNS ++ system_status.htm ++ -->
 <script type="text/javascript">//<![CDATA[
-	XHR.poll(10, '<%=luci.dispatcher.build_url("admin", "services", "ddns", "status")%>', null,
-		function(x, data)
+	// helper to move status data to the relevant
+	// screen objects
+	// called by XHR.poll and XHR.get
+	function _data2elements(x, data) {
+		var tbl = document.getElementById('ddns_status_table');
+		// security check
+		if ( !(tbl) ) { return; }
+
+		// clear all rows
+		while (tbl.rows.length > 1) 
+			tbl.deleteRow(1);
+
+		// variable for Modulo-Division use to set cbi-rowstyle-? (0 or 1)
+		var x = -1;
+		var i = 1;
+
+		// no data => no ddns-scripts Version 2 installed
+		if ( !data ) {
+			var txt = '<br /><strong><font color="red"><%:Old version of ddns-scripts installed%></font>' ;
+			var url = '<a href="' ;
+			url += '<%=luci.dispatcher.build_url("admin", "system", "packages")%>' ;
+			url += '"><%:install update here%></a></strong>' ;
+			var tr = tbl.insertRow(-1);
+			tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1);
+			var td = tr.insertCell(-1);
+			td.colSpan = 2 ;
+			td.innerHTML = txt + " - " + url
+			tr.insertCell(-1).colSpan = 3 ;
+			return;
+		}
+
+		// DDNS Service disabled
+		if (data[0].enabled == 0) {
+			var txt = '<strong><font color="red"><%:DDNS Autostart disabled%></font>' ;
+			var url = '<a href="' + data[0].url_up + '"><%:enable here%></a></strong>' ;
+			var tr = tbl.insertRow(-1);
+			tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1);
+			var td = tr.insertCell(-1);
+			td.colSpan = 2 ;
+			td.innerHTML = txt + " - " + url
+			tr.insertCell(-1).colSpan = 3 ;
+			x++ ;
+		}
+
+		for( i = 1; i < data.length; i++ )
 		{
-			var tbl = document.getElementById('ddns_status_table');
-			// security check
-			if ( !(tbl) ) { return; }
+			var tr = tbl.insertRow(-1);
+			tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1) ;
 
-			// clear all rows
-			while (tbl.rows.length > 1) 
-				tbl.deleteRow(1);
+			// configuration
+			tr.insertCell(-1).innerHTML = '<strong>' + data[i].section + '</strong>' ;
 
-			// variable for Modulo-Division use to set cbi-rowstyle-? (0 or 1)
-			var x = -1;
-			var i = 1;
+			// pid
+			// data[i].pid ignored here
 
-			// no data => no ddns-scripts Version 2 installed
-			if ( !data ) {
-				var txt = '<br /><strong><font color="red"><%:Old version of ddns-scripts installed%></font>' ;
-				var url = '<a href="' ;
-				url += '<%=luci.dispatcher.build_url("admin", "system", "packages")%>' ;
-				url += '"><%:install update here%></a></strong>' ;
-				var tr = tbl.insertRow(-1);
-				tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1);
-				var td = tr.insertCell(-1);
-				td.colSpan = 2 ;
-				td.innerHTML = txt + " - " + url
-				tr.insertCell(-1).colSpan = 3 ;
-				return;
+			// last update
+			// data[i].datelast ignored here
+
+			// next update
+			switch (data[i].datenext) {
+				case "_empty_":
+					tr.insertCell(-1).innerHTML = '<em><%:Unknown error%></em>' ;
+					break;
+				case "_stopped_":
+					tr.insertCell(-1).innerHTML = '<em><%:Stopped%></em>' ;
+					break;
+				case "_disabled_":
+					tr.insertCell(-1).innerHTML = '<em><%:Disabled%></em>' ;
+					break;
+				case "_noupdate_":
+					tr.insertCell(-1).innerHTML = '<em><%:Update error%></em>' ;
+					break;
+				case "_runonce_":
+					tr.insertCell(-1).innerHTML = '<em><%:Run once%></em>' ;
+					break;
+				case "_verify_":
+					tr.insertCell(-1).innerHTML = '<em><%:Verify%></em>';
+					break;
+				default:
+					tr.insertCell(-1).innerHTML = data[i].datenext ;
+					break;
 			}
 
-			// DDNS Service disabled
-			if (data[0].enabled == 0) {
-				var txt = '<strong><font color="red"><%:DDNS Autostart disabled%></font>' ;
-				var url = '<a href="' + data[0].url_up + '"><%:enable here%></a></strong>' ;
-				var tr = tbl.insertRow(-1);
-				tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1);
-				var td = tr.insertCell(-1);
-				td.colSpan = 2 ;
-				td.innerHTML = txt + " - " + url
-				tr.insertCell(-1).colSpan = 3 ;
-				x++ ;
-			}
+			// domain
+			if (data[i].domain == "_nodomain_")
+				tr.insertCell(-1).innerHTML = '<em><%:config error%></em>';
+			else
+				tr.insertCell(-1).innerHTML = data[i].domain;
 
-			for( i = 1; i < data.length; i++ )
-			{
-				var tr = tbl.insertRow(-1);
-				tr.className = 'cbi-section-table-row cbi-rowstyle-' + (((i + x) % 2) + 1) ;
-
-				// configuration
-				tr.insertCell(-1).innerHTML = '<strong>' + data[i].section + '</strong>' ;
-
-				// pid
-				// data[i].pid ignored here
-
-				// last update
-				// data[i].datelast ignored here
-
-				// next update
-				switch (data[i].datenext) {
-					case "_empty_":
-						tr.insertCell(-1).innerHTML = '<em><%:Unknown error%></em>' ;
-						break;
-					case "_stopped_":
-						tr.insertCell(-1).innerHTML = '<em><%:Stopped%></em>' ;
-						break;
-					case "_disabled_":
-						tr.insertCell(-1).innerHTML = '<em><%:Disabled%></em>' ;
-						break;
-					case "_noupdate_":
-						tr.insertCell(-1).innerHTML = '<em><%:Update error%></em>' ;
-						break;
-					case "_runonce_":
-						tr.insertCell(-1).innerHTML = '<em><%:Run once%></em>' ;
-						break;
-					case "_verify_":
-						tr.insertCell(-1).innerHTML = '<em><%:Verify%></em>';
-						break;
-					default:
-						tr.insertCell(-1).innerHTML = data[i].datenext ;
-						break;
-				}
-
-				// domain
-				if (data[i].domain == "_nodomain_")
-					tr.insertCell(-1).innerHTML = '<em><%:config error%></em>';
-				else
-					tr.insertCell(-1).innerHTML = data[i].domain;
-
-				// registered IP
-				switch (data[i].reg_ip) {
-					case "_nodomain_":
-						tr.insertCell(-1).innerHTML = '<em><%:Config error%></em>';
-						break;
-					case "_nodata_":
-						tr.insertCell(-1).innerHTML = '<em><%:No data%></em>';
-						break;
-					case "_noipv6_":
-						tr.insertCell(-1).innerHTML = '<em><%:IPv6 not supported%></em>';
-						break;
-					default:
-						tr.insertCell(-1).innerHTML = data[i].reg_ip;
-						break;
-				}
-
-				// monitored interfacce
-				if (data[i].iface == "_nonet_")
+			// registered IP
+			switch (data[i].reg_ip) {
+				case "_nodomain_":
 					tr.insertCell(-1).innerHTML = '<em><%:Config error%></em>';
-				else
-					tr.insertCell(-1).innerHTML = data[i].iface;
+					break;
+				case "_nodata_":
+					tr.insertCell(-1).innerHTML = '<em><%:No data%></em>';
+					break;
+				case "_noipv6_":
+					tr.insertCell(-1).innerHTML = '<em><%:IPv6 not supported%></em>';
+					break;
+				default:
+					tr.insertCell(-1).innerHTML = data[i].reg_ip;
+					break;
 			}
 
-			if (tbl.rows.length == 1 || (data[0].enabled == 0 && tbl.rows.length == 2) ) {
-				var br = '<br />';
-				if (tbl.rows.length > 1) 
-					br = '';
-				var tr = tbl.insertRow(-1);
-				tr.className = "cbi-section-table-row";
-				var td = tr.insertCell(-1);
-				td.colSpan = 5;
-				td.innerHTML = '<em>' + br + '<%:There is no service configured.%></em>' ;
-			}
+			// monitored interfacce
+			if (data[i].iface == "_nonet_")
+				tr.insertCell(-1).innerHTML = '<em><%:Config error%></em>';
+			else
+				tr.insertCell(-1).innerHTML = data[i].iface;
+		}
+
+		if (tbl.rows.length == 1 || (data[0].enabled == 0 && tbl.rows.length == 2) ) {
+			var br = '<br />';
+			if (tbl.rows.length > 1) 
+				br = '';
+			var tr = tbl.insertRow(-1);
+			tr.className = "cbi-section-table-row";
+			var td = tr.insertCell(-1);
+			td.colSpan = 5;
+			td.innerHTML = '<em>' + br + '<%:There is no service configured.%></em>' ;
+		}
+	}
+
+	// force to immediate show status (not waiting for XHR.poll)
+	XHR.get('<%=luci.dispatcher.build_url("admin", "services", "ddns", "status")%>', null,
+		function(x, data) {
+			_data2elements(x, data);
+		}
+	);
+
+	XHR.poll(10, '<%=luci.dispatcher.build_url("admin", "services", "ddns", "status")%>', null,
+		function(x, data) {
+			_data2elements(x, data);
 		}
 	);
 //]]></script>

--- a/applications/luci-ddns/root/etc/uci-defaults/luci-ddns
+++ b/applications/luci-ddns/root/etc/uci-defaults/luci-ddns
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-# needed for "Save and Apply" to restart ddns
+# no longer needed for "Save and Apply" to restart ddns
 uci -q batch <<-EOF >/dev/null
 	delete ucitrack.@ddns[-1]
-	add ucitrack ddns
-	set ucitrack.@ddns[-1].init="ddns"
 	commit ucitrack
 EOF
 

--- a/applications/luci-ddns/root/usr/lib/ddns/dynamic_dns_lucihelper.sh
+++ b/applications/luci-ddns/root/usr/lib/ddns/dynamic_dns_lucihelper.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 # /usr/lib/ddns/luci_dns_helper.sh
 #
-# Written by Christian Schoenebeck in August 2014 to support:
-# this script is used by luci-app-ddns
+# Written in August 2014
+# by Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+# This script is used by luci-app-ddns
 # - getting registered IP
 # - check if possible to get local IP
 # - verifing given DNS- or Proxy-Server
 #
-# variables in small chars are read from /etc/config/ddns
+# variables in small chars are read from /etc/config/ddns as parameter given here
 # variables in big chars are defined inside these scripts as gloval vars
 # variables in big chars beginning with "__" are local defined inside functions only
 # set -vx  	#script debugger
@@ -18,13 +19,13 @@
 
 # set -vx  	#script debugger
 
-# preset some variables wrong or not set in dynamic_dns_functions.sh
-SECTION_ID="dynamic_dns_lucihelper"
+# preset some variables, wrong or not set in dynamic_dns_functions.sh
+SECTION_ID="lucihelper"
 LOGFILE="$LOGDIR/$SECTION_ID.log"
-LUCI_HELPER="ACTIV"	# supress verbose and critical logging
+VERBOSE_MODE=0		# no console logging
 # global variables normally set by reading DDNS UCI configuration
-use_logfile=0
-use_syslog=0
+use_syslog=0		# no syslog
+use_logfile=0		# by default no logfile, can be changed here
 
 case "$1" in
 	get_registered_ip)
@@ -34,21 +35,24 @@ case "$1" in
 		force_ipversion=${4:-"0"}	# Force IP Version - default 0 - No
 		force_dnstcp=${5:-"0"}		# Force TCP on DNS - default 0 - No
 		dns_server=${6:-""}		# DNS server - default No DNS
+		write_log 7 "-----> get_registered_ip IP"
 		get_registered_ip IP
 		[ $? -ne 0 ] && IP=""
 		echo -n "$IP"			# suppress LF
 		;;
 	verify_dns)
-		# $2 == dns-server to verify	# no need for force_dnstcp because
+		# $2 : dns-server to verify	# no need for force_dnstcp because
 						# verify with nc (netcat) uses tcp anyway
 		use_ipv6=${3:-"0"}		# Use IPv6 - default IPv4
 		force_ipversion=${4:-"0"}	# Force IP Version - default 0 - No
+		write_log 7 "-----> verify_dns '$2'"
 		verify_dns "$2"
 		;;
 	verify_proxy)
-		# $2 == proxy string to verify
+		# $2 : proxy string to verify
 		use_ipv6=${3:-"0"}		# Use IPv6 - default IPv4
 		force_ipversion=${4:-"0"}	# Force IP Version - default 0 - No
+		write_log 7 "-----> verify_proxy '$2'"
 		verify_proxy "$2"
 		;;
 	get_local_ip)
@@ -62,7 +66,7 @@ case "$1" in
 		proxy="$8"			# proxy if set
 		force_ipversion="0"		# not needed but must be set
 		use_https="0"			# not needed but must be set
-		[ -n "$proxy" -a "$ip_source" == "web" ] && {
+		[ -n "$proxy" -a "$ip_source" = "web" ] && {
 			# proxy defined, used for ip_source=web
 			export HTTP_PROXY="http://$proxy"
 			export HTTPS_PROXY="http://$proxy"
@@ -70,13 +74,17 @@ case "$1" in
 			export https_proxy="http://$proxy"
 		}
 		# don't need IP only the return code
-		[ "$ip_source" == "web" -o  "$ip_source" == "script"] && {		
-			# we wait only 3 seconds for an 
+		[ "$ip_source" = "web" -o  "$ip_source" = "script" ] && {
+			# we wait only 3 seconds for an
 			# answer from "web" or "script"
-			__timeout 3 -- get_local_ip IP
-		} || get_local_ip IP
+			write_log 7 "-----> timeout 3 -- get_local_ip IP"
+			timeout 3 -- get_local_ip IP
+		} || {
+			write_log 7 "-----> get_local_ip IP"
+			get_local_ip IP
+		}
 		;;
-	*)	
-		return 1
+	*)
+		return 255
 		;;
 esac

--- a/po/de/ddns.po
+++ b/po/de/ddns.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: luci-app-ddns\n"
-"POT-Creation-Date: 2014-10-04 16:26+1000\n"
-"PO-Revision-Date: 2014-10-04 16:27+0100\n"
+"POT-Creation-Date: 2014-11-09 13:41+0100\n"
+"PO-Revision-Date: 2014-11-09 14:29+0100\n"
 "Last-Translator: Christian Schoenebeck <christian.schoenebeck@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -35,6 +35,9 @@ msgstr ""
 "Liste der definierten DDNS Konfigurationen und ihr aktueller Status.<br /"
 ">Wenn Sie Aktualisierungen für IPv4 und IPv6 senden möchten benötigen Sie "
 "zwei Konfigurationen z.B. 'myddns_ipv4' und 'myddns_ipv6'"
+
+msgid "Build"
+msgstr "Build"
 
 msgid ""
 "BusyBox's nslookup and Wget do not support to specify the IP version to use "
@@ -347,6 +350,9 @@ msgstr "Bitte [Speichern & Anwenden] Sie Änderungen zunächst"
 msgid "Please press [Read] button"
 msgstr "Bitte Protokolldatei einlesen"
 
+msgid "Please update to the current version!"
+msgstr "Aktualisieren Sie bitte auf die aktuelle Version!"
+
 msgid "Process ID"
 msgstr "Prozess ID"
 
@@ -377,6 +383,9 @@ msgstr "Dienst"
 msgid "Show more"
 msgstr "Zeige mehr"
 
+msgid "Software update required"
+msgstr "Softwareaktualisierung nötig"
+
 msgid "Source of IP address"
 msgstr "Quelle der IP-Adresse"
 
@@ -385,6 +394,13 @@ msgstr "Start / Stopp"
 
 msgid "Stopped"
 msgstr "Angehalten"
+
+msgid ""
+"The currently installed 'ddns-scripts' package did not support all available "
+"settings."
+msgstr ""
+"Die installierte Software 'ddns-scripts' unterstützt nicht alle verfügbaren "
+"Optionen."
 
 msgid "There is no service configured."
 msgstr "Kein Dienst konfiguriert"
@@ -418,6 +434,9 @@ msgid "User defined script to read systems IP-Address"
 msgstr ""
 "Definiert das Skript mit dem die  aktuelle IP-Adresse des System gelesen "
 "wird."
+
+msgid "Version Information"
+msgstr "Versionsinformationen"
 
 msgid ""
 "Writes detailed messages to log file. File will be truncated automatically."
@@ -490,6 +509,9 @@ msgstr "Stunden"
 msgid "install update here"
 msgstr "Aktualisierung hier installieren"
 
+msgid "installed"
+msgstr "installiert"
+
 msgid "interface"
 msgstr "Schnittstelle"
 
@@ -542,6 +564,9 @@ msgstr "nslookup kann den Namen nicht auflösen"
 msgid "or"
 msgstr "oder"
 
+msgid "or greater"
+msgstr "oder größer"
+
 msgid "please disable"
 msgstr "Bitte deaktivieren"
 
@@ -556,6 +581,9 @@ msgstr "Bitte 'IPv4' Adressversion auswählen in den"
 
 msgid "proxy port missing"
 msgstr "Proxy-Port fehlt"
+
+msgid "required"
+msgstr "erforderlich"
 
 msgid "seconds"
 msgstr "Sekunden"

--- a/po/templates/ddns.pot
+++ b/po/templates/ddns.pot
@@ -18,6 +18,9 @@ msgid ""
 "separate Configurations i.e. 'myddns_ipv4' and 'myddns_ipv6'"
 msgstr ""
 
+msgid "Build"
+msgstr ""
+
 msgid ""
 "BusyBox's nslookup and Wget do not support to specify the IP version to use "
 "for communication with DDNS Provider."
@@ -279,6 +282,9 @@ msgstr ""
 msgid "Please press [Read] button"
 msgstr ""
 
+msgid "Please update to the current version!"
+msgstr ""
+
 msgid "Process ID"
 msgstr ""
 
@@ -309,6 +315,9 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
+msgid "Software update required"
+msgstr ""
+
 msgid "Source of IP address"
 msgstr ""
 
@@ -316,6 +325,11 @@ msgid "Start / Stop"
 msgstr ""
 
 msgid "Stopped"
+msgstr ""
+
+msgid ""
+"The currently installed 'ddns-scripts' package did not support all available "
+"settings."
 msgstr ""
 
 msgid "There is no service configured."
@@ -345,6 +359,9 @@ msgid "Use HTTP Secure"
 msgstr ""
 
 msgid "User defined script to read systems IP-Address"
+msgstr ""
+
+msgid "Version Information"
 msgstr ""
 
 msgid ""
@@ -407,6 +424,9 @@ msgstr ""
 msgid "install update here"
 msgstr ""
 
+msgid "installed"
+msgstr ""
+
 msgid "interface"
 msgstr ""
 
@@ -458,6 +478,9 @@ msgstr ""
 msgid "or"
 msgstr ""
 
+msgid "or greater"
+msgstr ""
+
 msgid "please disable"
 msgstr ""
 
@@ -471,6 +494,9 @@ msgid "please select 'IPv4' address version in"
 msgstr ""
 
 msgid "proxy port missing"
+msgstr ""
+
+msgid "required"
 msgstr ""
 
 msgid "seconds"


### PR DESCRIPTION
fix verify of entry for DNS server Issue #244
    https://github.com/openwrt/luci/issues/244
add support for option 'update_script'
add display of version information when click on "Dynamic DNS" on
overview page
add verify of installed ddns-scripts version and show as hint if not
correct version
modified epoch to date conversation
cbi object Flag did not set section.changed state, fixed in
tools.flag_parse function
ucitrack entry no longer needed and removed
minor fixes

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
