### PR TITLE
luci-mod-freifunk: Fix "Undefined reference to net.iwdata"

### DIFF
--- a/modules/luci-mod-freifunk/luasrc/view/freifunk/public_status.htm
+++ b/modules/luci-mod-freifunk/luasrc/view/freifunk/public_status.htm
@@ -264,7 +264,7 @@ end
 			netlist[#netlist+1] = net:ifname()
 			netdevs[net:ifname()] = dev:name()
 
-			if net.iwdata.device then
+			if net.iwinfo.signal and net.iwinfo.bssid then
 				local signal = net.iwinfo.signal or "N/A"
 				local noise = net.iwinfo.noise or "N/A"
 				local q = net.iwinfo.quality or "0"


### PR DESCRIPTION
This PR fixes an Internal Server Error when requesting the Wireless Informations in luci-mod-freifunk. 
It checks an unindexed value "net.iwdata".

```
/usr/lib/lua/luci/dispatcher.lua:460: Failed to execute template dispatcher target for entry '/freifunk/status'. The called action terminated with an exception: /usr/lib/lua/luci/template.lua:97: Failed to execute template 'freifunk/public_status'. 

A runtime error occured: [string "/usr/lib/lua/luci/view/freifunk/public_stat..."]:116: attempt to index field 'iwdata' (a nil value) stack traceback: [C]: in function 'assert' /usr/lib/lua/luci/dispatcher.lua:460: in function 'dispatch' /usr/lib/lua/luci/dispatcher.lua:141: in function...
```

signed-off.by: Guido Lipke <lipkegu@gmail.com>