### PR TITLE
Backport 802.11r and 802.11w LuCI support to lede-17.01

### DIFF
--- a/modules/luci-base/luasrc/cbi/datatypes.lua
+++ b/modules/luci-base/luasrc/cbi/datatypes.lua
@@ -267,6 +267,13 @@ function wepkey(val)
 	end
 end
 
+function hexstring(val)
+        if val then
+                return (val:match("^[a-fA-F0-9]+$") ~= nil)
+        end
+        return false
+end
+
 function string(val)
 	return true		-- Everything qualifies as valid string
 end

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -1123,6 +1123,44 @@ if hwtype == "atheros" or hwtype == "mac80211" or hwtype == "prism2" then
 	password.password = true
 end
 
+-- ieee802.11w options
+if hwtype == "mac80211" then
+	ieee80211w = s:taboption("encryption", ListValue, "ieee80211w",
+		translate("802.11w Management Frame Protection"),
+		translate("Requires the 'full' version of wpad/hostapd " ..
+			"and support from the wifi driver <br>(as of Feb 2017: " ..
+			"ath9k and ath10k, in LEDE also mwlwifi and mt76)"))
+	ieee80211w.default = "0"
+	ieee80211w.rmempty = true
+	ieee80211w:value("0", translate("Disabled (default)"))
+	ieee80211w:value("1", translate("Optional"))
+	ieee80211w:value("2", translate("Required"))
+	ieee80211w:depends({mode="ap", encryption="wpa2"})
+	ieee80211w:depends({mode="ap-wds", encryption="wpa2"})
+	ieee80211w:depends({mode="ap", encryption="psk2"})
+	ieee80211w:depends({mode="ap", encryption="psk-mixed"})
+	ieee80211w:depends({mode="ap-wds", encryption="psk2"})
+	ieee80211w:depends({mode="ap-wds", encryption="psk-mixed"})
+
+	max_timeout = s:taboption("encryption", Value, "ieee80211w_max_timeout",
+			translate("802.11w maximum timeout"),
+			translate("802.11w Association SA Query maximum timeout"))
+	max_timeout:depends({ieee80211w="1"})
+	max_timeout:depends({ieee80211w="2"})
+	max_timeout.datatype = "uinteger"
+	max_timeout.placeholder = "1000"
+	max_timeout.rmempty = true
+
+	retry_timeout = s:taboption("encryption", Value, "ieee80211w_retry_timeout",
+			translate("802.11w retry timeout"),
+			translate("802.11w Association SA Query retry timeout"))
+	retry_timeout:depends({ieee80211w="1"})
+	retry_timeout:depends({ieee80211w="2"})
+	retry_timeout.datatype = "uinteger"
+	retry_timeout.placeholder = "201"
+	retry_timeout.rmempty = true
+end
+
 if hwtype == "atheros" or hwtype == "mac80211" or hwtype == "prism2" then
 	local wpasupplicant = fs.access("/usr/sbin/wpa_supplicant")
 	local hostcli = fs.access("/usr/sbin/hostapd_cli")


### PR DESCRIPTION
This PR contains three commits that backport the recent additions of 802.11r and 802.11w config options into the lede-17.01 branch.

Three commits:
* hexstring data type validation
* 802.11r support, roll-up of four commits
* 802.11w support, roll-up of two commits

Run-tested in LEDE 17.01 with ipq806x/R7800 and ar71xx/WDNR3700.
