### PR TITLE
luci-mod-admin-full: modified dependencies

### DIFF
--- a/modules/luci-mod-admin-full/Makefile
+++ b/modules/luci-mod-admin-full/Makefile
@@ -7,9 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Administration - full-featured for full control
-LUCI_DEPENDS:=+luci-base
-
-PKG_BUILD_DEPENDS:=iwinfo
+LUCI_DEPENDS:=+luci-base +libubus-lua +libiwinfo-lua
 
 include ../../luci.mk
 


### PR DESCRIPTION
libubus-lua needed here (not really by luci-base)
libiwinfo-lua needed to show wifi information
Due to changed LUCI_DEPENDS the PKG_BUILD_DEPENDS could be removed

Signed-off-by: Christian Schoenebeck <christian.schoenebeck@gmail.com>