### PR TITLE
luci-theme-material: set default font-size to 13px

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/css/style.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/css/style.css
@@ -72,6 +72,11 @@ html, body {
     padding: 0px;
     height: 100%;
     font-family: "Helvetica Neue", Helvetica, Microsoft Yahei, Hiragino Sans GB, WenQuanYi Micro Hei, sans-serif;
+    font-size: 62.5%; /* font-size 1rem = 10px on default browser settings */
+}
+
+body {
+    font-size: 1.3rem; /* 1.3rem = 13px */
 }
 
 select {


### PR DESCRIPTION
No default font size is set by this theme, so it will be the browser default (16px), this is too large for most people.

There are also the same feature requests from this thread's comments: https://forum.openwrt.org/viewtopic.php?id=59696