### PR TITLE
applications/asterisk: Remove incorrect dependency

### DIFF
--- a/applications/luci-app-asterisk/Makefile
+++ b/applications/luci-app-asterisk/Makefile
@@ -7,7 +7,6 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Support for Asterisk
-LUCI_DEPENDS:=+ahcpd
 
 include ../../luci.mk
 


### PR DESCRIPTION
ahcpd dependency appears to have come from a cut-n-paste from
luci-app-ahcpd.