### PR TITLE
luci-app-commands: allow executing without downloading on public links

### DIFF
--- a/applications/luci-app-commands/luasrc/view/commands.htm
+++ b/applications/luci-app-commands/luasrc/view/commands.htm
@@ -108,16 +108,19 @@
 
 		if (legend && output)
 		{
-			var link = location.protocol + '//' + location.hostname +
+			var prefix = location.protocol + '//' + location.hostname +
 			           (location.port ? ':' + location.port : '') +
-					   location.pathname.split(';')[0] + 'command/' +
-					   id + (args ? '/' + args : '');
-
+					   location.pathname.split(';')[0] + 'command/';
+			var suffix = (args ? '/' + args : '');
+			
+			var link = prefix + id + suffix;
+			var link_nodownload = prefix + id + "s" + suffix;
+			
 			legend.style.display = 'none';
 			output.parentNode.style.display = 'block';
 			output.innerHTML = String.format(
-				'<div class="alert-message"><%:Access command with%> <a href="%s">%s</a></div>',
-				link, link
+				'<div class="alert-message"><p><%:Download execution result%> <a href="%s">%s</a></p><p><%:Or display result%> <a href="%s">%s</a></p></div>',
+				link, link, link_nodownload, link_nodownload
 			);
 
 			location.hash = '#output';

--- a/applications/luci-app-commands/luasrc/view/commands_public.htm
+++ b/applications/luci-app-commands/luasrc/view/commands_public.htm
@@ -1,0 +1,50 @@
+<%#
+ Copyright 2016 t123yh <t123yh@outlook.com>
+ Licensed to the public under the Apache License 2.0.
+-%>
+
+<% css = [[
+.alert-success {
+    color: #3c763d;
+    background-color: #dff0d8;
+    border-color: #d6e9c6;
+}
+
+.alert {
+    padding: 15px;
+    margin-bottom: 20px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+}
+
+.alert-warning {
+    color: #8a6d3b;
+    background-color: #fcf8e3;
+    border-color: #faebcc;
+}
+]] -%>
+
+<%+header%>
+
+<% if exitcode == 0 then %>
+    <div class="alert alert-success" role="alert"> <%:Command executed successfully.%> </div>
+<% else %>
+    <div class="alert alert-warning" role="alert"> <%:Command exited with status code %> <%= exitcode %> </div>
+<% end %>
+
+<% if stdout ~= "" then %>
+    <h3><%:Standard Output%></h3>
+    <pre><%= stdout %></pre>
+<% end %>
+
+<% if stderr ~= "" then %>
+    <h3><%:Standard Error%></h3>
+    <pre><%= stderr %></pre>
+<% end %>
+
+<script>
+    <%# Display top bar on mobile devices -%>
+    document.getElementsByClassName('brand')[0].style.setProperty("display", "block", "important");
+</script>
+
+<%+footer%>

--- a/applications/luci-app-commands/po/en/commands.po
+++ b/applications/luci-app-commands/po/en/commands.po
@@ -11,9 +11,6 @@ msgstr ""
 msgid "A short textual description of the configured command"
 msgstr "A short textual description of the configured command"
 
-msgid "Access command with"
-msgstr "Access command with"
-
 msgid ""
 "Allow executing the command and downloading its output without prior "
 "authentication"
@@ -93,3 +90,21 @@ msgstr ""
 
 msgid "Waiting for command to complete..."
 msgstr "Waiting for command to complete..."
+
+msgid "Command executed successfully."
+msgstr "Command executed successfully."
+
+msgid "Command exited with status code "
+msgstr "Command exited with status code "
+
+msgid "Standard Output"
+msgstr "Standard Output"
+
+msgid "Standard Error"
+msgstr "Standard Error"
+
+msgid "Download execution result"
+msgstr "Download execution result"
+
+msgid "Or display result"
+msgstr "Or display result"

--- a/applications/luci-app-commands/po/zh-cn/commands.po
+++ b/applications/luci-app-commands/po/zh-cn/commands.po
@@ -14,9 +14,6 @@ msgstr ""
 msgid "A short textual description of the configured command"
 msgstr "简短描述命令用途"
 
-msgid "Access command with"
-msgstr "访问命令"
-
 msgid ""
 "Allow executing the command and downloading its output without prior "
 "authentication"
@@ -92,3 +89,21 @@ msgstr "此页面允许您配置自定义Shell命令，并可以从Web界面调�
 
 msgid "Waiting for command to complete..."
 msgstr "等待命令执行完成... ..."
+
+msgid "Command executed successfully."
+msgstr "命令成功执行。"
+
+msgid "Command exited with status code "
+msgstr "命令退出，状态码："
+
+msgid "Standard Output"
+msgstr "标准输出流"
+
+msgid "Standard Error"
+msgstr "标准错误流"
+
+msgid "Download execution result"
+msgstr "下载执行结果"
+
+msgid "Or display result"
+msgstr "显示执行结果"


### PR DESCRIPTION
Now we can get public links that shows execution result rather than downloading it.
We append an `s` behind the command name to show that we intend to show the result.
This is useful: we can just bookmark the link to do something, without having to download the result.

Signed-off-by: t123yh t123yh@outlook.com
