### PR TITLE
luci-mod-admin-full: dnsmasq nonwildcard to binddynamic rename

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -520,9 +520,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -959,6 +956,9 @@ msgstr "Túnel dinàmic"
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2069,9 +2069,6 @@ msgid "Noise:"
 msgstr "Soroll:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3412,6 +3409,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -519,9 +519,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -970,6 +967,9 @@ msgid ""
 msgstr ""
 "Pro klienty alokovat DHCP adresy dynamicky. Pokud je volba zakázána, budou "
 "obsloužení pouze klienti se statickými výpůjčkami."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2091,9 +2091,6 @@ msgid "Noise:"
 msgstr "Šum:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3482,6 +3479,10 @@ msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Pomocí ISO/IEC 3166 alpha2 kódů zemí."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "Použít MTU na rozhraní tunelu"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -521,9 +521,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -967,6 +964,9 @@ msgid ""
 msgstr ""
 "DHCP Adressen dynamisch erzeugen. Wenn dies deaktiviert ist, werden nur "
 "Clients mit konfigurierten statischen Leases bedient"
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2097,9 +2097,6 @@ msgid "Noise:"
 msgstr "Noise:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3508,6 +3505,10 @@ msgstr "Benutze die von der Gegenstelle zugewiesenen DNS-Server"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Muss ein ISO/IEC 3166 Länderkürzel sein."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "Benutze MTU auf der Tunnelschnittstelle"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -528,9 +528,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -982,6 +979,9 @@ msgid ""
 msgstr ""
 "Δυναμική απόδοση DHCP διευθύνσεων στους πελάτες. Σε περίπτωση "
 "απενεργοποίησης, μόνο πελάτες με στατικα leases θα εξυπηρετούνται."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2099,9 +2099,6 @@ msgid "Noise:"
 msgstr "Θόρυβος:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3437,6 +3434,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -517,9 +517,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -960,6 +957,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2066,9 +2066,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3394,6 +3391,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -524,9 +524,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -976,6 +973,9 @@ msgid ""
 msgstr ""
 "Reparte direcciones DHCP dinámicamente a los clientes. Si se desactiva sólo "
 "se servirá a clientes con cesiones estáticas."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2105,9 +2105,6 @@ msgid "Noise:"
 msgstr "Ruido:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3507,6 +3504,10 @@ msgstr "Utiliza servidores DNS anunciados por otros"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Usa códigos de país ISO/IEC 3166 alpha2."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "MTU a usar en el interfaz de túnel"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -529,9 +529,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -986,6 +983,9 @@ msgid ""
 msgstr ""
 "Alloue dynamiquement des adresses pour les clients du DHCP. Si désactivé, "
 "seuls les clients ayant des baux statiques seront gérés."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2119,9 +2119,6 @@ msgid "Noise:"
 msgstr "Bruit :"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3526,6 +3523,10 @@ msgstr "Utiliser les serveurs DNS publiés par le distant"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Utiliser les codes-pays ISO/IEC 3166 alpha2."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "Utiliser le MTU sur l'interface du tunnel"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -518,9 +518,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -945,6 +942,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2039,9 +2039,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3352,6 +3349,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -523,9 +523,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -979,6 +976,9 @@ msgstr ""
 "Az ügyfelek számára kiosztott DHCP címek dinamikus lefoglalása. Letiltása "
 "esetén csak a statikus DHCP bérlettel rendelkező kliensek lesznek "
 "kiszolgálva."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2108,9 +2108,6 @@ msgid "Noise:"
 msgstr "Zaj:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3513,6 +3510,10 @@ msgstr "Másik fél által ajánlott DNS szerverek használata"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "ISO/IEC 3166 alpha2 országkódok használata"
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "MTU használata az alagút interfészen"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -529,9 +529,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -980,6 +977,9 @@ msgid ""
 msgstr ""
 "Fornisci dinamicamente gli indirizzi DHCP ai client. Se disabilitato, solo i "
 "client con un indirizzo statico saranno serviti."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2106,9 +2106,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3464,6 +3461,10 @@ msgstr "Usa i server DNS annunciati dal peer"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Usa i codici delle nazioni ISO/IEC 3166 alpha2."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "Usa MTU nel tunnel dell'interfaccia"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -519,10 +519,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-"ワイルドカード アドレスではなく、特定のインターフェースのみにバインドします。"
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -977,6 +973,9 @@ msgid ""
 msgstr ""
 "クライアントに対して動的にDHCPアドレスを割り振ります。無効に設定した場合、静"
 "的リースのみを行います。"
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2101,9 +2100,6 @@ msgstr "ノイズ:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
 msgstr ""
-
-msgid "Non-wildcard"
-msgstr "非ワイルドカード"
 
 msgid "None"
 msgstr "なし"
