### PR TITLE
[for-15.05] luci-app-ddns: support for backported ddns-scripts 2.7.6

### DIFF
--- a/applications/luci-app-ddns/Makefile
+++ b/applications/luci-app-ddns/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2015 The LuCI Team <luci@lists.subsignal.org>
+# Copyright (C) 2008-2017 The LuCI Team <luci@lists.subsignal.org>
 #
 # This is free software, licensed under the Apache License, Version 2.0 .
 #
@@ -10,7 +10,7 @@ PKG_NAME:=luci-app-ddns
 
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.2.4
+PKG_VERSION:=2.2.5
 
 # Release == build
 # increase on changes of translation files

--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua
@@ -1,4 +1,4 @@
--- Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+-- Copyright 2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 -- Licensed to the public under the Apache License 2.0.
 
 local NX   = require "nixio"
@@ -45,8 +45,8 @@ function ns.cfgvalue(self, section)
 	return self.map:get(section)
 end
 
--- allow_local_ip  -- ##########################################################
-local ali	= ns:option(Flag, "allow_local_ip")
+-- upd_privateip  -- ###########################################################
+local ali	= ns:option(Flag, "upd_privateip")
 ali.title	= translate("Allow non-public IP's")
 ali.description = translate("Non-public and by default blocked IP's") .. ":"
 		.. [[<br /><strong>IPv4: </strong>]]
@@ -65,8 +65,8 @@ function ali.validate(self, value)
 	return value
 end
 
--- date_format  -- #############################################################
-local df	= ns:option(Value, "date_format")
+-- ddns_dateformat  -- #########################################################
+local df	= ns:option(Value, "ddns_dateformat")
 df.title	= translate("Date format")
 df.description	= [[<a href="http://www.cplusplus.com/reference/ctime/strftime/" target="_blank">]]
 		.. translate("For supported codes look here") 
@@ -88,8 +88,8 @@ function df.validate(self, value)
 	return value
 end
 
--- run_dir  -- #################################################################
-local rd	= ns:option(Value, "run_dir")
+-- ddns_rundir  -- #############################################################
+local rd	= ns:option(Value, "ddns_rundir")
 rd.title	= translate("Status directory")
 rd.description	= translate("Directory contains PID and other status information for each running section")
 rd.rmempty	= true
@@ -101,8 +101,8 @@ function rd.validate(self, value)
 	return value
 end
 
--- log_dir  -- #################################################################
-local ld	= ns:option(Value, "log_dir")
+-- ddns_logdir  -- #############################################################
+local ld	= ns:option(Value, "ddns_logdir")
 ld.title	= translate("Log directory")
 ld.description	= translate("Directory contains Log files for each running section")
 ld.rmempty	= true
@@ -114,8 +114,8 @@ function ld.validate(self, value)
 	return value
 end
 
--- log_lines  -- ###############################################################
-local ll	= ns:option(Value, "log_lines")
+-- ddns_loglines  -- ###########################################################
+local ll	= ns:option(Value, "ddns_loglines")
 ll.title	= translate("Log length")
 ll.description	= translate("Number of last lines stored in log files")
 ll.rmempty	= true

--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua
@@ -1,4 +1,4 @@
--- Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+-- Copyright 2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 -- Licensed to the public under the Apache License 2.0.
 
 local CTRL = require "luci.controller.ddns"	-- this application's controller

--- a/applications/luci-app-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/tools/ddns.lua
@@ -1,4 +1,4 @@
--- Copyright 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+-- Copyright 2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 -- Licensed to the public under the Apache License 2.0.
 
 module("luci.tools.ddns", package.seeall)
@@ -35,17 +35,21 @@ end
 
 -- check if Wget with SSL support or cURL installed
 function check_ssl()
-	if (SYS.call([[ grep -i "\+ssl" /usr/bin/wget >/dev/null 2>&1 ]]) == 0) then
+	if NXFS.access("/usr/bin/wget-ssl") then
 		return true
+	elseif NXFS.access("/usr/bin/curl") then
+		return true
+	elseif NXFS.access("/usr/bin/uclient-fetch") then
+		return NXFS.access("/lib/libustream-ssl.so")
 	else
-		return NXFS.access("/usr/bin/curl")
+		return false
 	end
 end
 
 -- check if Wget with SSL or cURL with proxy support installed
 function check_proxy()
 	-- we prefere GNU Wget for communication
-	if (SYS.call([[ grep -i "\+ssl" /usr/bin/wget >/dev/null 2>&1 ]]) == 0) then
+	if NXFS.access("/usr/bin/wget-ssl") then
 		return true
 
 	-- if not installed cURL must support proxy
@@ -54,13 +58,13 @@ function check_proxy()
 
 	-- only BusyBox Wget is installed
 	else
-		return NXFS.access("/usr/bin/wget")
+		return NXFS.access("/usr/bin/wget") or NXFS.access("/usr/bin/uclient-fetch")
 	end
 end
 
 -- check if BIND host installed
 function check_bind_host()
-	return NXFS.access("/usr/bin/host")
+	return NXFS.access("/usr/bin/host") or NXFS.access("/usr/bin/khost")
 end
 
 -- convert epoch date to given format

--- a/applications/luci-app-ddns/luasrc/view/ddns/overview_status.htm
+++ b/applications/luci-app-ddns/luasrc/view/ddns/overview_status.htm
@@ -19,7 +19,7 @@
 			var section = data[i].section	// Section to handle
 			var cbx = document.getElementById("cbid.ddns." + section + ".enabled");		// Enabled
 			var btn = document.getElementById("cbid.ddns." + section + "._startstop");	// Start/Stop button
-			var rip = document.getElementById("cbid.ddns." + section + "._domainIP.two");	// Registered IP
+			var rip = document.getElementById("cbid.ddns." + section + "._lookupIP.two");	// Registered IP
 			var lup = document.getElementById("cbid.ddns." + section + "._update.one");	// Last Update
 			var nup = document.getElementById("cbid.ddns." + section + "._update.two");	// Next Update
 			if ( !(cbx && btn && rip && lup && nup) ) { return; }	// security check
@@ -81,7 +81,7 @@
 
 			// registered IP
 			// rip.innerHTML = "Registered IP";
-			if (data[i].domain == "_nodomain_")
+			if (data[i].lookup == "_nolookup_")
 				rip.innerHTML = '';
 			else if (data[i].reg_ip == "_nodata_")
 				rip.innerHTML = '<em><%:No data%></em>';

--- a/applications/luci-app-ddns/luasrc/view/ddns/system_status.htm
+++ b/applications/luci-app-ddns/luasrc/view/ddns/system_status.htm
@@ -73,11 +73,11 @@
 			if (data[j].domain == "_nodomain_")
 				tr.insertCell(-1).innerHTML = '<em><%:config error%></em>';
 			else
-				tr.insertCell(-1).innerHTML = data[j].domain;
+				tr.insertCell(-1).innerHTML = data[j].lookup;
 
 			// registered IP
 			switch (data[j].reg_ip) {
-				case "_nodomain_":
+				case "_nolookup_":
 					tr.insertCell(-1).innerHTML = '<em><%:Config error%></em>';
 					break;
 				case "_nodata_":


### PR DESCRIPTION
depends on pull: https://github.com/openwrt/packages/pull/3829

compiled ipk-packages available at
https://github.com/chris5560/OpenWrt-Backports/tree/master/for-CC15.05.01/luci-app-ddns

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>