### PR TITLE
luci-app-fwknopd: fix for qrencode >= v3.4.0.

### DIFF
--- a/applications/luci-app-fwknopd/luasrc/view/fwknopd-qr.htm
+++ b/applications/luci-app-fwknopd/luasrc/view/fwknopd-qr.htm
@@ -1,2 +1,2 @@
-<% print(luci.sys.exec("sh /usr/sbin/gen-qr.sh " .. self.tmp)) %>
+<% write(luci.sys.exec("sh /usr/sbin/gen-qr.sh " .. self.tmp):gsub("^<%?xml.*%?>\n","")) %>
 <% self.tmp = self.tmp + 1 %>

--- a/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
+++ b/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
@@ -23,4 +23,4 @@ if [ $hmac_key != "" ]; then
 qr="$qr HMAC_KEY:$hmac_key"
 fi
 
-qrencode -o - "$qr"
+qrencode -o - -t SVG "$qr"


### PR DESCRIPTION
Starting with qrencode v3.4.0, the XML prolog is prepended to the SVG
output which causes an XML parse error.  To address this, strip any XML
prolog from the generated output.

Also, as a precaution, explicitly set the qrencode output type to SVG to
to protect against a change in defaults.