### PR TITLE
wifi_add: help shouldn't depend on initial state

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi_add.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi_add.lua
@@ -44,7 +44,7 @@ m.hidden = {
 
 if iw and iw.mbssid_support then
 	replace = m:field(Flag, "replace", translate("Replace wireless configuration"),
-		translate("An additional network will be created if you leave this checked."))
+		translate("An additional network will be created if this is checked."))
 
 	function replace.cfgvalue() return "0" end
 else


### PR DESCRIPTION
Attempting to clarify the explantory text for the tickbox got confusing
when trying to include commentary on the default state of the box.  Make
the explanatory text box simply describe what the option does outright.

Signed-off-by: Karl Palsson <karlp@etactica.com>

Fixes: ccc9970c24fd9db110a62d47852d7d11247d2f13