### PR TITLE
Add LuCI support for HSO protocol (Option 3G card)

### DIFF
--- a/contrib/package/luci/Makefile
+++ b/contrib/package/luci/Makefile
@@ -192,6 +192,7 @@ endef
 $(eval $(call protocol,ppp,Support for PPP/PPPoE/PPPoA/PPtP))
 $(eval $(call protocol,ipv6,Support for DHCPv6/6in4/6to4/6rd/DS-Lite))
 $(eval $(call protocol,3g,Support for 3G,+PACKAGE_luci-proto-3g:comgt))
+$(eval $(call protocol,hso,Support for HSO,+PACKAGE_luci-proto-hso:comgt +PACKAGE_luci-proto-hso:kmod-usb-net +PACKAGE_luci-proto-hso:kmod-usb-net-hso))
 $(eval $(call protocol,relay,Support for relayd pseudo bridges,+PACKAGE_luci-proto-relay:relayd))
 
 

--- a/protocols/hso/Makefile
+++ b/protocols/hso/Makefile
@@ -1,0 +1,2 @@
+include ../../build/config.mk
+include ../../build/module.mk

--- a/protocols/hso/luasrc/model/cbi/admin_network/proto_hso.lua
+++ b/protocols/hso/luasrc/model/cbi/admin_network/proto_hso.lua
@@ -1,0 +1,158 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2011 Jo-Philipp Wich <xm@subsignal.org>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+]]--
+
+local map, section, net = ...
+
+local hsoname,hsotype,hsointerface
+local device, apn, service, pincode, username, password
+local ipv6, maxwait, defaultroute, metric, peerdns, dns,
+      keepalive_failure, keepalive_interval, demand
+
+
+device = section:taboption("general", Value, "device", translate("Control interface"))
+device.rmempty = false
+
+local device_suggestions = nixio.fs.glob("/dev/ttyHS*")
+	or nixio.fs.glob("/dev/tts/*")
+
+if device_suggestions then
+	local node
+	for node in device_suggestions do
+		hsoname = string.gsub(node,"/dev/","")
+		hsotype = nixio.fs.readfile("/sys/class/tty/" .. hsoname .. "/hsotype")
+		device:value(node, hsotype .. " (" .. node ..")" )
+		if string.find(hsotype,"Application") ~= nil then
+			device.default = node
+        end
+	end
+end
+
+
+service = section:taboption("general", Value, "service", translate("Service Type"))
+service.default = "umts"
+service:value("umts", "UMTS/GPRS")
+service:value("umts_only", translate("UMTS only"))
+service:value("gprs_only", translate("GPRS only"))
+
+
+apn = section:taboption("general", Value, "apn", translate("APN"))
+
+
+pincode = section:taboption("general", Value, "pincode", translate("PIN"))
+
+
+username = section:taboption("general", Value, "username", translate("PAP/CHAP username"))
+
+
+password = section:taboption("general", Value, "password", translate("PAP/CHAP password"))
+password.password = true
+
+
+if luci.model.network:has_ipv6() then
+
+	ipv6 = section:taboption("advanced", Flag, "ipv6",
+		translate("Enable IPv6 negotiation on the PPP link"))
+
+	ipv6.default = ipv6.disabled
+
+end
+
+
+maxwait = section:taboption("advanced", Value, "maxwait",
+	translate("Modem init timeout"),
+	translate("Maximum amount of seconds to wait for the modem to become ready"))
+
+maxwait.placeholder = "20"
+maxwait.datatype    = "min(1)"
+
+
+defaultroute = section:taboption("advanced", Flag, "defaultroute",
+	translate("Use default gateway"),
+	translate("If unchecked, no default route is configured"))
+
+defaultroute.default = defaultroute.enabled
+
+
+metric = section:taboption("advanced", Value, "metric",
+	translate("Use gateway metric"))
+
+metric.placeholder = "0"
+metric.datatype    = "uinteger"
+metric:depends("defaultroute", defaultroute.enabled)
+
+
+peerdns = section:taboption("advanced", Flag, "peerdns",
+	translate("Use DNS servers advertised by peer"),
+	translate("If unchecked, the advertised DNS server addresses are ignored"))
+
+peerdns.default = peerdns.enabled
+
+
+dns = section:taboption("advanced", DynamicList, "dns",
+	translate("Use custom DNS servers"))
+
+dns:depends("peerdns", "")
+dns.datatype = "ipaddr"
+dns.cast     = "string"
+
+
+keepalive_failure = section:taboption("advanced", Value, "_keepalive_failure",
+	translate("LCP echo failure threshold"),
+	translate("Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures"))
+
+function keepalive_failure.cfgvalue(self, section)
+	local v = m:get(section, "keepalive")
+	if v and #v > 0 then
+		return tonumber(v:match("^(%d+)[ ,]+%d+") or v)
+	end
+end
+
+function keepalive_failure.write() end
+function keepalive_failure.remove() end
+
+keepalive_failure.placeholder = "0"
+keepalive_failure.datatype    = "uinteger"
+
+
+keepalive_interval = section:taboption("advanced", Value, "_keepalive_interval",
+	translate("LCP echo interval"),
+	translate("Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold"))
+
+function keepalive_interval.cfgvalue(self, section)
+	local v = m:get(section, "keepalive")
+	if v and #v > 0 then
+		return tonumber(v:match("^%d+[ ,]+(%d+)"))
+	end
+end
+
+function keepalive_interval.write(self, section, value)
+	local f = tonumber(keepalive_failure:formvalue(section)) or 0
+	local i = tonumber(value) or 5
+	if i < 1 then i = 1 end
+	if f > 0 then
+		m:set(section, "keepalive", "%d %d" %{ f, i })
+	else
+		m:del(section, "keepalive")
+	end
+end
+
+keepalive_interval.remove      = keepalive_interval.write
+keepalive_interval.placeholder = "5"
+keepalive_interval.datatype    = "min(1)"
+
+
+demand = section:taboption("advanced", Value, "demand",
+	translate("Inactivity timeout"),
+	translate("Close inactive connection after the given amount of seconds, use 0 to persist connection"))
+
+demand.placeholder = "0"
+demand.datatype    = "uinteger"

