### PR TITLE
[lede-17.01] luci-app-unbound: service updates coordinated with application package

### DIFF
--- a/applications/luci-app-unbound/root/etc/uci-defaults/60_luci-unbound
+++ b/applications/luci-app-unbound/root/etc/uci-defaults/60_luci-unbound
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+uci -q batch <<-EOF >/dev/null
+  delete ucitrack.@unbound[-1]
+  add ucitrack unbound
+  set ucitrack.@unbound[-1].init=unbound
+  commit ucitrack
+EOF
+
+rm -f /tmp/luci-indexcache
+[ ! -x /usr/sbin/unbound-control ] && exit 0
+
+uci -q batch <<-EOF >/dev/null
+  set luci.unboundhosts=command
+  set luci.unboundhosts.name='Unbound Local Hosts'
+  set luci.unboundhosts.command='unbound-control -c /var/lib/unbound/unbound.conf list_local_data'
+  set luci.unboundzones=command
+  set luci.unboundzones.name='Unbound Local Zones'
+  set luci.unboundzones.command='unbound-control -c /var/lib/unbound/unbound.conf list_local_zones'
+  commit luci
+EOF
+
+rm -f /tmp/luci-indexcache
+exit 0
+


### PR DESCRIPTION
LEDE 17.01.0 pulled in Unbound "acts like dnsmasq" UCI behaviors, but the matching LuCI update was not carried in. Specifically, `add_local_fqdn` and `add_wan_fqdn` are supported by Unbound UCI but not LuCI. No failures but some configuration is not accessible to the novice user. Should be timed with PR https://github.com/openwrt/packages/pull/4072