### PR TITLE
cbi: Implement "readonly" property for "Value"

### DIFF
--- a/modules/luci-base/luasrc/cbi.lua
+++ b/modules/luci-base/luasrc/cbi.lua
@@ -1471,6 +1471,7 @@ function Value.__init__(self, ...)
 	self.template  = "cbi/value"
 	self.keylist = {}
 	self.vallist = {}
+	self.readonly = nil
 end
 
 function Value.reset_values(self)
@@ -1484,6 +1485,10 @@ function Value.value(self, key, val)
 	table.insert(self.vallist, tostring(val))
 end
 
+function Value.parse(self, section, novld)
+	if self.readonly then return end
+	AbstractValue.parse(self, section, novld)
+end
 
 -- DummyValue - This does nothing except being there
 DummyValue = class(AbstractValue)

--- a/modules/luci-base/luasrc/view/cbi/value.htm
+++ b/modules/luci-base/luasrc/view/cbi/value.htm
@@ -1,7 +1,7 @@
 <%+cbi/valueheader%>
 	<input type="<%=self.password and 'password" class="cbi-input-password' or 'text" class="cbi-input-text' %>" onchange="cbi_d_update(this.id)"<%=
 		attr("name", cbid) .. attr("id", cbid) .. attr("value", self:cfgvalue(section) or self.default) ..
-		ifattr(self.size, "size") .. ifattr(self.placeholder, "placeholder")
+		ifattr(self.size, "size") .. ifattr(self.placeholder, "placeholder") .. ifattr(self.readonly, "readonly")
 	%> />
 	<% if self.password then %><img src="<%=resource%>/cbi/reload.gif" style="vertical-align:middle" title="<%:Reveal/hide password%>" onclick="var e = document.getElementById('<%=cbid%>'); e.type = (e.type=='password') ? 'text' : 'password';" /><% end %>
 	<% if #self.keylist > 0 or self.datatype then -%>


### PR DESCRIPTION
Either use "DummyValue"
or (optical better) use "Value" with property "readonly" set "true".
modified cbi.lua and template cbi/value.htm

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>