### PR TITLE
luci-base: Avoid block umount on fstab apply

### DIFF
--- a/modules/luci-base/root/etc/config/ucitrack
+++ b/modules/luci-base/root/etc/config/ucitrack
@@ -29,7 +29,7 @@ config httpd
 	option init httpd
 
 config fstab
-	option init fstab
+	option exec '/sbin/block mount'
 
 config qos
 	option init qos


### PR DESCRIPTION
Default behaviour of changes to fstab (Mount Points) was
to use /etc/init.d/fstab restart, however this unmounts
filesystems via block umount which can cause the device
to fail, so replace the initscript call with an exec
of 'block mount'.

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>