### PR TITLE
luci-app-simple-adblock: initial commit of companion to simple-adblock

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -1,0 +1,13 @@
+# Copyright (c) 2017 Stan Grishin (stangri@melmac.net)
+# This is free software, licensed under the GNU General Public License v3.
+
+include $(TOPDIR)/rules.mk
+
+
+LUCI_TITLE:=Simple Adblock Web UI
+LUCI_DEPENDS:=+simple-adblock
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-simple-adblock/luasrc/controller/simpleadblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/controller/simpleadblock.lua
@@ -1,0 +1,7 @@
+module("luci.controller.simpleadblock", package.seeall)
+function index()
+	if not nixio.fs.access("/etc/config/simple-adblock") then
+		return
+	end
+	entry({"admin", "services", "simpleadblock"}, cbi("simpleadblock"), translate("Simple AdBlock"), 1)
+end

--- a/applications/luci-app-simple-adblock/luasrc/model/cbi/simpleadblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/model/cbi/simpleadblock.lua
@@ -1,0 +1,48 @@
+m = Map("simple-adblock", translate("Simple AdBlock Settings"), translate("Configuration of Simple AdBlock Settings"))
+s = m:section(NamedSection, "config", "simple-adblock")
+
+-- General options
+o1 = s:option(Flag, "enabled", translate("Enable Simple AdBlock"))
+o1.rmempty = false
+o1.default = 0
+
+o2 = s:option(ListValue, "verbosity", translate("Output Verbosity Setting"),translate("Controls system log and console output verbosity"))
+o2:value("0", translate("Suppress output"))
+o2:value("1", translate("Some output"))
+o2:value("2", translate("Verbose output"))
+o2.rmempty = false
+o2.default = 2
+
+o3 = s:option(ListValue, "force_dns", translate("Force Router DNS"), translate("Forces Router DNS use on local devices, also known as DNS Hijacking"))
+o3:value("0", translate("Let local devices use their own DNS servers if set"))
+o3:value("1", translate("Force Router DNS server to all local devices"))
+o3.rmempty = false
+o3.default = 1
+
+-- Whitelisted Domains
+d1 = s:option(DynamicList, "whitelist_domain", translate("Whitelisted Domains"), translate("Individual domains to be whitelisted"))
+d1.addremove = true
+d1.optional = true
+
+-- Blacklisted Domains
+d3 = s:option(DynamicList, "blacklist_domain", translate("Blacklisted Domains"), translate("Individual domains to be blacklisted"))
+d3.addremove = true
+d3.optional = true
+
+-- Whitelisted Domains URLs
+d2 = s:option(DynamicList, "whitelist_domains_url", translate("Whitelisted Domain URLs"), translate("URLs to lists of domains to be whitelisted"))
+d2.addremove = true
+d2.optional = true
+
+-- Blacklisted Domains URLs
+d4 = s:option(DynamicList, "blacklist_domains_url", translate("Blacklisted Domain URLs"), translate("URLs to lists of domains to be blacklisted"))
+d4.addremove = true
+d4.optional = true
+
+-- Blacklisted Hosts URLs
+d5 = s:option(DynamicList, "blacklist_hosts_url", translate("Blacklisted Hosts URLs"), translate("URLs to lists of hosts to be blacklisted"))
+d5.addremove = true
+d5.optional = true
+
+return m
+

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -1,0 +1,68 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "Simple AdBlock Settings"
+msgstr ""
+
+msgid "Configuration of Simple AdBlock Settings"
+msgstr ""
+
+msgid "Enable Simple AdBlock"
+msgstr ""
+
+msgid "Output Verbosity Setting"
+msgstr ""
+
+msgid "Controls system log and console output verbosity"
+msgstr ""
+
+msgid "Suppress output"
+msgstr ""
+
+msgid "Some output"
+msgstr ""
+
+msgid "Verbose output"
+msgstr ""
+
+msgid "Force Router DNS"
+msgstr ""
+
+msgid "Forces Router DNS use on local devices, also known as DNS Hijacking"
+msgstr ""
+
+msgid "Let local devices use their own DNS servers if set"
+msgstr ""
+
+msgid "Force Router DNS server to all local devices"
+msgstr ""
+
+msgid "Whitelisted Domains"
+msgstr ""
+
+msgid "Individual domains to be whitelisted"
+msgstr ""
+
+msgid "Blacklisted Domains"
+msgstr ""
+
+msgid "Individual domains to be blacklisted"
+msgstr ""
+
+msgid "Whitelisted Domain URLs"
+msgstr ""
+
+msgid "URLs to lists of domains to be whitelisted"
+msgstr ""
+
+msgid "Blacklisted Domain URLs"
+msgstr ""
+
+msgid "URLs to lists of domains to be blacklisted"
+msgstr ""
+
+msgid "Blacklisted Hosts URLs"
+msgstr ""
+
+msgid "URLs to lists of hosts to be blacklisted"
+msgstr ""

--- a/applications/luci-app-simple-adblock/root/etc/uci-defaults/40_luci-simple-adblock
+++ b/applications/luci-app-simple-adblock/root/etc/uci-defaults/40_luci-simple-adblock
@@ -1,0 +1,10 @@
+#!/bin/sh
+uci -q batch <<-EOF >/dev/null
+	delete ucitrack.@simple-adblock[-1]
+	add ucitrack simple-adblock
+	set ucitrack.@simple-adblock[-1].init=simple-adblock
+	commit ucitrack
+EOF
+
+rm -f /tmp/luci-indexcache
+exit 0


### PR DESCRIPTION
As advised in this [pull request to openwrt/packages](https://github.com/openwrt/packages/pull/3902) I'm separating luci-app-simple-adblock.

Signed-off-by: Stan Grishin <stangri@melmac.net>