### PR TITLE
statistics: cpu graph - add label definitions, add softirq and interrupt stats

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/cpu.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/cpu.lua
@@ -12,18 +12,18 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		number_format = "%5.1lf%%",
 		data = {
 			instances = { 
-				cpu = { "idle", "user", "system", "nice" }
+				cpu = { "idle", "user", "nice", "system", "softirq", "interrupt" }
 			},
 
 			options = {
-				cpu_idle      = { color = "ffffff" },
-				cpu_nice      = { color = "00e000" },
-				cpu_user      = { color = "0000ff" },
-				cpu_wait      = { color = "ffb000" },
-				cpu_system    = { color = "ff0000" },
-				cpu_softirq   = { color = "ff00ff" },
-				cpu_interrupt = { color = "a000a0" },
-				cpu_steal     = { color = "000000" }
+				cpu_idle      = { color = "ffffff", title = "Idle" },
+				cpu_nice      = { color = "00e000", title = "Nice" },
+				cpu_user      = { color = "0000ff", title = "User" },
+				cpu_wait      = { color = "ffb000", title = "Wait" },
+				cpu_system    = { color = "ff0000", title = "System" },
+				cpu_softirq   = { color = "ff00ff", title = "Softirq" },
+				cpu_interrupt = { color = "a000a0", title = "Interrupt" },
+				cpu_steal     = { color = "000000", title = "Steal" }
 			}
 		}
 	}


### PR DESCRIPTION
CPU plugin in the Luci statistics was missing the label definitions,
so the field labels are like "cpu_system" instead of "System".
Add proper label definitions to CPU (like the other plugins already have).

The statistics graph was also missing softirq and interrupt stats, although colors
for them were defined. Softirq consumes massive amount of CPU especially with
any qos in use, so it is important for the user to see also that data. Add both
softirq and interrupt stats to the graph.
