### PR TITLE
luci-proto-wireguard: do not depend on meta-package

### DIFF
--- a/protocols/luci-proto-wireguard/Makefile
+++ b/protocols/luci-proto-wireguard/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for WireGuard VPN
-LUCI_DEPENDS:=+wireguard
+LUCI_DEPENDS:=+kmod-wireguard +wireguard-tools
 
 PKG_MAINTAINER:=Dan Luedtke <mail@danrl.com>
 


### PR DESCRIPTION
Signed-off-by: Dan Luedtke <mail@danrl.com>

Fixes #855 