### PR TITLE
cbi.lua: Fix Flag.parse() to set "self.section.changed"

### DIFF
--- a/modules/luci-base/luasrc/cbi.lua
+++ b/modules/luci-base/luasrc/cbi.lua
@@ -1533,13 +1533,16 @@ function Flag.parse(self, section)
 
 	if fexists then
 		local fvalue = self:formvalue(section) and self.enabled or self.disabled
+		local cvalue = self:cfgvalue(section)
 		if fvalue ~= self.default or (not self.optional and not self.rmempty) then
 			self:write(section, fvalue)
 		else
 			self:remove(section)
 		end
+		if (fvalue ~= cvalue) then self.section.changed = true end
 	else
 		self:remove(section)
+		self.section.changed = true
 	end
 end
 


### PR DESCRIPTION
Add setting "self.section.changed" on changes like other values do.

Signed-off-by: Christian Schoenebeck <<hristian.schoenebeck@gmail.com>>