### PR TITLE
luci-theme-bootstrap: remove suspicious script include

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -172,7 +172,6 @@
 			<style title="text/css"><%= css %></style>
 		<% end -%>
 		<script src="<%=resource%>/xhr.js"></script>
-		<script src="<%=resource%>/jql.min.js"></script>
 	</head>
 
 	<body class="lang_<%=luci.i18n.context.lang%> <%- if node then %><%= striptags( node.title ) %><%- end %>">


### PR DESCRIPTION
With b3c69b1 a script src of jql.min.js was added. This file doesn't
exists and the commit message doesn't mention this addition.

Signed-off-by: Mathias Kresin <dev@kresin.me>