### PR TITLE
collections/luci-ssl: Make SSL backend depend on new global setting

### DIFF
--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -10,7 +10,7 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
 LUCI_TITLE:=Standard OpenWrt set with HTTPS support
-LUCI_DEPENDS:=+luci +libustream-polarssl +px5g
+LUCI_DEPENDS:=+luci +SSL_DEFAULT_POLARSSL:libustream-polarssl +SSL_DEFAULT_MBEDTLS:libustream-mbedtls +SSL_DEFAULT_OPENSSL:libustream-openssl +SSL_DEFAULT_CYASSL:libustream-cyassl +SSL_DEFAULT_MBEDTLS:px5g-mbedtls +SSL_DEFAULT_POLARSSL:px5g-polarssl +SSL_DEFAULT_OPENSSL:px5g-standalone +SSL_DEFAULT_CYASSL:px5g-standalone
 
 include ../../luci.mk
 


### PR DESCRIPTION
Core now has the ability to specify the global ssl backend,
use that to determine what SSL-using libraries/programs to
depend on

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>

Depends on the corresponding SSL library global selection for trunk.