### PR TITLE
Luci opkg/packages: Limit version string display to 26 chars

### DIFF
--- a/modules/luci-base/luasrc/model/ipkg.lua
+++ b/modules/luci-base/luasrc/model/ipkg.lua
@@ -139,6 +139,10 @@ local function _list(action, pat, cb)
 				desc = ""
 			end
 
+			if #version > 26 then
+				version = version:sub(1,21) .. ".." .. version:sub(-3,-1)
+			end
+
 			cb(name, version, desc)
 
 			name    = nil


### PR DESCRIPTION
Many packages currently include a git commit hash in version string.
That makes version strings very long and the version column takes much space
when listing available/installed packages in Luci.

Longest version string is 58 characters (micropython).
85 packages have at least 50 chars and 150 packages at least 40 chars.

Adjust Luci to display max. 26 characters (= luci's own version string).

Longer version strings are cut to: "first 21c" + ".." + "last 3c"

The last 3 chars are used to preserve the possible PKG_REVISION string.
E.g. 'opkg' has only hash+PKG_REVISION, so using only start of the string
might not be optimal.

Examples:

1.3.10-20150302-f2a889564b3a215902622b040a1247af38cb8203-1
1.3.10-20150302-f2a88..3-1

0.1-20150302-654c7d288603f7dae09eb09b57fb67b38c7ac6c3-1
0.1-20150302-654c7d28..3-1

9c97d5ecd795709c8584e972bfdf3aee3a5b846d-7
9c97d5ecd795709c8584e..d-7
