### PR TITLE
luci-app-olsr: depend on luci-lib-json

### DIFF
--- a/applications/luci-app-olsr/Makefile
+++ b/applications/luci-app-olsr/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=OLSR configuration and status module
-LUCI_DEPENDS:=+olsrd +olsrd-mod-jsoninfo +luci-lib-luaneightbl
+LUCI_DEPENDS:=+olsrd +olsrd-mod-jsoninfo +luci-lib-luaneightbl +luci-lib-json
 
 include ../../luci.mk
 


### PR DESCRIPTION
backport of https://github.com/openwrt/luci/commit/ba897c6a209eec3a4ea447a66407a385170ccb80

Signed-off-by: Sven Roederer <devel-sven@geroedel.de>