### PR TITLE
luci-app-vnstat: Fix blank graphs for iface names with underscores

### DIFF
--- a/applications/luci-app-vnstat/luasrc/view/vnstat.htm
+++ b/applications/luci-app-vnstat/luasrc/view/vnstat.htm
@@ -22,7 +22,7 @@ style = (style and #style > 0) and style or "s"
 --
 if iface then
 	style = style:gsub("[^%w]", "")
-	iface = iface:gsub("[^%w%.%-]", "")
+	iface = iface:gsub("[^%w%.%-%_]", "")
 
 	luci.http.prepare_content("image/png")
 


### PR DESCRIPTION
The regex used to process the iface query string argument in
vnstat.htm was stripping underscores, which caused the graph not to
display for interfaces with names containing underscores.  This
patch adds the underscore to that regex so that the interface name
will be correct and the graph will be displayed.

Signed-off-by: Michael Marley <michael@michaelmarley.com>