### PR TITLE
luci-base: add robots.txt

### DIFF
--- a/modules/luci-base/root/www/robots.txt
+++ b/modules/luci-base/root/www/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
There is no reason to have LuCI crawled by default.