### PR TITLE
luci-app-vpnbypass: directly enable service from Web UI.

### DIFF
--- a/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
+++ b/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
@@ -1,38 +1,53 @@
+readmeURL = "https://github.com/openwrt/packages/blob/master/net/vpnbypass/files/README.md"
+
 m = Map("vpnbypass", translate("VPN Bypass Settings"))
 s = m:section(NamedSection, "config", "vpnbypass")
 
 -- General options
-o1 = s:option(Flag, "enabled", translate("Enable VPN Bypass"))
-o1.rmempty = false
-o1.default = 0
+e = s:option(Flag, "enabled", translate("Enable VPN Bypass"))
+e.rmempty = false
+
+function e.cfgvalue(self, section)
+	return luci.sys.init.enabled("vpnbypass") and self.enabled or self.disabled
+end
+
+function e.write(self, section, value)
+	if value == "1" then
+		luci.sys.call("/etc/init.d/vpnbypass enable >/dev/null")
+		luci.sys.call("/etc/init.d/vpnbypass start >/dev/null")
+	else
+		luci.sys.call("/etc/init.d/vpnbypass stop >/dev/null")
+		luci.sys.call("/etc/init.d/vpnbypass disable >/dev/null")
+	end
+end
 
 -- Local Ports
 p1 = s:option(DynamicList, "localport", translate("Local Ports to Bypass"), translate("Local ports to trigger VPN Bypass"))
 p1.datatype    = "portrange"
 p1.placeholder = "0-65535"
-p1.addremove = true
-p1.optional = true
+p1.addremove = false
+p1.optional = false
 
 -- Remote Ports
 p2 = s:option(DynamicList, "remoteport", translate("Remote Ports to Bypass"), translate("Remote ports to trigger VPN Bypass"))
 p2.datatype    = "portrange"
 p2.placeholder = "0-65535"
-p2.addremove = true
-p2.optional = true
+p2.addremove = false
+p2.optional = false
 
 -- Local Subnets
 r1 = s:option(DynamicList, "localsubnet", translate("Local IP Addresses to Bypass"), translate("Local IP addresses or subnets with direct internet access (outside of the VPN tunnel)"))
 r1.datatype    = "ip4addr"
 r1.placeholder = luci.ip.new(uci.cursor():get("network", "lan", "ipaddr") .. "/" .. uci.cursor():get("network", "lan", "netmask"))
-r1.addremove = true
-r1.optional = true
+r1.addremove = false
+r1.optional = false
 
 -- Remote Subnets
 r2 = s:option(DynamicList, "remotesubnet", translate("Remote IP Addresses to Bypass"), translate("Remote IP addresses or subnets which will be accessed directly (outside of the VPN tunnel)"))
 r2.datatype    = "ip4addr"
 r2.placeholder = "0.0.0.0/0"
-r2.addremove = true
-r2.optional = true
+r2.addremove = false
+r2.optional = false
 
 -- Domains
 d = Map("dhcp")
@@ -40,7 +55,7 @@ s4 = d:section(TypedSection, "dnsmasq")
 s4.anonymous = true
 di = s4:option(DynamicList, "ipset", translate("Domains to Bypass"),
     translate("Domains to be accessed directly (outside of the VPN tunnel), see ")
-    .. [[<a href="https://github.com/openwrt/packages/tree/master/net/vpnbypass/files#bypass-domains-formatsyntax" target="_blank">]]
+		.. [[<a href="]] .. readmeURL .. [[#bypass-domains-formatsyntax" target="_blank">]]
     .. translate("README") .. [[</a>]] .. translate(" for syntax"))
 
 return m, d


### PR DESCRIPTION
Allows to enable/start and stop/disable service from Web UI.
Minor fix: show all fields.
Minor fix: readme URL is in variable allowing more compact lua code.
Signed-off-by: Stan Grishin <stangri@melmac.net>