### PR TITLE
modules/luci-base: Move LuCI FileUpload directory to /etc/luci-upload…

### DIFF
--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -22,6 +22,10 @@ HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/LuaSrcDiet-0.12.1
 
 include $(INCLUDE_DIR)/host-build.mk
 
+define Package/luci-base/conffiles
+/etc/luci-uploads
+endef
+
 include ../../luci.mk
 
 define Host/Configure

--- a/modules/luci-base/luasrc/cbi.lua
+++ b/modules/luci-base/luasrc/cbi.lua
@@ -38,7 +38,7 @@ function load(cbimap, ...)
 	require("luci.config")
 	require("luci.util")
 
-	local upldir = "/lib/uci/upload/"
+	local upldir = "/etc/luci-uploads/"
 	local cbidir = luci.util.libpath() .. "/model/cbi/"
 	local func, err
 


### PR DESCRIPTION
…s and save across sysupgrade

/lib/uci/upload is a rather odd place for configuration files

Also the files were not saved across sysupgrade, which is somewhat
counter-productive for configuration files.

Signed-off By: Daniel Dickinson <openwrt@daniel.thecshore.com>