### PR TITLE
luci-theme-material: remove the double slash (//) from menu url

### DIFF
--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -210,7 +210,7 @@
 			 %>
 			 <li class="slide">
 				 <a class="menu" data-title="<%=pcdata(striptags(nnode.title))%>" href="#"><%=pcdata(striptags(translate(nnode.title)))%></a>
-				 <%- submenu("/" .. category .. "/" .. r .. "/", nnode) %>
+				 <%- submenu(category .. "/" .. r .. "/", nnode) %>
 			 </li>
 			 <%          else %>
 			 <li>


### PR DESCRIPTION
before:

http://192.168.1.1/cgi-bin/luci//admin/status/overview

after:

http://192.168.1.1/cgi-bin/luci/admin/status/overview

similar issue: #625