### PR TITLE
sys.lua _nethints(): read location of dhcp.lease file from uci

### DIFF
--- a/modules/luci-base/luasrc/sys.lua
+++ b/modules/luci-base/luasrc/sys.lua
@@ -185,14 +185,18 @@ local function _nethints(what, callback)
 		end
 	end
 
-	if fs.access("/var/dhcp.leases") then
-		for e in io.lines("/var/dhcp.leases") do
-			mac, ip, name = e:match("^%d+ (%S+) (%S+) (%S+)")
-			if mac and ip then
-				_add(what, mac:upper(), ip, nil, name ~= "*" and name)
+	cur:foreach("dhcp", "dnsmasq",
+		function(s)
+			if s.leasefile and fs.access(s.leasefile) then
+				for e in io.lines(s.leasefile) do
+					mac, ip, name = e:match("^%d+ (%S+) (%S+) (%S+)")
+					if mac and ip then
+						_add(what, mac:upper(), ip, nil, name ~= "*" and name)
+					end
+				end
 			end
 		end
-	end
+	)
 
 	cur:foreach("dhcp", "host",
 		function(s)

--- a/modules/luci-base/luasrc/tools/status.lua
+++ b/modules/luci-base/luasrc/tools/status.lua
@@ -8,7 +8,7 @@ local uci = require "luci.model.uci".cursor()
 local function dhcp_leases_common(family)
 	local rv = { }
 	local nfs = require "nixio.fs"
-	local leasefile = "/var/dhcp.leases"
+	local leasefile = "/tmp/dhcp.leases"
 
 	uci:foreach("dhcp", "dnsmasq",
 		function(s)


### PR DESCRIPTION
status.lua - change default directory of dhcp.leases file
sys.lua - read location of dhcp.leases file from uci

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>