### PR TITLE
Closes #741: Can't delete disabled wireless networks

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_overview.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_overview.htm
@@ -427,7 +427,7 @@
 					<td class="cbi-value-field" style="width:310px;text-align:right">
 						<input id="<%=net:id()%>-iw-toggle" type="button" class="cbi-button cbi-button-reload" style="width:100px" onclick="wifi_shutdown('<%=net:id()%>', this)" title="<%:Delete this network%>" value="<%:Enable%>" />
 						<input type="button" class="cbi-button cbi-button-edit" style="width:100px" onclick="location.href='<%=net:adminlink()%>'" title="<%:Edit this network%>" value="<%:Edit%>" />
-						<input type="button" class="cbi-button cbi-button-remove" style="width:100px" onclick="wifi_delete('<%=net:ifname()%>')" title="<%:Delete this network%>" value="<%:Remove%>" />
+						<input type="button" class="cbi-button cbi-button-remove" style="width:100px" onclick="wifi_delete('<%=net:id()%>')" title="<%:Delete this network%>" value="<%:Remove%>" />
 					</td>
 				</tr>
 				<% end %>


### PR DESCRIPTION
When a wireless network is disabled it can't be removed. From
wifi_overview.htm the delete call is generated as wlan0, wlan1 or
whatever. This wlan is not working because it is disabled, then LuCI
deletes the virtual radio which really is named as wlan0.