### PR TITLE
luci-app-ocserv: uclibc's crypt() doesn't support sha2crypt

### DIFF
--- a/applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua
+++ b/applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua
@@ -30,7 +30,7 @@ function pwd.write(self, section, value)
 		pass = value
 	else
 		local t = tonumber(nixio.getpid()*os.time())
-		local salt = "$5$" .. t .. "$"
+		local salt = "$1$" .. t .. "$"
 		pass = nixio.crypt(value, salt)
 	end
 	Value.write(self, section, pass)


### PR DESCRIPTION
Signed-off-by: Nikos Mavrogiannopoulos <nmav@gnutls.org>