### PR TITLE
luci-app-vpnbypass: cbi file fix for README link and an unneeded section

### DIFF
--- a/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
+++ b/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
@@ -27,13 +27,12 @@ r2.addremove = true
 r2.optional = true
 
 -- Domains
-d1 = s:option(DynamicList, "domain", translate("Domains to Bypass"), translate("Domains which will be accessed directly (outside of the VPN tunnel)"))
-d1.addremove = true
-d1.optional = true
-
 d = Map("dhcp")
 s4 = d:section(TypedSection, "dnsmasq")
 s4.anonymous = true
-di = s4:option(DynamicList, "ipset", translate("Domains to Bypass"), translate("Domains to be accessed directly (outside of the VPN tunnel), see <a href='https://github.com/openwrt/packages/tree/master/net/vpnbypass/files#bypass-domains-formatsyntax'>README</a> for syntax"))
+di = s4:option(DynamicList, "ipset", translate("Domains to Bypass"),
+    translate("Domains to be accessed directly (outside of the VPN tunnel), see ")
+    .. [[<a href="https://github.com/openwrt/packages/tree/master/net/vpnbypass/files#bypass-domains-formatsyntax" target="_blank">]]
+    .. translate("README") .. [[</a>]] .. translate(" for syntax"))
 
 return m, d

--- a/applications/luci-app-vpnbypass/po/templates/vpnbypass.pot
+++ b/applications/luci-app-vpnbypass/po/templates/vpnbypass.pot
@@ -4,13 +4,7 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "Domains to Bypass"
 msgstr ""
 
-msgid ""
-"Domains to be accessed directly (outside of the VPN tunnel), see <a "
-"href='https://github.com/openwrt/packages/tree/master/net/vpnbypass/"
-"files#bypass-domains-formatsyntax'>README</a> for syntax"
-msgstr ""
-
-msgid "Domains which will be accessed directly (outside of the VPN tunnel)"
+msgid "Domains to be accessed directly (outside of the VPN tunnel), see"
 msgstr ""
 
 msgid "Enable VPN Bypass"
@@ -26,6 +20,9 @@ msgid "Local Ports to Bypass"
 msgstr ""
 
 msgid "Local ports to trigger VPN Bypass"
+msgstr ""
+
+msgid "README"
 msgstr ""
 
 msgid "Remote IP Subnets to Bypass"
@@ -45,4 +42,7 @@ msgid "VPN Bypass"
 msgstr ""
 
 msgid "VPN Bypass Settings"
+msgstr ""
+
+msgid "for syntax"
 msgstr ""


### PR DESCRIPTION
Hannu, as per your feedback I've removed the link to README from translatable section. I've also noticed I've accidentally left an unneeded section in the cbi file before.

There's no earth-shattering change, but I'm not going to touch this for a while, so I wanted to submit this now.

Thank you!

Signed-off-by: Stan Grishin <stangri@melmac.net>