### PR TITLE
luci-app-statistics: Fix disk space usage title

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/df.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/df.lua
@@ -6,7 +6,7 @@ module("luci.statistics.rrdtool.definitions.df", package.seeall)
 function rrdargs( graph, plugin, plugin_instance, dtype )
 
 	return {
-		title = "%H: Disk space usage on %di",
+		title = "%H: Disk space usage on %pi",
 		vlabel = "Bytes",
 		per_instance  = true,
 		number_format = "%5.1lf%sB",


### PR DESCRIPTION
Disk space usage title used wrong substitution and didn't actually
include the name of what disk space usage was for.