### PR TITLE
luci-lib-json: ignore null keys to allow encoding empty objects

### DIFF
--- a/libs/luci-lib-json/luasrc/json.lua
+++ b/libs/luci-lib-json/luasrc/json.lua
@@ -149,11 +149,13 @@ function Encoder.parse_iter(self, obj)
 		local first = true
 
 		for key, entry in pairs(obj) do
-			first = first or self:put(",")
-			first = first and false
-			self:parse_string(tostring(key))
-			self:put(":")
-			self:dispatch(entry)
+			if key ~= null then
+				first = first or self:put(",")
+				first = first and false
+				self:parse_string(tostring(key))
+				self:put(":")
+				self:dispatch(entry)
+			end
 		end
 
 		self:put("}")


### PR DESCRIPTION
There is currently no way to encode an empty object {}, as empty tables are
encoded as empty lists [].

With this patch, encode() will ignore table fields with the key json.null (which
doesn't make sense anyways). This allows adding a field with key json.null to
force encoding it as an object.

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>