### PR TITLE
statistics: fix ping graph label regression

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
@@ -9,7 +9,7 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		{ title = "%H: ICMP Round Trip Time", vlabel = "ms",
 		  number_format = "%5.1lf ms", data = {
 			sources = { ping = { "value" } },
-			options = { ping__ping = { noarea = true, title = "%di" } }
+			options = { ping__value = { noarea = true, title = "%di" } }
 		} },
 
 		-- Ping droprate


### PR DESCRIPTION
Backport of the relevant part of #444 

Update to collectd 5.4.1 changed the field from "ping" to "value",
which was changed in the graph definition here, but the label definition
was forgotten. Field's label now reads "ping_IPaddr_value".

Correct the label definition to show only IPaddr like the other two graphs.


@jow- 
