### PR TITLE
luci-lib-nixio: nixio_lstat calls stat instead of lstat

### DIFF
--- a/libs/luci-lib-nixio/src/fs.c
+++ b/libs/luci-lib-nixio/src/fs.c
@@ -355,7 +355,7 @@ static int nixio_stat(lua_State *L) {
 
 static int nixio_lstat(lua_State *L) {
 	nixio_stat_t buf;
-	if (stat(luaL_checkstring(L, 1), &buf)) {
+	if (lstat(luaL_checkstring(L, 1), &buf)) {
 		return nixio__perror(L);
 	} else {
 		nixio__push_stat(L, &buf);


### PR DESCRIPTION
Hi,

using the `nixio.fs` module I noticed the `nixio.fs.lstat()` function behaves the same way `nixio.fs.stat()` does. Looking at the source code I saw the `nixio_lstat()` C function calls `stat()` but not `lstat()`. This does not seem right.

Thank you in advance,
thoto
