### PR TITLE
luci-app-qos: remove l7 options

### DIFF
--- a/applications/luci-app-qos/luasrc/model/cbi/qos/qos.lua
+++ b/applications/luci-app-qos/luasrc/model/cbi/qos/qos.lua
@@ -53,25 +53,6 @@ dsth.rmempty = true
 dsth:value("", translate("all"))
 wa.cbi_add_knownips(dsth)
 
-l7 = s:option(ListValue, "layer7", translate("Service"))
-l7.rmempty = true
-l7:value("", translate("all"))
-
-local pats = io.popen("find /etc/l7-protocols/ -type f -name '*.pat'")
-if pats then
-	local l
-	while true do
-		l = pats:read("*l")
-		if not l then break end
-
-		l = l:match("([^/]+)%.pat$")
-		if l then
-			l7:value(l)
-		end
-	end
-	pats:close()
-end
-
 p = s:option(Value, "proto", translate("Protocol"))
 p:value("", translate("all"))
 p:value("tcp", "TCP")


### PR DESCRIPTION
Cleanup luci-app-qos, as it still contains references to l7 functionality that has been removed both from kernel and from qos-scripts.

Qos config page has a non-functional "Service" option and every visit to qos config page generates currently an error as no l7 files can be found.

     daemon.err uhttpd[2285]: find: /etc/l7-protocols/: No such file or directory

Patch removes "Service" option and the l7 file search.

Signed-off-by: Hannu Nyman <hannu.nyman@iki.fi>

@jow- 
Should I create a separate PR for for-15.05 branch ?
