### PR TITLE
luci-app-pbx: catch unset externhost

### DIFF
--- a/applications/luci-app-pbx/luasrc/model/cbi/pbx-users.lua
+++ b/applications/luci-app-pbx/luasrc/model/cbi/pbx-users.lua
@@ -56,6 +56,10 @@ if ipaddr == nil or ipaddr == "" then
    ipaddr = "(IP address not static)"
 end
 
+if externhost == nil or externhost == "" then
+   externhost = "(Domain/IP Address/Dynamic Domain not set)"
+end
+
 if bindport ~= nil then
    just_ipaddr = ipaddr
    ipaddr = ipaddr .. ":" .. bindport


### PR DESCRIPTION
When externhost ("_Domain/IP Address/Dynamic Domain_") is unset in advanced settings, the user account page fails to load with

```
/usr/lib/lua/luci/dispatcher.lua:433: Failed to execute cbi dispatcher target for entry '/admin/services/pbx/pbx-users'.
The called action terminated with an exception:
/usr/lib/lua/luci/i18n.lua:42: bad argument #2 to 'format' (string expected, got nil)
stack traceback:
	[C]: in function 'assert'
	/usr/lib/lua/luci/dispatcher.lua:433: in function 'dispatch'
	/usr/lib/lua/luci/dispatcher.lua:168: in function </usr/lib/lua/luci/dispatcher.lua:167>
```