### PR TITLE
Enable setting --script-security in client mode.

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -48,7 +48,7 @@ local knownParams = {
 		{ Flag,			"client_disconnect",			0,																translate("Run script cmd on client disconnection") },
 		{ Value,		"learn_address",				"/usr/bin/ovpn-learnaddress",									translate("Executed in server mode whenever an IPv4 address/route or MAC address is added to OpenVPN's internal routing table") },
 		{ Value,		"auth_user_pass_verify",		"/usr/bin/ovpn-userpass via-env",								translate("Executed in server mode on new client connections, when the client is still untrusted") },
-		{ ListValue,	"script_security",				{ 0, 1, 2, 3 },													translate("Policy level over usage of external programs and scripts"),	{mode="server" } },
+		{ ListValue,	"script_security",				{ 0, 1, 2, 3 },													translate("Policy level over usage of external programs and scripts") },
 	} },
 
 	{ "Networking", {


### PR DESCRIPTION
  This is useful in client mode as well, since it allows one to use --route-noexec and --up <cmd> or --route-up <cmd> to create routes manually instead of relying on whatever routes vpn server pushes down to the client.
  mode=server dependency in luci was introduced together with script_security by mmunz back in 2011, with no explanation in the commit why mode=server was there.