### PR TITLE
freifunk-common: neigh.sh: work also with unprettyfied JSON output

### DIFF
--- a/contrib/package/freifunk-common/files/usr/bin/neigh.sh
+++ b/contrib/package/freifunk-common/files/usr/bin/neigh.sh
@@ -66,7 +66,7 @@ VARS="$VARS neighborLinkQuality:NLQ linkCost:Cost remoteHostname:Host"
 
 for HOST in '127.0.0.1' '::1';do
 	json_init
-	json_load "$( echo /links | nc $HOST 9090 | grep ^'{' )"	# remove header/non-json
+	json_load "$( echo /links | nc $HOST 9090 | sed -n '/^[}{ ]/p' )"	# remove header/non-json
 
 	if json_is_a links array;then
 		json_select links


### PR DESCRIPTION
Older OLSRd-version outputs JSON humanreadable over multiple lines.
The introduced change in 524439cd1647e5d6d7b48f9c75ec5800a5444109 broke
the output for those users. Fix that be a finer filter regex.
Thanks to Thomas Huehn <thomas@net.t-labs.tu-berlin.de> for spotting that.