### PR TITLE
luci-mod-admin-full: add config possibility to hide led config page

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
@@ -27,8 +27,10 @@ function index()
 		entry({"admin", "system", "fstab", "swap"},  cbi("admin_system/fstab/swap"),  nil).leaf = true
 	end
 
-	if fs.access("/sys/class/leds") then
-		entry({"admin", "system", "leds"}, cbi("admin_system/leds"), _("<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"), 60)
+	if ( luci.config.show and luci.config.show.AdminSystemLeds or "1" ) == "1" then
+		if fs.access("/sys/class/leds") then
+			entry({"admin", "system", "leds"}, cbi("admin_system/leds"), _("<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"), 60)
+		end
 	end
 
 	entry({"admin", "system", "flashops"}, call("action_flashops"), _("Backup / Flash Firmware"), 70)


### PR DESCRIPTION
In some situation it is neccassery to hide the configuration possibility
for some pages. In this example the led page.

Under the config page /etc/config/luci there is a new config area with
the name "show". The page will always shown until you add the name
"AdminSystemLeds" with value "0" to the config.

For now the page "AdminSystemLeds" is configurable. See commit.

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>