### PR TITLE
luci-base: add dhcp to system ucitrack

### DIFF
--- a/modules/luci-base/root/etc/config/ucitrack
+++ b/modules/luci-base/root/etc/config/ucitrack
@@ -37,6 +37,7 @@ config qos
 config system
 	option init led
 	list affects luci_statistics
+	list affects dhcp
 
 config luci_splash
 	option init luci_splash


### PR DESCRIPTION
If hostname get changed in "/etc/config/system" dnsmasq should reloaded
his config to be reached again under the new URL [HOSTNAME].lan

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>