### PR TITLE
Add support for showing ipv6 NAT table in Luci

### DIFF
--- a/modules/luci-base/luasrc/sys/iptparser.lua
+++ b/modules/luci-base/luasrc/sys/iptparser.lua
@@ -19,6 +19,8 @@ luci.util   = require "luci.util"
 luci.sys    = require "luci.sys"
 luci.ip     = require "luci.ip"
 
+local pcall = pcall
+local io = require "io"
 local tonumber, ipairs, table = tonumber, ipairs, table
 
 module("luci.sys.iptparser")
@@ -37,6 +39,15 @@ function IptParser.__init__( self, family )
 	else
 		self._nulladdr = "::/0"
 		self._tables   = { "filter", "mangle", "raw" }
+                local ok, lines = pcall(io.lines, "/proc/net/ip6_tables_names")
+                if ok and lines then
+                        local line
+                        for line in lines do
+                                if line == "nat" then
+                                        self._tables = { "filter", "nat", "mangle", "raw" }
+                                end
+                        end
+                end
 		self._command  = "ip6tables -t %s --line-numbers -nxvL"
 	end
 

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/iptables.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/iptables.htm
@@ -9,6 +9,7 @@
 	require "luci.sys.iptparser"
 	local wba = require "luci.tools.webadmin"
 	local fs = require "nixio.fs"
+	local io = require "io"
 
 	local has_ip6tables = fs.access("/usr/sbin/ip6tables")
 	local mode = 4
@@ -47,6 +48,15 @@
 	local tables = { "Filter", "NAT", "Mangle", "Raw" }
 	if mode == 6 then
 		tables = { "Filter", "Mangle", "Raw" }
+		local ok, lines = pcall(io.lines, "/proc/net/ip6_tables_names")
+		if ok and lines then
+			local line
+			for line in lines do
+				if line == "nat" then
+					tables = { "Filter", "NAT", "Mangle", "Raw" }
+				end
+			end
+		end
 	end
 -%>
 


### PR DESCRIPTION
Show also the NAT table in Status->Firewall->IPv6 if table is present.

When kmod-nf-nat6 and kmod-ipt-nat6 are installed, the firewall has also
the 'nat' table for ipv6, and packages like 'adblock' utilize that table.

Currently that table is not shown on the Luci firewall status page,
although it is visible by 'ip6tables -L -v -t nat' from console.

This patch adds support for showing that table in Luci. 