### PR TITLE
luci-base: fix wrong pattern of urlencode() (encode '+' properly) #182

### DIFF
--- a/modules/luci-base/luasrc/http/protocol.lua
+++ b/modules/luci-base/luasrc/http/protocol.lua
@@ -72,7 +72,7 @@ function urlencode( str )
 
 	if type(str) == "string" then
 		str = str:gsub(
-			"([^a-zA-Z0-9$_%-%.%+!*'(),])",
+			"([^a-zA-Z0-9$_%-%.!*'(),])",
 			__chrenc
 		)
 	end


### PR DESCRIPTION
urldecode(urlencode(s)) == s

if s contains '+'