### PR TITLE
luci-ssl-openssl: Provide OpenSSL-based LuCI collection

### DIFF
--- a/collections/luci-ssl-openssl/Makefile
+++ b/collections/luci-ssl-openssl/Makefile
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2016 The LuCI Team
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TYPE:=col
+LUCI_BASENAME:=ssl-openssl
+
+LUCI_TITLE:=LuCI with HTTPS support (OpenSSL as SSL backend)
+LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
+ Note: px5g still requires libpolarssl
+LUCI_DEPENDS:=+luci +libustream-openssl +px5g
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+# Copyright (C) 2008-2016 The LuCI Team
 #
 # This is free software, licensed under the Apache License, Version 2.0 .
 #
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
-LUCI_TITLE:=Standard OpenWrt set with HTTPS support
+LUCI_TITLE:=LuCI with HTTPS support (PolarSSL as SSL backend)
 LUCI_DEPENDS:=+luci +libustream-polarssl +px5g
 
 include ../../luci.mk


### PR DESCRIPTION
@jow- 
Your opinion, please. 

The discussion with build000 got me into looking things and this might be the sensible first step on the LuCI side. I thought about creating a menu for selecting the SSL provider for luci-ssl, but then I thought that it is more-straightforward to keep the old luci-ssl intact and to create a new collection next to it.

* Add a new OpenSSL-based collection ```luci-ssl-openssl``` that uses libustream-openssl instead of the default libustream-polarssl. (Note: px5g is included and still needs libpolarssl, so both underlying SSL libs will be included. Mention that in the package description.)
* Mention PolarSSL in the title of luci-ssl.

------------
Additional thoughts:

The next step in the path towards "openssl-only" would be to look for openssl-based alternatives for px5g, e.g. a new px5g-openssl variant with only a script calling openssl, but that will require coordination between LEDE and Openwrt, as we can't define a core LuCI dependency for a package that exists only in one of them.

I have already tested creating certs for uhttpd with Openssl and it works ok by itself.
```
/usr/sbin/px5g  selfsigned -der -days 365 -newkey rsa:2048 -keyout ./test.key -out ./test.crt -subj /C="FI"/ST="Uusi maa"/L="Es poo"/CN="user"
```
openssl equivalent (Note: key is still in PEM format, but uhttpd copes with that)
```
openssl req -x509 -outform der -nodes -days 365 -newkey rsa:2048 -keyout ./test.key -out ./test.crt -subj /C="FI"/ST="Uusi maa"/L="Es poo"/CN="user"
```
But when I tried to figure out how to use the existing uhttpd init file without modifications (in order to have just a new px5g-openssl script replacing px5g), I stumbled into a problem: I have not been able to figure out how to pass double-quoted arguments from uhttpd init into a script that converts the received px5g command into a openssl command and calls openssl. The certificate subject contains double-quoted items and those quotes get parsed and removed. That leads into trouble if any of the cert subject field contains space.

https://git.lede-project.org/?p=source.git;a=blob;f=package/network/services/uhttpd/files/uhttpd.init;hb=HEAD#l46
So far it looks like the easiest solution would be modify the uhttpd init script itself to directly call openssl if px5g is not found. But I am not sure if that kind of solution would be acceptable.