### PR TITLE
Patch fix app statistics postinst

### DIFF
--- a/applications/luci-app-statistics/root/etc/uci-defaults/40_luci-statistics
+++ b/applications/luci-app-statistics/root/etc/uci-defaults/40_luci-statistics
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # register commit handler
-uci -q batch <<-EOF >/dev/null
+uci -q batch <<-EOF >/dev/null 2>&1 || true
 	delete ucitrack.@luci_statistics[-1]
 	add ucitrack luci_statistics
 	set ucitrack.@luci_statistics[-1].init=luci_statistics

--- a/luci.mk
+++ b/luci.mk
@@ -188,8 +188,9 @@ endef
 
 ifneq ($(LUCI_DEFAULTS),)
 define Package/$(PKG_NAME)/postinst
-[ -n "$${IPKG_INSTROOT}" ] || {$(foreach script,$(LUCI_DEFAULTS),
-	(. /etc/uci-defaults/$(script)) && rm -f /etc/uci-defaults/$(script))
+[ -n "$${IPKG_INSTROOT}" ] || grep -q uci-defaults /etc/functions.sh || {
+	$(foreach script,$(LUCI_DEFAULTS),
+	([ -r /etc/uci-defaults/$(script) ] && . /etc/uci-defaults/$(script)) && rm -f /etc/uci-defaults/$(script))
 	exit 0
 }
 endef


### PR DESCRIPTION
This pull request should fix https://github.com/openwrt/luci/issues/722 which occurs for two reasons: the update to default_postinst that activates uci-defaults during postinst (because LuCI had it's own logic for this), and an uci batch error in luci-app-statistics uci-defaults script.