### PR TITLE
luci-base,luci-mod-admin-full: fix bridge choice handling

### DIFF
--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -1063,7 +1063,7 @@ function protocol.get_interface(self)
 end
 
 function protocol.get_interfaces(self)
-	if self:is_bridge() or (self:is_virtual() and not self:is_floating()) then
+	if self:is_bridge() or (self:_get("_orig_bridge") == "true") or (self:is_virtual() and not self:is_floating()) then
 		local ifaces = { }
 
 		local ifn

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
@@ -28,7 +28,7 @@ fw.init(m.uci)
 local net = nw:get_network(arg[1])
 
 local function backup_ifnames(is_bridge)
-	if not net:is_floating() and not m:get(net:name(), "_orig_ifname") then
+	if not net:is_floating() then
 		local ifcs = net:get_interfaces() or { net:get_interface() }
 		if ifcs then
 			local _, ifn
@@ -273,13 +273,13 @@ if not net:is_floating() then
 
 		for i = 1, math.max(#old_ifs, #new_ifs) do
 			if old_ifs[i] ~= new_ifs[i] then
-				backup_ifnames()
 				for i = 1, #old_ifs do
 					net:del_interface(old_ifs[i])
 				end
 				for i = 1, #new_ifs do
 					net:add_interface(new_ifs[i])
 				end
+				backup_ifnames()
 				break
 			end
 		end


### PR DESCRIPTION
@jow- 

This fixes the issue that ifname can't be cleaned up when
an interface is switched back from bridge mode to "normal"
mode.

Therefore, the current ifnames and bridge choice are backed
up on every save-action.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>