### PR TITLE
Update network.lua

### DIFF
--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -666,8 +666,8 @@ function get_status_by_address(self, addr)
 end
 
 function get_wannet(self)
-	local net = self:get_status_by_route("0.0.0.0", 0)
-	return net and network(net)
+	local net, stat = self:get_status_by_route("0.0.0.0", 0)
+	return net and network(net, stat.proto)
 end
 
 function get_wandev(self)
@@ -676,8 +676,8 @@ function get_wandev(self)
 end
 
 function get_wan6net(self)
-	local net = self:get_status_by_route("::", 0)
-	return net and network(net)
+	local net, stat = self:get_status_by_route("::", 0)
+	return net and network(net, stat.proto)
 end
 
 function get_wan6dev(self)


### PR DESCRIPTION
I have now watched "Not connected" on status page for WAN status now 4 years and finally decided to fix the issue. I use a wwan device to provide a wan connection. This commit fixes that issue.

Fix display of WAN status when WAN is provided by using WWAN device or similar with other similar similar methods.
Explanation:
Before this, protocol was fetched from /etc/config/network for interface which often is wan_4 - but protocol is configured in file as wan, and therefore protocol is always none, since configuration is made for wan and then setup as wan_4 and possibly wan_6 if ipv6 is being used. This commit uses ubus to get used active protocol. For example, in case of qmi, it displays protocol as dhcp since even if I configured wan to use qmi, dhcp was used as a protocol for getting IP address.