### PR TITLE
theme/bootstrap: add a mssing class style in form section (#298)

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -421,6 +421,10 @@ fieldset legend {
 	/* IE6-7 */
 
 }
+form .cbi-tab-descr {
+	line-height: 18px;
+	margin-bottom: 18px;
+}
 
 form .clearfix,
 form .cbi-value {
@@ -1929,9 +1933,9 @@ td.cbi-value-field var {
 	float: left;
 }
 
-.uci-change-legend-label>ins,
-.uci-change-legend-label>del,
-.uci-change-legend-label>var {
+.uci-change-legend-label > ins,
+.uci-change-legend-label > del,
+.uci-change-legend-label > var {
 	float: left;
 	margin-right: 4px;
 	width: 10px;


### PR DESCRIPTION
NOTE: three <br /> in some luci-app's cbi-tab-descr section which help
to workaround must be removed. Check issue #298 

And may I know about some LuCI idea (freifunk proposed) of GSoC this year?
I've also post at the end of #333 