### PR TITLE
luci-statistics: fix uhttpd log spam from extra png close

### DIFF
--- a/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
+++ b/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
@@ -150,7 +150,6 @@ function statistics_render()
 		if png then
 			luci.http.prepare_content("image/png")
 			l12.pump.all(l12.source.file(png), luci.http.write)
-			png:close()
 		end
 		return
 	end


### PR DESCRIPTION
Fix log spam that uhttpd logging change has brought to surface.
```
Sun Mar  1 11:10:42 2015 daemon.err uhttpd[2293]: /usr/lib/lua/luci/dispatcher.lua:433: Failed to execute call dispatcher target for entry '/admin/statistics/graph/conntrack'.
Sun Mar  1 11:10:42 2015 daemon.err uhttpd[2293]: The called action terminated with an exception:
Sun Mar  1 11:10:42 2015 daemon.err uhttpd[2293]: .../luci/controller/luci_statistics/luci_statistics.lua:153: attempt to use a closed file
```
Closing the png file explicitly on line 153 is unnecessary, as ltn12's source.file method already closes the file after use.
https://github.com/openwrt/luci/blob/master/modules/luci-base/luasrc/ltn12.lua#L119

More info at https://dev.openwrt.org/ticket/19083#comment:2

Signed-off-by: Hannu Nyman <hannu.nyman@iki.fi>