### PR TITLE
luci-mod-admin-full: Store system time into RTC also

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
@@ -52,6 +52,7 @@ function action_clock_status()
 			luci.sys.call("date -s '%04d-%02d-%02d %02d:%02d:%02d'" %{
 				date.year, date.month, date.day, date.hour, date.min, date.sec
 			})
+			luci.sys.call("/etc/init.d/sysfixtime restart")
 		end
 	end
 


### PR DESCRIPTION
We're currently just setting system time, but we don't set battery
backed RTC. Time in the RTC is only set on the graceful shutdown, which
is quite hard to achieve on embedded devices.

In other words, on systems with battery backed RTC we currently don't
handle following use case properly:

1. Set system time from web UI (sets only system time, but not RTC)
2. Unplug the device from power

Then after the reboot, we've wrong system time again, because time set
in [1] is not saved to battery backed RTC.

Signed-off-by: Petr Štetiar <ynezz@true.cz>