### PR TITLE
luci-app-ddns: rollup to 2.3.0 to reflect changes on ddns-scripts

### DIFF
--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua
@@ -5,18 +5,14 @@ local NX   = require "nixio"
 local NXFS = require "nixio.fs"
 local DISP = require "luci.dispatcher"
 local SYS  = require "luci.sys"
+local CTRL = require "luci.controller.ddns"	-- this application's controller
 local DDNS = require "luci.tools.ddns"		-- ddns multiused functions
 
 -- cbi-map definition -- #######################################################
 local m = Map("ddns")
-
-m.title = [[<a href="]] .. DISP.build_url("admin", "services", "ddns") .. [[">]] 
-	.. translate("Dynamic DNS") .. [[</a>]]
-
-m.description = translate("Dynamic DNS allows that your router can be reached with " ..
-			"a fixed hostname while having a dynamically changing IP address.")
-
-m.redirect = DISP.build_url("admin", "services", "ddns")
+m.title		= CTRL.app_title_back()
+m.description	= CTRL.app_description()
+m.redirect	= DISP.build_url("admin", "services", "ddns")
 
 function m.commit_handler(self)
 	if self.changed then	-- changes ?
@@ -52,17 +48,7 @@ ali.description = translate("Non-public and by default blocked IP's") .. ":"
 		.. "0/8, 10/8, 100.64/10, 127/8, 169.254/16, 172.16/12, 192.168/16"
 		.. [[<br /><strong>IPv6: </strong>]]
 		.. "::/32, f000::/4"
-ali.reempty	= true
 ali.default	= "0"
-function ali.parse(self, section)
-	DDNS.flag_parse(self, section)
-end
-function ali.validate(self, value)
-	if value == self.default then
-		return "" -- default = empty
-	end
-	return value
-end
 
 -- date_format  -- #############################################################
 local df	= ns:option(Value, "date_format")
