### PR TITLE
luci-base: fix lua interpreter location

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -150,7 +150,7 @@ LUCI_LIBRARYDIR = $(LUA_LIBRARYDIR)/luci
 
 define SrcDiet
 	$(FIND) $(1) -type f -name '*.lua' | while read src; do \
-		if $(STAGING_DIR_HOST)/bin/lua $(STAGING_DIR_HOST)/bin/LuaSrcDiet \
+		if $(STAGING_DIR)/host/bin/lua $(STAGING_DIR)/host/bin/LuaSrcDiet \
 			--noopt-binequiv -o "$$$$src.o" "$$$$src"; \
 		then mv "$$$$src.o" "$$$$src"; fi; \
 	done

--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -37,9 +37,10 @@ define Host/Compile
 endef
 
 define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR)/host/bin
 	$(INSTALL_DIR) $(STAGING_DIR_HOST)/bin
 	$(INSTALL_BIN) src/po2lmo $(STAGING_DIR_HOST)/bin/po2lmo
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/LuaSrcDiet.lua $(STAGING_DIR_HOST)/bin/LuaSrcDiet
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/LuaSrcDiet.lua $(STAGING_DIR)/host/bin/LuaSrcDiet
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
An lua interpreter is required on the building host to run the
luasrcdiet lua script.  Due to a build change, the interpreter was not
being installed to the correct location.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>