### PR TITLE
luci-app-vpnbypass: add datatypes and placeholders to fields

### DIFF
--- a/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
+++ b/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
@@ -8,21 +8,29 @@ o1.default = 0
 
 -- Local Ports
 p1 = s:option(DynamicList, "localport", translate("Local Ports to Bypass"), translate("Local ports to trigger VPN Bypass"))
+p1.datatype    = "portrange"
+p1.placeholder = "0-65535"
 p1.addremove = true
 p1.optional = true
 
 -- Remote Ports
 p2 = s:option(DynamicList, "remoteport", translate("Remote Ports to Bypass"), translate("Remote ports to trigger VPN Bypass"))
+p2.datatype    = "portrange"
+p2.placeholder = "0-65535"
 p2.addremove = true
 p2.optional = true
 
 -- Local Subnets
-r1 = s:option(DynamicList, "localsubnet", translate("Local IP Subnets to Bypass"), translate("Local IP ranges with direct internet access (outside of the VPN tunnel)"))
+r1 = s:option(DynamicList, "localsubnet", translate("Local IP Addresses to Bypass"), translate("Local IP addresses or subnets with direct internet access (outside of the VPN tunnel)"))
+r1.datatype    = "ip4addr"
+r1.placeholder = luci.ip.new(uci.cursor():get("network", "lan", "ipaddr") .. "/" .. uci.cursor():get("network", "lan", "netmask"))
 r1.addremove = true
 r1.optional = true
 
 -- Remote Subnets
-r2 = s:option(DynamicList, "remotesubnet", translate("Remote IP Subnets to Bypass"), translate("Remote IP ranges which will be accessed directly (outside of the VPN tunnel)"))
+r2 = s:option(DynamicList, "remotesubnet", translate("Remote IP Addresses to Bypass"), translate("Remote IP addresses or subnets which will be accessed directly (outside of the VPN tunnel)"))
+r2.datatype    = "ip4addr"
+r2.placeholder = "0.0.0.0/0"
 r2.addremove = true
 r2.optional = true
 

--- a/applications/luci-app-vpnbypass/po/templates/vpnbypass.pot
+++ b/applications/luci-app-vpnbypass/po/templates/vpnbypass.pot
@@ -10,10 +10,12 @@ msgstr ""
 msgid "Enable VPN Bypass"
 msgstr ""
 
-msgid "Local IP Subnets to Bypass"
+msgid "Local IP Addresses to Bypass"
 msgstr ""
 
-msgid "Local IP ranges with direct internet access (outside of the VPN tunnel)"
+msgid ""
+"Local IP addresses or subnets with direct internet access (outside of the "
+"VPN tunnel)"
 msgstr ""
 
 msgid "Local Ports to Bypass"
@@ -25,11 +27,12 @@ msgstr ""
 msgid "README"
 msgstr ""
 
-msgid "Remote IP Subnets to Bypass"
+msgid "Remote IP Addresses to Bypass"
 msgstr ""
 
 msgid ""
-"Remote IP ranges which will be accessed directly (outside of the VPN tunnel)"
+"Remote IP addresses or subnets which will be accessed directly (outside of "
+"the VPN tunnel)"
 msgstr ""
 
 msgid "Remote Ports to Bypass"


### PR DESCRIPTION
I've added datatypes and placeholders for both local and remote ports/addresses fields.
I've also made minor modifications to translatable labels and rebuilt the pot-file.

Signed-off-by: Stan Grishin <stangri@melmac.net>