### PR TITLE
luci: ignore '::1' in realtime connections

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/connections.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/connections.htm
@@ -153,7 +153,8 @@
 						{
 							var c  = conn[i];
 
-							if (c.src == '127.0.0.1' && c.dst == '127.0.0.1')
+							if ((c.src == '127.0.0.1' && c.dst == '127.0.0.1')
+							|| (c.src == '::1' && c.dst == '::1'))
 								continue;
 
 							var tr = conn_table.rows[0].parentNode.insertRow(-1);

--- a/modules/luci-mod-admin-full/src/luci-bwc.c
+++ b/modules/luci-mod-admin-full/src/luci-bwc.c
@@ -521,8 +521,8 @@ static int run_daemon(void)
 				if (strstr(line, "TIME_WAIT"))
 					continue;
 
-				if (strstr(line, "src=127.0.0.1 ") &&
-				    strstr(line, "dst=127.0.0.1 "))
+				if ((strstr(line, "src=127.0.0.1 ") && strstr(line, "dst=127.0.0.1 ")) 
+				|| (strstr(line, "src=::1 ") && strstr(line, "dst=::1 ")))
 					continue;
 
 				if (sscanf(line, "%*s %*d %s", ifname) || sscanf(line, "%s %*d", ifname))


### PR DESCRIPTION
luci ignores only 127.0.0.1 in real time connections.
The dnsmasq.init script sets up resolv.conf(s) as such.
With alternate DNS servers configured 'localhost' will
resolve to '127.0.0.1' or '::1'. The connections graph
will spam itself. openwrt/luci#996

It works and it was *too easy*. @hnyman please
check this, but it might be the answer.