### PR TITLE
ifaces.lua:fix generating /etc/config/dhcp section

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
@@ -135,7 +135,7 @@ end
 
 -- dhcp setup was requested, create section and reload page
 if m:formvalue("cbid.dhcp._enable._enable") then
-	m.uci:section("dhcp", "dhcp", nil, {
+	m.uci:section("dhcp", "dhcp", arg[1], {
 		interface = arg[1],
 		start     = "100",
 		limit     = "150",


### PR DESCRIPTION
modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua:138
generating /etc/config/dhcp section:
>config dhcp
>	option interface 'lan2'
Fix:
>config dhcp 'lan2'
>	option interface 'lan2'