### PR TITLE
luci/statistics: Fix nut UPS graphs

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/nut.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/nut.lua
@@ -44,9 +44,6 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		y_max = "100",
 		number_format = "%5.1lf%%",
 		data = {
-		        sources = {
-				percent = { "percent" }
-			},
 			instances = {
 				percent = "charge"
 			},
@@ -77,9 +74,6 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		vlabel = "Minutes",
 		number_format = "%.1lfm",
 		data = {
-			sources = {
-				timeleft = { "timeleft" }
-			},
 			instances = {
 				timeleft = { "battery" }
 			},


### PR DESCRIPTION
At some point since I last checked, the nut plugin for collectd changed the
names of the timeleft and percent datasets. Update the luci module to match
so that those graphs are generated correctly again.

Signed-off-by: David Woodhouse <David.Woodhouse@intel.com>
(cherry picked from commit 41ec4c68adf7e6545aa10b359fea1883bec79b3e)