### PR TITLE
luci-mod-admin-full: restore opkg feed config capability

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/ipkg.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/ipkg.lua
@@ -3,8 +3,10 @@
 -- Licensed to the public under the Apache License 2.0.
 
 local ipkgfile = "/etc/opkg.conf"
+local distfeeds = "/etc/opkg/distfeeds.conf"
+local customfeeds = "/etc/opkg/customfeeds.conf"
 
-f = SimpleForm("ipkgconf", translate("OPKG-Configuration"))
+f = SimpleForm("ipkgconf", translate("OPKG-Configuration"), translate("General options for opkg"))
 
 f:append(Template("admin_system/ipkg"))
 
@@ -22,4 +24,38 @@ function f.handle(self, state, data)
 	return true
 end
 
-return f
+g = SimpleForm("distfeedconf", translate("Distribution feeds"),
+	translate("Build/distribution specific feed definitions. This file will NOT be preserved in any sysupgrade."))
+
+d = g:field(TextValue, "lines2")
+d.rows = 10
+function d.cfgvalue()
+	return nixio.fs.readfile(distfeeds) or ""
+end
+
+function d.write(self, section, data)
+	return nixio.fs.writefile(distfeeds, data:gsub("\r\n", "\n"))
+end
+
+function g.handle(self, state, data)
+	return true
+end
+
+h = SimpleForm("customfeedconf", translate("Custom feeds"),
+	translate("Custom feed definitions, e.g. private feeds. This file can be preserved in a sysupgrade."))
+
+c = h:field(TextValue, "lines3")
+c.rows = 10
+function c.cfgvalue()
+	return nixio.fs.readfile(customfeeds) or ""
+end
+
+function c.write(self, section, data)
+	return nixio.fs.writefile(customfeeds, data:gsub("\r\n", "\n"))
+end
+
+function h.handle(self, state, data)
+	return true
+end
+
+return f, g, h


### PR DESCRIPTION
opkg config was recently changed by https://dev.openwrt.org/changeset/46491/

Existing /etc/opkg.conf was split to three:
   /etc/opkg.conf -> base opkg configuration
   /etc/opkg/distfeeds.conf -> default Openwrt package feeds
   /etc/opkg/customfeeds.conf -> custom package feeds

Since then, the actual feed definitions have not been visible/configurable, as only /etc/opkg.conf has been visible in Luci.

This patch restores the capability to see and edit package feed definitions.

@jow- 
Could you please check this up, and possible polish it a bit. The form works ok, each of the three files can be edited/saved individually, but it looks a bit crude.