@@ -71,7 +57,6 @@ df.description	= [[<a href="http://www.cplusplus.com/reference/ctime/strftime/" 
 		.. translate("For supported codes look here") 
 		.. [[</a>]]
 df.template	= "ddns/global_value"
-df.rmempty	= true
 df.default	= "%F %R"
 df.date_string	= ""
 function df.cfgvalue(self, section)
@@ -80,54 +65,44 @@ function df.cfgvalue(self, section)
 	self.date_string = DDNS.epoch2date(epoch, value)
 	return value
 end
-function df.validate(self, value)
-	if value == self.default then
-		return "" -- default = empty
-	end
-	return value
+function df.parse(self, section, novld)
+	DDNS.value_parse(self, section, novld)
 end
 
 -- run_dir  -- #################################################################
 local rd	= ns:option(Value, "run_dir")
 rd.title	= translate("Status directory")
 rd.description	= translate("Directory contains PID and other status information for each running section")
-rd.rmempty	= true
 rd.default	= "/var/run/ddns"
-function rd.validate(self, value)
-	if value == self.default then
-		return "" -- default = empty
-	end
-	return value
+-- no need to validate. if empty default is used everything else created by dns-scripts
+function rd.parse(self, section, novld)
+	DDNS.value_parse(self, section, novld)
 end
 
 -- log_dir  -- #################################################################
 local ld	= ns:option(Value, "log_dir")
 ld.title	= translate("Log directory")
 ld.description	= translate("Directory contains Log files for each running section")
-ld.rmempty	= true
 ld.default	= "/var/log/ddns"
-function ld.validate(self, value)
-	if value == self.default then
-		return "" -- default = empty
-	end
-	return value
+-- no need to validate. if empty default is used everything else created by dns-scripts
+function ld.parse(self, section, novld)
+	DDNS.value_parse(self, section, novld)
 end
 
 -- log_lines  -- ###############################################################
 local ll	= ns:option(Value, "log_lines")
 ll.title	= translate("Log length")
 ll.description	= translate("Number of last lines stored in log files")
-ll.rmempty	= true
 ll.default	= "250"
 function ll.validate(self, value)
 	local n = tonumber(value)
 	if not n or math.floor(n) ~= n or n < 1 then
 		return nil, self.title .. ": " .. translate("minimum value '1'")
 	end
-	if value == self.default then
-		return "" -- default = empty
-	end
 	return value
+end
+function ll.parse(self, section, novld)
+	DDNS.value_parse(self, section, novld)
 end
 
 -- use_curl  -- ################################################################
@@ -139,17 +114,7 @@ and NXFS.access("/usr/bin/curl") then
 		.. [[<br />]]
 		.. translate("To use cURL activate this option.")
 	pc.orientation	= "horizontal"
-	pc.rmempty	= true
 	pc.default	= "0"
-	function pc.parse(self, section)
-		DDNS.flag_parse(self, section)
-	end
-	function pc.validate(self, value)
-		if value == self.default then
-			return "" -- default = empty
-		end
-		return value
-	end
 end
 
 return m

--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua
@@ -1,9 +1,9 @@
 -- Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 -- Licensed to the public under the Apache License 2.0.
 
-local CTRL = require "luci.controller.ddns"	-- this application's controller
 local DISP = require "luci.dispatcher"
 local SYS  = require "luci.sys"
+local CTRL = require "luci.controller.ddns"	-- this application's controller
 local DDNS = require "luci.tools.ddns"		-- ddns multiused functions
 
 -- check supported options -- ##################################################
@@ -11,8 +11,6 @@ local DDNS = require "luci.tools.ddns"		-- ddns multiused functions
 has_ssl     = DDNS.check_ssl()		-- HTTPS support and --bind-network / --interface
 has_proxy   = DDNS.check_proxy()	-- Proxy support
 has_dnstcp  = DDNS.check_bind_host()	-- DNS TCP support
--- correct ddns-scripts version
-need_update = DDNS.ipkg_ver_compare(DDNS.ipkg_ver_installed("ddns-scripts"), "<<", CTRL.DDNS_MIN)
 
 -- html constants
 font_red = [[<font color="red">]]
@@ -22,15 +20,9 @@ bold_off = [[</strong>]]
 
 -- cbi-map definition -- #######################################################
 m = Map("ddns")
-
-m.title = [[<a href="]] .. DISP.build_url("admin", "services", "ddns") .. [[">]] ..
-		translate("Dynamic DNS") .. [[</a>]]
-
-m.description = translate("Dynamic DNS allows that your router can be reached with " ..
-			"a fixed hostname while having a dynamically changing " ..
-			"IP address.")
-
-m.redirect = DISP.build_url("admin", "services", "ddns")
+m.title		= CTRL.app_title_back()
+m.description	= CTRL.app_description()
+m.redirect	= DISP.build_url("admin", "services", "ddns")
 
 -- SimpleSection definition -- #################################################
 -- show Hints to optimize installation and script usage
@@ -39,7 +31,7 @@ s = m:section( SimpleSection,
 	translate("Below a list of configuration tips for your system to run Dynamic DNS updates without limitations") )
 
 -- ddns_scripts needs to be updated for full functionality
-if need_update then
+if not CTRL.service_ok() then
 	local dv = s:option(DummyValue, "_update_needed")
 	dv.titleref = DISP.build_url("admin", "system", "packages")
 	dv.rawhtml  = true

--- a/applications/luci-app-ddns/luasrc/view/ddns/detail_logview.htm
+++ b/applications/luci-app-ddns/luasrc/view/ddns/detail_logview.htm
@@ -6,7 +6,7 @@
 		var txt = document.getElementById("cbid.ddns." + section + "._logview.txt");	// TextArea
 		if ( !txt ) { return; }	// security check
 
-		XHR.get('<%=url('admin/services/ddns/logview')%>/' + section, null,
+		XHR.get('<%=url([[admin]], [[services]], [[ddns]], [[logview]])%>/' + section, null,
 			function(x) {
 				if (x.responseText == "_nodata_")
 					txt.value = "<%:File not found or empty%>";

--- a/applications/luci-app-ddns/luasrc/view/ddns/overview_status.htm
+++ b/applications/luci-app-ddns/luasrc/view/ddns/overview_status.htm
@@ -19,7 +19,7 @@
 			var section = data[i].section	// Section to handle
 			var cbx = document.getElementById("cbid.ddns." + section + ".enabled");		// Enabled
 			var btn = document.getElementById("cbid.ddns." + section + "._startstop");	// Start/Stop button
-			var rip = document.getElementById("cbid.ddns." + section + "._domainIP.two");	// Registered IP
+			var rip = document.getElementById("cbid.ddns." + section + "._lookupIP.two");	// Registered IP
 			var lup = document.getElementById("cbid.ddns." + section + "._update.one");	// Last Update
 			var nup = document.getElementById("cbid.ddns." + section + "._update.two");	// Next Update
 			if ( !(cbx && btn && rip && lup && nup) ) { return; }	// security check
@@ -76,12 +76,12 @@
 					break;
 			}
 
-			// domain
-			// (data[i].domain ignored here
+			// lookup
+			// (data[i].lookup ignored here
 
 			// registered IP
 			// rip.innerHTML = "Registered IP";
-			if (data[i].domain == "_nodomain_")
+			if (data[i].lookup == "_nolookup_")
 				rip.innerHTML = '';
 			else if (data[i].reg_ip == "_nodata_")
 				rip.innerHTML = '<em><%:No data%></em>';
@@ -136,7 +136,7 @@
 
 		// do start/stop
 		var btnXHR = new XHR();
-		btnXHR.post('<%=url('admin/services/ddns/startstop')%>/' + section + '/' + cbx.checked, { token: '<%=token%>' },
+		btnXHR.post('<%=url([[admin]], [[services]], [[ddns]], [[startstop]])%>/' + section + '/' + cbx.checked, { token: '<%=token%>' },
 			function(x, data) {
 				if (x.responseText == "_uncommitted_") {
 					// we need a trick to display Ampersand "&" in stead of "&#38;" or "&amp;"
@@ -155,7 +155,7 @@
 	}
 
 	// force to immediate show status on page load (not waiting for XHR.poll)
-	XHR.get('<%=url('admin/services/ddns/status')%>', null,
+	XHR.get('<%=url([[admin]], [[services]], [[ddns]], [[status]])%>', null,
 		function(x, data) {
 			if (data) { _data2elements(data); }
 		}
@@ -164,7 +164,7 @@
 	// define only ONE XHR.poll in a page because if one is running it blocks the other one
 	// optimum is to define on Map or Section Level from here you can reach all elements
 	// we need update every 15 seconds only
-	XHR.poll(15, '<%=url('admin/services/ddns/status')%>', null,
+	XHR.poll(5, '<%=url([[admin]], [[services]], [[ddns]], [[status]])%>', null,
 		function(x, data) {
 			if (data) { _data2elements(data); }
 		}

--- a/applications/luci-app-ddns/luasrc/view/ddns/system_status.htm
+++ b/applications/luci-app-ddns/luasrc/view/ddns/system_status.htm
@@ -69,15 +69,15 @@
 					break;
 			}
 
-			// domain
-			if (data[j].domain == "_nodomain_")
+			// lookup
+			if (data[j].lookup == "_nolookup_")
 				tr.insertCell(-1).innerHTML = '<em><%:config error%></em>';
 			else
-				tr.insertCell(-1).innerHTML = data[j].domain;
+				tr.insertCell(-1).innerHTML = data[j].lookup;
 
 			// registered IP
 			switch (data[j].reg_ip) {
-				case "_nodomain_":
+				case "_nolookup_":
 					tr.insertCell(-1).innerHTML = '<em><%:Config error%></em>';
 					break;
 				case "_nodata_":
@@ -111,13 +111,13 @@
 	}
 
 	// force to immediate show status (not waiting for XHR.poll)
-	XHR.get('<%=url('admin/services/ddns/status')%>', null,
+	XHR.get('<%=url([[admin]], [[services]], [[ddns]], [[status]])%>', null,
 		function(x, data) {
 			if (data) { _data2elements(x, data); }
 		}
 	);
 
-	XHR.poll(5, '<%=url('admin/services/ddns/status')%>', null,
+	XHR.poll(15, '<%=url([[admin]], [[services]], [[ddns]], [[status]])%>', null,
 		function(x, data) {
 			if (data) { _data2elements(x, data); }
 		}
@@ -132,7 +132,7 @@
 		<tr class="cbi-section-table-titles">
 			<th class="cbi-section-table-cell"><%:Configuration%></th>
 			<th class="cbi-section-table-cell"><%:Next Update%></th>
-			<th class="cbi-section-table-cell"><%:Hostname/Domain%></th>
+			<th class="cbi-section-table-cell"><%:Lookup Hostname%></th>
 			<th class="cbi-section-table-cell"><%:Registered IP%></th>
 			<th class="cbi-section-table-cell"><%:Network%></th>
 		</tr>

--- a/applications/luci-app-ddns/po/de/ddns.po
+++ b/applications/luci-app-ddns/po/de/ddns.po
@@ -1,15 +1,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: luci-app-ddns\n"
-"POT-Creation-Date: 2015-05-08 21:29+0100\n"
-"PO-Revision-Date: 2015-05-08 21:47+0100\n"
+"POT-Creation-Date: 2015-11-04 19:10-0100\n"
+"PO-Revision-Date: 2015-11-14 18:31+0100\n"
 "Last-Translator: Christian Schoenebeck <christian.schoenebeck@gmail.com>\n"
 "Language-Team: \n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.7.5\n"
+"X-Generator: Poedit 1.8.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-Basepath: .\n"
@@ -70,6 +70,9 @@ msgstr ""
 msgid "Casual users should not change this setting"
 msgstr "Standard Benutzer sollten diese Einstellung nicht ändern."
 
+msgid "Change provider"
+msgstr "Anbieter wechseln"
+
 msgid "Check Interval"
 msgstr "Prüfinterval"
 
@@ -124,6 +127,12 @@ msgstr "Eigenes Update-Skript"
 
 msgid "DDNS Autostart disabled"
 msgstr "DDNS Autostart deaktiviert"
+
+msgid "DDNS Client Configuration"
+msgstr "DDNS Client Konfiguration"
+
+msgid "DDNS Client Documentation"
+msgstr "DDNS Client Dokumentation"
 
 msgid "DDNS Service provider"
 msgstr "DDNS-Dienstanbieter"
@@ -195,6 +204,9 @@ msgstr ""
 
 msgid "Disabled"
 msgstr "Deaktiviert"
+
+msgid "Domain"
+msgstr "Domäne"
 
 msgid "Dynamic DNS"
 msgstr "Dynamisches DNS"
@@ -284,8 +296,10 @@ msgstr "HTTPS nicht unterstützt"
 msgid "Hints"
 msgstr "Hinweise"
 
-msgid "Hostname/Domain"
-msgstr "Rechnername/Domäne"
+msgid "Hostname/FQDN to validate, if IP update happen or necessary"
+msgstr ""
+"Hostname/FQDN um zu überprüfen, ob eine Aktualisierung stattgefunden hat "
+"oder notwendig ist"
 
 msgid "IP address source"
 msgstr "IP-Adressquelle"
@@ -385,6 +399,12 @@ msgstr "Protokoll in Datei schreiben"
 msgid "Log to syslog"
 msgstr "Systemprotokoll verwenden"
 
+msgid "Lookup Hostname"
+msgstr "Nachschlage-Hostname"
+
+msgid "NOT installed"
+msgstr "NICHT installiert"
+
 msgid ""
 "Neither GNU Wget with SSL nor cURL installed to select a network to use for "
 "communication."
@@ -454,6 +474,21 @@ msgstr ""
 msgid "On Error the script will stop execution after given number of retrys"
 msgstr "Das Skript wird nach der gegebenen Anzahl von Fehlversuchen beendet."
 
+msgid "OpenWrt Wiki"
+msgstr "OpenWrt Wiki"
+
+msgid "Optional Encoded Parameter"
+msgstr "Optionaler codierten Parameter"
+
+msgid "Optional Parameter"
+msgstr "Optionaler Parameter"
+
+msgid "Optional: Replaces [PARAMENC] in Update-URL (URL-encoded)"
+msgstr "Optional: Ersetzt [PARAMENC] in der Update-URL (URL-codiert)"
+
+msgid "Optional: Replaces [PARAMOPT] in Update-URL (NOT URL-encoded)"
+msgstr "Optional: Ersetzt [PARAMENC] in der Update-URL (NICHT URL-codiert)"
+
 msgid "Overview"
 msgstr "Übersicht"
 
@@ -484,17 +519,20 @@ msgstr "Prozess ID"
 msgid "Read / Reread log file"
 msgstr "Protokolldatei (neu) einlesen"
 
+msgid "Really change DDNS provider?"
+msgstr "Wirklich DDNS-Anbieter wechseln?"
+
 msgid "Registered IP"
 msgstr "Registrierte IP"
 
 msgid "Replaces [DOMAIN] in Update-URL"
 msgstr "Ersetzt [DOMAIN] in der Update-URL"
 
-msgid "Replaces [PASSWORD] in Update-URL"
-msgstr "Ersetzt [PASSWORD] in der Update-URL"
+msgid "Replaces [PASSWORD] in Update-URL (URL-encoded)"
+msgstr "Ersetzt [PASSWORD] in der Update-URL (URL-codiert)"
 
-msgid "Replaces [USERNAME] in Update-URL"
-msgstr "Ersetzt [USERNAME] in der Update-URL"
+msgid "Replaces [USERNAME] in Update-URL (URL-encoded)"
+msgstr "Ersetzt [USERNAME] in der Update-URL (URL-codiert)"
 
 msgid "Run once"
 msgstr "Einmalig ausführen"
@@ -528,7 +566,7 @@ msgstr ""
 "Optionen."
 
 msgid "The default setting of '0' will retry infinite."
-msgstr "Der Standard-Wert von '0' wird es endlosen erneut versuchen."
+msgstr "Beim Standard-Wert von '0' wird es endlos erneut versucht."
 
 msgid "There is no service configured."
 msgstr "Kein Dienst konfiguriert"
@@ -661,8 +699,8 @@ msgstr "Stunden"
 msgid "installed"
 msgstr "installiert"
 
-msgid "invalid - Sample"
-msgstr "ungültig - Beispiel"
+msgid "invalid FQDN / required - Sample"
+msgstr "ungültige FQDN / Pflichtfeld - Beispiel"
 
 msgid "minimum value '0'"
 msgstr "Minimum Wert '0'"

--- a/applications/luci-app-ddns/po/templates/ddns.pot
+++ b/applications/luci-app-ddns/po/templates/ddns.pot
@@ -50,6 +50,9 @@ msgstr ""
 msgid "Casual users should not change this setting"
 msgstr ""
 
+msgid "Change provider"
+msgstr ""
+
 msgid "Check Interval"
 msgstr ""
 
@@ -94,6 +97,12 @@ msgid "Custom update-script"
 msgstr ""
 
 msgid "DDNS Autostart disabled"
+msgstr ""
+
+msgid "DDNS Client Configuration"
+msgstr ""
+
+msgid "DDNS Client Documentation"
 msgstr ""
 
 msgid "DDNS Service provider"
@@ -147,6 +156,9 @@ msgid ""
 msgstr ""
 
 msgid "Disabled"
+msgstr ""
+
+msgid "Domain"
 msgstr ""
 
 msgid "Dynamic DNS"
@@ -230,7 +242,7 @@ msgstr ""
 msgid "Hints"
 msgstr ""
 
-msgid "Hostname/Domain"
+msgid "Hostname/FQDN to validate, if IP update happen or necessary"
 msgstr ""
 
 msgid "IP address source"
@@ -315,6 +327,12 @@ msgstr ""
 msgid "Log to syslog"
 msgstr ""
 
+msgid "Lookup Hostname"
+msgstr ""
+
+msgid "NOT installed"
+msgstr ""
+
 msgid ""
 "Neither GNU Wget with SSL nor cURL installed to select a network to use for "
 "communication."
@@ -373,6 +391,21 @@ msgstr ""
 msgid "On Error the script will stop execution after given number of retrys"
 msgstr ""
 
+msgid "OpenWrt Wiki"
+msgstr ""
+
+msgid "Optional Encoded Parameter"
+msgstr ""
+
+msgid "Optional Parameter"
+msgstr ""
+
+msgid "Optional: Replaces [PARAMENC] in Update-URL (URL-encoded)"
+msgstr ""
+
+msgid "Optional: Replaces [PARAMOPT] in Update-URL (NOT URL-encoded)"
+msgstr ""
+
 msgid "Overview"
 msgstr ""
 
@@ -403,16 +436,19 @@ msgstr ""
 msgid "Read / Reread log file"
 msgstr ""
 
+msgid "Really change DDNS provider?"
+msgstr ""
+
 msgid "Registered IP"
 msgstr ""
 
 msgid "Replaces [DOMAIN] in Update-URL"
 msgstr ""
 
-msgid "Replaces [PASSWORD] in Update-URL"
+msgid "Replaces [PASSWORD] in Update-URL (URL-encoded)"
 msgstr ""
 
-msgid "Replaces [USERNAME] in Update-URL"
+msgid "Replaces [USERNAME] in Update-URL (URL-encoded)"
 msgstr ""
 
 msgid "Run once"
@@ -563,7 +599,7 @@ msgstr ""
 msgid "installed"
 msgstr ""
 
-msgid "invalid - Sample"
+msgid "invalid FQDN / required - Sample"
 msgstr ""
 
 msgid "minimum value '0'"


### PR DESCRIPTION
- support for new options "lookup_host", "param_enc" and "param_opt"
- rewritten ddns provider handling to only show/check needed options "domain", "username", etc.
- modified version check/handling incl. using new ipkg.compare_versions function
- modified map.title and map.description generation
- changed XHR.poll interval to 15 seconds on system status page
- using new value_parse function for testing and later implementation into cbi.lua
- some optimizations

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>