### PR TITLE
luci-proto-wireguard: Fix misleading description

### DIFF
--- a/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
+++ b/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
@@ -103,7 +103,8 @@ allowed_ips = peers:option(
   "allowed_ips",
   translate("Allowed IPs"),
   translate("Required. IP addresses and prefixes that this peer is allowed " ..
-            "to use inside the tunnel. Routes will be added accordingly.")
+            "to use inside the tunnel. Usually the peer's tunnel IP " ..
+            "addresses and the networks the peer routes through the tunnel.")
 )
 allowed_ips.datatype = "ipaddr"
 allowed_ips.optional = false


### PR DESCRIPTION
Description was misleading, as the routes are not created automatically. We have
a flag to create routes. Added a hint what to fill into the AlledIPs field as
users repeatedly have struggled to use it correctly. Thanks to Stefan Agner for
providing feedback on this.

Signed-off-by: Dan Luedtke <mail@danrl.com>