### PR TITLE
luci.http.protocol: Allow posts to contain more than a single chunk

### DIFF
--- a/modules/base/luasrc/http/protocol.lua
+++ b/modules/base/luasrc/http/protocol.lua
@@ -658,7 +658,7 @@ function parse_message_body( src, msg, filecb )
 
 			if not ok and err then
 				return nil, err
-			elseif not err then
+			elseif not ok then -- eof
 				return true
 			end
 		end


### PR DESCRIPTION
-- This is a backport of https://github.com/openwrt/luci/pull/258 for the BB branch.  I know it's not strictly necessary for BB, but I can't work out an easy way of carrying this as a local patch.

The ltn12.pump.step() loop in parse_message_body was incorrectly testing
for EOF, and returning after the first chunk, even if further chunks
were available.  The loop in parse_message_header made the correct
check, and test code making raw ajax json posts now succeeds for posts

> = 2048 bytes.

Signed-off-by: Karl Palsson karlp@remake.is
