### PR TITLE
luci-mod-admin-full: update IPv4/IPv6 list views

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_overview.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_overview.htm
@@ -149,30 +149,20 @@
 
 						if (ifc.ipaddrs && ifc.ipaddrs.length)
 						{
-							html += '<strong><%:IPv4%>: </strong>';
-
 							for (var i = 0; i < ifc.ipaddrs.length; i++)
 								html += String.format(
-									'%s%s',
-									i ? ', ' : '',
+									'<strong><%:IPv4%>:</strong> %s<br />',
 									ifc.ipaddrs[i]
 								);
-
-							html += '<br />';
 						}
 
 						if (ifc.ip6addrs && ifc.ip6addrs.length)
 						{
-							html += '<strong><%:IPv6%>: </strong>';
-
 							for (var i = 0; i < ifc.ip6addrs.length; i++)
 								html += String.format(
-									'%s%s',
-									i ? ', ' : '',
-									ifc.ip6addrs[i].toUpperCase()
+									'<strong><%:IPv6%>:</strong> %s<br />',
+									ifc.ip6addrs[i]
 								);
-
-							html += '<br />';
 						}
 
 						d.innerHTML = html;


### PR DESCRIPTION
For better view of 'Interface Overview' IPv4/IPv6 addresses for
interfaces should be displayed as lists, but not as comma separated
strings.