### PR TITLE
[luci-app-fwknopd] Remove usage of dynamic tag.

### DIFF
--- a/applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua
+++ b/applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua
@@ -1,19 +1,19 @@
 -- Copyright 2015 Jonathan Bennett <jbennett@incomsystems.biz>
 -- Licensed to the public under the GNU General Public License v2.
-
+tmp = 0
 m = Map("fwknopd", translate("Firewall Knock Operator"))
 
 s = m:section(TypedSection, "global", translate("Enable Uci/Luci control")) -- Set uci control on or off
 s.anonymous=true
 s:option(Flag, "uci_enabled", translate("Enable config overwrite"), translate("When unchecked, the config files in /etc/fwknopd will be used as is, ignoring any settings here."))
-qr = s:option(DummyValue, "note0", "dummy")
-qr.template = "fwknopd-qr"
-qr:depends("uci_enabled", "1")
 
 s = m:section(TypedSection, "access", translate("access.conf stanzas")) -- set the access.conf settings
 s.anonymous=true
 s.addremove=true
-s.dynamic=true
+qr = s:option(DummyValue, "note0", "dummy")
+qr.tmp = tmp
+qr.template = "fwknopd-qr"
+qr:depends("uci_enabled", "1")
 s:option(Value, "SOURCE", "SOURCE", translate("Use ANY for any source ip"))
 k1 = s:option(Value, "KEY", "KEY", translate("Define the symmetric key used for decrypting an incoming SPA packet that is encrypted by the fwknop client with Rijndael."))
 k1:depends("keytype", translate("Normal Key"))
@@ -40,15 +40,13 @@ s:option(Value, "REQUIRE_SOURCE_ADDRESS", "REQUIRE_SOURCE_ADDRESS", translate("F
 					This makes it impossible to use the -s command line argument on the fwknop client command line, so either -R \
 					has to be used to automatically resolve the external address (if the client behind a NAT) or the client must \
 					know the external IP and set it via the -a argument."))
-s:option(DummyValue, "note1", translate("Enter custom access.conf variables below:"))
 
 s = m:section(TypedSection, "config", translate("fwknopd.conf config options")) 
 s.anonymous=true
-s.dynamic=true
 s:option(Value, "MAX_SPA_PACKET_AGE", "MAX_SPA_PACKET_AGE", translate("Maximum age in seconds that an SPA packet will be accepted. defaults to 120 seconds"))
 s:option(Value, "PCAP_INTF", "PCAP_INTF", translate("Specify the ethernet interface on which fwknopd will sniff packets."))
 s:option(Value, "ENABLE_IPT_FORWARDING", "ENABLE_IPT_FORWARDING", translate("Allow SPA clients to request access to services through an iptables firewall instead of just to it."))
-s:option(DummyValue, "note2", translate("Enter custom fwknopd.conf variables below:"))
+s:option(Value, "ENABLE_NAT_DNS", "ENABLE_NAT_DNS", translate("Allow SPA clients to request forwarding destination by DNS name."))
 
 return m
 

--- a/applications/luci-app-fwknopd/luasrc/view/fwknopd-qr.htm
+++ b/applications/luci-app-fwknopd/luasrc/view/fwknopd-qr.htm
@@ -1,1 +1,2 @@
-<% print(luci.sys.exec("sh /usr/sbin/gen-qr.sh")) %>
+<% print(luci.sys.exec("sh /usr/sbin/gen-qr.sh " .. self.tmp)) %>
+<% self.tmp = self.tmp + 1 %>

--- a/applications/luci-app-fwknopd/root/etc/uci-defaults/40_luci-fwknopd
+++ b/applications/luci-app-fwknopd/root/etc/uci-defaults/40_luci-fwknopd
@@ -16,6 +16,7 @@ uci set fwknopd.@access[0].hkeytype='Base 64 key'
 uci set fwknopd.@access[0].KEY_BASE64=`fwknopd --key-gen | awk '/^KEY/ {print $2;}'`
 uci set fwknopd.@access[0].HMAC_KEY_BASE64=`fwknopd --key-gen | awk '/^HMAC/ {print $2;}'`
 uci set fwknopd.@config[0].ENABLE_IPT_FORWARDING='y'
+uci set fwknopd.@config[0].ENABLE_NAT_DNS='y'
 
 uci commit fwknopd
 rm -f /tmp/luci-indexcache

--- a/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
+++ b/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
+entry_num=0
+if [ "$1" != "" ]; then
+entry_num=$1
+fi
 
-key_base64=$(uci get fwknopd.@access[0].KEY_BASE64)
-key=$(uci get fwknopd.@access[0].KEY)
-hmac_key_base64=$(uci get fwknopd.@access[0].HMAC_KEY_BASE64)
-hmac_key=$(uci get fwknopd.@access[0].HMAC_KEY)
+key_base64=$(uci get fwknopd.@access[$entry_num].KEY_BASE64)
+key=$(uci get fwknopd.@access[$entry_num].KEY)
+hmac_key_base64=$(uci get fwknopd.@access[$entry_num].HMAC_KEY_BASE64)
+hmac_key=$(uci get fwknopd.@access[$entry_num].HMAC_KEY)
 
 if [ $key_base64 != "" ]; then
 qr="KEY_BASE64:$key_base64"


### PR DESCRIPTION
Also adds NAT-DNS as a default setting, and enables a QR-code per access.conf entry
Signed-off-by: Jonathan Bennett <JBennett@incomsystems.biz>