### PR TITLE
luci: add luci-ssl-mbedtls build option

### DIFF
--- a/collections/luci-ssl-mbedtls/Makefile
+++ b/collections/luci-ssl-mbedtls/Makefile
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2008-2016 The LuCI Team
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TYPE:=col
+LUCI_BASENAME:=ssl-mbedtls
+
+LUCI_TITLE:=LuCI with HTTPS support (mbedTLS as SSL backend)
+LUCI_DEPENDS:=+luci +libustream-mbedtls +px5g
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
Build using mbedtls v2 SSL library instead of polarssl/mbedtls v1

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>

Perhaps this can be the start of a migration to mbedTLS rather than relying on polarssl?  px5g and libustream-ssl all have mbedtls variants in LEDE.  On a simple luci ssl build this package allows use of the more modern mbedtls lib alone.