### PR TITLE
luci-app-firewall: remove redirect on zone detail write

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/zone-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/zone-details.lua
@@ -68,12 +68,6 @@ function name.write(self, section, value)
 		out.exclude = value
 		inp.exclude = value
 	end
-
-	m.redirect = ds.build_url("admin/network/firewall/zones", value)
-	m.title = "%s - %s" %{
-		translate("Firewall - Zone Settings"),
-		translatef("Zone %q", value or "?")
-	}
 end
 
 p = {


### PR DESCRIPTION
This fixes an inconsistency because on the interface configuration if you
press Save&Apply it will go back to overview page. On firewall zone it
only goes back to firewall zone-detail. Same behaviour on all pages is a good
user experience.

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>