### PR TITLE
luci-app-firewall: add masq6 option for zones

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/zone-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/zone-details.lua
@@ -88,7 +88,8 @@ for i, v in ipairs(p) do
 	v:value("ACCEPT", translate("accept"))
 end
 
-s:taboption("general", Flag, "masq", translate("Masquerading"))
+s:taboption("general", Flag, "masq", translate("IPv4 Masquerading"))
+s:taboption("general", Flag, "masq6", translate("IPv6 Masquerading"))
 s:taboption("general", Flag, "mtu_fix", translate("MSS clamping"))
 
 net = s:taboption("general", Value, "network", translate("Covered networks"))

--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/zones.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/zones.lua
@@ -71,7 +71,8 @@ for i, v in ipairs(p) do
 	v:value("ACCEPT", translate("accept"))
 end
 
-s:option(Flag, "masq", translate("Masquerading"))
+s:option(Flag, "masq", translate("IPv4 Masquerading"))
+s:option(Flag, "masq6", translate("IPv6 Masquerading"))
 s:option(Flag, "mtu_fix", translate("MSS clamping"))
 
 return m


### PR DESCRIPTION
Depends on a firewall3 patch: [[PATCH v2 0/2] firewall3: add support for IPv6 NAT (i.e. masquerading)](https://lists.openwrt.org/pipermail/openwrt-devel/2015-May/032906.html)

Signed-off-by: Lars Gierth <larsg@systemli.org>