### PR TITLE
app-statistics: df: Don't separate disk usage types

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/df.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/df.lua
@@ -8,7 +8,6 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 	return {
 		title = "%H: Disk space usage on %pi",
 		vlabel = "Bytes",
-		per_instance  = true,
 		number_format = "%5.1lf%sB",
 
 		data = {


### PR DESCRIPTION
The df plugin wasn't displaying useful lables for the space
used vs free vs reserved due to title override.  This patch
fixes that issues by removing the per-instance setting.

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>