### PR TITLE
Fixed build error

### DIFF
--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -37,9 +37,9 @@ define Host/Compile
 endef
 
 define Host/Install
-	$(INSTALL_DIR) $(1)/bin
-	$(INSTALL_BIN) src/po2lmo $(1)/bin/po2lmo
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/LuaSrcDiet.lua $(1)/bin/LuaSrcDiet
+	$(INSTALL_DIR) $(HOST_BUILD_PREFIX)/bin
+	$(INSTALL_BIN) src/po2lmo $(HOST_BUILD_PREFIX)/bin/po2lmo
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/LuaSrcDiet.lua $(HOST_BUILD_PREFIX)/bin/LuaSrcDiet
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Due to wrong path in Makefile it tried to install into host's /bin
instead of prefixed buildroot