### PR TITLE
luci-app-wireguard: Fixed display issue with translation

### DIFF
--- a/applications/luci-app-wireguard/luasrc/view/wireguard.htm
+++ b/applications/luci-app-wireguard/luasrc/view/wireguard.htm
@@ -174,7 +174,7 @@
       var ifid = iface['public_key'] + "_";
       var s = String.format(
         '<strong><%:Public Key%>: </strong>%s' +
-        '<br /><strong><%:Listening Port%>: </strong>%<%:s%>',
+        '<br /><strong><%:Listening Port%>: </strong>%s',
         iface['public_key'],
         iface['listening_port']
       );


### PR DESCRIPTION
Fixed issue where "Listening port" value is displayed as "%s" when
applying translation.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>