### PR TITLE
statistics: fix conntrack and ping regression caused by collectd changes

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/conntrack.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/conntrack.lua
@@ -9,6 +9,10 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		vlabel = "Count",
 		number_format = "%5.0lf",
 		data = {
+			-- collectd 5.5+: specify "" to exclude "max" instance
+			instances = {
+				conntrack = { "" }
+			},
 			sources = {
 				conntrack = { "value" }
 			},

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
@@ -9,7 +9,7 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		{ title = "%H: ICMP Round Trip Time", vlabel = "ms",
 		  number_format = "%5.1lf ms", data = {
 			sources = { ping = { "value" } },
-			options = { ping__ping = { noarea = true, title = "%di" } }
+			options = { ping__value = { noarea = true, title = "%di" } }
 		} },
 
 		-- Ping droprate


### PR DESCRIPTION
Collectd 5.5.0  (https://github.com/openwrt/packages/pull/1575)  introduced new data to conntrack plugin (https://github.com/collectd/collectd/commit/c66eedcd0cae3019928e03c9c38538fca10d59c8): 
In addition to the number of the tracked connections there is also the static max conntrack limit value and the calculated use percentage.

Luci statistics's conntrack plugin interpretes "conntrack-max" as a new data instance and includes it in the graph in addition to the real "conntrack" number.

Eliminate "max" from graph by specifying empty "" instance as data source.

Ps. The plugin might later be expanded to show also the percentage graph, but as the max value is usually static, it would not provide much additional value.