### PR TITLE
luci-mod-freifunk: fix lookup of community-name

### DIFF
--- a/modules/luci-mod-freifunk/luasrc/model/cbi/freifunk/basics.lua
+++ b/modules/luci-mod-freifunk/luasrc/model/cbi/freifunk/basics.lua
@@ -16,7 +16,7 @@ community.rmempty = false
 local profile
 for profile in fs.glob(profiles) do
 	local name = uci:get_first(profile, "community", "name") or "?"
-	community:value(profile, name)
+	community:value(string.gsub(profile, "/etc/config/profile_", ""), name)
 end
 
 


### PR DESCRIPTION
restore the lookup of the freifunk community-name stored in
uci "freifunk.community.name".
In https://github.com/openwrt/luci/commit/9780ee382e72f8a5fb69e337a3fcc51fc0914883
the value changed to the complete path of the community-profile, e.g.
"/etc/config/profile_berlin". This causes lookup problems on other
pages, like "mod-freifunk -> overview -> index" (view/freifunk/index.htm line37, line 54).
And as the option suggests it's the community-name not the community-profile path.

Signed-off-by: Sven Roederer devel-sven@geroedel.de