### PR TITLE
luci-app-minidlna: permit minidlna after sysupgrade

### DIFF
--- a/applications/luci-app-minidlna/root/etc/uci-defaults/40_luci-minidlna
+++ b/applications/luci-app-minidlna/root/etc/uci-defaults/40_luci-minidlna
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-/etc/init.d/minidlna enabled && {
-	/etc/init.d/minidlna stop
-	/etc/init.d/minidlna disable
-}
-
 uci -q batch <<-EOF >/dev/null
 	delete ucitrack.minidlna
 	set ucitrack.minidlna=minidlna


### PR DESCRIPTION
Do not disable minidlna after sysupgrade, rather trust the config
enabled status in /etc/config/minidlna.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>