### PR TITLE
luci-base: Add option to check linked libraries

### DIFF
--- a/modules/luci-base/luasrc/util.lua
+++ b/modules/luci-base/luasrc/util.lua
@@ -636,6 +636,23 @@ function libpath()
 	return require "nixio.fs".dirname(ldebug.__file__)
 end
 
+function checklib(fullpathexe, wantedlib)
+	local fs = require "nixio.fs"
+	local haveldd = fs.access('/usr/bin/ldd')
+	if not haveldd then
+		return -1
+	end
+	local libs = exec("/usr/bin/ldd " .. fullpathexe)
+	if not libs then
+		return 0
+	end
+	for k, v in ipairs(split(libs)) do
+		if v:find(wantedlib) then
+			return 1
+		end
+	end
+	return 0
+end
 
 --
 -- Coroutine safe xpcall and pcall versions modified for Luci


### PR DESCRIPTION
Some packages have different variants that have different
capabilities depending on which libraries against which
they are linked.  Add a function to check which library a
binary links against in order to determine available
functionality.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

This is used by various pull requests coming up.