### PR TITLE
luci-mod-admin-full: new hostapd functionality for 80211w/r detection

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -901,8 +901,8 @@ end
 
 if hwtype == "atheros" or hwtype == "mac80211" or hwtype == "prism2" then
 
-	-- Probe EAP support as a proxy for determining if 802.11r support is present
-	local has_ap_eap  = (os.execute("hostapd -veap >/dev/null 2>/dev/null") == 0)
+	-- Probe 802.11r support (and EAP support as a proxy for Openwrt)
+	local has_80211r = (os.execute("hostapd -v11r 2>/dev/null || hostapd -veap 2>/dev/null") == 0)
 
 	ieee80211r = s:taboption("encryption", Flag, "ieee80211r",
 		translate("802.11r Fast Transition"),
@@ -912,7 +912,7 @@ if hwtype == "atheros" or hwtype == "mac80211" or hwtype == "prism2" then
 	ieee80211r:depends({mode="ap", encryption="wpa2"})
 	ieee80211r:depends({mode="ap-wds", encryption="wpa"})
 	ieee80211r:depends({mode="ap-wds", encryption="wpa2"})
-	if has_ap_eap then
+	if has_80211r then
 		ieee80211r:depends({mode="ap", encryption="psk"})
 		ieee80211r:depends({mode="ap", encryption="psk2"})
 		ieee80211r:depends({mode="ap", encryption="psk-mixed"})
@@ -1125,16 +1125,16 @@ end
 
 -- ieee802.11w options
 if hwtype == "mac80211" then
-   local has_ap_eap  = (os.execute("hostapd -veap >/dev/null 2>/dev/null") == 0)
-   if has_ap_eap then
+   local has_80211w = (os.execute("hostapd -v11w 2>/dev/null || hostapd -veap 2>/dev/null") == 0)
+   if has_80211w then
 	ieee80211w = s:taboption("encryption", ListValue, "ieee80211w",
 		translate("802.11w Management Frame Protection"),
 		translate("Requires the 'full' version of wpad/hostapd " ..
 			"and support from the wifi driver <br />(as of Feb 2017: " ..
 			"ath9k and ath10k, in LEDE also mwlwifi and mt76)"))
-	ieee80211w.default = "0"
+	ieee80211w.default = ""
 	ieee80211w.rmempty = true
-	ieee80211w:value("0", translate("Disabled (default)"))
+	ieee80211w:value("", translate("Disabled (default)"))
 	ieee80211w:value("1", translate("Optional"))
 	ieee80211w:value("2", translate("Required"))
 	ieee80211w:depends({mode="ap", encryption="wpa2"})


### PR DESCRIPTION
@jow- 
Could you please check this one out:

Use the new hostapd functionality (in LEDE) to detect 802.11r and 802.11w more properly. Leave the old logic in place for Openwrt.

* I wonder if it would be more efficient performance-wise to use just one variable and just "or" the two os.execute statements (to avoid two os.executes in case the first one already provides a positive answer)

----

This goes outside the core scope of the PR but is related: 

Regarding 80211w:

There have been a few forum discussions from persons who have got ieee80211w=0 option in their hostapd config, and it prevents radio from getting up if there is no 80211w support. 

* Hostapd startup uci script places also the unnecessary ieee80211w=0 value to the final hostapd config file, although that value value means that ieee80211w is disabled. That should be changed in the main LEDE source:
  https://github.com/lede-project/source/blob/cb801b052cc38db807ecc6e10b9c06cb0d45491f/package/network/services/hostapd/files/hostapd.sh#L406
  https://github.com/lede-project/source/blob/cb801b052cc38db807ecc6e10b9c06cb0d45491f/package/network/services/hostapd/files/hostapd.sh#L693

  (note that 80211r is handled properly: 0 is ignored by using "gt": https://github.com/lede-project/source/blob/cb801b052cc38db807ecc6e10b9c06cb0d45491f/package/network/services/hostapd/files/hostapd.sh#L364)
 
* Scenario how they got the uci config option might be: try a private/community build with full wpad, edit wireless options, get the 80211w=0 option to wireless config, sysupgrade to release build or private build with wpad-mini, and the option stays there causing trouble.

Regarding 80211w values, is there a good way to delete '0' values from a ListValue option type? Currently the "option ieee80211w 0" line appears to the /etc/config/wireless if any encryption options are edited when 80211w support is present, although there is no need for that line. As far as I have been able to determine, it is because the allowed values are 0,1,2 and default is 0 but not "", so .rmempty does not work.

I have thought that I might try changing the line ` ieee80211w:value("0", translate("Disabled (default)")) ` to have ` value("" ` , so that the default would be empty, but would that work?

Any other solutions?