### PR TITLE
luci-app-upnp: Adding and displaying "Description" to upnp data

### DIFF
--- a/applications/luci-app-upnp/luasrc/controller/upnp.lua
+++ b/applications/luci-app-upnp/luasrc/controller/upnp.lua
@@ -19,8 +19,12 @@ function index()
 end
 
 function act_status()
+	local uci = luci.model.uci.cursor()
+	local lease_file = uci:get("upnpd", "config", "upnp_lease_file")
+	
 	local ipt = io.popen("iptables --line-numbers -t nat -xnvL MINIUPNPD 2>/dev/null")
 	if ipt then
+		local upnpf = lease_file and io.open(lease_file, "r")
 		local fwd = { }
 		while true do
 			local ln = ipt:read("*l")
@@ -29,23 +33,32 @@ function act_status()
 			elseif ln:match("^%d+") then
 				local num, proto, extport, intaddr, intport =
 					ln:match("^(%d+).-([a-z]+).-dpt:(%d+) to:(%S-):(%d+)")
+				local descr = ""
 
 				if num and proto and extport and intaddr and intport then
 					num     = tonumber(num)
 					extport = tonumber(extport)
 					intport = tonumber(intport)
+					
+					if upnpf then
+						local uln = upnpf:read("*l")
+						if uln then descr = uln:match(string.format("^%s:%d:%s:%d:%%d*:(.*)$", proto:upper(), extport, intaddr, intport)) end
+						if not descr then descr = "" end
+					end
 
 					fwd[#fwd+1] = {
 						num     = num,
 						proto   = proto:upper(),
 						extport = extport,
 						intaddr = intaddr,
-						intport = intport
+						intport = intport,
+						descr = descr
 					}
 				end
 			end
 		end
 
+		if upnpf then upnpf:close() end
 		ipt:close()
 
 		luci.http.prepare_content("application/json")

--- a/applications/luci-app-upnp/luasrc/view/upnp_status.htm
+++ b/applications/luci-app-upnp/luasrc/view/upnp_status.htm
@@ -29,9 +29,10 @@
 					tr.insertCell(-1).innerHTML = st[i].extport;
 					tr.insertCell(-1).innerHTML = st[i].intaddr;
 					tr.insertCell(-1).innerHTML = st[i].intport;
+					tr.insertCell(-1).innerHTML = st[i].descr;
 
 					tr.insertCell(-1).innerHTML = String.format(
-						'<input class="cbi-button cbi-input-remove" type="button" value="<%:Delete Redirect%>" onclick="upnp_delete_fwd(%d)" />',
+						'<input class="cbi-button cbi-input-remove" type="button" value="<%:Delete%>" onclick="upnp_delete_fwd(%d)" />',
 							st[i].num
 					);
 				}
@@ -58,6 +59,7 @@
 			<th class="cbi-section-table-cell"><%:External Port%></th>
 			<th class="cbi-section-table-cell"><%:Client Address%></th>
 			<th class="cbi-section-table-cell"><%:Client Port%></th>
+			<th class="cbi-section-table-cell"><%:Description%></th>
 			<th class="cbi-section-table-cell">&#160;</th>
 		</tr>
 		<tr class="cbi-section-table-row">


### PR DESCRIPTION
Getting the Description data from upnp_lease_file. This data often displays the Application Name which made the upnp call. If the upnp_lease_file doesn't exist, it'll just return a blank entry under "Description".

upnp_lease_file order example: TCP:33333:192.168.0.100:33333:1485578298:NAT-PMP 33333 tcp
As an optimisation, since the upnp_lease_file has only active leases and is ordered by epoch timestamp (5th column above), and since "iptables --line-numbers -t nat -xnvL MINIUPNPD" has active leases and is also displayed in order of rule applied (time). This means the order of these two sources will be the same. This prevents us from "searching" the upnp_lease_file for every rule, and instead for the n'th rule, look at the n'th upnp_lease_file line. As a result we only need to read in one line at a time. For a safety, the upnp_lease_file description is always checked to see if it matches the rule it's being assigned to. If it doesn't match it'll return blank. This means we'll never put an incorrect description to a upnp rule, even if someone messes with the upnp_lease_file.
This is the case on my system, more testing may be necessary? If this is false we'll need to loop over the upnp_lease_file for every rule, or read in the whole upnp_lease_file once for the iptables loop.

The Description column is added to the upnp_status, and the "Delete Redirect" renamed to "Delete" to make more horizontal space in the table.

Signed-off-by: Cody R. Brown <dev@codybrown.ca>