### PR TITLE
Use relative paths to luci.mk

### DIFF
--- a/applications/luci-app-ddns/Makefile
+++ b/applications/luci-app-ddns/Makefile
@@ -33,6 +33,6 @@ help
 	$(PKG_MAINTAINER)
 endef
 
-include $(TOPDIR)/feeds/luci/luci.mk
+include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-privoxy/Makefile
+++ b/applications/luci-app-privoxy/Makefile
@@ -33,6 +33,6 @@ help
 	$(PKG_MAINTAINER)
 endef
 
-include $(TOPDIR)/feeds/luci/luci.mk
+include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-radicale/Makefile
+++ b/applications/luci-app-radicale/Makefile
@@ -36,6 +36,6 @@ help
 	$(PKG_MAINTAINER)
 endef
 
-include $(TOPDIR)/feeds/luci/luci.mk
+include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
If absolute path to `luci.mk` (i.e. `$(TOPDIR)/feeds/luci/luci.mk`) is specified and LuCI feed has a different name than "luci", errors like this one are raised:
```
Makefile:36: /openwrt/feeds/feedname/luci.mk: No such file or directory
```
This pull request contains fixes for three applications that use absolute paths in their Makefiles and replaces them with relative ones.