### PR TITLE
Fix app statistics postinst

### DIFF
--- a/applications/luci-app-statistics/root/etc/uci-defaults/40_luci-statistics
+++ b/applications/luci-app-statistics/root/etc/uci-defaults/40_luci-statistics
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # register commit handler
-uci -q batch <<-EOF >/dev/null
+uci -q batch <<-EOF >/dev/null 2>&1 || true
 	delete ucitrack.@luci_statistics[-1]
 	add ucitrack luci_statistics
 	set ucitrack.@luci_statistics[-1].init=luci_statistics

--- a/luci.mk
+++ b/luci.mk
@@ -188,8 +188,9 @@ endef
 
 ifneq ($(LUCI_DEFAULTS),)
 define Package/$(PKG_NAME)/postinst
-[ -n "$${IPKG_INSTROOT}" ] || {$(foreach script,$(LUCI_DEFAULTS),
-	(. /etc/uci-defaults/$(script)) && rm -f /etc/uci-defaults/$(script))
+[ -n "$${IPKG_INSTROOT}" ] || grep -q uci-defaults /lib/functions.sh || {
+	$(foreach script,$(LUCI_DEFAULTS),
+	([ -r /etc/uci-defaults/$(script) ] && . /etc/uci-defaults/$(script)) && rm -f /etc/uci-defaults/$(script))
 	exit 0
 }
 endef


### PR DESCRIPTION
Should fix https://github.com/openwrt/luci/issues/722.  There were two errors:

1) Spurious uci warnings when installing app-statistics on a system with no existing app-statistics (due to deleting etc non-existent entries).  We simply drop the error; if debugging is need that can be removed and the uci-default run manually.
2) luci.mk had a postinst that automatically performed uci-defaults scriptlets on install but LEDE trunk also does this so the uci-defaults file was missing for the latter's execution.  We omit LuCI's 'live uci-defaults' on new enough LEDE.