### PR TITLE
luci-theme-bootstrap: fix minor CSS errors

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -447,7 +447,7 @@ form .cbi-value:before, form .cbi-value:after  {
 	zoom: 1;
 }
 
-form .clearfix:after
+form .clearfix:after,
 form .cbi-value:after {
 	clear: both;
 }
@@ -996,7 +996,7 @@ a.menu:after, .dropdown-toggle:after {
 .menu-dropdown li, .dropdown-menu li {
 	float: none;
 	display: block;
-	background-color: none;
+	background-color: transparent;
 }
 
 .menu-dropdown .divider, .dropdown-menu .divider {
@@ -1732,7 +1732,6 @@ a.label:hover {
 	  color: #808080;
 	  display: inline-block;
 	  font-size: 13px;
-	  height: 22 dpx;
 	  line-height: 18px;
 }
 


### PR DESCRIPTION
Add missing comma, 'none' is not a valid value for background-color (changed to 'transparent') and 'dpx' is not a valid unit for height (removed)

Signed-off-by: Arjen de Korte \<build+luci@de-korte.org\>