### PR TITLE
[RFC] luci-base: utils: Make checklib return a boolean

### DIFF
--- a/modules/luci-base/luasrc/util.lua
+++ b/modules/luci-base/luasrc/util.lua
@@ -640,18 +640,18 @@ function checklib(fullpathexe, wantedlib)
 	local fs = require "nixio.fs"
 	local haveldd = fs.access('/usr/bin/ldd')
 	if not haveldd then
-		return -1
+		return false
 	end
 	local libs = exec("/usr/bin/ldd " .. fullpathexe)
 	if not libs then
-		return 0
+		return false
 	end
 	for k, v in ipairs(split(libs)) do
 		if v:find(wantedlib) then
-			return 1
+			return true
 		end
 	end
-	return 0
+	return false
 end
 
 --


### PR DESCRIPTION
Using tristate is counter-intuitive and probably doesn't provide a lot
of benefit so we use a boolean and treat "don't know" as false (because
it is safer than showing options that are not actually available).

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

This pull request is per Hynam's request so he can test before I have a chance to.  I haven't tested to case of library not present (e.g. to omit show options for dnssec for dnsmasq without crypto compiled in (required for dnssec support).