@@ -3494,6 +3490,10 @@ msgstr "ピアから通知されたDNSサーバーを使用する"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "ISO/IEC 3166 alpha2の国コードを使用します。"
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "トンネルインターフェースのMTUを設定"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -511,9 +511,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -959,6 +956,9 @@ msgid ""
 msgstr ""
 "동적으로 DHCP 주소를 client 에게 할당합니다.  만약 비활성화시, static lease "
 "가 설정된 client 만 주소 제공이 이루어집니다."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2057,9 +2057,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3399,6 +3396,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr "Peer 가 권장한 DNS 서버 사용"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -503,9 +503,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -930,6 +927,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2039,9 +2039,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3370,6 +3367,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -515,9 +515,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -966,6 +963,9 @@ msgid ""
 msgstr ""
 "Dynamisk tildeling av DHCP adresser til klienter. Om deaktivert, kan en kun "
 "bruke klienter med statisk leie."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2082,9 +2082,6 @@ msgid "Noise:"
 msgstr "Støy:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3479,6 +3476,10 @@ msgstr "Bruk DNS servere annonsert av peer"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Bruk ISO/IEC 3166 alpha2 landskoder."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "Bruk MTU på tunnel grensesnitt"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -531,9 +531,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -991,6 +988,9 @@ msgid ""
 msgstr ""
 "Dynamicznie rezerwuje adresy DHCP dla klientów. Jeśli jest wyłączone tylko "
 "klienci posiadający stałe dzierżawy będą obsłużeni."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2127,9 +2127,6 @@ msgid "Noise:"
 msgstr "Szum:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3541,6 +3538,10 @@ msgstr "Użyj serwerów DNS rozgłaszanych przez peera"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Użyj kodów kraju ISO/IEC 3166 alpha2"
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "Użyj MTU na interfejsie tunelu"

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -559,11 +559,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr "Interface Vinculada"
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-"Vincule somente para as explicitamenteinterfaces ao invés do endereço "
-"coringa."
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr "Vincule o túnel a esta interface (opcional)"
 
@@ -1026,6 +1021,9 @@ msgid ""
 msgstr ""
 "Aloca dinamicamente os endereços do DHCP para os clientes. Se desabilitado, "
 "somente os clientes com atribuições estáticas serão servidos. "
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr "Comprimento dos bits EA"
@@ -2211,9 +2209,6 @@ msgid "Non Pre-emtive CRC errors (CRC_P)"
 msgstr ""
 "Erros CRC Não Preemptivos<abbr title=\"Non Pre-emptive CRC errors\">CRC_P</"
 "abbr>"
-
-msgid "Non-wildcard"
-msgstr "Sem caracter curinga"
 
 msgid "None"
 msgstr "Nenhum"
@@ -3662,6 +3657,10 @@ msgstr "Use os servidores DNS anunciados pelo parceiro"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Usar códigos de países ISO/IEC 3166 alpha2."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr ""

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -528,9 +528,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -982,6 +979,9 @@ msgid ""
 msgstr ""
 "Alocar dinamicamente endereços DHCP para clientes. Se desativado, só os "
 "clientes com reservas estáticas serão servidos."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2106,9 +2106,6 @@ msgid "Noise:"
 msgstr "Ruído:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3476,6 +3473,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr "Usar os servidores DNS fornecidos pelo parceiro"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -511,9 +511,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -936,6 +933,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2036,9 +2036,6 @@ msgid "Noise:"
 msgstr "Zgomot:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3344,6 +3341,10 @@ msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Foloseste codurile de tara ISO/IEC 3166 alpha2."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr ""

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -528,9 +528,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -980,6 +977,9 @@ msgid ""
 msgstr ""
 "Динамически выделять DHCP-адреса клиентам. Если выключено, то будут "
 "обслужены только клиенты с постоянно арендованными адресами."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2112,9 +2112,6 @@ msgid "Noise:"
 msgstr "Шум:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3514,6 +3511,10 @@ msgstr "Использовать объявляемые узлом DNS-серв�
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Использовать коды стран ISO/IEC 3166 alpha2."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "Использовать MTU на интерфейсе туннеля"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -497,9 +497,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -917,6 +914,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2011,9 +2011,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3313,6 +3310,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -503,9 +503,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -923,6 +920,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2017,9 +2017,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3319,6 +3316,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -490,9 +490,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -910,6 +907,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2004,9 +2004,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3306,6 +3303,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -510,9 +510,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -930,6 +927,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2024,9 +2024,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3326,6 +3323,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -537,9 +537,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -992,6 +989,9 @@ msgid ""
 msgstr ""
 "Динамічне виділення DHCP-адрес для клієнтів. Якщо вимкнути, будуть "
 "обслуговуватися тільки клієнти, які мають статичні оренди."
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2120,9 +2120,6 @@ msgid "Noise:"
 msgstr "Шум:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3530,6 +3527,10 @@ msgstr "Використовувати DNS-сервери, оголошуван�
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "Використовуйте коди країн згідно ISO/IEC 3166 alpha2."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "Використовувати на тунельному інтерфейсі MTU"

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -504,9 +504,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -935,6 +932,9 @@ msgstr ""
 msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
