### PR TITLE
libs/luci-lib-httpclient: fix not straightforward behavior of httpclient

### DIFF
--- a/libs/luci-lib-httpclient/luasrc/httpclient.lua
+++ b/libs/luci-lib-httpclient/luasrc/httpclient.lua
@@ -323,7 +323,7 @@ function request_raw(uri, options)
 		end
 	end
 	
-	return response.code, response, linesrc(true), sock
+	return response.code, response, linesrc(true)..sock:readall(), sock
 end
 
 function cookie_parse(cookiestr)

--- a/libs/luci-lib-httpclient/luasrc/httpclient.lua
+++ b/libs/luci-lib-httpclient/luasrc/httpclient.lua
@@ -97,7 +97,11 @@ end
 function request_raw(uri, options)
 	options = options or {}
 	local pr, auth, host, port, path
-	
+
+	if options.params then
+		uri = uri .. '?' .. http.urlencode_params(options.params)
+	end
+
 	if uri:find("%[") then
 		if uri:find("@") then
 			pr, auth, host, port, path = uri:match("(%w+)://(.+)@(%b[]):?([0-9]*)(.*)")

--- a/libs/luci-lib-httpclient/luasrc/httpclient.lua
+++ b/libs/luci-lib-httpclient/luasrc/httpclient.lua
@@ -176,6 +176,25 @@ function request_raw(uri, options)
 		options.method = options.method or "POST"
 	end
 
+	if options.cookies then
+		local cookiedata = {}
+		for _, c in ipairs(options.cookies) do
+			local cdo = c.flags.domain
+			local cpa = c.flags.path
+			if   (cdo == host or cdo == "."..host or host:sub(-#cdo) == cdo) 
+			 and (cpa == path or cpa == "/" or cpa .. "/" == path:sub(#cpa+1))
+			 and (not c.flags.secure or pr == "https")
+			then
+				cookiedata[#cookiedata+1] = c.key .. "=" .. c.value
+			end 
+		end
+		if headers["Cookie"] then
+			headers["Cookie"] = headers["Cookie"] .. "; " .. table.concat(cookiedata, "; ")
+		else
+			headers["Cookie"] = table.concat(cookiedata, "; ")
+		end
+	end
+
 	-- Assemble message
 	local message = {(options.method or "GET") .. " " .. path .. " " .. protocol}
 	
@@ -188,20 +207,7 @@ function request_raw(uri, options)
 			end
 		end
 	end
-	
-	if options.cookies then
-		for _, c in ipairs(options.cookies) do
-			local cdo = c.flags.domain
-			local cpa = c.flags.path
-			if   (cdo == host or cdo == "."..host or host:sub(-#cdo) == cdo) 
-			 and (cpa == path or cpa == "/" or cpa .. "/" == path:sub(#cpa+1))
-			 and (not c.flags.secure or pr == "https")
-			then
-				message[#message+1] = "Cookie: " .. c.key .. "=" .. c.value
-			end 
-		end
-	end
-	
+
 	message[#message+1] = ""
 	message[#message+1] = ""
 	


### PR DESCRIPTION
commit c30cf9abd4e1e46731e36552ae2f459a27c5cf46
Fix response body only have partial content when under a slow network

commit b6d4f32dcc4bba2645d3758c3dc027fe0e2b4d14
Send cookies in a single header line, which follow browsers' behavior. If not, cookies may not be recognized by some webserver.

commit 3dbdff70960ec8c7de7d5a54721a560941627e0b
add params support in options, it is convenient to user.

Signed-off-by: Yuzo <hyzgog@gmail.com>