### PR TITLE
luci-mod-admin-full: add sleep before sysupgrade

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
@@ -276,7 +276,7 @@ function action_flashops()
 				msg   = luci.i18n.translate("The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It might be necessary to renew the address of your computer to reach the device again, depending on your settings."),
 				addr  = (#keep > 0) and "192.168.1.1" or nil
 			})
-			fork_exec("killall dropbear uhttpd; sleep 1; /sbin/sysupgrade %s %q" %{ keep, image_tmp })
+			fork_exec("sleep 1; killall dropbear uhttpd; sleep 1; /sbin/sysupgrade %s %q" %{ keep, image_tmp })
 		end
 	elseif reset_avail and luci.http.formvalue("reset") then
 		--


### PR DESCRIPTION
- Under some conditions the system will shutdown
  uhttpd before the page will be delivered to
  the client. Waiting one second should eleminate
  this behaviour.

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>