### PR TITLE
luci-mod-admin-full: Look also if the file /etc/config/fstab exists.

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
@@ -21,7 +21,7 @@ function index()
 	entry({"admin", "system", "startup"}, form("admin_system/startup"), _("Startup"), 45)
 	entry({"admin", "system", "crontab"}, form("admin_system/crontab"), _("Scheduled Tasks"), 46)
 
-	if fs.access("/sbin/block") then
+	if fs.access("/sbin/block") and fs.access("/etc/config/fstab") then
 		entry({"admin", "system", "fstab"}, cbi("admin_system/fstab"), _("Mount Points"), 50)
 		entry({"admin", "system", "fstab", "mount"}, cbi("admin_system/fstab/mount"), nil).leaf = true
 		entry({"admin", "system", "fstab", "swap"},  cbi("admin_system/fstab/swap"),  nil).leaf = true


### PR DESCRIPTION
This pull request adds a condition, which checks whether the file "/etc/config/fstab" exists before it allows access to "mount points".

Signed-off-by: Guido Lipke <lipkegu@gmail.com>