### PR TITLE
luci-themes: luci.main.mediaurlbase not set correctly

### DIFF
--- a/themes/luci-theme-bootstrap/root/etc/uci-defaults/luci-theme-bootstrap
+++ b/themes/luci-theme-bootstrap/root/etc/uci-defaults/luci-theme-bootstrap
@@ -1,6 +1,7 @@
 #!/bin/sh
 uci batch <<-EOF
 	set luci.themes.Bootstrap=/luci-static/bootstrap
+	set luci.main.mediaurlbase=/luci-static/bootstrap
 	commit luci
 EOF
 exit 0

--- a/themes/luci-theme-freifunk-bno/root/etc/uci-defaults/luci-theme-freifunk-bno
+++ b/themes/luci-theme-freifunk-bno/root/etc/uci-defaults/luci-theme-freifunk-bno
@@ -1,6 +1,6 @@
 #!/bin/sh
 uci batch <<-EOF
 	set luci.themes.Freifunk_BNO=/luci-static/freifunk-bno
+	set luci.main.mediaurlbase=/luci-static/freifunk-bno
         commit luci
 EOF
-	

--- a/themes/luci-theme-freifunk-generic/root/etc/uci-defaults/luci-theme-freifunk-generic
+++ b/themes/luci-theme-freifunk-generic/root/etc/uci-defaults/luci-theme-freifunk-generic
@@ -1,4 +1,5 @@
 uci batch <<-EOF
-        set luci.themes.Freifunk_Generic=/luci-static/freifunk-generic
+	set luci.themes.Freifunk_Generic=/luci-static/freifunk-generic
+	set luci.main.mediaurlbase=/luci-static/freifunk-generic
         commit luci
 EOF

--- a/themes/luci-theme-openwrt/root/etc/uci-defaults/luci-theme-openwrt
+++ b/themes/luci-theme-openwrt/root/etc/uci-defaults/luci-theme-openwrt
@@ -1,6 +1,6 @@
 #!/bin/sh
 uci batch <<-EOF
 	set luci.themes.OpenWrt=/luci-static/openwrt.org
+	set luci.main.mediaurlbase=/luci-static/openwrt.org
         commit luci
 EOF
-	


### PR DESCRIPTION
Currently by default theme Bootstrap is installed but
luci.main.mediaurlbase (it holds the current active theme) still has
openwrt.org set.
I did not find the mechanism how LuCI starts Bootstrap theme but the
installation should set luci.main.mediaurlbase correctly.

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>