### PR TITLE
Add luci-proto-ncm for comgt-ncm

### DIFF
--- a/protocols/luci-proto-ncm/Makefile
+++ b/protocols/luci-proto-ncm/Makefile
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Support for NCM
+LUCI_DEPENDS:=+comgt-ncm
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
+++ b/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
@@ -1,0 +1,157 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2015 Cezary Jackiewicz <cezary.jackiewicz@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+]]--
+
+local map, section, net = ...
+
+local device, apn, service, pincode, username, password, dialnumber
+local ipv6, maxwait, defaultroute, metric, peerdns, dns,
+      keepalive_failure, keepalive_interval, demand
+
+
+device = section:taboption("general", Value, "device", translate("Modem device"))
+device.rmempty = false
+
+local device_suggestions = nixio.fs.glob("/dev/cdc-wdm*")
+	or nixio.fs.glob("/dev/ttyUSB*")
+
+if device_suggestions then
+	local node
+	for node in device_suggestions do
+		device:value(node)
+	end
+end
+
+
+mode = section:taboption("general", Value, "mode", translate("Service Type"))
+mode.default = "auto"
+mode:value("preferlte", translate("Prefer LTE"))
+mode:value("preferumts", translate("Prefer UMTS"))
+mode:value("lte", "LTE")
+mode:value("umts", "UMTS/GPRS")
+mode:value("gsm", translate("GPRS only"))
+mode:value("auto", translate("auto"))
+
+
+apn = section:taboption("general", Value, "apn", translate("APN"))
+
+
+pincode = section:taboption("general", Value, "pincode", translate("PIN"))
+
+
+username = section:taboption("general", Value, "username", translate("PAP/CHAP username"))
+
+
+password = section:taboption("general", Value, "password", translate("PAP/CHAP password"))
+password.password = true
+
+dialnumber = section:taboption("general", Value, "dialnumber", translate("Dial number"))
+dialnumber.placeholder = "*99***1#"
+
+if luci.model.network:has_ipv6() then
+
+	ipv6 = section:taboption("advanced", ListValue, "ipv6")
+	ipv6:value("auto", translate("Automatic"))
+	ipv6:value("0", translate("Disabled"))
+	ipv6:value("1", translate("Manual"))
+	ipv6.default = "auto"
+
+end
+
+
+maxwait = section:taboption("advanced", Value, "maxwait",
+	translate("Modem init timeout"),
+	translate("Maximum amount of seconds to wait for the modem to become ready"))
+
+maxwait.placeholder = "20"
+maxwait.datatype    = "min(1)"
+
+
+defaultroute = section:taboption("advanced", Flag, "defaultroute",
+	translate("Use default gateway"),
+	translate("If unchecked, no default route is configured"))
+
+defaultroute.default = defaultroute.enabled
+
+metric = section:taboption("advanced", Value, "metric",
+	translate("Use gateway metric"))
+
+metric.placeholder = "0"
+metric.datatype    = "uinteger"
+metric:depends("defaultroute", defaultroute.enabled)
+
+
+peerdns = section:taboption("advanced", Flag, "peerdns",
+	translate("Use DNS servers advertised by peer"),
+	translate("If unchecked, the advertised DNS server addresses are ignored"))
+
+peerdns.default = peerdns.enabled
+
+
+dns = section:taboption("advanced", DynamicList, "dns",
+	translate("Use custom DNS servers"))
+
+dns:depends("peerdns", "")
+dns.datatype = "ipaddr"
+dns.cast     = "string"
+
+
+keepalive_failure = section:taboption("advanced", Value, "_keepalive_failure",
+	translate("LCP echo failure threshold"),
+	translate("Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures"))
+
+function keepalive_failure.cfgvalue(self, section)
+	local v = m:get(section, "keepalive")
+	if v and #v > 0 then
+		return tonumber(v:match("^(%d+)[ ,]+%d+") or v)
+	end
+end
+
+function keepalive_failure.write() end
+function keepalive_failure.remove() end
+
+keepalive_failure.placeholder = "0"
+keepalive_failure.datatype    = "uinteger"
+
+
+keepalive_interval = section:taboption("advanced", Value, "_keepalive_interval",
+	translate("LCP echo interval"),
+	translate("Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold"))
+
+function keepalive_interval.cfgvalue(self, section)
+	local v = m:get(section, "keepalive")
+	if v and #v > 0 then
+		return tonumber(v:match("^%d+[ ,]+(%d+)"))
+	end
+end
+
+function keepalive_interval.write(self, section, value)
+	local f = tonumber(keepalive_failure:formvalue(section)) or 0
+	local i = tonumber(value) or 5
+	if i < 1 then i = 1 end
+	if f > 0 then
+		m:set(section, "keepalive", "%d %d" %{ f, i })
+	else
+		m:del(section, "keepalive")
+	end
+end
+
+keepalive_interval.remove      = keepalive_interval.write
+keepalive_interval.placeholder = "5"
+keepalive_interval.datatype    = "min(1)"
+
+
+demand = section:taboption("advanced", Value, "demand",
+	translate("Inactivity timeout"),
+	translate("Close inactive connection after the given amount of seconds, use 0 to persist connection"))
+
+demand.placeholder = "0"
+demand.datatype    = "uinteger"

--- a/protocols/luci-proto-ncm/luasrc/model/network/proto_ncm.lua
+++ b/protocols/luci-proto-ncm/luasrc/model/network/proto_ncm.lua
@@ -1,0 +1,61 @@
+--[[
+LuCI - Network model - NCM protocol extension
+
+Copyright 2015 Cezary Jackiewicz <cezary.jackiewicz@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+]]--
+
+local netmod = luci.model.network
+
+local proto = netmod:register_protocol("ncm")
+local interface = luci.model.network.interface
+
+function proto.get_i18n(self)
+	return luci.i18n.translate("NCM")
+end
+
+function proto.opkg_package(self)
+	return "comgt-ncm"
+end
+
+function proto.is_installed(self)
+	return nixio.fs.access("/lib/netifd/proto/ncm.sh")
+end
+
+function proto.is_floating(self)
+	return true
+end
+
+function proto.is_virtual(self)
+	return true
+end
+
+function proto.get_interface(self)
+	local _ifname=netmod.protocol.ifname(self)
+	if not _ifname then
+		_ifname = "wan"
+	end
+	return interface(_ifname, self)
+end
+
+function proto.get_interfaces(self)
+	return nil
+end
+
+function proto.contains_interface(self, ifc)
+	return (netmod:ifnameof(ifc) == self:ifname())
+end
+
+netmod:register_pattern_virtual("^ncm-%%w")


### PR DESCRIPTION
NCM is used by some 3G/LTE dongles.
First introduced in https://github.com/lede-project/source/commit/51a5ff094703c4db984284913d605e83e819d99c

light modified file taken from OpenWRT/Gargoyle github
https://github.com/obsy/packages/tree/master/luci-proto-wwan

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>