### PR TITLE
LuCI: Display the proper LuCI git branch in GUI

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -66,6 +66,19 @@ PKG_VERSION?=$(if $(DUMP),x,$(strip $(shell \
 	echo "$$revision" \
 )))
 
+PKG_GITBRANCH?=$(if $(DUMP),x,$(strip $(shell \
+	variant="LuCI"; \
+	if git log -1 >/dev/null 2>/dev/null; then \
+		branch="$$(git symbolic-ref --short -q HEAD 2>/dev/null)"; \
+		if [ "$$branch" != "master" ]; then \
+			variant="LuCI $$branch branch"; \
+		else \
+			variant="LuCI Master"; \
+		fi; \
+	fi; \
+	echo "$$variant" \
+)))
+
 PKG_RELEASE?=1
 PKG_INSTALL:=$(if $(realpath src/Makefile),1)
 PKG_BUILD_DEPENDS += lua/host luci-base/host $(LUCI_BUILD_DEPENDS)
@@ -121,7 +134,7 @@ endef
 
 ifneq ($(wildcard ${CURDIR}/src/Makefile),)
  MAKE_PATH := src/
- MAKE_VARS += FPIC="$(FPIC)" LUCI_VERSION="$(PKG_VERSION)"
+ MAKE_VARS += FPIC="$(FPIC)" LUCI_VERSION="$(PKG_VERSION)" LUCI_GITBRANCH="$(PKG_GITBRANCH)"
 
  define Build/Compile
 	$(call Build/Compile/Default,clean compile)

--- a/modules/luci-base/src/Makefile
+++ b/modules/luci-base/src/Makefile
@@ -11,7 +11,7 @@ parser.so: template_parser.o template_utils.o template_lmo.o template_lualib.o
 	$(CC) $(LDFLAGS) -shared -o $@ $^
 
 version.lua:
-	./mkversion.sh $@ $(LUCI_VERSION)
+	./mkversion.sh $@ $(LUCI_VERSION) "$(LUCI_GITBRANCH)"
 
 compile: parser.so version.lua
 

--- a/modules/luci-base/src/mkversion.sh
+++ b/modules/luci-base/src/mkversion.sh
@@ -1,28 +1,5 @@
 #!/bin/sh
 
-if svn info >/dev/null 2>/dev/null; then
-	if [ "${4%%/*}" = "branches" ]; then
-		variant="LuCI ${4##*[-/]} Branch"
-	elif [ "${4%%/*}" = "tags" ]; then
-		variant="LuCI ${4##*[-/]} Release"
-	else
-		variant="LuCI Trunk"
-	fi
-elif git status >/dev/null 2>/dev/null; then
-	tag="$(git describe --tags 2>/dev/null)"
-	branch="$(git symbolic-ref --short -q HEAD 2>/dev/null)"
-
-	if [ -n "$tag" ]; then
-		variant="LuCI $tag Release"
-	elif [ "$branch" != "master" ]; then
-		variant="LuCI ${branch##*-} Branch"
-	else
-		variant="LuCI Master"
-	fi
-else
-	variant="LuCI"
-fi
-
 cat <<EOF > $1
 local pcall, dofile, _G = pcall, dofile, _G
 
@@ -36,6 +13,6 @@ else
 	distversion = "Development Snapshot"
 end
 
-luciname    = "$variant"
+luciname    = "${3:-LuCI}"
 luciversion = "${2:-Git}"
 EOF


### PR DESCRIPTION
Adjust luci.mk and luci-base to find out correctly if Luci is built from master or from a branch. (Assume that Luci is permanently in git, forget about Luci svn revisions.) Display that branch name in the footer and the overview page.

### Background