--- a/protocols/hso/luasrc/model/cbi/admin_network/proto_hso.lua
+++ b/protocols/hso/luasrc/model/cbi/admin_network/proto_hso.lua
@@ -1,7 +1,7 @@
 --[[
 LuCI - Lua Configuration Interface
 
-Copyright 2011 Jo-Philipp Wich <xm@subsignal.org>
+Copyright 2015 Stanislas Bertrand <stanislasbertrand@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/protocols/hso/luasrc/model/network/proto_hso.lua
+++ b/protocols/hso/luasrc/model/network/proto_hso.lua
@@ -1,7 +1,7 @@
 --[[
-LuCI - Network model - 3G, PPP, PPtP, PPPoE and PPPoA protocol extension
+LuCI - Network model - HSO protocol extension
 
-Copyright 2011 Jo-Philipp Wich <xm@subsignal.org>
+Copyright 2015 Stanislas Bertrand <stanislasbertrand@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ limitations under the License.
 ]]--
 
 local netmod = luci.model.network
-
-local _, p
 
 local proto = netmod:register_protocol("hso")
 

--- a/protocols/hso/luasrc/model/network/proto_hso.lua
+++ b/protocols/hso/luasrc/model/network/proto_hso.lua
@@ -1,0 +1,59 @@
+--[[
+LuCI - Network model - 3G, PPP, PPtP, PPPoE and PPPoA protocol extension
+
+Copyright 2011 Jo-Philipp Wich <xm@subsignal.org>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+]]--
+
+local netmod = luci.model.network
+
+local _, p
+
+local proto = netmod:register_protocol("hso")
+
+function proto.ifname(self)
+		return "hso-" .. self.sid
+end
+
+function proto.get_i18n(self)
+	return luci.i18n.translate("HSO")
+end
+
+function proto.opkg_package(self)
+	return "comgt"
+end
+
+function proto.is_installed(self)
+	return nixio.fs.access("/lib/netifd/proto/hso.sh")
+end
+
+function proto.is_floating(self)
+	return false
+end
+
+function proto.is_virtual(self)
+	return false
+end
+
+function proto.get_interfaces(self)
+	return netmod.protocol.get_interfaces(self)
+end
+
+function proto.contains_interface(self, ifc)
+	return netmod.protocol.contains_interface(self, ifc)
+end
+
+netmod:register_pattern_virtual("^hso-%%w")
+


### PR DESCRIPTION
LuCI interface for HSO protocol to support Option 3G cards.
To use along with comgt + patch https://dev.openwrt.org/attachment/ticket/6995/comgt-hso_141012.patch
![image](https://cloud.githubusercontent.com/assets/7697801/5334920/da1bef5e-7e52-11e4-82f5-7f6bdf07285f.png)