### PR TITLE
luci-app-vpnbypass: include dnsmasq settings, link to README

### DIFF
--- a/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
+++ b/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
@@ -1,4 +1,4 @@
-m = Map("vpnbypass", translate("VPN Bypass Settings"), translate("Configuration of VPN Bypass Settings"))
+m = Map("vpnbypass", translate("VPN Bypass Settings"))
 s = m:section(NamedSection, "config", "vpnbypass")
 
 -- General options
@@ -31,5 +31,9 @@ d1 = s:option(DynamicList, "domain", translate("Domains to Bypass"), translate("
 d1.addremove = true
 d1.optional = true
 
-return m
+d = Map("dhcp")
+s4 = d:section(TypedSection, "dnsmasq")
+s4.anonymous = true
+di = s4:option(DynamicList, "ipset", translate("Domains to Bypass"), translate("Domains to be accessed directly (outside of the VPN tunnel), see <a href='https://github.com/openwrt/packages/tree/master/net/vpnbypass/files#bypass-domains-formatsyntax'>README</a> for syntax"))
 
+return m, d

--- a/applications/luci-app-vpnbypass/po/templates/vpnbypass.pot
+++ b/applications/luci-app-vpnbypass/po/templates/vpnbypass.pot
@@ -1,10 +1,13 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-msgid "Configuration of VPN Bypass Settings"
+msgid "Domains to Bypass"
 msgstr ""
 
-msgid "Domains to Bypass"
+msgid ""
+"Domains to be accessed directly (outside of the VPN tunnel), see <a "
+"href='https://github.com/openwrt/packages/tree/master/net/vpnbypass/"
+"files#bypass-domains-formatsyntax'>README</a> for syntax"
 msgstr ""
 
 msgid "Domains which will be accessed directly (outside of the VPN tunnel)"


### PR DESCRIPTION
Updated luci-app to directly edit dnsmasq ipsets and link to README on github.

Signed-off-by: Stan Grishin <stangri@melmac.net>