### PR TITLE
modules/base: dispatcher: use default language if automatic choice fails

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -197,6 +197,7 @@ function dispatch(request)
 	assert(conf.main,
 		"/etc/config/luci seems to be corrupt, unable to find section 'main'")
 
+	local i18n = require "luci.i18n"
 	local lang = conf.main.lang or "auto"
 	if lang == "auto" then
 		local aclang = http.getenv("HTTP_ACCEPT_LANGUAGE") or ""
@@ -208,7 +209,10 @@ function dispatch(request)
 			end
 		end
 	end
-	require "luci.i18n".setlanguage(lang)
+	if lang == "auto" then
+		lang = i18n.default
+	end
+	i18n.setlanguage(lang)
 
 	local c = ctx.tree
 	local stat


### PR DESCRIPTION
Fall back to default language if "auto" is configured, but none provided by
the browser matches.

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>