### PR TITLE
Luci-app-fwknopd: Update uci-defaults as key-gen is now exposed in th…

### DIFF
--- a/applications/luci-app-fwknopd/root/etc/uci-defaults/luci-fwknopd
+++ b/applications/luci-app-fwknopd/root/etc/uci-defaults/luci-fwknopd
@@ -8,12 +8,10 @@ uci batch <<EOF
 	commit ucitrack
 EOF
 
-if [ -f /usr/bin/fwknop ]; then
-	uci set fwknopd.@access[0].keytype='Base 64 key'
-	uci set fwknopd.@access[0].hkeytype='Base 64 key'
-	uci set fwknopd.@access[0].KEY_BASE64=`fwknop --key-gen | awk '/^KEY/ {print $2;}'`
-	uci set fwknopd.@access[0].HMAC_KEY_BASE64=`fwknop --key-gen | awk '/^HMAC/ {print $2;}'`
-	uci commit fwknopd
-fi
+uci set fwknopd.@access[0].keytype='Base 64 key'
+uci set fwknopd.@access[0].hkeytype='Base 64 key'
+uci set fwknopd.@access[0].KEY_BASE64=`fwknopd --key-gen | awk '/^KEY/ {print $2;}'`
+uci set fwknopd.@access[0].HMAC_KEY_BASE64=`fwknopd --key-gen | awk '/^HMAC/ {print $2;}'`
+uci commit fwknopd
 rm -f /tmp/luci-indexcache
 exit 0


### PR DESCRIPTION
…e fwknopd binary

Signed-off-by: Jonathan Bennett <jbennett@incomsystems.biz>

@jow- This fix depends on pull request 1284 in the packages repo. It also needs to go into the for-15.05 branch. I can cherrypick and make another pull request, or you can just push it. 

Thanks,
Jonathan