### PR TITLE
themes/bootstrap: add media queries to bootstrap-theme for better responsive UI on mobile devices

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
@@ -1,3 +1,21 @@
 header h3 a, header .brand {
 	display:none !important;
 }
+
+@media screen and (max-device-width: 600px) {
+	#maincontent.container {
+		margin-top: 30px;
+	}
+}
+
+@media screen and (max-device-width: 360px) {
+	#maincontent.container {
+		margin-top: 60px;
+	}
+}
+
+@media screen and (max-device-width: 200px) {
+	#maincontent.container {
+		margin-top: 230px;
+	}
+}


### PR DESCRIPTION
This is a workaround to prevent the navigation bar from covering the title of the section below on mobile browsers.
Let's just have a look. 

**Before:**
![screenshot_2015-02-28-23-52-59](https://cloud.githubusercontent.com/assets/1352729/6426763/3dcb7b94-bfa5-11e4-9dd7-c12c954b8a89.png)
The title of STATUS was gone.

**After:** 
![screenshot_2015-02-28-23-00-38](https://cloud.githubusercontent.com/assets/1352729/6426775/96925f0e-bfa5-11e4-9cd6-08e7aff0c9ea.png)
The title of STATUS appeared.

I have tested some other languages like Simplified Chinese, etc, and they just work fine. But this is just an workaround.

Dear all,
I've heard that this year freifunk provide an idea of [LuCI Bootstrap3 Theme](http://wiki.freifunk.net/Ideas#LuCI_Bootstrap3_Theme) for [GSoC 2015](https://www.google-melange.com/gsoc/homepage/google/gsoc2015).
Could someone tell me who would be mentors of LuCI or someone reponsible for that? I really want to participate in this idea?

Thank you and kind regards,
Wensheng Tang