### PR TITLE
luci-app-wireguard: Add Japanese translation

### DIFF
--- a/applications/luci-app-wireguard/po/ja/wireguard.po
+++ b/applications/luci-app-wireguard/po/ja/wireguard.po
@@ -1,0 +1,74 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2017-02-28 00:31+0900\n"
+"Last-Translator: INAGAKI Hiroshi <musashino.open@gmail.com>\n"
+"Language-Team: \n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.12\n"
+"X-Poedit-Basepath: .\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "Allowed IPs"
+msgstr "許可されたIP"
+
+msgid "Collecting data..."
+msgstr "データ収集中です..."
+
+msgid "Configuration"
+msgstr "設定"
+
+msgid "Data Received"
+msgstr "受信済みデータ"
+
+msgid "Data Transmitted"
+msgstr "送信済みデータ"
+
+msgid "Endpoint"
+msgstr "エンドポイント"
+
+msgid "Firewall Mark"
+msgstr "ファイアウォール マーク"
+
+msgid "Interface"
+msgstr "インターフェース"
+
+msgid "Interface does not have a public key!"
+msgstr "インターフェースに公開鍵がありません！"
+
+msgid "Latest Handshake"
+msgstr "最新のハンドシェイク"
+
+msgid "Listen Port"
+msgstr "待ち受けポート"
+
+msgid "Never"
+msgstr "無し"
+
+msgid "Peer"
+msgstr "ピア"
+
+msgid "Persistent Keepalive"
+msgstr "永続的なキープアライブ"
+
+msgid "Public Key"
+msgstr "公開鍵"
+
+msgid "WireGuard Status"
+msgstr "WireGuard ステータス"
+
+msgid "h ago"
+msgstr "時間前"
+
+msgid "m ago"
+msgstr "分前"
+
+msgid "over a day ago"
+msgstr "1日以上前"
+
+msgid "s ago"
+msgstr "秒前"

--- a/applications/luci-app-wireguard/po/templates/wireguard.pot
+++ b/applications/luci-app-wireguard/po/templates/wireguard.pot
@@ -1,0 +1,62 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "Allowed IPs"
+msgstr ""
+
+msgid "Collecting data..."
+msgstr ""
+
+msgid "Configuration"
+msgstr ""
+
+msgid "Data Received"
+msgstr ""
+
+msgid "Data Transmitted"
+msgstr ""
+
+msgid "Endpoint"
+msgstr ""
+
+msgid "Firewall Mark"
+msgstr ""
+
+msgid "Interface"
+msgstr ""
+
+msgid "Interface does not have a public key!"
+msgstr ""
+
+msgid "Latest Handshake"
+msgstr ""
+
+msgid "Listen Port"
+msgstr ""
+
+msgid "Never"
+msgstr ""
+
+msgid "Peer"
+msgstr ""
+
+msgid "Persistent Keepalive"
+msgstr ""
+
+msgid "Public Key"
+msgstr ""
+
+msgid "WireGuard Status"
+msgstr ""
+
+msgid "h ago"
+msgstr ""
+
+msgid "m ago"
+msgstr ""
+
+msgid "over a day ago"
+msgstr ""
+
+msgid "s ago"
+msgstr ""


### PR DESCRIPTION
Added po templates file and Japanese translations.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>