### PR TITLE
treewide: cleanup references to madwifi

### DIFF
--- a/applications/luci-app-meshwizard/luasrc/model/cbi/freifunk/meshwizard.lua
+++ b/applications/luci-app-meshwizard/luasrc/model/cbi/freifunk/meshwizard.lua
@@ -103,10 +103,7 @@ uci:foreach("wireless", "wifi-device", function(section)
 
 	-- Channel selection
 
-	if hwtype == "atheros" then
-		local cc = util.trim(sys.exec("grep -i '" .. syscc .. "' /lib/wifi/cc_translate.txt |cut -d ' ' -f 2")) or 0
-		sys.exec('"echo " .. cc .. " > /proc/sys/dev/" .. device .. "/countrycode"')
-	elseif hwtype == "mac80211" then
+	if hwtype == "mac80211" then
 		sys.exec("iw reg set " .. syscc)
 	elseif hwtype == "broadcom" then
 		sys.exec ("wlc country " .. syscc)

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -349,12 +349,6 @@ plugins = {
 		{ }
 	},
 
-	madwifi = {
-		{ "WatchSet" },
-		{ },
-		{ "Interfaces", "WatchAdds" }
-	},
-
 	memory = { 
 		{ },
 		{ },

--- a/contrib/package/freifunk-common/Makefile
+++ b/contrib/package/freifunk-common/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-common
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-common/files/etc/config/freifunk
+++ b/contrib/package/freifunk-common/files/etc/config/freifunk
@@ -104,12 +104,6 @@ config 'defaults' 'wifi_iface'
 	option 'bssid' '12:CA:FF:EE:BA:BE'
 	option 'mcast_rate' '6000'
 
-config 'defaults' 'madwifi_wifi_iface'
-        option 'bgscan' '0'
-	option 'sw_merge' '1'
-        option 'probereq' '1'
-        option 'mcast_rate' '5500'
-
 config 'defaults' 'interface'
 	option 'netmask' '255.255.0.0'
 	option 'dns' '8.8.8.8 212.204.49.83 141.1.1.1'

--- a/contrib/package/meshwizard/Makefile
+++ b/contrib/package/meshwizard/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meshwizard
-PKG_RELEASE:=0.3.2
+PKG_RELEASE:=0.3.3
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/meshwizard/files/usr/bin/meshwizard/helpers/rename-wifi.sh
+++ b/contrib/package/meshwizard/files/usr/bin/meshwizard/helpers/rename-wifi.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # This script renames IB_wifi_ interface names into real interface names used on this system.
-# E.g. wireless.IB_wifi0 would become wireless.wifi0 on madwifi and wireless.radio0 on mac80211
+# E.g. wireless.IB_wifi0 would become wireless.radio0 on mac80211
 
 . $dir/functions.sh
 

--- a/contrib/package/meshwizard/files/usr/bin/meshwizard/helpers/setup_wifi.sh
+++ b/contrib/package/meshwizard/files/usr/bin/meshwizard/helpers/setup_wifi.sh
@@ -59,11 +59,6 @@ uci set wireless.$net\_iface=wifi-iface
 # create new wifi-iface for $net from defaults
 set_defaults "wifi_iface_" wireless.$net\_iface
 
-# overwrite some settings for type atheros (madwifi)
-if [ "$type" = "atheros" ]; then
-       set_defaults "madwifi_wifi_iface_" wireless.${net}
-fi
-
 # overwrite defaults
 bssid="$($dir/helpers/gen_bssid.sh $channel $community)"
 

--- a/contrib/package/meshwizard/files/usr/bin/meshwizard/helpers/supports_vap.sh
+++ b/contrib/package/meshwizard/files/usr/bin/meshwizard/helpers/supports_vap.sh
@@ -8,9 +8,7 @@ if [ -z "$dev" -o -z "$type" ]; then
 	exit 1
 fi
 
-if [ "$type" = "atheros" ]; then
-        exit 0
-elif [ "$type" = "mac80211" ]; then
+if [ "$type" = "mac80211" ]; then
 	# not hostapd[-mini], no VAP
 	if [ ! -x /usr/sbin/hostapd ]; then
 		echo "WARNING: hostapd[-mini] is required to be able to use VAP with mac80211."

--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -1362,8 +1362,6 @@ function wifidev.get_i18n(self)
 	local t = "Generic"
 	if self.iwinfo.type == "wl" then
 		t = "Broadcom"
-	elseif self.iwinfo.type == "madwifi" then
-		t = "Atheros"
 	end
 
 	local m = ""

--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_overview.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_overview.htm
@@ -66,10 +66,6 @@
 
 			return name
 
-		-- madwifi
-		elseif name == "ath" or name == "wifi" then
-			return translatef("Atheros 802.11%s Wireless Controller", bands)
-
 		-- ralink
 		elseif name == "ra" then
 			return translatef("RaLink 802.11%s Wireless Controller", bands)

--- a/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/wifi.lua
+++ b/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/wifi.lua
@@ -156,18 +156,6 @@ end
 
 local hwtype = m:get(wifidevs[1], "type")
 
-if hwtype == "atheros" then
-	mode = s:option(ListValue, "hwmode", translate("Mode"))
-	mode.override_values = true
-	mode:value("", "auto")
-	mode:value("11b", "802.11b")
-	mode:value("11g", "802.11g")
-	mode:value("11a", "802.11a")
-	mode:value("11bg", "802.11b+g")
-	mode.rmempty = true
-end
-
-
 ch = s:option(Value, "channel", translate("Channel"))
 for i=1, 14 do
 	ch:value(i, i .. " (2.4 GHz)")
@@ -224,7 +212,7 @@ encr.override_values = true
 encr:value("none", "No Encryption")
 encr:value("wep", "WEP")
 
-if hwtype == "atheros" or hwtype == "mac80211" then
+if hwtype == "mac80211" then
 	local supplicant = fs.access("/usr/sbin/wpa_supplicant")
 	local hostapd    = fs.access("/usr/sbin/hostapd")
 
@@ -288,7 +276,7 @@ port:depends({mode="ap", encryption="wpa2"})
 port.rmempty = true
 
 
-if hwtype == "atheros" or hwtype == "mac80211" then
+if hwtype == "mac80211" then
 	nasid = s:option(Value, "nasid", translate("NAS ID"))
 	nasid:depends({mode="ap", encryption="wpa"})
 	nasid:depends({mode="ap", encryption="wpa2"})
@@ -339,7 +327,7 @@ if hwtype == "atheros" or hwtype == "mac80211" then
 end
 
 
-if hwtype == "atheros" or hwtype == "broadcom" then
+if hwtype == "broadcom" then
 	iso = s:option(Flag, "isolate", translate("AP-Isolation"), translate("Prevents Client to Client communication"))
 	iso.rmempty = true
 	iso:depends("mode", "ap")
@@ -349,7 +337,7 @@ if hwtype == "atheros" or hwtype == "broadcom" then
 	hide:depends("mode", "ap")
 end
 
-if hwtype == "mac80211" or hwtype == "atheros" then
+if hwtype == "mac80211" then
 	bssid:depends({mode="adhoc"})
 end
 


### PR DESCRIPTION
Remove from LuCI the code related to the deprecated madwifi driver. The last references to the driver were removed from Openwrt main code two years ago with https://github.com/openwrt/openwrt/commit/0be32368ad57192f5b92c96f61021b6d8752469e

Run-tested with
* ipq806x / R7800
* ar71xx / WNDR3700

I will also disable the madwifi plugin in collectd (in the packages repo).

@jow- 

