### PR TITLE
modules/luci-mod-rpc: fix #466 #427 attempt to index global 'luci' (a nil value) 

### DIFF
--- a/modules/luci-mod-rpc/luasrc/controller/rpc.lua
+++ b/modules/luci-mod-rpc/luasrc/controller/rpc.lua
@@ -49,10 +49,10 @@ function rpc_auth()
 	server.challenge = function(user, pass)
 		local sid, token, secret
 
-		require "luci.config"
+		local config = require "luci.config"
 
 		if sys.user.checkpasswd(user, pass) then
-			local sdat = util.ubus("session", "create", { timeout = luci.config.sauth.sessiontime })
+			local sdat = util.ubus("session", "create", { timeout = config.sauth.sessiontime })
 			if sdat then
 				sid = sdat.ubus_rpc_session
 				token = sys.uniqueid(16)


### PR DESCRIPTION
Calling auth  method returns:

```
HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: application/json
Cache-Control: no-cache
Expires: 0

{"id":1,"error":{"message":"Invalid params.","data":"/usr/lib/lua/luci/controller/rpc.lua:53: attempt to index global 'luci' (a nil value)","code":-32602},"jsonrpc":"2.0"}
```

with fff7c6c

````
HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: application/json
Set-Cookie: sysauth=e37acdcb0f23ea40bb0d98fce88e0309; path=/
Cache-Control: no-cache
Expires: 0

{"id":1,"jsonrpc":"2.0","result":"e37acdcb0f23ea40bb0d98fce88e0309"}
```

Ref: https://dev.openwrt.org/ticket/20361#no2