### PR TITLE
theme-bootstrap: fix invalid use of 'linear-gradient'

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -803,7 +803,7 @@ header .fill {
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #333333), color-stop(100%, #222222));
 	background-image: -webkit-linear-gradient(top, #333333, #222222);
 	background-image: -o-linear-gradient(top, #333333, #222222);
-	background-image: linear-gradient(top, #333333, #222222);
+	background-image: linear-gradient(to bottom, #333333, #222222);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#333333', endColorstr='#222222', GradientType=0);
 	-webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 	-moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
@@ -918,7 +918,7 @@ header div > ul .dropdown-menu li a:hover,
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #292929), color-stop(100%, #191919));
 	background-image: -webkit-linear-gradient(top, #292929, #191919);
 	background-image: -o-linear-gradient(top, #292929, #191919);
-	background-image: linear-gradient(top, #292929, #191919);
+	background-image: linear-gradient(to bottom, #292929, #191919);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#292929', endColorstr='#191919', GradientType=0);
 	color: #ffffff;
 }
@@ -1029,7 +1029,7 @@ header .dropdown-menu a.hover,
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #eeeeee), color-stop(100%, #dddddd));
 	background-image: -webkit-linear-gradient(top, #eeeeee, #dddddd);
 	background-image: -o-linear-gradient(top, #eeeeee, #dddddd);
-	background-image: linear-gradient(top, #eeeeee, #dddddd);
+	background-image: linear-gradient(to bottom, #eeeeee, #dddddd);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#eeeeee', endColorstr='#dddddd', GradientType=0);
 	color: #404040;
 	text-decoration: none;
@@ -1195,7 +1195,7 @@ header .dropdown-menu a.hover,
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #ffffff), color-stop(100%, #f5f5f5));
 	background-image: -webkit-linear-gradient(top, #ffffff, #f5f5f5);
 	background-image: -o-linear-gradient(top, #ffffff, #f5f5f5);
-	background-image: linear-gradient(top, #ffffff, #f5f5f5);
+	background-image: linear-gradient(to bottom, #ffffff, #f5f5f5);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#f5f5f5', GradientType=0);
 	border: 1px solid #ddd;
 	-webkit-border-radius: 3px;
@@ -1262,7 +1262,7 @@ footer {
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #ee5f5b), color-stop(100%, #c43c35));
 	background-image: -webkit-linear-gradient(top, #ee5f5b, #c43c35);
 	background-image: -o-linear-gradient(top, #ee5f5b, #c43c35);
-	background-image: linear-gradient(top, #ee5f5b, #c43c35);
+	background-image: linear-gradient(to bottom, #ee5f5b, #c43c35);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ee5f5b', endColorstr='#c43c35', GradientType=0);
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: #c43c35 #c43c35 #882a25;
@@ -1278,7 +1278,7 @@ footer {
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #62c462), color-stop(100%, #57a957));
 	background-image: -webkit-linear-gradient(top, #62c462, #57a957);
 	background-image: -o-linear-gradient(top, #62c462, #57a957);
-	background-image: linear-gradient(top, #62c462, #57a957);
+	background-image: linear-gradient(to bottom, #62c462, #57a957);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#62c462', endColorstr='#57a957', GradientType=0);
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: #57a957 #57a957 #3d773d;
@@ -1294,7 +1294,7 @@ footer {
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #5bc0de), color-stop(100%, #339bb9));
 	background-image: -webkit-linear-gradient(top, #5bc0de, #339bb9);
 	background-image: -o-linear-gradient(top, #5bc0de, #339bb9);
-	background-image: linear-gradient(top, #5bc0de, #339bb9);
+	background-image: linear-gradient(to bottom, #5bc0de, #339bb9);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#5bc0de', endColorstr='#339bb9', GradientType=0);
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: #339bb9 #339bb9 #22697d;
@@ -1354,7 +1354,7 @@ footer {
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #049cdb), color-stop(100%, #0064cd));
 	background-image: -webkit-linear-gradient(top, #049cdb, #0064cd);
 	background-image: -o-linear-gradient(top, #049cdb, #0064cd);
-	background-image: linear-gradient(top, #049cdb, #0064cd);
+	background-image: linear-gradient(to bottom, #049cdb, #0064cd);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#049cdb', endColorstr='#0064cd', GradientType=0);
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: #0064cd #0064cd #003f81;
@@ -1627,7 +1627,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fceec1), color-stop(100%, #eedc94));
 	background-image: -webkit-linear-gradient(top, #fceec1, #eedc94);
 	background-image: -o-linear-gradient(top, #fceec1, #eedc94);
-	background-image: linear-gradient(top, #fceec1, #eedc94);
+	background-image: linear-gradient(to bottom, #fceec1, #eedc94);
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fceec1', endColorstr='#eedc94', GradientType=0);
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: #eedc94 #eedc94 #e4c652;


### PR DESCRIPTION
The linear-gradient function syntax uses 'to bottom' instead of 'top' for a gradient from top to bottom.

Signed-off-by: Arjen de Korte \<build+openwrt@de-korte.org\>