### PR TITLE
luci-ssl: Remove polarssl dependancy

### DIFF
--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -10,7 +10,7 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
 LUCI_TITLE:=Standard OpenWrt set with HTTPS support
-LUCI_DEPENDS:=+luci +libustream-polarssl +px5g
+LUCI_DEPENDS:=+luci +libustream +px5g
 
 include ../../luci.mk
 


### PR DESCRIPTION
The openssl backend seems to work in addition to the polarssl one. I imagine mbedtls does as well.