### PR TITLE
luci-app-privoxy: remove map.title hack

### DIFF
--- a/applications/luci-app-privoxy/Makefile
+++ b/applications/luci-app-privoxy/Makefile
@@ -10,11 +10,11 @@ PKG_NAME:=luci-app-privoxy
 
 # Version == major.minor.patch
 # increase "minor" on new functionality and "patch" on patches/optimization
-PKG_VERSION:=1.0.4
+PKG_VERSION:=1.0.5
 
 # Release == build
 # increase on changes of translation files
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
 PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua
+++ b/applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua
@@ -14,7 +14,7 @@ local HELP = [[<a href="http://www.privoxy.org/user-manual/config.html#%s" targe
 local VERINST = CTRL.ipkg_ver_installed("privoxy")
 local VEROK   = CTRL.ipkg_ver_compare(VERINST,">=",CTRL.PRIVOXY_MIN)
 
-local TITLE = [[</a><a href="javascript:alert(']]
+local TITLE = [[<a href="javascript:alert(']]
 		.. translate("Version Information")
 		.. [[\n\nluci-app-privoxy]]
 		.. [[\n\t]] .. translate("Version") .. [[:\t]]
@@ -26,6 +26,7 @@ local TITLE = [[</a><a href="javascript:alert(']]
 		.. [[\n\n]]
  	.. [[')">]]
 	.. translate("Privoxy WEB proxy")
+	.. [[</a>]]
 
 local DESC = translate("Privoxy is a non-caching web proxy with advanced filtering "
 		.. "capabilities for enhancing privacy, modifying web page data and HTTP headers, "


### PR DESCRIPTION
remove map.title hack; no longer needed

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>