### PR TITLE
luci-proto-wireguard: WireGuard VPN Protocol (New)

### DIFF
--- a/protocols/luci-proto-wireguard/Makefile
+++ b/protocols/luci-proto-wireguard/Makefile
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Support for WireGuard VPN
+LUCI_DEPENDS:=+wireguard
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
+++ b/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
@@ -1,0 +1,162 @@
+-- Copyright 2016 Dan Luedtke <mail@danrl.com>
+-- Licensed to the public under the Apache License 2.0.
+
+
+local map, section, net = ...
+local ifname = net:get_interface():name()
+local private_key, listen_port, addresses
+local metric, mtu, preshared_key
+local peers, public_key, allowed_ips, endpoint, persistent_keepalive
+
+
+-- general ---------------------------------------------------------------------
+
+private_key = section:taboption(
+  "general",
+  Value,
+  "private_key",
+  translate("Private Key"),
+  translate("Required. Base64-encoded private key for this interface.")
+)
+private_key.password = true
+private_key.datatype = "and(minlength(44),maxlength(44))"
+private_key.optional = false
+
+
+listen_port = section:taboption(
+  "general",
+  Value,
+  "listen_port",
+  translate("Listen Port"),
+  translate("Optional. UDP port used for outgoing and incoming packets.")
+)
+listen_port.datatype = "port"
+listen_port.placeholder = "51820"
+listen_port.optional = true
+
+
+addresses = section:taboption(
+  "general",
+  DynamicList,
+  "addresses",
+  translate("IP Addresses"),
+  translate("Required. IP adress(es) of the tunnel interface in prefix " ..
+            "notation.")
+)
+addresses.datatype = "or(ip6addr, ip4addr)"
+addresses.placeholder = "fd00:13:37::1/64"
+addresses.optional = false
+
+
+-- advanced --------------------------------------------------------------------
+
+metric = section:taboption(
+  "advanced",
+  Value,
+  "metric",
+  translate("Metric"),
+  translate("Optional.")
+)
+metric.datatype = "uinteger"
+metric.placeholder = "0"
+metric.optional = true
+
+
+mtu = section:taboption(
+  "advanced",
+  Value,
+  "mtu",
+  translate("MTU"),
+  translate("Optional. Maximum Transmission Unit of tunnel interface.")
+)
+mtu.datatype = "range(1280,1423)"
+mtu.placeholder = "1423"
+mtu.optional = true
+
+
+preshared_key = section:taboption(
+  "advanced",
+  Value,
+  "preshared_key",
+  translate("Preshared Key"),
+  translate("Optional. Adds in an additional layer of symmetric-key " ..
+            "cryptography for post-quantum resistance.")
+)
+preshared_key.password = true
+preshared_key.datatype = "and(minlength(44),maxlength(44))"
+preshared_key.optional = true
+
+
+-- peers -----------------------------------------------------------------------
+
+peers = map:section(
+  TypedSection,
+  "wireguard_" .. string.sub(ifname, 4),
+  translate("Peers"),
+  translate("Further information about Wireguard interfaces and peers " ..
+            "at <a href=\"http://wireguard.io\">wireguard.io</a>.")
+)
+peers.template = "cbi/tsection"
+peers.anonymous = true
+peers.addremove = true
+
+
+public_key = peers:option(
+  Value,
+  "public_key",
+  translate("Public Key"),
+  translate("Required. Public key of peer.")
+)
+public_key.datatype = "and(minlength(44),maxlength(44))"
+public_key.optional = false
+
+
+allowed_ips = peers:option(
+  DynamicList,
+  "allowed_ips",
+  translate("Allowed IPs"),
+  translate("Required. IP addresses and prefixes that this peer is allowed " ..
+            "to use inside the tunnel. Routes will be added accordingly.")
+)
+allowed_ips.datatype = "or(ip6addr, ip4addr)"
+allowed_ips.optional = false
+
+
+route_allowed_ips = peers:option(
+  Flag,
+  "route_allowed_ips",
+  translate("Route Allowed IPs"),
+  translate("Optional. Create routes for Allowed IPs for this peer.")
+)
+route_allowed_ips.enabled = "enabled"
+route_allowed_ips.disabled = "disabled"
+
+
+endpoint_host = peers:option(
+  Value,
+  "endpoint_host",
+  translate("Endpoint Host"),
+  translate("Optional. Host of peer. Names are resolved " ..
+            "prior to bringing up the interface."))
+endpoint_host.placeholder = "vpn.example.com"
+endpoint_host.datatype = "host"
+
+
+endpoint_port = peers:option(
+  Value,
+  "endpoint_port",
+  translate("Endpoint Port"),
+  translate("Optional. Port of peer."))
+endpoint_port.placeholder = "51820"
+endpoint_port.datatype = "port"
+
+
+persistent_keepalive = peers:option(
+  Value,
+  "persistent_keepalive",
+  translate("Persistent Keep Alive"),
+  translate("Optional. Seconds between keep alive messages. " ..
+            "Default is 0 (disabled). Recommended value if " ..
+            "this device is behind a NAT is 25."))
+persistent_keepalive.datatype = "range(0, 65535)"
+persistent_keepalive.placeholder = "0"

--- a/protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua
+++ b/protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua
@@ -1,0 +1,44 @@
+-- Copyright 2016 Dan Luedtke <mail@danrl.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local netmod = luci.model.network
+local interface = luci.model.network.interface
+local proto = netmod:register_protocol("wireguard")
+
+function proto.get_i18n(self)
+  return luci.i18n.translate("Wireguard VPN")
+end
+
+function proto.ifname(self)
+  return "wg-" .. self.sid
+end
+
+function proto.get_interface(self)
+  return interface(self:ifname(), self)
+end
+
+function proto.opkg_package(self)
+  return "wireguard-tools"
+end
+
+function proto.is_installed(self)
+  return nixio.fs.access("/lib/netifd/proto/wireguard.sh")
+end
+
+function proto.is_floating(self)
+  return true
+end
+
+function proto.is_virtual(self)
+  return true
+end
+
+function proto.get_interfaces(self)
+  return nil
+end
+
+function proto.contains_interface(self, ifc)
+   return (netmod:ifnameof(ifc) == self:ifname())
+end
+
+netmod:register_pattern_virtual("^wg-%w")


### PR DESCRIPTION
This adds support for WireGuard VPN protocol. It has been tested for a while.

Development repo and screenshots: https://github.com/danrl/luci-proto-wireguard

> WireGuard is an extremely simple yet fast and modern VPN that utilizes state-of-the-art cryptography. It aims to be faster, simpler, leaner, and more useful than IPSec, while avoiding the massive headache. It intends to be considerably more performant than OpenVPN. WireGuard is designed as a general purpose VPN for running on embedded interfaces and super computers alike, fit for many different circumstances.

https://www.wireguard.io

Thanks to all the testers and the creators of wireguard for their great support.

Signed-off-by: Dan Lüdtke <mail@danrl.com>