### PR TITLE
Allow host:port value for l2tp `server` option

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/value.htm
+++ b/modules/luci-base/luasrc/view/cbi/value.htm
@@ -29,7 +29,7 @@
 		<%- end -%>');
 		<%- end %>
 		<% if self.datatype then -%>
-		cbi_validate_field('<%=cbid%>', <%=tostring((self.optional or self.rmempty) == true)%>, '<%=self.datatype:gsub("'", "\\'")%>');
+		cbi_validate_field('<%=cbid%>', <%=tostring((self.optional or self.rmempty) == true)%>, '<%=self.datatype:gsub("\\", "\\\\"):gsub("'", "\\'")%>');
 		<%- end %>
 	//]]></script>
 	<% end -%>

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua
@@ -8,7 +8,7 @@ local ipv6, defaultroute, metric, peerdns, dns, mtu
 
 
 server = section:taboption("general", Value, "server", translate("L2TP Server"))
-server.datatype = "host"
+server.datatype = "or(host, hostport)"
 
 
 username = section:taboption("general", Value, "username", translate("PAP/CHAP username"))


### PR DESCRIPTION
This PR also contains a fix for escaping lua string to js repr.