### PR TITLE
luci-app-statistics: Fix missing title in df graphs

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/df.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/df.lua
@@ -6,7 +6,7 @@ module("luci.statistics.rrdtool.definitions.df", package.seeall)
 function rrdargs( graph, plugin, plugin_instance, dtype )
 
 	return {
-		title = "%H: Disk space usage on %di",
+		title = "%H: Disk space usage on %pi",
 		vlabel = "Bytes",
 		per_instance  = true,
 		number_format = "%5.1lf%sB",


### PR DESCRIPTION
It used data source instance name instead of plugin instance name which resulted in missing phrase in graph title, e.g.:

`hostname: Disk space usage on`

vs

`hostname: Disk space usage on overlay-boot`