### PR TITLE
Add px5g-mbedtls as depdency

### DIFF
--- a/collections/luci-ssl-openssl/Makefile
+++ b/collections/luci-ssl-openssl/Makefile
@@ -11,8 +11,8 @@ LUCI_BASENAME:=ssl-openssl
 
 LUCI_TITLE:=LuCI with HTTPS support (OpenSSL as SSL backend)
 LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
- Note: px5g still requires libpolarssl
-LUCI_DEPENDS:=+luci +libustream-openssl +px5g
+ Note: px5g still requires libmbedtls
+LUCI_DEPENDS:=+luci +libustream-openssl +px5g-mbedtls
 
 include ../../luci.mk
 

--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -10,7 +10,7 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
 LUCI_TITLE:=LuCI with HTTPS support (mbedTLS as SSL backend)
-LUCI_DEPENDS:=+luci +libustream-mbedtls +px5g
+LUCI_DEPENDS:=+luci +libustream-mbedtls +px5g-mbedtls
 
 include ../../luci.mk
 


### PR DESCRIPTION
As https://github.com/lede-project/source/pull/655 changes it to px5g-mbedtls for consistency add the proper dependency name.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>