### PR TITLE
restored missing lib-nixio tls providers

### DIFF
--- a/libs/luci-lib-nixio/Makefile
+++ b/libs/luci-lib-nixio/Makefile
@@ -9,6 +9,46 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=NIXIO POSIX library
 LUCI_DEPENDS:=+PACKAGE_luci-lib-nixio_openssl:libopenssl +PACKAGE_luci-lib-nixio_cyassl:libcyassl +liblua
 
+define Package/luci-lib-nixio/config
+	choice
+		prompt "TLS Provider"
+		default PACKAGE_luci-lib-nixio_notls
+
+		config PACKAGE_luci-lib-nixio_notls
+			bool "Disabled"
+
+		config PACKAGE_luci-lib-nixio_axtls
+			bool "Builtin (axTLS)"
+
+		config PACKAGE_luci-lib-nixio_cyassl
+			bool "CyaSSL"
+			select PACKAGE_libcyassl
+
+		config PACKAGE_luci-lib-nixio_openssl
+			bool "OpenSSL"
+			select PACKAGE_libopenssl
+	endchoice
+endef
+
+NIXIO_TLS:=
+
+ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_axtls),)
+  NIXIO_TLS:=axtls
+endif
+
+ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_openssl),)
+  NIXIO_TLS:=openssl
+endif
+
+ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_cyassl),)
+  NIXIO_TLS:=cyassl
+  #LUCI_CFLAGS+=-I$(STAGING_DIR)/usr/include/cyassl
+  $(warning POPIPOPIAA)
+endif
+
+MAKE_EXTRA_VARS := NIXIO_TLS="$(NIXIO_TLS)"
+
 include ../../luci.mk
+
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/libs/luci-lib-nixio/src/Makefile
+++ b/libs/luci-lib-nixio/src/Makefile
@@ -35,6 +35,7 @@ ifeq ($(NIXIO_TLS),cyassl)
 	TLS_DEPENDS = cyassl-compat.o
 	TLS_CFLAGS = -include cyassl-compat.h
 	NIXIO_OBJ += cyassl-compat.o
+	NIXIO_CFLAGS+=-I$(STAGING_DIR)/usr/include/cyassl
 endif
 
 ifeq ($(NIXIO_TLS),)

--- a/luci.mk
+++ b/luci.mk
@@ -134,7 +134,7 @@ endef
 
 ifneq ($(wildcard ${CURDIR}/src/Makefile),)
  MAKE_PATH := src/
- MAKE_VARS += FPIC="$(FPIC)" LUCI_VERSION="$(PKG_VERSION)" LUCI_GITBRANCH="$(PKG_GITBRANCH)"
+ MAKE_VARS += FPIC="$(FPIC)" LUCI_VERSION="$(PKG_VERSION)" LUCI_GITBRANCH="$(PKG_GITBRANCH)"  $(MAKE_EXTRA_VARS)
 
  define Build/Compile
 	$(call Build/Compile/Default,clean compile)


### PR DESCRIPTION
My lua application is using nixio tls (with openssl or cyassl)
In chaos-calmer it simply disapeared.

I restored the menus, and added a simple system to forward the env variable to the sub makefile.

This is tested OK with cyassl and openssl.
