### PR TITLE
mod-admin-full: Allow to create multiple DHCP/DNS server instances

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -12,8 +12,8 @@ m = Map("dhcp", translate("DHCP and DNS"),
 		"firewalls"))
 
 s = m:section(TypedSection, "dnsmasq", translate("Server Settings"))
-s.anonymous = true
-s.addremove = false
+s.anonymous = false
+s.addremove = true
 
 s:tab("general", translate("General Settings"))
 s:tab("files", translate("Resolv and Hosts Files"))
@@ -286,6 +286,17 @@ time = s:option(Value, "leasetime", translate("Lease time"))
 time.rmempty  = true
 
 hostid = s:option(Value, "hostid", translate("<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"))
+
+local l = s:option(ListValue, "instance", translate("Instance"))
+l.datatype = "uciname"
+l:reset_values()
+
+l:value("", translate("Any"))
+local instancecursor = m.uci
+instancecursor:foreach("dhcp", "dnsmasq", function(sect)
+	l:value(sect['.name'])
+end)
+
 
 ipc.neighbors({ family = 4 }, function(n)
 	if n.mac and n.dest then

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/hosts.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/hosts.lua
@@ -19,6 +19,16 @@ ip = s:option(Value, "ip", translate("IP address"))
 ip.datatype = "ipaddr"
 ip.rmempty  = true
 
+local l = s:option(ListValue, "instance", translate("Instance"))
+l.datatype = "uciname"
+l:reset_values()
+
+l:value("", translate("Any"))
+local instancecursor = m.uci
+instancecursor:foreach("dhcp", "dnsmasq", function(sect)
+	l:value(sect['.name'])
+end)
+
 ipc.neighbors({ }, function(n)
 	if n.mac and n.dest and not n.dest:is6linklocal() then
 		ip:value(n.dest:string(), "%s (%s)" %{ n.dest:string(), n.mac })

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
@@ -509,6 +509,27 @@ if has_dnsmasq and net:proto() == "static" then
 		s:taboption("ipv6", DynamicList, "dns", translate("Announced DNS servers"))
 		s:taboption("ipv6", DynamicList, "domain", translate("Announced DNS domains"))
 
+		local l = s:taboption("advanced", ListValue, "instance", translate("Instance"),
+			translate("DHCP instance to which to limit this interface."))
+		l.datatype = "uciname"
+		l:reset_values()
+
+		l:value("", translate("Any"))
+		local instancecursor = m.uci
+		instancecursor:foreach("dhcp", "dnsmasq", function(sect)
+			l:value(sect['.name'])
+		end)
+
+		s:taboption("advanced", Value, "leasefile",
+			translate("Leasefile"),
+				translate("file where given <abbr title=\"Dynamic Host Configuration Protocol\">DHCP</" ..
+				"abbr>-leases will be stored"))
+
+
+		local instancecursor = m.uci
+		instancecursor:foreach("dhcp", "dnsmasq", function(sect)
+			l:value(sect['.name'])
+		end)
 	else
 		m2 = nil
 	end


### PR DESCRIPTION
Trunk LEDE now has ability to launch multiple instances of
DNSMasq which can be useful.

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>