### PR TITLE
mod-admin-full: Add IPv6 Prefix Delegation information to Status Pages

### DIFF
--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -950,6 +950,13 @@ function protocol.dns6addrs(self)
 	return dns
 end
 
+function protocol.ip6prefix(self)
+	local prefix = self:_ubus("ipv6-prefix")
+	if prefix and #prefix > 0 then
+		return "%s/%d" %{ prefix[1].address, prefix[1].mask }
+	end
+end
+
 function protocol.is_bridge(self)
 	return (not self:is_virtual() and self:type() == "bridge")
 end

--- a/modules/luci-mod-admin-full/luasrc/controller/admin/network.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/network.lua
@@ -238,6 +238,7 @@ function iface_status(ifaces)
 				ipaddrs    = net:ipaddrs(),
 				ip6addrs   = net:ip6addrs(),
 				dnsaddrs   = net:dnsaddrs(),
+				ip6prefix  = net:ip6prefix(),
 				name       = device:shortname(),
 				type       = device:type(),
 				ifname     = device:name(),

--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_overview.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_overview.htm
@@ -164,6 +164,11 @@
 									ifc.ip6addrs[i]
 								);
 						}
+						
+						if (ifc.ip6prefix)
+						{
+							html += String.format('<strong><%:IPv6-PD%>:</strong> %s<br />', ifc.ip6prefix);
+						}
 
 						d.innerHTML = html;
 					}

--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_status.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_status.htm
@@ -54,6 +54,11 @@
 								ifc.ip6addrs[i]
 							);
 					}
+					
+					if (ifc.ip6prefix)
+					{
+						html += String.format('<strong><%:IPv6-PD%>:</strong> %s<br />', ifc.ip6prefix);
+					}
 
 					d.innerHTML = html;
 				}

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -76,12 +76,14 @@
 
 		if wan6 then
 			rv.wan6 = {
-				ip6addr = wan6:ip6addr(),
-				gw6addr = wan6:gw6addr(),
-				dns     = wan6:dns6addrs(),
-				uptime  = wan6:uptime(),
-				ifname  = wan6:ifname(),
-				link    = wan6:adminlink()
+				ip6addr   = wan6:ip6addr(),
+				gw6addr   = wan6:gw6addr(),
+				dns       = wan6:dns6addrs(),
+				ip6prefix = wan6:ip6prefix(),
+				uptime    = wan6:uptime(),
+				proto     = wan6:proto(),
+				ifname    = wan6:ifname(),
+				link      = wan6:adminlink()
 			}
 		end
 
@@ -233,9 +235,34 @@
 			if (ifc6 && ifc6.ifname && ifc6.proto != 'none')
 			{
 				var s = String.format(
-					'<strong><%:Address%>: </strong>%s<br />' +
+					'<strong><%:Type%>: </strong>%s%s<br />',
+						ifc6.proto, (ifc6.ip6prefix) ? '-pd' : ''
+				);
+				
+				if (!ifc6.ip6prefix)
+				{
+					s += String.format(
+						'<strong><%:Address%>: </strong>%s<br />',
+						(ifc6.ip6addr) ? ifc6.ip6addr : '::'
+					);
+				}
+				else
+				{
+					s += String.format(
+						'<strong><%:Prefix Delegated%>: </strong>%s<br />',
+						ifc6.ip6prefix
+					);
+					if (ifc6.ip6addr)
+					{
+						s += String.format(
+							'<strong><%:Address%>: </strong>%s<br />',
+							ifc6.ip6addr
+						);
+					}
+				}
+
+				s += String.format(
 					'<strong><%:Gateway%>: </strong>%s<br />',
-						(ifc6.ip6addr) ? ifc6.ip6addr : '::',
 						(ifc6.gw6addr) ? ifc6.gw6addr : '::'
 				);
 


### PR DESCRIPTION
The Overview page and Network>Interfaces page currently do not give much information about IPv6, particularly with Prefix Delegated setups. In these setups, ISP will delegate a prefix to the router. Currently LuCI doesn't display this Prefix Delegation from the ISP anywhere. A number of changes was added to this commit:

1) self:_ubus("ipv6-prefix") was extracted and put into protocol.ip6prefix.
2) Network>Interfaces page, if a .ip6prefix is present, show it under Status. (IPv6-PD).
3) On the Overview page, "Type" and "Prefix Delegated" has been added to the IPv6 Network Overview Status:
  - Type will display the .proto, similar to the IPv4 case. If a .ip6prefix is present, it'll display a "-pd" at the end of the Type: i.e. dhcpv6-pd vs. dhcpv6.
  - If no .ip6prefix is present, it'll do what it does currently, and just show Address, or :: if no address is present.
  - If .ip6prefix is present, it'll show the "Prefix Delegated", it'll also hide "Address" if no address is present, else it'll show ifc6.ip6addr as well.

Signed-off-by: Cody R. Brown <dev@codybrown.ca>