### PR TITLE
Pull request fixapp statistics postinst

### DIFF
--- a/applications/luci-app-statistics/root/etc/uci-defaults/40_luci-statistics
+++ b/applications/luci-app-statistics/root/etc/uci-defaults/40_luci-statistics
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 # register commit handler
-uci -q batch <<-EOF >/dev/null
+uci -q batch <<-EOF >/dev/null 2>&1 || true
 	delete ucitrack.@luci_statistics[-1]
 	add ucitrack luci_statistics
+	uci delete ucitrack.@luci_statistics[-1]
 	set ucitrack.@luci_statistics[-1].init=luci_statistics
 	commit ucitrack
 EOF

--- a/luci.mk
+++ b/luci.mk
@@ -188,8 +188,9 @@ endef
 
 ifneq ($(LUCI_DEFAULTS),)
 define Package/$(PKG_NAME)/postinst
-[ -n "$${IPKG_INSTROOT}" ] || {$(foreach script,$(LUCI_DEFAULTS),
-	(. /etc/uci-defaults/$(script)) && rm -f /etc/uci-defaults/$(script))
+[ -n "$${IPKG_INSTROOT}" ] || grep -q uci-defaults /etc/functions.sh || {
+	$(foreach script,$(LUCI_DEFAULTS),
+	([ -r /etc/uci-defaults/$(script) ] && . /etc/uci-defaults/$(script)) && rm -f /etc/uci-defaults/$(script))
 	exit 0
 }
 endef


### PR DESCRIPTION
This PR contains two commit that fix luci-app-statistics error messages

The first commit suppresses extraneous uci warnings when installing with no previous uci (the batch command emits an error on deleting a non-present entry)

The second commit prevent luci from immediately running uci-defaults in postinst if default_postinst already does that (because default_postinst will complain about missing fail since LuCI removes the uci-defaults file(s).