### PR TITLE
luci-mod-admin-full: Fix display problem of wifi_add

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi_add.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi_add.lua
@@ -16,7 +16,7 @@ if not iw then
 	return
 end
 
-m = SimpleForm("network", translate("Joining Network: %q", http.formvalue("join")))
+m = SimpleForm("network", translatef("Joining Network: %q", http.formvalue("join")))
 m.cancel = translate("Back to scan results")
 m.reset = false
 


### PR DESCRIPTION
Fixed an issue where the target network name is displayed as "%q" on wlan
connection destination network settings page.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>