### PR TITLE
luci-app-ddns: removing unneeded assert

### DIFF
--- a/applications/luci-app-ddns/Makefile
+++ b/applications/luci-app-ddns/Makefile
@@ -10,7 +10,7 @@ PKG_NAME:=luci-app-ddns
 
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.2.4
+PKG_VERSION:=2.3.1
 
 # Release == build
 # increase on changes of translation files

--- a/applications/luci-app-ddns/luasrc/controller/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/controller/ddns.lua
@@ -22,7 +22,7 @@ local srv_ver_min = "2.5.0"			-- minimum version of service required
 local srv_ver_cmd = [[/usr/lib/ddns/dynamic_dns_updater.sh --version | awk {'print $2'}]]
 local app_name    = "luci-app-ddns"
 local app_title   = "Dynamic DNS"
-local app_version = "2.3.0-1"
+local app_version = "2.3.1-1"
 
 function index()
 	local nxfs	= require "nixio.fs"		-- global definitions not available

--- a/applications/luci-app-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/tools/ddns.lua
@@ -166,8 +166,6 @@ function value_parse(self, section, novld)
 			return		-- so data is missing
 		end
 	end
-	-- for whatever reason errtxt set and not handled above
-	assert( not (errtxt and (#errtxt > 0)), "unhandled validate error" )
 
 	-- lets continue with value returned from validate
 	eq_cfg  = ( vvalue == cvalue )			-- update equal_config flag


### PR DESCRIPTION
- remove unneeded assert() in tools/ddns.lua fix #611
- set PKG_VERSION to the correct value from controller/ddns.lua

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>