### PR TITLE
luci-app-bcp38: added bcp38 application

### DIFF
--- a/applications/luci-app-bcp38/Makefile
+++ b/applications/luci-app-bcp38/Makefile
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2010 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=BCP38 LuCI interface
+LUCI_DEPENDS:=+luci-admin-full +bcp38
+
+PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-bcp38/luasrc/controller/bcp38.lua
+++ b/applications/luci-app-bcp38/luasrc/controller/bcp38.lua
@@ -1,0 +1,7 @@
+module("luci.controller.bcp38", package.seeall)
+
+function index()
+	entry({"admin", "network", "firewall", "bcp38"},
+		cbi("bcp38"),
+		_("BCP38"), 50).dependent = false
+end

--- a/applications/luci-app-bcp38/luasrc/model/cbi/bcp38.lua
+++ b/applications/luci-app-bcp38/luasrc/model/cbi/bcp38.lua
@@ -1,0 +1,60 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2014 Toke Høiland-Jørgensen <toke@toke.dk>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+local wa = require "luci.tools.webadmin"
+local net = require "luci.model.network".init()
+local ifaces = net:get_interfaces()
+
+m = Map("bcp38", translate("BCP38"),
+	translate("This function blocks packets with private address destinations " ..
+		"from going out onto the internet as per " ..
+		"<a href=\"http://tools.ietf.org/html/bcp38\">BCP 38</a>. " ..
+		"For IPv6, only source specific default routes are installed, so " ..
+		"no BCP38 firewall routes are needed."))
+
+s = m:section(TypedSection, "bcp38", translate("BCP38 config"))
+s.anonymous = true
+-- BASIC
+e = s:option(Flag, "enabled", translate("Enable"))
+e.rmempty = false
+
+a = s:option(Flag, "detect_upstream", translate("Auto-detect upstream IP"),
+				translate("Attempt to automatically detect if the upstream IP " ..
+					"will be blocked by the configuration, and add an exception if it will. " ..
+					"If this does not work correctly, you can add exceptions manually below."))
+a.rmempty = false
+
+n = s:option(ListValue, "interface", translate("Interface name"), translate("Interface to apply the blocking to " ..
+							"(should be the upstream WAN interface)."))
+for _, iface in ipairs(ifaces) do
+     if iface:is_up() then
+	n:value(iface:name())
+     end
+end
+n.rmempty = false
+
+ma = s:option(DynamicList, "match",
+	translate("Blocked IP ranges"))
+
+ma.datatype = "ip4addr"
+
+nm = s:option(DynamicList, "nomatch",
+	translate("Allowed IP ranges"), translate("Takes precedence over blocked ranges. "..
+						  "Use to whitelist your upstream network if you're behind a double NAT " ..
+						  "and the auto-detection doesn't work."))
+
+nm.datatype = "ip4addr"
+
+
+return m

--- a/applications/luci-app-bcp38/root/etc/uci-defaults/60_luci-bcp38
+++ b/applications/luci-app-bcp38/root/etc/uci-defaults/60_luci-bcp38
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+uci -q batch <<-EOF >/dev/null
+	delete ucitrack.@bcp38[-1]
+	add ucitrack bcp38
+        add_list ucitrack.@bcp38[0].affects=firewall
+	commit ucitrack
+EOF
+
+rm -f /tmp/luci-indexcache
+exit 0


### PR DESCRIPTION
This application was moved from the packages repository to luci.

Signed-off-by: Dan Luedtke <mail@danrl.com>

What I do not know how to implement best is this part:
````
define Package/luci-app-bcp38/postrm
#!/bin/sh
uci delete ucitrack.@bcp38[0]
uci commit
endef
````
What is the correct trigger in the LuCI build system for that?

This  PR depends on: https://github.com/openwrt/packages/pull/4013 