### PR TITLE
Pull request fstab improvements

### DIFF
--- a/modules/luci-base/luasrc/util.lua
+++ b/modules/luci-base/luasrc/util.lua
@@ -151,6 +151,28 @@ function striptags(value)
 	return value and tparser.striptags(tostring(value))
 end
 
+-- for bash, ash and similar shells single-quoted strings are taken
+-- literally except for single quotes (which terminate the string)
+-- (and the exception noted below for dash (-) at the start of a
+-- command line parameter).
+function shellsqescape(value)
+   local res
+   res, _ = string.gsub(res, "'", "'\\''")
+   return res
+end
+
+-- bash, ash and other similar shells interpret a dash (-) at the start
+-- of a command-line parameters as an option indicator regardless of
+-- whether it is inside a single-quoted string.  It must be backlash
+-- escaped to resolve this.  This requires in some funky special-case
+-- handling.  It may actually be a property of the getopt function
+-- rather than the shell proper.
+function shellstartsqescape(value)
+   res, _ = string.gsub(value, "^\-", "\\-")
+   res, _ = string.gsub(res, "^-", "\-")
+   return shellsqescape(value)
+end
+
 -- containing the resulting substrings. The optional max parameter specifies
 -- the number of bytes to process, regardless of the actual length of the given
 -- string. The optional last parameter, regex, specifies whether the separator

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
@@ -35,6 +35,29 @@ block:close()
 
 
 m = Map("fstab", translate("Mount Points"))
+s = m:section(TypedSection, "global", translate("Global Settings"))
+s.addremove = false
+s.anonymous = true
+
+o = s:option(Flag, "anon_swap", translate("Anonymous Swap"), translate("Mount swap not specifically configured"))
+o.default = o.disabled
+o.rmempty = false
+
+o = s:option(Flag, "anon_mount", translate("Anonymous Mount"), translate("Mount filesystems not specifically configured"))
+o.default = o.disabled
+o.rmempty = false
+
+o = s:option(Flag, "auto_swap", translate("Automount Swap"), translate("Automatically mount swap on hotplug"))
+o.default = o.enabled
+o.rmempty = false
+
+o = s:option(Flag, "auto_mount", translate("Automount Filesystem"), translate("Automatically mount filesystems on hotplug"))
+o.default = o.enabled
+o.rmempty = false
+
+o = s:option(Flag, "check_fs", translate("Check fileystems before mount"), translate("Automatically check filesystem for errors before mounting"))
+o.default = o.disabled
+o.rmempty = false
 
 local mounts = luci.sys.mounts()
 local non_system_mounts = {}

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
@@ -33,11 +33,18 @@ until not ln
 
 block:close()
 
-
 m = Map("fstab", translate("Mount Points"))
 s = m:section(TypedSection, "global", translate("Global Settings"))
 s.addremove = false
 s.anonymous = true
+
+detect = s:option(Button, "block_detect", translate("Generate Config"), translate("Find all currently attached filesystems and swap and replace configuration with defaults based on what was detected"))
+detect.inputstyle = "reload"
+
+detect.write = function(self, section)
+	luci.sys.call("block detect >/etc/config/fstab")
+	luci.http.redirect(luci.dispatcher.build_url("admin/system", "fstab"))
+end
 
 o = s:option(Flag, "anon_swap", translate("Anonymous Swap"), translate("Mount swap not specifically configured"))
 o.default = o.disabled

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
@@ -39,6 +39,7 @@ m = Map("fstab", translate("Mount Points"))
 local mounts = luci.sys.mounts()
 local non_system_mounts = {}
 for rawmount, val in pairs(mounts) do
+    if (string.find(val.mountpoint, "/tmp/.jail") == nil) then
       repeat 
           val.umount = false
           if (val.mountpoint == "/") then


### PR DESCRIPTION
This pull request contains a series of commits that do the following:

1) Add the ability to unmount non-system mounts from the UI.
2) Hides jail bind mounts from the UI mounts list.
3) Adds the 'global' settings for fstab (e.g. anonymous mounts).
4) Adds a button to do block detect and write the output to /etc/config/fstab (in order for mounts points config to find new block devices).