### PR TITLE
Redirect to root on empty path

### DIFF
--- a/modules/luci-base/luasrc/http.lua
+++ b/modules/luci-base/luasrc/http.lua
@@ -208,6 +208,7 @@ function splice(fd, size)
 end
 
 function redirect(url)
+	if url == "" then url = "/" end
 	status(302, "Found")
 	header("Location", url)
 	close()


### PR DESCRIPTION
* Prevents an empty Location header
* Useful in environments where build_url() could return an empty string (such as http server rewrites requests to /cgi-bin/luci)