### PR TITLE
Pull request validator rework

### DIFF
--- a/applications/luci-app-pbx-voicemail/luasrc/model/cbi/pbx-voicemail.lua
+++ b/applications/luci-app-pbx-voicemail/luasrc/model/cbi/pbx-voicemail.lua
@@ -92,7 +92,7 @@ s = m:section(NamedSection, "voicemail_smtp", "voicemail", translate("Outgoing m
 s.anonymous = true
 
 serv = s:option(Value, "smtp_server", translate("SMTP Server Hostname or IP Address"))
-serv.datatype = "host"
+serv.datatype = "host(0)"
 
 port = s:option(Value, "smtp_port", translate("SMTP Port Number"))
 port.datatype = "port"

--- a/applications/luci-app-pbx/luasrc/model/cbi/pbx-advanced.lua
+++ b/applications/luci-app-pbx/luasrc/model/cbi/pbx-advanced.lua
@@ -264,7 +264,7 @@ h = s:taboption("remote_usage", Value, "externhost", translate("Domain/IP Addres
                 The best thing to input is a static IP address. If your IP address is dynamic and it changes, \
                 your configuration will become invalid. Hence, it's recommended to set up Dynamic DNS in this case. \
                 and enter your Dynamic DNS hostname here. You can configure Dynamic DNS with the luci-app-ddns package."))
-h.datatype = "host"
+h.datatype = "host(0)"
 
 p = s:taboption("remote_usage", Value, "bindport", translate("External SIP Port"),
                 translate("Pick a random port number between 6500 and 9500 for the service to listen on. \

--- a/applications/luci-app-pbx/luasrc/model/cbi/pbx-voip.lua
+++ b/applications/luci-app-pbx/luasrc/model/cbi/pbx-voip.lua
@@ -84,7 +84,7 @@ function pwd.write(self, section, value)
 end
 
 h = s:option(Value, "host", translate("SIP Server/Registrar"))
-h.datatype = "host"
+h.datatype = "host(0)"
 
 p = s:option(ListValue, "register", translate("Enable Incoming Calls (Register via SIP)"),
              translate("This option should be set to \"Yes\" if you have a DID \(real telephone number\) \
@@ -103,7 +103,7 @@ p.default = "yes"
 from = s:option(Value, "fromdomain",
                 translate("SIP Realm (needed by some providers)"))
 from.optional = true
-from.datatype = "host"
+from.datatype = "host(0)"
 
 port = s:option(Value, "port", translate("SIP Server/Registrar Port"))
 port.optional = true
@@ -111,6 +111,6 @@ port.datatype = "port"
 
 op = s:option(Value, "outboundproxy", translate("Outbound Proxy"))
 op.optional = true
-op.datatype = "host"
+op.datatype = "host(0)"
 
 return m

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/olsrd.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/olsrd.lua
@@ -12,7 +12,7 @@ enable.default = 0
 
 host = s:option(Value, "Host", translate("Host"), translate("IP or hostname where to get the txtinfo output from"))
 host.placeholder = "127.0.0.1"
-host.datatype = "host"
+host.datatype = "host(1)"
 host.rmempty = true
 
 port = s:option(Value, "Port", translate("Port"))

--- a/applications/luci-app-tinyproxy/luasrc/model/cbi/tinyproxy.lua
+++ b/applications/luci-app-tinyproxy/luasrc/model/cbi/tinyproxy.lua
@@ -227,7 +227,7 @@ ta = s:option(Value, "target", translate("Target host"),
 
 ta.rmempty = true
 ta.placeholder = "0.0.0.0/0"
-ta.datatype = "host"
+ta.datatype = "host(1)"
 
 
 v = s:option(Value, "via", translate("Via proxy"),
@@ -235,5 +235,6 @@ v = s:option(Value, "via", translate("Via proxy"),
 
 v:depends({type="proxy"})
 v.placeholder = "10.0.0.1:8080"
+v.datatype = "ip4addrport"
 
 return m

--- a/applications/luci-app-watchcat/luasrc/model/cbi/watchcat/watchcat.lua
+++ b/applications/luci-app-watchcat/luasrc/model/cbi/watchcat/watchcat.lua
@@ -38,7 +38,7 @@ period = s:option(Value, "period",
 pinghost = s:option(Value, "pinghosts", 
 		    translate("Ping host"),
 		    translate("Host address to ping"))
-pinghost.datatype = "host"
+pinghost.datatype = "host(1)"
 pinghost.default = "8.8.8.8"
 pinghost:depends({mode="ping"})
 

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -139,10 +139,11 @@ var cbi_validators = {
 		return (this.match(/^([a-fA-F0-9]{2}:){5}[a-fA-F0-9]{2}$/) != null);
 	},
 
-	'host': function()
+	'host': function(ipv4only)
 	{
 		return cbi_validators.hostname.apply(this) ||
-			cbi_validators.ipaddr.apply(this);
+			((ipv4only != 1) && cbi_validators.ipaddr.apply(this)) ||
+			((ipv4only == 1) && cb_validators.ip4addr.apply(this));
 	},
 
 	'hostname': function()
@@ -161,12 +162,12 @@ var cbi_validators = {
 			cbi_validators.host.apply(this);
 	},
 
-	'hostport': function()
+	'hostport': function(ipv4only)
 	{
 		var hp = this.split(/:/);
 
 		if (hp.length == 2)
-			return (cbi_validators.host.apply(hp[0]) &&
+			return (cbi_validators.host.apply(hp[0], ipv4only) &&
 			        cbi_validators.port.apply(hp[1]));
 
 		return false;

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -172,15 +172,36 @@ var cbi_validators = {
 		return false;
 	},
 
-	'ipaddrport': function()
+	'ip4addrport': function()
 	{
 		var hp = this.split(/:/);
 
 		if (hp.length == 2)
 			return (cbi_validators.ipaddr.apply(hp[0]) &&
 			        cbi_validators.port.apply(hp[1]));
-
 		return false;
+	},
+
+	'ipaddrport': function(bracket)
+	{
+		if (this.match(/^([^\[\]:]+):([^:]+)$/)) {
+			var addr = RegExp.$1
+			var port = RegExp.$2
+			return (cbi_validators.ip4addr.apply(addr) &&
+				cbi_validators.port.apply(port));
+                } else if ((bracket == 1) && (this.match(/^\[(.+)\]:([^:]+)$/))) {
+			var addr = RegExp.$1
+			var port = RegExp.$2
+			return (cbi_validators.ip6addr.apply(addr) &&
+				cbi_validators.port.apply(port));
+                } else if ((bracket != 1) && (this.match(/^([^\[\]]+):([^:]+)$/))) {
+			var addr = RegExp.$1
+			var port = RegExp.$2
+			return (cbi_validators.ip6addr.apply(addr) &&
+				cbi_validators.port.apply(port));
+		} else {
+			return false;
+		}
 	},
 
 	'wpakey': function()

--- a/modules/luci-base/luasrc/cbi/datatypes.lua
+++ b/modules/luci-base/luasrc/cbi/datatypes.lua
@@ -176,17 +176,22 @@ function hostname(val)
 	return false
 end
 
-function host(val)
-	return hostname(val) or ipaddr(val)
+function host(val, ipv4only)
+	return hostname(val) or ((ipv4only == 1) and ip4addr(val)) or ((not (ipv4only == 1)) and ipaddr(val))
 end
 
 function network(val)
 	return uciname(val) or host(val)
 end
 
-function hostport(val)
+function hostport(val, ipv4only)
 	local h, p = val:match("^([^:]+):([^:]+)$")
-	return not not (h and p and host(h) and port(p))
+	return not not (h and p and host(h, ipv4only) and port(p))
+end
+
+function ip4addrport(val, bracket)
+	local h, p = val:match("^([^:]+):([^:]+)$")
+	return (h and p and ip4addr(h) and port(p))
 end
 
 function ip4addrport(val)
@@ -199,7 +204,7 @@ function ipaddrport(val, bracket)
 	if (h and p and ip4addr(h) and port(p)) then
 		return true
 	elseif (bracket == 1) then
-		h, p = val:match("^(%[.+%]):([^:]+)$")
+		h, p = val:match("^%[(.+)%]:([^:]+)$")
 		if  (h and p and ip6addr(h) and port(p)) then
 			return true
 		end

--- a/modules/luci-base/luasrc/cbi/datatypes.lua
+++ b/modules/luci-base/luasrc/cbi/datatypes.lua
@@ -189,9 +189,23 @@ function hostport(val)
 	return not not (h and p and host(h) and port(p))
 end
 
-function ipaddrport(val)
+function ip4addrport(val)
 	local h, p = val:match("^([^:]+):([^:]+)$")
-	return not not (h and p and ipaddr(h) and port(p))
+	return (h and p and ip4addr(h) and port(p))
+end
+
+function ipaddrport(val, bracket)
+	local h, p = val:match("^([^%[%]:]+):([^:]+)$")
+	if (h and p and ip4addr(h) and port(p)) then
+		return true
+	elseif (bracket == 1) then
+		h, p = val:match("^(%[.+%]):([^:]+)$")
+		if  (h and p and ip6addr(h) and port(p)) then
+			return true
+		end
+	end
+	h, p = val:match("^([^%[%]]+):([^:]+)$")
+	return (h and p and ip6addr(h) and port(p))
 end
 
 function wpakey(val)

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -135,7 +135,7 @@ rd = s:taboption("general", DynamicList, "rebind_domain",
 	translate("List of domains to allow RFC1918 responses for"))
 
 rd:depends("rebind_protection", "1")
-rd.datatype = "host"
+rd.datatype = "host(1)"
 rd.placeholder = "ihost.netflix.com"
 
 

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -749,7 +749,7 @@ auth_server:depends({mode="ap", encryption="wpa2"})
 auth_server:depends({mode="ap-wds", encryption="wpa"})
 auth_server:depends({mode="ap-wds", encryption="wpa2"})
 auth_server.rmempty = true
-auth_server.datatype = "host"
+auth_server.datatype = "host(0)"
 
 auth_port = s:taboption("encryption", Value, "auth_port", translate("Radius-Authentication-Port"), translatef("Default %d", 1812))
 auth_port:depends({mode="ap", encryption="wpa"})
@@ -773,7 +773,7 @@ acct_server:depends({mode="ap", encryption="wpa2"})
 acct_server:depends({mode="ap-wds", encryption="wpa"})
 acct_server:depends({mode="ap-wds", encryption="wpa2"})
 acct_server.rmempty = true
-acct_server.datatype = "host"
+acct_server.datatype = "host(0)"
 
 acct_port = s:taboption("encryption", Value, "acct_port", translate("Radius-Accounting-Port"), translatef("Default %d", 1813))
 acct_port:depends({mode="ap", encryption="wpa"})

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/system.lua
@@ -204,7 +204,7 @@ if has_ntpd then
 
 
 		o = s:option(DynamicList, "server", translate("NTP server candidates"))
-		o.datatype = "host"
+		o.datatype = "host(0)"
 		o:depends("enable", "1")
 
 		-- retain server list even if disabled

--- a/protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_aiccu.lua
+++ b/protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_aiccu.lua
@@ -39,7 +39,7 @@ protocol.optional = true
 server = section:taboption("general", Value, "server",
 	translate("Tunnel setup server"),
 	translate("Optional, specify to override default server (tic.sixxs.net)"))
-server.datatype = "host"
+server.datatype = "host(0)"
 server.optional = true
 
 

--- a/protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua
+++ b/protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua
@@ -13,7 +13,7 @@ oc_key_file = "/etc/openconnect/user-key-" .. ifc .. ".pem"
 oc_ca_file = "/etc/openconnect/ca-" .. ifc .. ".pem"
 
 server = section:taboption("general", Value, "server", translate("VPN Server"))
-server.datatype = "host"
+server.datatype = "host(0)"
 
 port = section:taboption("general", Value, "port", translate("VPN Server port"))
 port.placeholder = "443"

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua
@@ -8,7 +8,7 @@ local ipv6, defaultroute, metric, peerdns, dns, mtu
 
 
 server = section:taboption("general", Value, "server", translate("L2TP Server"))
-server.datatype = "or(host, hostport)"
+server.datatype = "or(host(1), hostport(1))"
 
 
 username = section:taboption("general", Value, "username", translate("PAP/CHAP username"))

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppossh.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppossh.lua
@@ -8,7 +8,7 @@ local sshuser, server, port, ssh_options, identity, ipaddr, peeraddr
 sshuser = section:taboption("general", Value, "sshuser", translate("SSH username"))
 
 server = section:taboption("general", Value, "server", translate("SSH server address"))
-server.datatype = "host"
+server.datatype = "host(0)"
 
 port = section:taboption("general", Value, "port", translate("SSH server port"))
 port.datatype = "port"

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua
@@ -9,7 +9,7 @@ local defaultroute, metric, peerdns, dns,
 
 
 server = section:taboption("general", Value, "server", translate("VPN Server"))
-server.datatype = "host"
+server.datatype = "host(0)"
 
 
 username = section:taboption("general", Value, "username", translate("PAP/CHAP username"))


### PR DESCRIPTION
Make ipaddrport supprt ipv4 and ipv6, add ipv4addrport and add option ipv4only for hostport which allows hostport to accept only ipv4 IP addresses when an IP address rather than host name is specified (for apps and protocols that don't support ipv6).

Also update affected consumers of host and hostport datatype.