### PR TITLE
luci-app-upnp: Stop sys upgrade disabling miniupnpd service on first boot after upgrade

### DIFF
--- a/applications/luci-app-upnp/root/etc/uci-defaults/luci-upnp
+++ b/applications/luci-app-upnp/root/etc/uci-defaults/luci-upnp
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-/etc/init.d/miniupnpd enabled && {
-	/etc/init.d/miniupnpd stop
-	/etc/init.d/miniupnpd disable
-}
-
-rm -f /tmp/luci-indexcache
-exit 0


### PR DESCRIPTION
Stop sys upgrade disabling miniupnpd service on first boot after upgrade.
I spent a lot of time tracking this behaviour down which only occurs if you have luci-app-upnp installed.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk> 