### PR TITLE
freifunk-common: neigh.sh: fix for new olsrd 0.9.5

### DIFF
--- a/contrib/package/freifunk-common/files/usr/bin/neigh.sh
+++ b/contrib/package/freifunk-common/files/usr/bin/neigh.sh
@@ -66,7 +66,8 @@ VARS="$VARS neighborLinkQuality:NLQ linkCost:Cost remoteHostname:Host"
 
 for HOST in '127.0.0.1' '::1';do
 	json_init
-	json_load "$(echo /links|nc ${HOST} 9090)"
+	json_load "$( echo /links | nc $HOST 9090 | grep ^'{' )"	# remove header/non-json
+
 	if json_is_a links array;then
 		json_select links
 		for v in ${VARS};do


### PR DESCRIPTION
Starting with version 0.9.5 the new olsr-deamon behaves
more standard-compliant and outputs correct HTTP-headers.
This would confuse the script and abort parsing.

Fix that by only trying to parse the JSON-value and
just ignore the other stuff. After this, we can see neighbours again.

Thanks to FreifunkUFO <ufo@rund.freifunk.net> for spotting this.