### PR TITLE
statistics: support better autoscaling in rrdtool, improve memory graph's y-axis

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
@@ -457,6 +457,12 @@ function Graph._generic( self, opts, plugin, plugin_instance, dtype, index )
 			_ti ( _args, "-X" )
 			_ti ( _args, opts.units_exponent )
 		end
+		if opts.alt_autoscale then
+			_ti ( _args, "-A" )
+		end
+		if opts.alt_autoscale_max then
+			_ti ( _args, "-M" )
+		end
 
 		-- store additional rrd options
 		if opts.rrdopts then

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/memory.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/memory.lua
@@ -17,6 +17,8 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		title = "%H: Memory usage",
 		vlabel = "MB",
 		number_format = "%5.1lf%s",
+		y_min = "0",
+		alt_autoscale_max = true,
 		data = {
 			instances = { 
 				memory = { "free", "buffered", "cached", "used" }


### PR DESCRIPTION
* Implement support in Luci statistics for alternative scaling of the y-axis. By default, rrdtool will autoscale to 1,2,5,10,20,50,100,200,... etc., which is not always suitable (e.g. memory charts for a device with 128 MB). Rrdtool 1.0.50 already supports alternative autoscaling that creates a tighter y-axis (info at http://oss.oetiker.ch/rrdtool/doc/rrdgraph.en.html ). Implement graph-level options in Luci statistics to support those boolean options as "alt_autoscale" and "alt_autoscale_max". 

* Memory plugin: utilise alt_autoscale_max to make the memory chart y-axis to scale better for devices with e.g. 128 MB RAM. Also fix the axis min value to 0 to better show the "Used" memory.

Original scaling (axis 20-200):
![memorygraph_bad_scaling](https://cloud.githubusercontent.com/assets/7926856/9429547/976ce0c2-49dc-11e5-958a-2ebaaa2741a2.PNG)

Modified scaling (axis 0-140):
![memorygraph_fixed_scaling](https://cloud.githubusercontent.com/assets/7926856/9429549/9e866a72-49dc-11e5-9cbd-d25b72d6a833.PNG)
