### PR TITLE
luci-base: use default install paths for host utils

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -150,8 +150,7 @@ LUCI_LIBRARYDIR = $(LUA_LIBRARYDIR)/luci
 
 define SrcDiet
 	$(FIND) $(1) -type f -name '*.lua' | while read src; do \
-		if $(STAGING_DIR)/host/bin/lua $(STAGING_DIR)/host/bin/LuaSrcDiet \
-			--noopt-binequiv -o "$$$$src.o" "$$$$src"; \
+		if LuaSrcDiet --noopt-binequiv -o "$$$$src.o" "$$$$src"; \
 		then mv "$$$$src.o" "$$$$src"; fi; \
 	done
 endef

--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -37,10 +37,9 @@ define Host/Compile
 endef
 
 define Host/Install
-	$(INSTALL_DIR) $(STAGING_DIR)/host/bin
-	$(INSTALL_DIR) $(STAGING_DIR_HOST)/bin
-	$(INSTALL_BIN) src/po2lmo $(STAGING_DIR_HOST)/bin/po2lmo
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/LuaSrcDiet.lua $(STAGING_DIR)/host/bin/LuaSrcDiet
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) src/po2lmo $(1)/bin/po2lmo
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/LuaSrcDiet.lua $(1)/bin/LuaSrcDiet
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Also, don't make any assumptions about the staging dir lua and LuaSrcDiet
were installed to.

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>