### PR TITLE
Add 802.11r fast transition support to wifi.lua

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -900,18 +900,74 @@ end
 
 
 if hwtype == "atheros" or hwtype == "mac80211" or hwtype == "prism2" then
-	nasid = s:taboption("encryption", Value, "nasid", translate("NAS ID"),
-		translate("Used for two different purposes: RADIUS NAS ID and " ..
-			  "802.11r R0KH-ID. Not needed with normal WPA(2)-PSK."))
+	local hostapd = fs.access("/usr/sbin/hostapd")
+
+	-- Probe EAP support as a proxy for determining if 802.11r support is present
+	local has_ap_eap  = (os.execute("hostapd -veap >/dev/null 2>/dev/null") == 0)
+
+	ieee80211r = s:taboption("encryption", Flag, "ieee80211r", translate("802.11r Fast Transition"))
+	ieee80211r:depends({mode="ap", encryption="wpa"})
+	ieee80211r:depends({mode="ap", encryption="wpa2"})
+	ieee80211r:depends({mode="ap-wds", encryption="wpa"})
+	ieee80211r:depends({mode="ap-wds", encryption="wpa2"})
+	if has_ap_eap then
+		ieee80211r:depends({mode="ap", encryption="psk"})
+		ieee80211r:depends({mode="ap", encryption="psk2"})
+	end
+	ieee80211r.rmempty = true
+	
+	nasid = s:taboption("encryption", Value, "nasid", translate("NAS ID"))
+
 	nasid:depends({mode="ap", encryption="wpa"})
 	nasid:depends({mode="ap", encryption="wpa2"})
 	nasid:depends({mode="ap-wds", encryption="wpa"})
 	nasid:depends({mode="ap-wds", encryption="wpa2"})
-	nasid:depends({mode="ap", encryption="psk"})
-	nasid:depends({mode="ap", encryption="psk2"})
-	nasid:depends({mode="ap", encryption="psk-mixed"})
+	nasid:depends({ieee80211r="1"})
 	nasid.rmempty = true
+	mobility_domain = s:taboption("encryption", Value, "mobility_domain", translate("Mobility Domain"))
+	mobility_domain:depends({ieee80211r="1"})
+	mobility_domain.placeholder = "4f57"
+	mobility_domain.rmempty = true
 
+	r0_key_lifetime = s:taboption("encryption", Value, "r0_key_lifetime", translate("R0 Key Lifetime"), translate("minutes"))
+	r0_key_lifetime:depends({ieee80211r="1"})
+	r0_key_lifetime.placeholder = "10000"
+	r0_key_lifetime.rmempty = true
+
+	r1_key_holder = s:taboption("encryption", Value, "r1_key_holder", translate("R1 Key Holder"), translate("6-octet identifier as a hex string - no colons"))
+	r1_key_holder:depends({ieee80211r="1"})
+	r1_key_holder.placeholder = "00004f577274"
+	r1_key_holder.rmempty = true
+
+	reassociation_deadline = s:taboption("encryption", Value, "reassociation_deadline", translate("Reassociation Deadline"), translate("time units (TUs / 1.024 ms) [1000-65535]"))
+	reassociation_deadline:depends({ieee80211r="1"})
+	reassociation_deadline.placeholder = "1000"
+	reassociation_deadline.rmempty = true
+
+	pmk_r1_push = s:taboption("encryption", Flag, "pmk_r1_push", translate("PMK R1 Push"))
+	pmk_r1_push:depends({ieee80211r="1"})
+	pmk_r1_push.placeholder = "0"
+	pmk_r1_push.rmempty = true
+
+	r0kh = s:taboption("encryption", DynamicList, "r0kh", translate("External R0 Key Holder List"),
+		translate("List of R0KHs in the same Mobility Domain. ".. 
+                           "<br>Format: MAC-address,NAS-Identifier,128-bit key as hex string. "..
+                           "<br>This list is used to map R0KH-ID (NAS Identifier) to a destination MAC address "..
+                           "when requesting PMK-R1 key from the R0KH that the STA "..
+                           "used during the Initial Mobility Domain Association."))
+
+	r0kh:depends({ieee80211r="1"})
+	r0kh.rmempty = true
+
+	r1kh = s:taboption("encryption", DynamicList, "r1kh", translate("External R1 Key Holder List"),
+		translate ("List of R1KHs in the same Mobility Domain. "..
+					"<br>Format: MAC-address,R1KH-ID as 6 octets with colons,128-bit key as hex string. ".. 
+					"<br>This list is used to map R1KH-ID to a destination MAC address "..
+					"when sending PMK-R1 key from the R0KH. This is also the "..
+					"list of authorized R1KHs in the MD that can request PMK-R1 keys."))
+	r1kh:depends({ieee80211r="1"})
+	r1kh.rmempty = true
+	
 	eaptype = s:taboption("encryption", ListValue, "eap_type", translate("EAP-Method"))
 	eaptype:value("tls",  "TLS")
 	eaptype:value("ttls", "TTLS")

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -903,6 +903,7 @@ if hwtype == "atheros" or hwtype == "mac80211" or hwtype == "prism2" then
 	local hostapd = fs.access("/usr/sbin/hostapd")
 
 	-- Probe EAP support as a proxy for determining if 802.11r support is present
+	
 	local has_ap_eap  = (os.execute("hostapd -veap >/dev/null 2>/dev/null") == 0)
 
 	ieee80211r = s:taboption("encryption", Flag, "ieee80211r", translate("802.11r Fast Transition"))

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -900,7 +900,6 @@ end
 
 
 if hwtype == "atheros" or hwtype == "mac80211" or hwtype == "prism2" then
-	local hostapd = fs.access("/usr/sbin/hostapd")
 
 	-- Probe EAP support as a proxy for determining if 802.11r support is present
 	


### PR DESCRIPTION
Adds support for 802.11r fast transition to luci.  

The R0KH & R1KH options are not perfect as it would be better to separate out each option and do some sanity checking on the values, but that is beyond my capabilities.

Also addresses the issue of #844 