### PR TITLE
luci-proto-3g: add dialnumber option

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -643,6 +643,9 @@ msgstr "Configuració de dispositiu"
 msgid "Diagnostics"
 msgstr "Diagnòstics"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Directori"
 

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -649,6 +649,9 @@ msgstr "Nastavení zařízení"
 msgid "Diagnostics"
 msgstr "Diagnostika"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Adresář"
 

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -648,6 +648,9 @@ msgstr "Gerätekonfiguration"
 msgid "Diagnostics"
 msgstr "Diagnosen"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Verzeichnis"
 

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -658,6 +658,9 @@ msgstr "Παραμετροποίηση Συσκευής"
 msgid "Diagnostics"
 msgstr "Διαγνωστικά"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Κατάλογος"
 

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -644,6 +644,9 @@ msgstr "Device Configuration"
 msgid "Diagnostics"
 msgstr "Diagnostics"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Directory"
 

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -657,6 +657,9 @@ msgstr "Configuración del dispositivo"
 msgid "Diagnostics"
 msgstr "Diagnósticos"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Directorio"
 

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -665,6 +665,9 @@ msgstr "Configuration de l'équipement"
 msgid "Diagnostics"
 msgstr "Diagnostics"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Répertoire"
 

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -637,6 +637,9 @@ msgstr "הגדרות מכשיר"
 msgid "Diagnostics"
 msgstr "אבחון"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr ""
 

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -658,6 +658,9 @@ msgstr "Eszköz beállítások"
 msgid "Diagnostics"
 msgstr "Diagnosztika"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Könyvtár"
 

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -662,6 +662,9 @@ msgstr "Configurazione del dispositivo"
 msgid "Diagnostics"
 msgstr "Diagnostica"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Cartella"
 

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -647,6 +647,9 @@ msgstr "デバイス設定"
 msgid "Diagnostics"
 msgstr "診断機能"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "ディレクトリ"
 

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -617,6 +617,9 @@ msgstr ""
 msgid "Diagnostics"
 msgstr ""
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr ""
 

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -647,6 +647,9 @@ msgstr "Enhet Konfigurasjon"
 msgid "Diagnostics"
 msgstr "Nettverksdiagnostikk"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Katalog"
 

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -668,6 +668,9 @@ msgstr "Konfiguracja urządzenia"
 msgid "Diagnostics"
 msgstr "Diagnostyka"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Katalog"
 

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -663,6 +663,9 @@ msgstr "Configuração do Dispositivo"
 msgid "Diagnostics"
 msgstr "Diagnóstico"
 
+msgid "Dial number"
+msgstr "Número de discagem"
+
 msgid "Directory"
 msgstr "Diretório"
 

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -659,6 +659,9 @@ msgstr "Configuração do Dispositivo"
 msgid "Diagnostics"
 msgstr "Diagnósticos"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Directório"
 

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -630,6 +630,9 @@ msgstr "Configurarea dispozitivului"
 msgid "Diagnostics"
 msgstr "Diagnosticuri"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Director"
 

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -660,6 +660,9 @@ msgstr "Конфигурация устройства"
 msgid "Diagnostics"
 msgstr "Диагностика"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Директория"
 

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -610,6 +610,9 @@ msgstr ""
 msgid "Diagnostics"
 msgstr ""
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr ""
 

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -616,6 +616,9 @@ msgstr ""
 msgid "Diagnostics"
 msgstr ""
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr ""
 

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -603,6 +603,9 @@ msgstr ""
 msgid "Diagnostics"
 msgstr ""
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr ""
 

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -623,6 +623,9 @@ msgstr ""
 msgid "Diagnostics"
 msgstr ""
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr ""
 

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -669,6 +669,9 @@ msgstr "Конфігурація пристрою"
 msgid "Diagnostics"
 msgstr "Діагностика"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "Каталог"
 

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -619,6 +619,9 @@ msgstr ""
 msgid "Diagnostics"
 msgstr ""
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr ""
 

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -625,6 +625,9 @@ msgstr "设备配置"
 msgid "Diagnostics"
 msgstr "网络诊断"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "目录"
 

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -632,6 +632,9 @@ msgstr "設定設備"
 msgid "Diagnostics"
 msgstr "診斷"
 
+msgid "Dial number"
+msgstr ""
+
 msgid "Directory"
 msgstr "目錄"
 

--- a/protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua
+++ b/protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua
@@ -12,7 +12,7 @@ You may obtain a copy of the License at
 
 local map, section, net = ...
 
-local device, apn, service, pincode, username, password
+local device, apn, service, pincode, username, password, dialnumber
 local ipv6, maxwait, defaultroute, metric, peerdns, dns,
       keepalive_failure, keepalive_interval, demand
 
@@ -51,6 +51,8 @@ username = section:taboption("general", Value, "username", translate("PAP/CHAP u
 password = section:taboption("general", Value, "password", translate("PAP/CHAP password"))
 password.password = true
 
+dialnumber = section:taboption("general", Value, "dialnumber", translate("Dial number"))
+dialnumber.placeholder = "*99***1#"
 
 if luci.model.network:has_ipv6() then
 


### PR DESCRIPTION
UCI network already permit dialnumber option for 3g interfaces.
This adds dialnumber to luci protocol 3g. Also it introduces a
new translation string "Dial number", added to template and updated
on each language (all empty but pt-br).

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

I don't know if I should or not update translation files.