### PR TITLE
luci-base: change index.html to be more like current themes

### DIFF
--- a/modules/luci-base/root/www/index.html
+++ b/modules/luci-base/root/www/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Cache-Control" content="no-cache" />
 <meta http-equiv="refresh" content="0; URL=/cgi-bin/luci" />
 </head>
-<body style="background-color: black">
-<a style="color: white; text-decoration: none" href="/cgi-bin/luci">LuCI - Lua Configuration Interface</a>
+<body style="background-color: white">
+<a style="color: black; font-family: arial, helvetica, sans-serif;" href="/cgi-bin/luci">LuCI - Lua Configuration Interface</a>
 </body>
 </html>


### PR DESCRIPTION
I propose that the black Luci entrance page (visible for a second) with the black background is changed to have a white background to be more like the other parts of Luci.

The current page dates at least from luci-0.8 in 2008 (https://github.com/openwrt/luci/blob/luci-0.8/libs/sgi-cgi/htdocs/index.html), and the themes at that time may have been darker, but currently the shortly flashing black background seems strange.

The font is left unspecified, so the browser defaults are used. In Windows systems both IE and Firefox use Times New Roman, creating a visible difference to other parts of Luci.

Change index.html that is visible for a second when entering Luci:
* Black text on white background (instead of white on black)
* Specify font as Arial / Helvetica
