### PR TITLE
freifunk-profiles: add profile Cottbus

### DIFF
--- a/contrib/package/community-profiles/files/etc/config/profile_cottbus
+++ b/contrib/package/community-profiles/files/etc/config/profile_cottbus
@@ -1,0 +1,37 @@
+config 'community' 'profile'
+	option 'name' 'Freifunk Cottbus'
+	option 'homepage' 'http://cottbus.freifunk.net'
+	option 'ssid' 'cottbus.freifunk.net'
+	option 'ssid_scheme' 'ssidonly'
+	option 'mesh_network' '10.35.0.0/16'
+	option 'splash_network' '10.104.0.0/16'
+	option 'splash_prefix' '27'
+	option 'latitude' '51.757689'
+	option 'longitude' '13.40948'
+
+config 'defaults' 'wifi_device'
+	option 'channel' '13'
+
+config 'defaults' 'wifi_device_5'
+	option 'channel' '36'
+
+config 'defaults' 'wifi_iface'
+	option 'mcast_rate' '6000'
+
+config 'defaults' 'wifi_iface_5'
+	option 'mcast_rate' '12000'
+
+config 'defaults' 'bssidscheme'
+	option '13'	'D2:CA:FF:EE:BA:BE'
+	option '36'	'02:36:CA:FF:EE:EE'
+
+config 'defaults' 'ssidscheme'
+	option '13'	'intern-ch13.cottbus.freifunk.net'
+	option '36'	'intern-ch36.cottbus.freifunk.net'
+
+config 'defaults' 'interface'
+	option 'netmask' '255.255.255.255'
+	option 'dns' '85.214.20.141 213.73.91.35 194.150.168.168 2001:4ce8::53 2001:910:800::12'
+
+config 'dhcp' 'dhcp'
+	option 'leasetime' '5m'


### PR DESCRIPTION
- add the current community-file for freifunk Cottbus to for-15.05 branch
- this is a copy of the file with all commits up to "Jan 4, 2016"

Signed-off-by: Sven Roederer <devel-sven@geroedel.de>