### PR TITLE
luci-app-ddns: update to support ddns-scripts 2.7.6

### DIFF
--- a/applications/luci-app-ddns/Makefile
+++ b/applications/luci-app-ddns/Makefile
@@ -1,16 +1,18 @@
 #
-# Copyright (C) 2008-2016 The LuCI Team <luci@lists.subsignal.org>
+# Copyright 2008 Steven Barth <steven@midlink.org>
+# Copyright 2008 Jo-Philipp Wich <jow@openwrt.org>
+# Copyright 2013 Manuel Munz <freifunk at somakoma dot de>
+# Copyright 2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
-# This is free software, licensed under the Apache License, Version 2.0 .
-#
+# This is free software, licensed under the Apache License, Version 2.0
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=luci-app-ddns
+# PKG_NAME:=luci-app-ddns
 
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.4.7
+PKG_VERSION:=2.4.8
 
 # Release == build
 # increase on changes of translation files
@@ -22,15 +24,13 @@ PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 # LuCI specific settings
 LUCI_TITLE:=LuCI Support for Dynamic DNS Client (ddns-scripts)
 LUCI_DEPENDS:=+luci-mod-admin-full +ddns-scripts
-LUCI_PKGARCH:=all
+# LUCI_PKGARCH:=all
 
 define Package/$(PKG_NAME)/config
 # shown in make menuconfig <Help>
 help
 	$(LUCI_TITLE)
-	.
 	Version: $(PKG_VERSION)-$(PKG_RELEASE)
-	$(PKG_MAINTAINER)
 endef
 
 include ../../luci.mk

--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua
@@ -16,7 +16,8 @@ m.redirect	= DISP.build_url("admin", "services", "ddns")
 
 function m.commit_handler(self)
 	if self.changed then	-- changes ?
-		os.execute("/etc/init.d/ddns reload &")	-- reload configuration
+		local command = CTRL.luci_helper .. " -- reload"
+		os.execute(command)	-- reload configuration
 	end
 end
 
@@ -40,8 +41,8 @@ function ns.cfgvalue(self, section)
 	return self.map:get(section)
 end
 
--- allow_local_ip  -- ##########################################################
-local ali	= ns:option(Flag, "allow_local_ip")
+-- upd_privateip  -- ###########################################################
+local ali	= ns:option(Flag, "upd_privateip")
 ali.title	= translate("Allow non-public IP's")
 ali.description = translate("Non-public and by default blocked IP's") .. ":"
 		.. [[<br /><strong>IPv4: </strong>]]
@@ -50,8 +51,8 @@ ali.description = translate("Non-public and by default blocked IP's") .. ":"
 		.. "::/32, f000::/4"
 ali.default	= "0"
 
--- date_format  -- #############################################################
-local df	= ns:option(Value, "date_format")
+-- ddns_dateformat  -- #########################################################
+local df	= ns:option(Value, "ddns_dateformat")
 df.title	= translate("Date format")
 df.description	= [[<a href="http://www.cplusplus.com/reference/ctime/strftime/" target="_blank">]]
 		.. translate("For supported codes look here") 
@@ -69,8 +70,8 @@ function df.parse(self, section, novld)
 	DDNS.value_parse(self, section, novld)
 end
 
--- run_dir  -- #################################################################
-local rd	= ns:option(Value, "run_dir")
+-- ddns_rundir  -- #############################################################
+local rd	= ns:option(Value, "ddns_rundir")
 rd.title	= translate("Status directory")
 rd.description	= translate("Directory contains PID and other status information for each running section")
 rd.default	= "/var/run/ddns"
@@ -79,8 +80,8 @@ function rd.parse(self, section, novld)
 	DDNS.value_parse(self, section, novld)
 end
 
--- log_dir  -- #################################################################
-local ld	= ns:option(Value, "log_dir")
+-- ddns_logdir  -- #############################################################
+local ld	= ns:option(Value, "ddns_logdir")
 ld.title	= translate("Log directory")
 ld.description	= translate("Directory contains Log files for each running section")
 ld.default	= "/var/log/ddns"
@@ -89,8 +90,8 @@ function ld.parse(self, section, novld)
 	DDNS.value_parse(self, section, novld)
 end
 
--- log_lines  -- ###############################################################
-local ll	= ns:option(Value, "log_lines")
+-- ddns_loglines  -- ###########################################################
+local ll	= ns:option(Value, "ddns_loglines")
 ll.title	= translate("Log length")
 ll.description	= translate("Number of last lines stored in log files")
 ll.default	= "250"

--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua
@@ -24,7 +24,7 @@ s = m:section( SimpleSection,
 	translate("Hints"),
 	translate("Below a list of configuration tips for your system to run Dynamic DNS updates without limitations") )
 
--- ddns_scripts needs to be updated for full functionality
+-- ddns-scripts needs to be updated for full functionality
 if not CTRL.service_ok() then
 	local so = s:option(DummyValue, "_update_needed")
 	so.titleref = DISP.build_url("admin", "system", "packages")

--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/overview.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/overview.lua
@@ -33,10 +33,13 @@ m.description	= CTRL.app_description()
 
 m.on_after_commit = function(self)
 	if self.changed then	-- changes ?
+		local command = CTRL.luci_helper
 		if SYS.init.enabled("ddns") then	-- ddns service enabled, restart all
-			os.execute("/etc/init.d/ddns restart")
+			command = command .. " -- restart"
+			os.execute(command)
 		else	-- ddns service disabled, send SIGHUP to running