+msgstr ""
+
+msgid "Dynamically bind"
 msgstr ""
 
 msgid "EA-bits length"
@@ -2041,9 +2041,6 @@ msgid "Noise:"
 msgstr ""
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3368,6 +3365,10 @@ msgid "Use DNS servers advertised by peer"
 msgstr ""
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
+msgstr ""
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
 msgstr ""
 
 msgid "Use MTU on tunnel interface"

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -510,9 +510,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr "绑定接口"
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr "仅绑定到特定接口，而不是全部地址。"
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr "将隧道绑定到此接口(可选)。"
 
@@ -936,6 +933,9 @@ msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
 msgstr "动态分配DHCP地址。如果禁用，则只能为静态租用表中的客户端提供网络服务。"
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr "EA位长度"
@@ -2037,9 +2037,6 @@ msgstr "噪声:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
 msgstr "非抢占CRC错误(CRC_P)"
-
-msgid "Non-wildcard"
-msgstr "非通配符"
 
 msgid "None"
 msgstr "无"
@@ -3374,6 +3371,10 @@ msgstr "使用端局通告的DNS服务器"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "参考ISO/IEC 3166 alpha2国家代码。"
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "隧道接口的MTU"

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -509,9 +509,6 @@ msgstr ""
 msgid "Bind interface"
 msgstr ""
 
-msgid "Bind only to specific interfaces rather than wildcard address."
-msgstr ""
-
 msgid "Bind the tunnel to this interface (optional)."
 msgstr ""
 
@@ -948,6 +945,9 @@ msgid ""
 "Dynamically allocate DHCP addresses for clients. If disabled, only clients "
 "having static leases will be served."
 msgstr "幫用戶端動態發配DHCP位址. 假如關閉的話,僅有有靜態位址的用戶端能被服務"
+
+msgid "Dynamically bind"
+msgstr ""
 
 msgid "EA-bits length"
 msgstr ""
@@ -2048,9 +2048,6 @@ msgid "Noise:"
 msgstr "噪音比:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
-
-msgid "Non-wildcard"
 msgstr ""
 
 msgid "None"
@@ -3403,6 +3400,10 @@ msgstr "使用終端發布的DNS伺服器"
 
 msgid "Use ISO/IEC 3166 alpha2 country codes."
 msgstr "使用Use ISO/IEC 3166 alpha2 國碼."
+
+msgid ""
+"Use Linux only API to bind to interfaces rather than wildcard addresses."
+msgstr ""
 
 msgid "Use MTU on tunnel interface"
 msgstr "在通道介面上使用的MTU數值"

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -237,23 +237,21 @@ o = s:taboption("general", Flag, "localservice",
 o.optional = false
 o.rmempty = false
 
-o = s:taboption("general", Flag, "nonwildcard",
-	translate("Non-wildcard"),
-	translate("Bind only to specific interfaces rather than wildcard address."))
+o = s:taboption("general", Flag, "binddynamic",
+	translate("Dynamically bind"),
+	translate("Use Linux only API to bind to interfaces rather than wildcard addresses."))
 o.optional = false
-o.rmempty = false
+o.rmempty = true
 
 o = s:taboption("general", DynamicList, "interface",
 	translate("Listen Interfaces"),
 	translate("Limit listening to these interfaces, and loopback."))
 o.optional = true
-o:depends("nonwildcard", true)
 
 o = s:taboption("general", DynamicList, "notinterface",
 	translate("Exclude interfaces"),
 	translate("Prevent listening on these interfaces."))
 o.optional = true
-o:depends("nonwildcard", true)
 
 m:section(SimpleSection).template = "admin_network/lease_status"
 


### PR DESCRIPTION
'non-wildcard' interfaces enables dnsmasq's '--bind-dynamic' mode.  This
binds to interfaces rather than wildcard addresses *and* keeps track of
interface comings/goings via a unique Linux api.

Quoting dnsmasq's author "bind-dynamic (bind individual addresses, keep
up with changes in interface config) ... On linux, there's actually no
sane reason not to use --bind-dynamic, and it's only not the default for
historical reasons."

Update luci to be aware of the 'nonwildcard' to 'binddynamic' rename and
update descriptions.  Unfortunately this has led to the loss of the only
2 translations (Japanese & Cantonese) of the original descriptions.

Removed the dependency of 'nonwildcard' enabling access to
'listen/exlude' interfaces.  This was bogus anyway, dnsmasq has no
requirement for 'bind dynamic' to enable include/exclude interfaces.  In
fact the dnsmasq init script took notice of include/exclude interfaces
irrespective of the original 'nonwildcard' parameter.

Sync translations.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>

Companion dnsmasq PR https://github.com/lede-project/source/pull/880