### PR TITLE
unbound: add uci-default script

### DIFF
--- a/applications/luci-app-unbound/root/etc/uci-defaults/60_luci-unbound
+++ b/applications/luci-app-unbound/root/etc/uci-defaults/60_luci-unbound
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+uci -q batch <<-EOF >/dev/null
+  delete ucitrack.@unbound[-1]
+  add ucitrack unbound
+  set ucitrack.@unbound[-1].init=unbound
+  commit ucitrack
+EOF
+
+rm -f /tmp/luci-indexcache
+[ ! -x /usr/sbin/unbound-control ] && exit 0
+
+uci -q batch <<-EOF >/dev/null
+  set luci.unboundhosts=command
+  set luci.unboundhosts.name='Unbound Local Hosts'
+  set luci.unboundhosts.command='unbound-control -c /var/lib/unbound/unbound.conf list_local_data'
+  set luci.unboundzones=command
+  set luci.unboundzones.name='Unbound Local Zones'
+  set luci.unboundzones.command='unbound-control -c /var/lib/unbound/unbound.conf list_local_zones'
+  commit luci
+EOF
+
+rm -f /tmp/luci-indexcache
+exit 0
+


### PR DESCRIPTION
Tested: TL-Archer-C7 LEDE Trunk
Description: 
Also if unbound-control is installed, then configure so
luci-app-commands can quickly show the "local zones" and
"local data" (aka hosts). This helps diagnose DHCP-DNS
zone data and adblock zone data.