### PR TITLE
for-15.05: statistics: Backport recent improvements

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
@@ -457,6 +457,12 @@ function Graph._generic( self, opts, plugin, plugin_instance, dtype, index )
 			_ti ( _args, "-X" )
 			_ti ( _args, opts.units_exponent )
 		end
+		if opts.alt_autoscale then
+			_ti ( _args, "-A" )
+		end
+		if opts.alt_autoscale_max then
+			_ti ( _args, "-M" )
+		end
 
 		-- store additional rrd options
 		if opts.rrdopts then

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/cpu.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/cpu.lua
@@ -12,18 +12,18 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		number_format = "%5.1lf%%",
 		data = {
 			instances = { 
-				cpu = { "idle", "user", "system", "nice" }
+				cpu = { "idle", "user", "nice", "system", "softirq", "interrupt" }
 			},
 
 			options = {
-				cpu_idle      = { color = "ffffff" },
-				cpu_nice      = { color = "00e000" },
-				cpu_user      = { color = "0000ff" },
-				cpu_wait      = { color = "ffb000" },
-				cpu_system    = { color = "ff0000" },
-				cpu_softirq   = { color = "ff00ff" },
-				cpu_interrupt = { color = "a000a0" },
-				cpu_steal     = { color = "000000" }
+				cpu_idle      = { color = "ffffff", title = "Idle" },
+				cpu_nice      = { color = "00e000", title = "Nice" },
+				cpu_user      = { color = "0000ff", title = "User" },
+				cpu_wait      = { color = "ffb000", title = "Wait" },
+				cpu_system    = { color = "ff0000", title = "System" },
+				cpu_softirq   = { color = "ff00ff", title = "Softirq" },
+				cpu_interrupt = { color = "a000a0", title = "Interrupt" },
+				cpu_steal     = { color = "000000", title = "Steal" }
 			}
 		}
 	}

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/cpu.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/cpu.lua
@@ -8,11 +8,12 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 	return {
 		title = "%H: Processor usage on core #%pi",
 		y_min = "0",
+		alt_autoscale_max = true,
 		vlabel = "Percent",
 		number_format = "%5.1lf%%",
 		data = {
 			instances = { 
-				cpu = { "idle", "user", "nice", "system", "softirq", "interrupt" }
+				cpu = { "user", "nice", "system", "softirq", "interrupt" }
 			},
 
 			options = {

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/memory.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/memory.lua
@@ -17,6 +17,8 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		title = "%H: Memory usage",
 		vlabel = "MB",
 		number_format = "%5.1lf%s",
+		y_min = "0",
+		alt_autoscale_max = true,
 		data = {
 			instances = { 
 				memory = { "free", "buffered", "cached", "used" }

--- a/applications/luci-app-statistics/luasrc/view/admin_statistics/index.htm
+++ b/applications/luci-app-statistics/luasrc/view/admin_statistics/index.htm
@@ -8,7 +8,10 @@
 
 <h2><a id="content" name="content"><%:Statistics%></a></h2>
 
-<p><%_The statistics package is based on <a href="http://collectd.org/index.shtml">Collectd</a>
-and uses <a href="http://oss.oetiker.ch/rrdtool/">RRD Tool</a> to render diagram images from collected data.%></p>
+<p><%_The statistics package uses <a href="https://collectd.org/">Collectd</a>
+to gather data and <a href="http://oss.oetiker.ch/rrdtool/">RRDtool</a> to
+render diagram images.%></p>
+
+<p><%_You can install additional collectd-mod-* plugins to enable more statistics.%></p>
 
 <%+footer%>


### PR DESCRIPTION
Backport the small improvements/tweaks in luci-app-statistics from trunk to for-15.05.

* Clarify statistics section introduction
* support rrdtool's alt_autoscale and alt_autoscale_max options in graph definitions
* memory graph: improve y-axis scaling
* cpu graph: add proper titles to legend, remove idle and add softirq & interrupt data items

