### PR TITLE
luci-base: Add HttpOnly flag to the sysauth cookie

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -382,7 +382,7 @@ function dispatch(request)
 					end
 
 					if sess and token then
-						http.header("Set-Cookie", 'sysauth=%s; path=%s' %{ sess, build_url() })
+						http.header("Set-Cookie", 'sysauth=%s; path=%s; HttpOnly' %{ sess, build_url() })
 
 						ctx.authsession = sess
 						ctx.authtoken = token


### PR DESCRIPTION
If the browsers enforces HttpOnly, a client side script will be unable
to read or write the session cookie.
https://www.owasp.org/index.php/HttpOnly

This minor code change may prevent client-side attacks (cookie stealing),
but should not break anything. Free security :)

The Secure flag would be nice too, but it is impossible for Lua to
determine if https is enforced at the server level.

This is my first contribution here, sorry if I missed something. Commit is gpg signed+signed-off-by