### PR TITLE
[Makefile] make include of luci.mk relative

### DIFF
--- a/applications/luci-app-ddns/Makefile
+++ b/applications/luci-app-ddns/Makefile
@@ -33,6 +33,6 @@ help
 	$(PKG_MAINTAINER)
 endef
 
-include $(TOPDIR)/feeds/luci/luci.mk
+include ../luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-privoxy/Makefile
+++ b/applications/luci-app-privoxy/Makefile
@@ -33,6 +33,6 @@ help
 	$(PKG_MAINTAINER)
 endef
 
-include $(TOPDIR)/feeds/luci/luci.mk
+include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-radicale/Makefile
+++ b/applications/luci-app-radicale/Makefile
@@ -36,6 +36,6 @@ help
 	$(PKG_MAINTAINER)
 endef
 
-include $(TOPDIR)/feeds/luci/luci.mk
+include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
- fixes "file not found" when directory is not named "luci"
- alignment with other Makefiles

Signed-off-by: Sven Roederer <devel-sven@geroedel.de>