### PR TITLE
luci-mod-admin-full: add DUID option to static leases section

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -285,6 +285,18 @@ ip.datatype = "or(ip4addr,'ignore')"
 time = s:option(Value, "leasetime", translate("Lease time"))
 time.rmempty  = true
 
+duid = s:option(Value, "duid", translate("<abbr title=\"The DHCP Unique Identifier\">DUID</abbr>"))
+fp = io.open("/var/hosts/odhcpd")
+if fp then
+	for line in fp:lines() do
+		local net_val, duid_val = string.match(line, "# (%S+)%s+(%S+)")
+		if duid_val then
+			duid:value(duid_val, duid_val)
+		end
+	end
+	fp:close()
+end
+
 hostid = s:option(Value, "hostid", translate("<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"))
 
 ipc.neighbors({ family = 4 }, function(n)


### PR DESCRIPTION
It adds field for DUID value to LuCI static leases configuration.
This should solve usability issue mentioned in https://github.com/openwrt/luci/issues/940

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>