### PR TITLE
luci.http: fix wrong SCRIPT_NAME under mini_httpd

### DIFF
--- a/modules/base/luasrc/http.lua
+++ b/modules/base/luasrc/http.lua
@@ -45,6 +45,13 @@ function Request.__init__(self, env, sourcein, sinkerr)
 	-- File handler nil by default to let .content() work
 	self.filehandler = nil
 
+	-- Workaround for wrong SCRIPT_NAME under mini_httpd with vhosts enabled
+	if string.find(env.SERVER_SOFTWARE, "^mini_httpd") then
+		if env.PATH_INFO then
+			env.SCRIPT_NAME = env.SCRIPT_NAME:gsub(env.PATH_INFO, "")
+		end
+	end
+
 	-- HTTP-Message table
 	self.message = {
 		env = env,


### PR DESCRIPTION
The `SCRIPT_NAME` CGI environment variable should be set to the path of
the current CGI executable, relative to the document root. On a default
OpenWrt installation, this would be `/cgi-bin/luci`.

Under mini_httpd, the `SCRIPT_NAME` variable is set correctly as long as
virtual hosts are not enabled. When virtual hosts are enabled, however,
the `SCRIPT_NAME` set by mini_httpd incorrectly includes the extra path
information that follows the pathname of the script. Because LuCI uses
the `SCRIPT_NAME` variable to build URLs, the web interface is made
unusable.

This commit provides a workaround for the incorrect `SCRIPT_NAME`. Before
the CGI environment variables are read into the table used by `getenv()`,
`SCRIPT_NAME` is modified by stripping the value of `PATH_INFO`, which
contains the extra path information that incorrectly appears in
`SCRIPT_NAME`, thereby leaving `SCRIPT_NAME` with its correct value.

Signed-off-by: Seamus Murray <srm@sdf.org>
