### PR TITLE
Luci support for NCM protocol configuration (comgt-ncm)

### DIFF
--- a/protocols/luci-proto-ncm/Makefile
+++ b/protocols/luci-proto-ncm/Makefile
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Support for NCM Protocol
+LUCI_DEPENDS:=+comgt-ncm
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
+++ b/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
@@ -1,0 +1,35 @@
+-- Copyright 2016 Joerg Schueler-Maroldt <schueler.maroldt@gmail.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local map, section, net = ...
+
+local device, apn, pincode, auth, username, password
+local ipv6, maxwait, defaultroute, metric, peerdns, dns,
+      keepalive_failure, keepalive_interval, demand
+
+
+ifname = section:taboption("general", Value, "ifname", translate("Network device"))
+ifname.rmempty = false
+local ifname_suggestions = nixio.fs.glob("/dev/wwan[0-9]*")
+if ifname_suggestions then
+	local node
+	for node in ifname_suggestions do
+		ifname:value(node)
+	end
+end
+
+apn = section:taboption("general", Value, "apn", translate("Access Point Name (APN)"))
+pincode = section:taboption("general", Value, "pincode", translate("SIM-Pincode"))
+username = section:taboption("general", Value, "username", translate("Username"))
+password = section:taboption("general", Value, "password", translate("Password"))
+password.password = true
+delay = section:taboption("general", Value, "delay", translate("Delay before start AT-commands"))
+mode = section:taboption("general", Value, "mode", translate("Network mode"))
+mode:value("", translate("No change"))
+mode:value("auto", "Automatic")
+mode:value("preferlte", "prefer LTE")
+mode:value("preferumts", "prefer UMTS")
+mode:value("lte", "LTE only")
+mode:value("umts", "UMTS only")
+mode:value("gsm", "GSM/EDGE only")
+

--- a/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
+++ b/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
@@ -2,23 +2,21 @@
 -- Licensed to the public under the Apache License 2.0.
 
 local map, section, net = ...
+local device, apn, ipv6, pincode, username, password, delay, mode
 
-local device, apn, pincode, auth, username, password
-local ipv6, maxwait, defaultroute, metric, peerdns, dns,
-      keepalive_failure, keepalive_interval, demand
-
-
-ifname = section:taboption("general", Value, "ifname", translate("Network device"))
-ifname.rmempty = false
-local ifname_suggestions = nixio.fs.glob("/dev/wwan[0-9]*")
-if ifname_suggestions then
+device = section:taboption("general", Value, "device", translate("Control device"))
+device.rmempty = false
+local device_suggestions = nixio.fs.glob("/dev/tty[A-Z]*")
+if device_suggestions then
 	local node
-	for node in ifname_suggestions do
-		ifname:value(node)
+	for node in device_suggestions do
+		device:value(node)
 	end
 end
 
 apn = section:taboption("general", Value, "apn", translate("Access Point Name (APN)"))
+ipv6 = section:taboption("general", Flag, "ipv6", translate("IPv4/IPv6 APN"))
+ipv6.default = '1'
 pincode = section:taboption("general", Value, "pincode", translate("SIM-Pincode"))
 username = section:taboption("general", Value, "username", translate("Username"))
 password = section:taboption("general", Value, "password", translate("Password"))

--- a/protocols/luci-proto-ncm/luasrc/model/network/proto_ncm.lua
+++ b/protocols/luci-proto-ncm/luasrc/model/network/proto_ncm.lua
@@ -1,0 +1,16 @@
+-- Copyright 2016 Joerg Schueler-Maroldt <schueler.maroldt@gmail.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local proto = luci.model.network:register_protocol("ncm")
+
+function proto.get_i18n(self)
+	return luci.i18n.translate("NCM Network")
+end
+
+function proto.is_installed(self)
+	return nixio.fs.access("/lib/netifd/proto/ncm.sh")
+end
+
+function proto.opkg_package(self)
+	return "comgt-ncm"
+end


### PR DESCRIPTION
The support for ncm in luci is very simple because all is done in comgt-ncm.
To get ist work do this in openwrt-root:
Get "feeds/luci/protocols/luci-proto-ncm"
_rm -rf feeds/luci.tmp/
rm -rf tmp/*
./scripts/feeds update -a
./scripts/feeds install -a
make menuconfig_
Select LuCI / Protocols / luci-proto-ncm
