### PR TITLE
Fixed default DNS settings for community Potsdam

### DIFF
--- a/contrib/package/community-profiles/files/etc/config/profile_potsdam
+++ b/contrib/package/community-profiles/files/etc/config/profile_potsdam
@@ -13,3 +13,7 @@ config 'defaults' 'wifi_device'
 
 config 'defaults' 'bssidscheme'
 	option '5' '02:CA:FF:EE:BA:BE'
+
+config 'defaults' 'interface'
+        option 'dns' '85.214.20.141 213.73.91.35 194.150.168.168'
+


### PR DESCRIPTION
Without this the router remains dyfunctional when selecting community Potsdam.