### PR TITLE
luci-app-miniupnpd: restore missing luci install file

### DIFF
--- a/applications/luci-app-upnp/root/etc/uci-defaults/40_luci-miniupnp
+++ b/applications/luci-app-upnp/root/etc/uci-defaults/40_luci-miniupnp
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+uci -q batch <<-EOF >/dev/null
+	delete ucitrack.@upnpd[-1]
+	add ucitrack upnpd
+	set ucitrack.@upnpd[-1]=miniupnpd
+	commit ucitrack
+EOF
+
+rm -f /tmp/luci-indexcache
+exit 0


### PR DESCRIPTION
Restore luci indexcache handling incorrect removed in
https://github.com/openwrt/luci/commit/387a06bb73462312c075e53ce9e6002d4af09e92

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>