### PR TITLE
luci-app-firewall: validate zone name to enforce fw3 max. length

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/zone-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/zone-details.lua
@@ -76,6 +76,15 @@ function name.write(self, section, value)
 	}
 end
 
+function name.validate(self, value)
+	-- fw3 defines 14 as the maximum length of zone name
+	if #value > 14 then
+		return nil, translate("Zone name is too long")
+	else
+		return value
+	end
+end
+
 p = {
 	s:taboption("general", ListValue, "input", translate("Input")),
 	s:taboption("general", ListValue, "output", translate("Output")),


### PR DESCRIPTION
fw3 sets the maximum length of the zone name to 14 and ignores zone definitions with too long names.
http://nbd.name/gitweb.cgi?p=firewall3.git;a=blob;f=zones.h;hb=HEAD#l25
http://nbd.name/gitweb.cgi?p=firewall3.git;a=blob;f=zones.c;hb=HEAD#l195

Add a simple validation to ensure that the new zone name is short enough.
This should fix issue #345