-			os.execute("killall -1 dynamic_dns_updater.sh")
+			command = command .. " -- reload"
+			os.execute(command)
 		end
 	end
 end
@@ -52,7 +55,7 @@ if show_hints or need_update or not_enabled then
 
 	s = m:section( SimpleSection, translate("Hints") )
 
-	-- ddns_scripts needs to be updated for full functionality
+	-- ddns-scripts needs to be updated for full functionality
 	if need_update then
 		local dv = s:option(DummyValue, "_update_needed")
 		dv.titleref = DISP.build_url("admin", "system", "packages")
@@ -119,18 +122,21 @@ function dom.set_one(self, section)
 	end
 end
 function dom.set_two(self, section)
-	local lookup = self.map:get(section, "lookup_host") or ""
-	if lookup == "" then return "" end
+	local lookup_host = self.map:get(section, "lookup_host") or ""
+	if lookup_host == "" then return "" end
 	local dnsserver = self.map:get(section, "dnsserver") or ""
 	local use_ipv6 = tonumber(self.map:get(section, "use_ipv6") or 0)
 	local force_ipversion = tonumber(self.map:get(section, "force_ipversion") or 0)
 	local force_dnstcp = tonumber(self.map:get(section, "force_dnstcp") or 0)
-	local command = [[/usr/lib/ddns/dynamic_dns_lucihelper.sh]]
-	if not NXFS.access(command, "rwx", "rx", "rx") then
-		NXFS.chmod(command, 755)
-	end
-	command = command .. [[ get_registered_ip ]] .. lookup .. [[ ]] .. use_ipv6 ..
-		[[ ]] .. force_ipversion .. [[ ]] .. force_dnstcp .. [[ ]] .. dnsserver
+	local is_glue = tonumber(self.map:get(section, "is_glue") or 0)
+	local command = CTRL.luci_helper .. [[ -]]
+	if (use_ipv6 == 1) then command = command .. [[6]] end
+	if (force_ipversion == 1) then command = command .. [[f]] end
+	if (force_dnstcp == 1) then command = command .. [[t]] end
+	if (is_glue == 1) then command = command .. [[g]] end
+	command = command .. [[l ]] .. lookup_host
+	if (#dnsserver > 0) then command = command .. [[ -d ]] .. dnsserver end
+	command = command .. [[ -- get_registered_ip]]
 	local ip = SYS.exec(command)
 	if ip == "" then ip = translate("no data") end
 	return ip

--- a/applications/luci-app-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/tools/ddns.lua
@@ -57,7 +57,7 @@ end
 function epoch2date(epoch, format)
 	if not format or #format < 2 then
 		local uci = UCI.cursor()
-		format    = uci:get("ddns", "global", "date_format") or "%F %R"
+		format    = uci:get("ddns", "global", "ddns_dateformat") or "%F %R"
 		uci:unload("ddns")
 	end
 	format = format:gsub("%%n", "<br />")	-- replace newline
@@ -67,18 +67,18 @@ end
 
 -- read lastupdate from [section].update file
 function get_lastupd(section)
-	local uci     = UCI.cursor()
-	local run_dir = uci:get("ddns", "global", "run_dir") or "/var/run/ddns"
-	local etime   = tonumber(NXFS.readfile("%s/%s.update" % { run_dir, section } ) or 0 )
+	local uci   = UCI.cursor()
+	local rdir  = uci:get("ddns", "global", "ddns_rundir") or "/var/run/ddns"
+	local etime = tonumber(NXFS.readfile("%s/%s.update" % { rdir, section } ) or 0 )
 	uci:unload("ddns")
 	return etime
 end
 
 -- read PID from run file and verify if still running
 function get_pid(section)
-	local uci     = UCI.cursor()
-	local run_dir = uci:get("ddns", "global", "run_dir") or "/var/run/ddns"
-	local pid     = tonumber(NXFS.readfile("%s/%s.pid" % { run_dir, section } ) or 0 )
+	local uci  = UCI.cursor()
+	local rdir = uci:get("ddns", "global", "ddns_rundir") or "/var/run/ddns"
+	local pid  = tonumber(NXFS.readfile("%s/%s.pid" % { rdir, section } ) or 0 )
 	if pid > 0 and not NX.kill(pid, 0) then
 		pid = 0
 	end

--- a/applications/luci-app-ddns/luasrc/view/ddns/global_value.htm
+++ b/applications/luci-app-ddns/luasrc/view/ddns/global_value.htm
@@ -4,7 +4,7 @@
 <script type="text/javascript">//<![CDATA[
 	// event handler on changed date
 	function onkeyup_date(value) {
-		var obj = document.getElementById("cbid.ddns.global.date_format.help");
+		var obj = document.getElementById("cbid.ddns.global.ddns_dateformat.help");
 		if ( !obj ) { return; }	// security check
 
 		if ( value == "" || value.length == 0 ) { value = "%F %R"; }

--- a/applications/luci-app-ddns/root/etc/uci-defaults/40_luci-ddns
+++ b/applications/luci-app-ddns/root/etc/uci-defaults/40_luci-ddns
@@ -7,4 +7,4 @@ uci -q batch <<-EOF >/dev/null
 EOF
 
 rm -f /tmp/luci-indexcache
-exit 0
+return 0


### PR DESCRIPTION
needed changes to support ddns-scripts 2.7.6
- new command line options of dynamic_ddns_lucihelper.sh
- renamed global config options
- new location of services files

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>