### PR TITLE
luci-app-pppoe-server: Add PPPoE server configuration

### DIFF
--- a/applications/luci-app-rp-pppoe-server/Makefile
+++ b/applications/luci-app-rp-pppoe-server/Makefile
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Roaring Penguing PPPoE Server
+LUCI_DEPENDS:=+rp-pppoe-server
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-rp-pppoe-server/luasrc/controller/rp-pppoe-server.lua
+++ b/applications/luci-app-rp-pppoe-server/luasrc/controller/rp-pppoe-server.lua
@@ -1,0 +1,13 @@
+-- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.controller.rp-pppoe-server", package.seeall)
+
+function index()
+	if not nixio.fs.access("/etc/config/pppoe") then
+		return
+	end
+
+	entry({"admin", "services", "rp-pppoe-server"}, cbi("rp-pppoe-server"), _("RP PPPoE Server"))
+end
+

--- a/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
+++ b/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
@@ -1,0 +1,72 @@
+-- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local m, s, o
+
+local nixio = require "nixio"
+
+m = Map("pppoe", translate("Roaring Penguin PPPoE Server"),
+	translate("PPPoE Server Configuration"))
+
+s = m:section(TypedSection, "pppoe_server", translate("Server Configuration"))
+s.addremove = false
+s.anonymous = true
+
+o = s:option(Value, "interface", translate("Interface"), translate("Interface on which to listen."))
+o.template = "cbi/network_ifacelist"
+o.nocreate = true
+
+o = s:option(Value, "ac_name", translate("Access Concentrator Name"))
+o.optional = true
+
+o = s:option(DynamicList, "service_name", translate("Service Name"))
+o.optional = true
+
+o = s:option(Value, "maxsessionsperpeer", translate("Maximum sessions per peer"))
+o.optional = true
+o.datatype = "uinteger"
+
+o = s:option(Value, "localip", translate("IP of listening side"))
+o.datetype = "ipaddr"
+
+o = s:option(Value, "firstremoteip", translate("First remote IP"))
+o.datatype = "ipaddr"
+
+o = s:option(Value, "maxsessions", translate("Maximum sessions"))
+o.datatype = "uinteger"
+o.default = 64
+o.optional = true
+
+o = s:option(Value, "optionsfile", translate("Options file"))
+o.default = "/etc/ppp/pppoe-server-options"
+o.optional = true
+
+o = s:option(Flag, "randomsessions", translate("Random session selection"), translate("Instead of starting at beginning and going to end, randomize session number"))
+o.optional = true
+
+o = s:option(Value, "unit", translate("Unit"), translate("PPP unit number"))
+o.optional = true
+o.datatype = "uinteger"
+o.default = 0
+
+o = s:option(Value, "offset", translate("Offset"), translate("PPP offset"))
+o.optional = true
+o.datatype = "uinteger"
+o.default = 0
+
+o = s:option(Value, "timeout", translate("Timeout"))
+o.optional = true
+o.datatype = "uinteger"
+o.default = 60
+
+o = s:option(Value, "mss", translate("MSS"))
+o.optional = true
+o.datatype = "uinteger"
+o.default = 1468
+
+
+o = s:option(Flag, "sync", translate("Sync"))
+o.optional = true
+o.default = false
+
+return m


### PR DESCRIPTION
Adds support for rp-pppoe-server configuration once pending
pull request for packages feed gets applied.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>