### PR TITLE
luci-app-ddns: pass the is_glue option value to the helper

### DIFF
--- a/applications/luci-app-ddns/Makefile
+++ b/applications/luci-app-ddns/Makefile
@@ -10,7 +10,7 @@ PKG_NAME:=luci-app-ddns
 
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.4.4
+PKG_VERSION:=2.4.5
 
 # Release == build
 # increase on changes of translation files

--- a/applications/luci-app-ddns/luasrc/controller/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/controller/ddns.lua
@@ -190,9 +190,11 @@ local function _get_status()
 		local dnsserver	= s["dns_server"] or ""
 		local force_ipversion = tonumber(s["force_ipversion"] or 0)
 		local force_dnstcp = tonumber(s["force_dnstcp"] or 0)
+		local is_glue = tonumber(s["is_glue"] or 0)
 		local command = [[/usr/lib/ddns/dynamic_dns_lucihelper.sh]]
 		command = command .. [[ get_registered_ip ]] .. lookup_host .. [[ ]] .. use_ipv6 ..
-			[[ ]] .. force_ipversion .. [[ ]] .. force_dnstcp .. [[ ]] .. dnsserver
+			[[ ]] .. force_ipversion .. [[ ]] .. force_dnstcp .. [[ ]] .. dnsserver ..
+			[[ ]] .. is_glue
 		local reg_ip = SYS.exec(command)
 		if reg_ip == "" then
 			reg_ip = "_nodata_"


### PR DESCRIPTION
Otherwise the log is spammed with:

```uhttpd[2037]: sh: 1: unknown operand ```

Signed-off-by: Mathias Kresin <dev@kresin.me>