### PR TITLE
build: Backport "generate strictly increasing git revisions"

### DIFF
--- a/build/mkrevision.sh
+++ b/build/mkrevision.sh
@@ -14,7 +14,10 @@ TOPDIR="${0%mkrevision.sh}"
 	elif git log -1 >/dev/null 2>/dev/null; then
 		revision="svn-r$(LC_ALL=C git log -1 | sed -ne 's/.*git-svn-id: .*@\([0-9]\+\) .*/\1/p')"
 		if [ "$revision" = "svn-r" ]; then
-			revision="git-$(LC_ALL=C git log -1 --pretty=%h)"
+			set -- $(git log -1 --format="%ct %h")
+			secs="$(($1 % 86400))"
+			yday="$(date --utc --date="@$1" "+%y.%j")"
+			revision="$(printf 'git-%s.%05d-%s' "$yday" "$secs" "$2")"
 		fi
 	else
 		revision="unknown"


### PR DESCRIPTION
Enhance luci-0.12's build/mkrevision.sh by backporting the code to generate strictly increasing git revisions.The corresponding check-in master was: https://github.com/openwrt/luci/commit/0856030c79f3febdafa627511cf1be4c72edf09b

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
