### PR TITLE
sys.lua & status.lua: correct path to dhcp.leases file

### DIFF
--- a/modules/luci-base/luasrc/sys.lua
+++ b/modules/luci-base/luasrc/sys.lua
@@ -186,8 +186,8 @@ local function _nethints(what, callback)
 		end
 	end
 
-	if fs.access("/var/dhcp.leases") then
-		for e in io.lines("/var/dhcp.leases") do
+	if fs.access("/tmp/dhcp.leases") then
+		for e in io.lines("/tmp/dhcp.leases") do
 			mac, ip, name = e:match("^%d+ (%S+) (%S+) (%S+)")
 			if mac and ip then
 				_add(what, mac:upper(), ip, nil, name ~= "*" and name)

--- a/modules/luci-base/luasrc/tools/status.lua
+++ b/modules/luci-base/luasrc/tools/status.lua
@@ -8,7 +8,7 @@ local uci = require "luci.model.uci".cursor()
 local function dhcp_leases_common(family)
 	local rv = { }
 	local nfs = require "nixio.fs"
-	local leasefile = "/var/dhcp.leases"
+	local leasefile = "/tmp/dhcp.leases"
 
 	uci:foreach("dhcp", "dnsmasq",
 		function(s)


### PR DESCRIPTION
If removing link from /var to /tmp to save ram i.e. on pivot-overlay you
will get no lease data inside LuCI. dnsmasq is writing to /tmp/dhcp.leases.

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>