### PR TITLE
Update wifi_add.lua

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi_add.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi_add.lua
@@ -44,7 +44,7 @@ m.hidden = {
 
 if iw and iw.mbssid_support then
 	replace = m:field(Flag, "replace", translate("Replace wireless configuration"),
-		translate("An additional network will be created if you leave this checked."))
+		translate("An additional network will be created if you leave this unchecked."))
 
 	function replace.cfgvalue() return "0" end
 else


### PR DESCRIPTION
The text does not match what is happening in the interface. It used to say "if you leave this unchecked" implying that by default the box was unchecked. It was not, by default the box was checked. Someone was kind enough to go in and fix it, but they went too far.  To fix it, either the box had to be changed to be unchecked by default, or the text needed to be changed to say checked instead of unchecked. In the most recent attempt to remedy the problem, someone changed both the text and the box, so now the box is unchecked by default, and the text now says "checked", which essentially recreated the original problem. Right now, the box is unchecked (best imho) the text just needs to be changed to match. With this minor change, it will now match the text: "An additional network will be created if you leave this unchecked"