### PR TITLE
Internet Access Control Scheduler App

### DIFF
--- a/applications/luci-app-accesscontrol/Makefile
+++ b/applications/luci-app-accesscontrol/Makefile
@@ -1,0 +1,18 @@
+# Copyright (C) 2016 Openwrt.org
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+#
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI Access Control Configuration
+PKG_NAME:=luci-app-accesscontrol
+PKG_VERSION:=1.2
+PKG_RELEASE=$(PKG_SOURCE_VERSION)
+PKG_MAINTAINER:=August Germar <august@anonabox.com>
+LUCI_DEPENDS:=
+
+#
+include ../../luci.mk
+#
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-accesscontrol/luasrc/controller/access_control.lua
+++ b/applications/luci-app-accesscontrol/luasrc/controller/access_control.lua
@@ -1,0 +1,29 @@
+--[[
+LuCI - Lua Configuration Interface - Internet access control
+
+Copyright 2015 Krzysztof Szuster.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+module("luci.controller.access_control", package.seeall)
+
+function index()
+	if not nixio.fs.access("/etc/config/firewall") then
+		return
+	end
+--	if not nixio.fs.access("/etc/config/access_control") then
+--		return
+--	end
+	
+	local page
+	page = entry({"admin", "network", "access_control"}, 
+	    cbi("access_control"), _("Access Control"))
+	page.dependent = true
+end

--- a/applications/luci-app-accesscontrol/luasrc/controller/access_control.lua
+++ b/applications/luci-app-accesscontrol/luasrc/controller/access_control.lua
@@ -2,7 +2,7 @@
 LuCI - Lua Configuration Interface - Internet access control
 
 Copyright 2015 Krzysztof Szuster.
-
+Copyright 2016 prpl Foundation
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/applications/luci-app-accesscontrol/luasrc/model/cbi/access_control.lua
+++ b/applications/luci-app-accesscontrol/luasrc/model/cbi/access_control.lua
@@ -1,0 +1,172 @@
+--[[
+LuCI - Lua Configuration Interface - Internet access control
+
+Copyright 2015 Krzysztof Szuster.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+local CONFIG_FILE_RULES = "firewall"  
+local CONFIG_FILE_AC    = "access_control"
+local ma, mr, s, o
+
+ma = Map(CONFIG_FILE_AC, translate("Internet Access Schedule Control"),
+    translate("Access Schedule Control allows you to manage Internet access for specific local hosts.<br/>\
+       Each rule defines which user has blocked access to the internet. The rules may be active permanently or in certain time of day.<br/>\
+       Use the dropdown menu under MAC address (Computer Name) to select which device you would like to make a schedule for, then a start and stop time and days of the week. <br/>\
+       Start and End times are notated in 24 hour (military) time based on UTC. <br/> \
+       UTC is always the same regardless of what timezone you are in, for example, if you are in California (PST timezone) and it is 11am, UTC is currently 6pm, which you would put into the Start or End time fields as 18:00. <br/>\
+       To check what time it is in UTC right now, click <a href=\"https://www.timeanddate.com/worldclock/timezone/utc\"> here. </a>  <br/> \
+       The rules may also be restricted to specific days of the week."))
+if CONFIG_FILE_AC==CONFIG_FILE_RULES then
+    mr = ma
+else
+    mr = Map(CONFIG_FILE_RULES)
+end
+---------------------------------------------------------------------------------------------
+--  General switch
+
+s = ma:section(NamedSection, "general", "access_control", "General switch")
+    o_global_enable = s:option(Flag, "enabled", translate("Enabled"))
+        o_global_enable.rmempty = false
+        
+---------------------------------------------------------------------------------------------
+-- Rule table
+
+s = mr:section(TypedSection, "rule", translate("Client Rules"))
+    s.addremove = true
+    s.anonymous = true
+--    s.sortable  = true
+    s.template = "cbi/tblsection"
+    -- hidden, constant options
+    s.defaults.enabled = "0"
+    s.defaults.src     = "*" --"lan", "guest" or enything on local side
+    s.defaults.dest    = "wan"
+    s.defaults.target  = "REJECT"
+    s.defaults.proto    = "0"
+    s.defaults.extra = "--kerneltz"
+    
+    -- only AC-related rules
+    s.filter = function(self, section)
+	      return self.map:get (section, "ac_enabled") ~= nil
+    end
+        
+    o = s:option(Flag, "ac_enabled", translate("Enabled"))
+        o.default = '1'
+        o.rmempty  = false
+    
+        -- ammend "enabled" option and set weekdays  
+        function o.write(self, section, value)
+            wd_write (self, section, value)
+            local key = o_global_enable:cbid (o_global_enable.section.section)
+            --  "cbid.access_control.general.enabled"
+            local global_enable = o_global_enable.map:formvalue (key)
+            if global_enable == "1" then
+                self.map:set(section, "enabled", value)
+            else
+                self.map:set(section, "enabled", "0")
+            end	
+--            self.map:set(section, "src",  "*")
+--            self.map:set(section, "dest", "wan")
+--            self.map:set(section, "target", "REJECT")
+--            self.map:set(section, "proto", "0")
+--            self.map:set(section, "extra", "--kerneltz")
+            return Flag.write(self, section, value)
+        end
+      
+    o = s:option(Value, "name", "Description")
+--        o.rmempty = false  -- force validate
+--        -- better validate, then: o.datatype = "minlength(1)"
+--        o.validate = function(self, val, sid)
+--            if type(val) ~= "string" or #val == 0 then
+--                return nil, translate("Name must be specified!")
+--            end
+--            return val
+--        end
+        
+     o = s:option(Value, "src_mac", "MAC address (Computer Name) ") 
+        o.rmempty = false
+        o.datatype = "macaddr"
+        luci.sys.net.mac_hints(function(mac, name)
+            o:value(mac, "%s (%s)" %{ mac, name })
+        end)
+
+    function validate_time(self, value, section)
+        local hh, mm
+        hh,mm = string.match (value, "^(%d?%d):(%d%d)$")
+        hh = tonumber (hh)
+        mm = tonumber (mm)
+        if hh and mm and hh <= 23 and mm <= 59 then
+            return value
+        else
+            return nil, "Time value must be HH:MM or empty"
+        end
+    end
+    o = s:option(Value, "start_time", "Start time")
+        o.rmempty = true  -- do not validae blank
+        o.validate = validate_time 
+        o.size = 5
+    o = s:option(Value, "stop_time", "End time") 
+        o.rmempty = true  -- do not validae blank
+        o.validate = validate_time
+        o.size = 5
+
+    local Days = {'mon','tue','wed','thu','fri','sat','sun'}
+    local Days1 = translate('MTWTFSS')
+    
+    function make_day (nday)
+        local day = Days[nday]
+        local label = Days1:sub (nday,nday)
+        local o = s:option(Flag, day, label)
+        o.default = '1'
+        o.rmempty = false  --  always call write
+        
+        -- read from weekdays actually
+        function o.cfgvalue(self, s)
+            local days = self.map:get (s, "weekdays")
+            if days==nil then
+                return '1'
+            end
+            return string.find (days, day) and '1' or '0'
+        end
+     
+        --  prevent saveing option in config file   
+        function o.write(self, section, value)
+            self.map:set(section, self.option, '')
+        end
+    end
+  
+    for i=1,7 do   
+        make_day (i)
+    end   
+    
+    function wd_write(self, section, value)
+        value=''
+        local cnt=0
+        for _,day in ipairs (Days) do
+            local key = "cbid."..self.map.config.."."..section.."."..day
+--io.stderr:write (tostring(key)..'='..tostring(mr:formvalue(key))..'\n')
+            if mr:formvalue(key) then
+                value = value..' '..day
+                cnt = cnt+1
+            end
+        end
+        if cnt==7  then  --all days means no filterung 
+            value = ''
+        end
+        self.map:set(section, "weekdays", value)
+    end
+
+
+if CONFIG_FILE_AC==CONFIG_FILE_RULES then
+  return ma
+else
+  return ma, mr
+end
+

--- a/applications/luci-app-accesscontrol/root/etc/config/access_control
+++ b/applications/luci-app-accesscontrol/root/etc/config/access_control
@@ -1,0 +1,4 @@
+
+config access_control 'general'
+	option enabled '1'
+


### PR DESCRIPTION
Internet Access Control Scheduler (Update 3)

Description:

This is an updated version of a Luci app that allows scheduling of network access to hosts on the LAN based on time of day and Mac address. Built and tested for BB,CC,DD and Trunk.
Continuing work of original version by Krzysztof Szuster: https://github.com/k-szuster
- All references to original author left in.
- Added myself as maintainer contact. (original project apparently abandoned)
- Added additional documentation regarding UTC and the difference between kernel time and local "system" time to make it easier for the end user.
- This is an updated version of previous pull requests: #783 and #786 
  -more info and platform independant .ipk for testing at:  https://github.com/augustgermar/luci-app-accesscontrol
- Comments welcome! Thank you.

Signed-off-by: August Germar august@anonabox.com
