### PR TITLE
luci-base: luci.tools.status: properly parse infinite dnsmasq leases

### DIFF
--- a/modules/luci-base/luasrc/tools/status.lua
+++ b/modules/luci-base/luasrc/tools/status.lua
@@ -26,17 +26,18 @@ local function dhcp_leases_common(family)
 				break
 			else
 				local ts, mac, ip, name, duid = ln:match("^(%d+) (%S+) (%S+) (%S+) (%S+)")
+				local expire = tonumber(ts) or 0
 				if ts and mac and ip and name and duid then
 					if family == 4 and not ip:match(":") then
 						rv[#rv+1] = {
-							expires  = os.difftime(tonumber(ts) or 0, os.time()),
+							expires  = (expire ~= 0) and os.difftime(expire, os.time()),
 							macaddr  = mac,
 							ipaddr   = ip,
 							hostname = (name ~= "*") and name
 						}
 					elseif family == 6 and ip:match(":") then
 						rv[#rv+1] = {
-							expires  = os.difftime(tonumber(ts) or 0, os.time()),
+							expires  = (expire ~= 0) and os.difftime(expire, os.time()),
 							ip6addr  = ip,
 							duid     = (duid ~= "*") and duid,
 							hostname = (name ~= "*") and name


### PR DESCRIPTION
The expiry time in a dnsmasq lease file line may be 0 (i.e. expiry date = 01/01/1970 00:00:00 GMT) to denote an infinite lease time, so adjust the code to properly support that.

The expiry attribute of the lease object will be set to "false" in case of an infinite lease. This is to mimic the odhcp code below.
If the expiry date is not equal to 0, then just do exactly what was done before (return the os.diff of current time and ts).

Signed-off-by: Cody R. Brown <dev@codybrown.ca>