### PR TITLE
Graph the max value rather than avg if rrdsingle disabled

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
@@ -171,16 +171,29 @@ function Graph._generic( self, opts, plugin, plugin_instance, dtype, index )
 
 		-- is first source in stack or overlay source: source_stk = source_nnl
 		if not prev or source.overlay then
+		     if self.opts.rrasingle then
 			-- create cdef statement for cumulative stack (no NaNs) and also
                         -- for display (preserving NaN where no points should be displayed)
 			_tif( _args, "CDEF:%s_stk=%s_nnl", source.sname, source.sname )
 			_tif( _args, "CDEF:%s_plot=%s_avg", source.sname, source.sname )
+		     else
+			-- create cdef statement for cumulative stack (no NaNs) and also
+                        -- for display (preserving NaN where no points should be displayed)
+			_tif( _args, "CDEF:%s_stk=%s_nnl", source.sname, source.sname )
+			_tif( _args, "CDEF:%s_plot=%s_max", source.sname, source.sname )
+		     end
 
 		-- is subsequent source without overlay: source_stk = source_nnl + previous_stk
 		else
+		     if self.opts.rrasingle then
 			-- create cdef statement
 			_tif( _args, "CDEF:%s_stk=%s_nnl,%s_stk,+", source.sname, source.sname, prev )
 			_tif( _args, "CDEF:%s_plot=%s_avg,%s_stk,+", source.sname, source.sname, prev )
+		     else
+			-- create cdef statement
+			_tif( _args, "CDEF:%s_stk=%s_nnl,%s_stk,+", source.sname, source.sname, prev )
+			_tif( _args, "CDEF:%s_plot=%s_max,%s_stk,+", source.sname, source.sname, prev )
+		     end
 		end
 
 		-- create multiply by minus one cdef if flip is enabled


### PR DESCRIPTION
With rrdsingle the average values are used for graphing. As the
timescale increases (say over a day or month) the average values
progressively reduce.  Using the maximum value over the longer periods
is arguably no less deceptive but it does produce more informative
graphs.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>