### PR TITLE
luci-base:Turn off pattern matching when generating distversion

### DIFF
--- a/modules/luci-base/src/mkversion.sh
+++ b/modules/luci-base/src/mkversion.sh
@@ -10,7 +10,7 @@ if pcall(dofile, "/etc/openwrt_release") and _G.DISTRIB_DESCRIPTION then
 	distversion = _G.DISTRIB_DESCRIPTION
 	if _G.DISTRIB_REVISION then
 		distrevision = _G.DISTRIB_REVISION
-		if not distversion:find(distrevision) then
+		if not distversion:find(distrevision,1,true) then
 			distversion = distversion .. " " .. distrevision
 		end
 	end


### PR DESCRIPTION
Otherwize the distrevision may be displayed twice if it contains some special matching patterns.(For example I am using "git-$hash" in my own OpenWrt branch.)
Signed-off-by: Chuanhong Guo <gch981213@gmail.com>