Now that the Openwrt main repo is only git based, private CC15.05 builds display the Luci version strangely. The Luci branch name contains actually the main Openwrt git repo's branch and hash:
```
LuCI 15.05-261-gc75367d Release (git-16.043.44305-e2f9172)
```
The "15.05-261-gc75367d Release" is actually the description of the 15.05 since the release tag in the main Openwrt repo, not the Luci git revision. The reason for that is the following:
* when Luci is built, the make for the luci-base modules runs the src/mkversion.sh script that is used to generate version.lua, which provides the version strings in a live Luci GUI.
* But mkversion.sh is apparently run from the < buildroot >/build_dir, not from the actual dir in feeds/luci/modules/... , so it evaluates the surroundings of build_dir instead of the Luci repo. So it uses the main Openwrt git repo as the reference.
The key contents of version.lua in a CC15.05 build:
```
luciname    = "LuCI 15.05-261-gc75367d Release"
luciversion = "git-16.043.44305-e2f9172"
```
That matches the output of the git commands in mkversion.sh when run in the CC15.05 Openwrt repo.
```
perus@ub1510:/Openwrt/chaos$ git describe --tags
15.05-261-gc75367d
perus@ub1510:/Openwrt/chaos$ git symbolic-ref --short -q HEAD
master

perus@ub1510:/Openwrt/chaos/feeds/luci$ git describe --tags
fatal: No names found, cannot describe anything.
perus@ub1510:/Openwrt/chaos/feeds/luci$ git symbolic-ref --short -q HEAD
for-15.05
```
### Solution

* Evaluate the git branch in luci.mk and pass that to LuCI submodules as a make variable. Use branch name, ignore tags.
* Deprecate svn detection in luci-base's mkversion.sh that generates version.lua. Simply use the git-based value passed from luci.mk by make.

I was unable to figure out the correct way the identify the current Makefile's directory in mkversion.sh, and I did not like a solution to change to $TOPDIR/feeds/luci (which worked), so I figured out a solution that moves the branch evaluation to luci.mk, where the git revision detection is already done (the "git-16.043.44305-e2f9172" part).

This pull request is intended for both DD trunk (Luci master) and the CC for-15.05 branch.
I have tested with both, and it works ok.

Example results in DD trunk and CC15.05:
```
DD trunk:
luciname    = "LuCI Master"
luciversion = "git-16.068.36122-ac9b31c"

Display in GUI: 
Powered by LuCI Master (git-16.068.36122-ac9b31c) / OpenWrt Designated Driver r48975 
----

CC15.05:
luciname    = "LuCI for-15.05 branch"
luciversion = "git-16.043.44305-e2f9172"

Display in GUI: 
Powered by LuCI for-15.05 branch (git-16.043.44305-e2f9172) / OpenWrt Chaos Calmer 15.05
```
I left the "for-" in ```for-15.05```, but that could be also formatted as ```15.05```.

@jow- 
Your input to this?
If ok for trunk, I will cherry pick this also to the CC15.05, where it is actually needed. The identical patch works in both of them. (The fix is mainly needed for CC15.05, but the same problem is also in trunk, Luci GUI currently adjusts its displayed branch name based on Openwrt branch instead of Luci branch.)

### Additional fix for displaying the Openwrt main repo's revision in a CC15.05 build

As a further note, I have patched my own build's Openwrt include/version.mk in CC15.05 to evaluate the svn revision properly also in the CC15.05 branch. But that is an issue for the main Openwrt repo, not Luci:
```
--- a/include/version.mk
+++ b/include/version.mk
@@ -21,7 +21,7 @@ qstrip_escape=$(subst ','\'',$(call qstrip,$(1)))
 #'
 
 VERSION_NUMBER:=$(call qstrip_escape,$(CONFIG_VERSION_NUMBER))
-VERSION_NUMBER:=$(if $(VERSION_NUMBER),$(VERSION_NUMBER),15.05)
+VERSION_NUMBER:=$(if $(VERSION_NUMBER),$(VERSION_NUMBER),15.05-$(REVISION))
 VERSION_CODE:=$(call qstrip_escape,$(CONFIG_VERSION_NUMBER))
 VERSION_CODE:=$(if $(VERSION_CODE),$(VERSION_CODE),Chaos Calmer)
```
That make the version string to be displayed properly also for the detailed svn part:
```
Powered by LuCI for-15.05 branch (git-16.043.44305-e2f9172) / OpenWrt Chaos Calmer 15.05-r48925
```
That change should be implemented in the Openwrt CC15.05 branch, I think. The current choice of displaying only the "15.05" in /etc/openwrt_release is strange as that hides the actual revision and changes since the release.

While writing this I realised that there is also an alternative: Luci's version.lua uses only the DISTRIB_DESCRIPTION field from /etc/openwrt_release as the version designation, and in trunk that includes svn revision by default, while in branches that does not contain it by default. In both, the revision is additionally in the DISTRIB_REVISION field. Luci's version.lua could be patched to evaluate and include the DISTRIB_REVISION if we are in a branch instead of trunk.
