### PR TITLE
statistics: Add support for entropy stats

### DIFF
--- a/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
+++ b/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
@@ -30,6 +30,7 @@ function index()
 		disk		= _("Disk Usage"),
 		dns			= _("DNS"),
 		email		= _("Email"),
+		entropy		= _("Entropy"),
 		exec		= _("Exec"),
 		interface	= _("Interfaces"),
 		iptables	= _("Firewall"),
@@ -53,7 +54,7 @@ function index()
 	-- our collectd menu
 	local collectd_menu = {
 		output  = { "csv", "network", "rrdtool", "unixsock" },
-		system  = { "cpu", "df", "disk", "email", "exec", "irq", "load", "memory", "nut", "processes", "uptime" },
+		system  = { "cpu", "df", "disk", "email", "entropy", "exec", "irq", "load", "memory", "nut", "processes", "uptime" },
 		network = { "conntrack", "dns", "interface", "iptables", "netlink", "olsrd", "ping", "splash_leases", "tcpconns", "iwinfo" }
 	}
 

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/entropy.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/entropy.lua
@@ -1,0 +1,14 @@
+-- Copyright 2015 Hannu Nyman <hannu.nyman@iki.fi>
+-- Licensed to the public under the Apache License 2.0.
+
+m = Map("luci_statistics",
+	translate("Entropy Plugin Configuration"),
+	translate("The entropy plugin collects statistics about the available entropy."))
+
+s = m:section( NamedSection, "collectd_entropy", "luci_statistics" )
+
+enable = s:option( Flag, "enable", translate("Enable this plugin") )
+enable.default = 0
+
+return m
+

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/entropy.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/entropy.lua
@@ -1,0 +1,19 @@
+-- Copyright 2015 Hannu Nyman <hannu.nyman@iki.fi>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.statistics.rrdtool.definitions.entropy", package.seeall)
+
+function rrdargs( graph, plugin, plugin_instance, dtype )
+
+	return {
+		title = "%H: Available entropy",
+		vlabel = "bits",
+		number_format = "%4.0lf",
+		data = {
+			types = { "entropy" },
+			options = { entropy = { title = "Entropy %di" } }
+		}
+	}
+
+end
+

--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -45,6 +45,9 @@ config 'statistics' 'collectd_email'
 	option 'SocketFile' '/var/run/collectd/email.sock'
 	option 'SocketGroup' 'nogroup'
 
+config 'statistics' 'collectd_entropy'
+	option 'enable' '0'
+
 config 'statistics' 'collectd_exec'
 	option 'enable' '0'
 

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -303,6 +303,12 @@ plugins = {
 		{ }
 	},
 
+	entropy = {
+		{ },
+		{ },
+		{ }
+	},
+
 	exec	= config_exec,
 
 	interface = {


### PR DESCRIPTION
Add statistics on the available entropy into Luci statistics.

This PR utilises collectd-mod-entropy, which was created by https://github.com/openwrt/packages/pull/1717

The amount of entropy is typically rather limited in embedded systems. Monitoring the available entropy might be useful in some debugging situations.

Example graph:
![entropy-plugin](https://cloud.githubusercontent.com/assets/7926856/9514873/2f86de8c-4ca6-11e5-91cd-d8afe0839d8e.png)


