### PR TITLE
luci-app-privoxy: Skip validation of Enabled flag

### DIFF
--- a/applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua
+++ b/applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua
@@ -151,9 +151,9 @@ ena.rmempty	= false
 function ena.cfgvalue(self, section)
 	return (SYS.init.enabled("privoxy")) and "1" or "0"
 end
-function ena.validate(self, value)
-	error("Validate " .. value)
-end
+--function ena.validate(self, value)
+--	error("Validate " .. value)
+--end
 function ena.write(self, section, value)
 	--error("Write " .. value)
 	if value == "1" then


### PR DESCRIPTION
In luci-app-privoxy, ena.validate cause all change to the config from the luci app failed with exception.
Bug from openwrt bleeding edge.

Signed-off-by: Tim Zhang <ttimasdf@users.noreply.github.com>