### PR TITLE
luci-app-statistics: Remove usually empty std.dev. graph from ping page

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
@@ -23,16 +23,6 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 			types   = { "ping_droprate" },
 			options = { ping_droprate = {
 				noarea = true, overlay = true, title = "%di" } }
-		} },
-
-		-- Ping standard deviation
-		{ title = "%H: ICMP Standard Deviation",
-		  vlabel = "ms",
-		  number_format = "%5.2lf ms",
-		  data = {
-			types   = { "ping_stddev" },
-			options = { ping_stddev = {
-				noarea = true, overlay = true, title = "%di" } }
-		} },
+		} }
 	}
 end


### PR DESCRIPTION
Remove the usually empty standard deviation graph from the ping page.

The graph is empty for most users as collectd measures standard deviation of individual pings inside the general interval of statistics collection. Default setting for both ping interval and general collection interval is 30s in Luci statistics, meaning just 1 ping per interval, which leads to empty graph.

(To provide relevant data, the ping interval should be 1/4-1/5 of the general collection interval. Even then the graph does not look very informative due to different scaling than the latency graph.)

Note that this commit does not change collectd itself, which continues to collect and calculate also the std.dev. data, which can be fetched with 'rrdtool' if needed.

Note:
Instead of directly committing, I make this proposal as a pull request, as this cleanup action marginally reduces the already existing functionality.