### PR TITLE
[Patch][cbi.lua] Flag.parse() did not set "changed" state

### DIFF
--- a/modules/base/luasrc/cbi.lua
+++ b/modules/base/luasrc/cbi.lua
@@ -1533,13 +1533,18 @@ function Flag.parse(self, section)
 
 	if fexists then
 		local fvalue = self:formvalue(section) and self.enabled or self.disabled
+		local cvalue = self:cfgvalue(section)
 		if fvalue ~= self.default or (not self.optional and not self.rmempty) then
 			self:write(section, fvalue)
 		else
 			self:remove(section)
 		end
+		if (fvalue ~= cvalue) then
+			self.section.changed = true
+		end
 	else
 		self:remove(section)
+		self.section.changed = true
 	end
 end
 


### PR DESCRIPTION
Fix the problem that function Flag.parse() did not set "changed" to true like other derivatives of AbstractValue do and defined inside AbstractValue.parse().

Signed-off-by: Christian Schoenebeck <christian.schoenebeck@gmail.com>
