### PR TITLE
Add initial luci-app-fwknopd - a way to control the firewall knock daemon from luci

### DIFF
--- a/applications/luci-app-fwknopd/Makefile
+++ b/applications/luci-app-fwknopd/Makefile
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2015 The LuCI Team <luci@lists.subsignal.org>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Fwknopd config - web config for the firewall knock daemon
+LUCI_DEPENDS:=+fwknopd
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-fwknopd/luasrc/controller/fwknopd.lua
+++ b/applications/luci-app-fwknopd/luasrc/controller/fwknopd.lua
@@ -1,0 +1,15 @@
+-- Copyright 2015 Jonathan Bennett <jbennett@incomsystems.biz>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.controller.fwknopd", package.seeall)
+
+function index()
+	if not nixio.fs.access("/etc/config/fwknopd") then
+		return
+	end
+
+	local page
+
+	page = entry({"admin", "services", "fwknopd"}, cbi("fwknopd"), _("Firewall Knock Daemon"))
+	page.dependent = true
+end

--- a/applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua
+++ b/applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua
@@ -1,0 +1,22 @@
+-- Copyright 2015 Jonathan Bennett <jbennett@incomsystems.biz>
+-- Licensed to the public under the Apache License 2.0.
+
+m = Map("fwknopd", translate("Firewall Knock Operator"))
+
+s = m:section(TypedSection, "global", "Enable Uci/Luci control") -- Set uci control on or off
+s.anonymous=true
+s:option(Flag, "uci_enabled", "Enable config overwrite", "When unchecked, the config files in /etc/fwknopd will be used as is, ignoring any settings here.")
+
+s = m:section(TypedSection, "access", "access.conf stanzas") -- set the access.conf settings
+s.anonymous=true
+s.addremove=true
+s.dynamic=true
+s:option(Value, "SOURCE", "SOURCE", "Use ANY for any source ip")
+s:option(Value, "HMAC_KEY", "HMAC_KEY", "The hmac key")
+s:option(Value, "KEY", "KEY", "The spa key")
+
+s = m:section(TypedSection, "config", "general config options") -- set the access.conf settings
+s.anonymous=true
+s.dynamic=true
+s:option(Value, "MAX_SPA_PACKET_AGE", "MAX_SPA_PACKET_AGE", "Maximum age in seconds that an SPA packet will be accepted (defaults to 120 seconds)")
+return m


### PR DESCRIPTION
Signed-off-by: Jonathan Bennett <jbennett@incomsystems.biz>

This application depends on an update to the fwknop package, currently pull request 1244 for openwrt/packages. Any corrections or comments welcome.

~Jonathan Bennett