### PR TITLE
luci-mod-admin-full: Add option to set wireless interface name

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -475,6 +475,9 @@ if hwtype == "mac80211" then
 	wmm:depends({mode="ap"})
 	wmm:depends({mode="ap-wds"})
 	wmm.default = wmm.enabled
+	
+	ifname = s:taboption("advanced", Value, "ifname", translate("Interface name"), translate("Override default interface name"))
+	ifname.optional = true
 end
 
 


### PR DESCRIPTION
With mac80211 you can set the wireless interface;
expose this capability.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>