### PR TITLE
luci-ssl: Don't force PolarSSL as SSL library and remove key generator

### DIFF
--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -10,7 +10,7 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
 LUCI_TITLE:=Standard OpenWrt set with HTTPS support
-LUCI_DEPENDS:=+luci +uhttpd-mod-tls
+LUCI_DEPENDS:=+luci +uhttpd-mod-tls +px5g
 
 include ../../luci.mk
 

--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -10,7 +10,7 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
 LUCI_TITLE:=Standard OpenWrt set with HTTPS support
-LUCI_DEPENDS:=+luci +libustream-polarssl +px5g
+LUCI_DEPENDS:=+luci +uhttpd-mod-tls
 
 include ../../luci.mk
 


### PR DESCRIPTION
The uhttpd-mod-tls module that is required for handling HTTPS can be build against several cryptographic libraries. Instead of forcing LuCI to use the PolarSSL library, depend on uhttpd-mod-tls.

Signed-off-by: Arjen M de Korte build+openwrt@de-korte.org