### PR TITLE
base: webadmin: Don't take substring of nil variable

### DIFF
--- a/modules/luci-base/luasrc/tools/webadmin.lua
+++ b/modules/luci-base/luasrc/tools/webadmin.lua
@@ -96,7 +96,7 @@ function iface_get_network(iface)
 			if net.l3_device == iface or net.device == iface then
 				-- cross check with uci to filter out @name style aliases
 				local uciname = cur:get("network", net.interface, "ifname")
-				if not uciname or uciname:sub(1, 1) ~= "@" then
+				if type(uciname) == "string" and uciname:sub(1,1) ~= "@" or uciname then
 					return net.interface
 				end
 			end


### PR DESCRIPTION
When converting interface names to UCI network names
webadmin fails if there is no UCI network name because
webadmin failed to ensure uciname has a value before
attempting to take a substring.

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>