### PR TITLE
luci-proto-wireguard: mark package as arch indep.

### DIFF
--- a/protocols/luci-proto-wireguard/Makefile
+++ b/protocols/luci-proto-wireguard/Makefile
@@ -8,6 +8,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for WireGuard VPN
 LUCI_DEPENDS:=+kmod-wireguard +wireguard-tools
+LUCI_PKGARCH:=all
 
 PKG_MAINTAINER:=Dan Luedtke <mail@danrl.com>
 


### PR DESCRIPTION
Marks package luci-proto-wireguard as architecture independent.

Signed-off-by: Dan Luedtke <mail@danrl.com>