### PR TITLE
luci-freifunk-diagnostics: change adress to an ipv6-enabled host

### DIFF
--- a/applications/luci-freifunk-diagnostics/luasrc/view/freifunk/diagnostics.htm
+++ b/applications/luci-freifunk-diagnostics/luasrc/view/freifunk/diagnostics.htm
@@ -72,7 +72,7 @@ local has_traceroute6 = fs.access("/usr/bin/traceroute6")
 			<br />
 
 			<div style="width:30%; float:left">
-				<input style="margin: 5px 0" type="text" value="openwrt.org" name="ping" /><br />
+				<input style="margin: 5px 0" type="text" value="dev.openwrt.org" name="ping" /><br />
 				<% if has_ping6 then %>
 				<select name="ping_proto" style="width:auto">
 					<option value="" selected="selected"><%:IPv4%></option>
@@ -85,7 +85,7 @@ local has_traceroute6 = fs.access("/usr/bin/traceroute6")
 			</div>
 
 			<div style="width:33%; float:left">
-				<input style="margin: 5px 0" type="text" value="openwrt.org" name="traceroute" /><br />
+				<input style="margin: 5px 0" type="text" value="dev.openwrt.org" name="traceroute" /><br />
 				<% if has_traceroute6 then %>
 				<select name="traceroute_proto" style="width:auto">
 					<option value="" selected="selected"><%:IPv4%></option>


### PR DESCRIPTION
the openwrt.org host has no ipv6. 
so the ping6 / traceroute6 test wasnt possible for people who are using this for testing. i changed it to an openwrt-host which already has ipv6..