### PR TITLE
freifunk-common: neigh.sh - show hostnames

### DIFF
--- a/contrib/package/freifunk-common/files/usr/bin/neigh.sh
+++ b/contrib/package/freifunk-common/files/usr/bin/neigh.sh
@@ -2,9 +2,35 @@
 
 . /usr/share/libubox/jshn.sh
 
-VARS="localIP:Local remoteIP:Remote validityTime:vTime linkQuality:LQ neighborLinkQuality:NLQ linkCost:Cost"
+read_hostnames()
+{
+	local file_hostnames='/var/run/hosts_olsr'
+	local line ip hostname
 
-for HOST in 127.0.0.1 ::1;do
+	[ -e "$file_hostnames" ] || return
+
+	while read -r line; do {
+		case "$line" in
+			[0-9]*)
+				# 10.63.160.161  AlexLaterne    # 10.63.160.161
+				set -f
+				set +f -- $line
+				ip="$1"
+				hostname="$2"
+
+				# global vars, e.g. IP_1_2_3_4='foo'
+				eval IP_${ip//./_}="$hostname"
+			;;
+		esac
+	} done <"$file_hostnames"
+}
+
+read_hostnames		# TODO! IPv6 not implemented yet
+
+VARS='localIP:Local remoteIP:Remote validityTime:vTime linkQuality:LQ'
+VARS="$VARS neighborLinkQuality:NLQ linkCost:Cost remoteHostname:Host"
+
+for HOST in '127.0.0.1' '::1';do
 	json_init
 	json_load "$(echo /links|nc ${HOST} 9090)"
 	if json_is_a links array;then
@@ -29,6 +55,7 @@ for HOST in 127.0.0.1 ::1;do
 				;;*)
 					for v in ${VARS};do
 						eval printf \"%-\${_${v%:*}}s \" \$${v%:*}
+						eval remoteHostname="\$IP_${remoteIP//./_}"
 					done
 					echo
 				;;esac

--- a/contrib/package/freifunk-common/files/usr/bin/neigh.sh
+++ b/contrib/package/freifunk-common/files/usr/bin/neigh.sh
@@ -7,10 +7,10 @@ hostsfile_getname()
 	local i=0
 	local value file
 
-	while value="$( uci -q get olsrd.@LoadPlugin[i].library )"; do {
-		case "$file" in
-			*'olsrd_nameservice.so.'*)
-				file="$( uci -q get olsrd.@LoadPlugin[i].hosts_file )"
+	while value="$( uci -q get olsrd.@LoadPlugin[$i].library )"; do {
+		case "$value" in
+			'olsrd_nameservice.so.'*)
+				file="$( uci -q get olsrd.@LoadPlugin[$i].hosts_file )"
 				break
 			;;
 		esac


### PR DESCRIPTION
if nameservice-plugin is configured, we read
in all hostnames and show them in the output:

root@box:~ neigh.sh
Local      Remote       vTime  LQ       NLQ      Cost Host
10.63.2.61 10.63.42.125 182157 1.000000 1.000000 1024 mid2.UFO