### PR TITLE
luci-proto-wireguard: enable addressing for tunnel interfaces

### DIFF
--- a/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
+++ b/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
@@ -1,4 +1,4 @@
--- Copyright 2016 Dan Luedtke <mail@danrl.com>
+-- Copyright 2016-2017 Dan Luedtke <mail@danrl.com>
 -- Licensed to the public under the Apache License 2.0.
 
 
@@ -33,6 +33,16 @@ listen_port = section:taboption(
 listen_port.datatype = "port"
 listen_port.placeholder = "51820"
 listen_port.optional = true
+
+addresses = section:taboption(
+  "general",
+  DynamicList,
+  "addresses",
+  translate("IP Addresses"),
+  translate("Recommended. IP addresses of the WireGuard interface.")
+)
+addresses.datatype = "ipaddr"
+addresses.optional = true
 
 
 -- advanced --------------------------------------------------------------------


### PR DESCRIPTION
Enable static addresses on WireGuard tunnel interfaces without requiring
an static address interface.

This removes the requirement to use a static address interface on top of a
WireGuard tunnel interface in the majority of cases. In the past, users have
been confused by the current approach and asked for a simpler way to configure
WireGuard interfaces.

Signed-off-by: Dan Luedtke <mail@danrl.com>

**PS: If possible, please merge before Mon Jan 16 2017 so this change will be part of the upcoming freeze.**