### PR TITLE
luci-app-ipvs: add Virtual Server Load Balancer configuration

### DIFF
--- a/applications/luci-app-ipvs/Makefile
+++ b/applications/luci-app-ipvs/Makefile
@@ -1,0 +1,35 @@
+#
+# Copyright 2017 Mauro Mozzarelli <mauro@ezplanet.org>
+#
+# This is free software, licensed under the Apache License, Version 2.0
+
+include $(TOPDIR)/rules.mk
+
+# PKG_NAME:=luci-app-ipvs
+
+# Version == major.minor.patch
+# increase on new functionality (minor) or patches (patch)
+PKG_VERSION:=1.0.0
+
+# Release == build
+# increase on changes of translation files
+PKG_RELEASE:=1
+
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Mauro Mozzarelli <mauro@ezplanet.org>
+
+# LuCI specific settings
+LUCI_TITLE:=IP Virtual Server Load Balancer configuration
+LUCI_DEPENDS:=+luci-mod-admin-full +ipvsadm
+# LUCI_PKGARCH:=all
+
+define Package/$(PKG_NAME)/config
+# shown in make menuconfig <Help>
+help
+	$(LUCI_TITLE)
+	Version: $(PKG_VERSION)-$(PKG_RELEASE)
+endef
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ipvs/luasrc/controller/ipvs.lua
+++ b/applications/luci-app-ipvs/luasrc/controller/ipvs.lua
@@ -1,0 +1,12 @@
+-- Copyright 2017 Mauro Mozzarelli <mauro@ezplanet.org>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.controller.ipvs", package.seeall)
+
+function index()
+	entry({"admin", "network", "ipvs"}, cbi("ipvs/ipvs"), "VS Load Balancer", 30).dependent=false
+	entry({"admin", "network", "ipvs", "real"},    cbi("ipvs/real"),    nil ).leaf = true
+	entry({"admin", "network", "ipvs", "virtual"}, cbi("ipvs/virtual"), nil ).leaf = true
+	entry({"admin", "status", "ipvs"}, template("ipvs"), _("VS Load Balancer"))
+end
+

--- a/applications/luci-app-ipvs/luasrc/model/cbi/ipvs/ipvs.lua
+++ b/applications/luci-app-ipvs/luasrc/model/cbi/ipvs/ipvs.lua
@@ -1,0 +1,78 @@
+-- Copyright 2017 Mauro Mozzarelli <mauro@ezplanet.org>
+-- Licensed to the public under the Apache License 2.0.
+
+local sys = require "luci.sys"
+local ds  = require "luci.dispatcher"
+local net = require "luci.model.network".init()
+
+map = Map("ipvs", "Virtual Server Load Balancer", translate("Configure Virtual Server Load Balancer")) -- Edit config file /etc/config/ipvs
+
+function map.on_before_commit(self)
+	sys.exec("/etc/init.d/ipvsadm stop")
+end
+function map.on_after_commit(self)
+	sys.exec("/etc/init.d/ipvsadm start")
+end
+
+-- General Section
+gl = map:section(TypedSection, "vipvs", translate("General"))
+
+on = gl:option(Flag, "enabled", "Enabled")
+on.default = "0"
+
+role = gl:option(ListValue, "role", "Role")
+role:value("master", "Master")
+role:value("backup", "Backup")
+
+master = gl:option(Value, "master", translate("Master IPv4 address"))
+master:depends("role", "backup")
+master.optional = false
+master.datatype = "ip4addr"
+
+ni = gl:option(Value, "interface", translate("Interface"),
+	translate("Multicast interface for connection sync"))
+
+ni.template    = "cbi/network_netlist"
+ni.nocreate    = true
+ni.unspecified = false
+
+sid = gl:option(Value, "syncid", translate("Id for connection sync"), translate("0=no filtering; 1-255 = synchronize only with servers using matching Id"))
+sid.datatype = "range(0,255)"
+sid.default = "1"
+
+ali = gl:option(Value, "alias_offset", translate("Interface alias displacement"))
+ali.default = "0"
+ali.datatype = "range(0,100)"
+
+-- Real Servers Section
+rs = map:section(TypedSection, "real", "Real Servers")
+rs.template = "cbi/tblsection"
+rs.anonymous = false
+rs.addremove = true
+rs.extedit = ds.build_url("admin", "network", "ipvs", "real", "%s")
+
+rip = rs:option(Value, "ipaddr", translate("IP Address"))
+rip.datatype = "ip4addr"
+
+pfw = rs:option(ListValue, "packet_forwarding", translate("Packet Forwarding"))
+pfw:value("direct", "Direct Routing")
+pfw:value("tunnel", "Tunneling")
+pfw:value("nat", "Masquerading (NAT)")
+
+wgt = rs:option(Value, "weight", translate("Weight"))
+wgt.datatype = "range(1,65535)"
+
+-- Virtual Server Section
+vs = map:section(TypedSection, "virtual", translate("Virtual Servers"))
+vs.template = "cbi/tblsection"
+vs.anonymous = false
+vs.addremove = true
+vs.extedit = ds.build_url("admin", "network", "ipvs", "virtual", "%s")
+
+vs:option(Flag, "enabled", translate("Enabled"))
+vs:option(DummyValue, "interface", translate("Interface"))
+vs:option(DummyValue, "vip", translate("Virtual IPv4"))
+vs:option(DummyValue, "scheduler", translate("Scheduler"))
+
+return map
+

--- a/applications/luci-app-ipvs/luasrc/model/cbi/ipvs/real.lua
+++ b/applications/luci-app-ipvs/luasrc/model/cbi/ipvs/real.lua
@@ -1,0 +1,45 @@
+-- Copyright 2017 Mauro Mozzarelli <mauro@ezplanet.org>
+-- Licensed to the public under the Apache License 2.0.
+
+local sys = require "luci.sys"
+local net = require "luci.model.network".init()
+
+map = Map("ipvs", translate("Real Server Details"), translate("VS Load Balancer: Configure Real Server Details")) -- Edit config file /etc/config/ipvs
+map.redirect = luci.dispatcher.build_url("admin/network/ipvs")
+
+function map.on_before_commit(self)
+	sys.exec("/etc/init.d/ipvsadm stop")
+end
+function map.on_after_commit(self)
+	sys.exec("/etc/init.d/ipvsadm start")
+end
+
+-- Real Server Section
+rs = map:section(NamedSection, arg[1], "real", translatef("Real Server %q", arg[1]))
+
+rip = rs:option(Value, "ipaddr", translate("IP Address"))
+rip.datatype = "ip4addr"
+
+pfw = rs:option(ListValue, "packet_forwarding", translate("Packet Forwarding"))
+pfw:value("direct", "Direct Routing")
+pfw:value("tunnel", "Tunneling")
+pfw:value("nat", "Masquerading (NAT)")
+
+wgt = rs:option(Value, "weight", translate("Weight"), translate("1-65535 - The capacity of a server relative to others in the pool"))
+wgt.datatype = "range(1,65535)"
+
+ut = rs:option(Value, "u_threshold", translate("Upper connection threshold"), translate("0-65535 - If > 0 no new connections will be sent when the threshold is exceeded"))
+ut.datatype = "range(0,65535)"
+
+lt = rs:option(Value, "l_threshold", translate("Lower connection threshold"), translate("0-65535 - If > 0 New connections will be sent when the total drops below the threshold"))
+lt.datatype = "range(0,65535)"
+
+ca = rs:option(ListValue, "probe_method", translate("Server probe method")) 
+ca:value("ping")
+ca:value("wget")
+
+caw = rs:option(Value, "probe_url", translate("wget URL path"), translate("The URL will be composed by http://[server ip address]/path"))
+caw:depends("probe_method", "wget")
+
+return map
+

--- a/applications/luci-app-ipvs/luasrc/model/cbi/ipvs/virtual.lua
+++ b/applications/luci-app-ipvs/luasrc/model/cbi/ipvs/virtual.lua
@@ -1,0 +1,68 @@
+-- Copyright 2017 Mauro Mozzarelli <mauro@ezplanet.org>
+-- Licensed to the public under the Apache License 2.0.
+
+local sys = require "luci.sys"
+local net = require "luci.model.network".init()
+
+map = Map("ipvs", translate("Virtual Server Details"), translate("VS Load Balancer: Configure Virtual Server Details")) -- Edit config file /etc/config/ipvs
+map.redirect = luci.dispatcher.build_url("admin/network/ipvs")
+
+function map.on_before_commit(self)
+	sys.exec("/etc/init.d/ipvsadm stop")
+end
+function map.on_after_commit(self)
+	sys.exec("/etc/init.d/ipvsadm start")
+end
+
+-- Virtual Server Section
+vs = map:section(NamedSection, arg[1], "virtual", translatef("Virtual Server %q", arg[1]))
+
+ena = vs:option(Flag, "enabled", translate("Enabled"))
+
+vip = vs:option(Value, "vip", translate("Virtual IPv4"))
+vip.datatype = "ip4addr"
+
+vni = vs:option(Value, "interface", translate("Router Interface"))
+vni.template    = "cbi/network_netlist"
+vni.nocreate    = true
+vni.unspecified = false
+
+ali = vs:option(Value, "alias", translate("Interface alias"), translate("Absolute value, must not be the same as another virtual server using the same interface (if unsure leave blank)"))
+ali.datatype = "range(1,240)"
+
+sch = vs:option(ListValue, "scheduler", translate("Scheduler"))
+sch:value("rr"   , "Round Robin")
+sch:value("wrr"  , "Weighted Round Robin")
+sch:value("lc"   , "Least Connections")
+sch:value("wlc"  , "Weighted Least Connections")
+sch:value("dh"   , "Destination Hash")
+sch:value("sh"   , "Source Hash")
+sch:value("lblc" , "Locality-Based Least Connections")
+sch:value("lblcr", "Locality-Based Least Connections with Replication")
+sch:value("sed"  , "Shortest Expected Delay")
+sch:value("nq"   , "Never Queue")
+
+per = vs:option(Flag, "persistent", translate("Persistent"))
+
+-- Physical Server Section
+rs = vs:option(DynamicList, "real", "Real Servers")
+map.uci:foreach("ipvs", "real",
+function(s)	
+	rs:value(s[".name"])
+end)
+
+-- Virtual Server Section
+ipp = map:section(TypedSection, arg[1], "IP Forward")
+ipp.template = "cbi/tblsection"
+ipp.anonymous = true
+ipp.addremove = true
+
+protocol = ipp:option(ListValue, "protocol", translate("Protocol"))
+protocol:value("tcp", "tcp")
+protocol:value("udp", "udp")
+
+ipp:option(Value, "src_port", translate("Source Port"), translate("0 or blank=all ports (requires Direct Routing)"))
+ipp:option(Value, "dest_port", translate("Destination Port"), translate("applies to Masquerade only, otherwise ignored"))
+
+return map
+

--- a/applications/luci-app-ipvs/luasrc/view/ipvs.htm
+++ b/applications/luci-app-ipvs/luasrc/view/ipvs.htm
@@ -1,0 +1,29 @@
+<%#
+ Copyright 2017 Mauro Mozzarelli <mauro@ezplanet.org>
+ Licensed to the public under the Apache License 2.0.
+-%>
+
+<%-
+	local ipvs_list = luci.util.exec("/sbin/ipvsadm -ln")
+	local ipvs_conn = luci.util.exec("/sbin/ipvsadm -lcn")
+	local ipvs_log  = luci.util.exec("cat /tmp/loadbalancer.log")
+-%>
+<%+header%>
+<h2 name="content"><%:Virtual Server Load Balancer Status%></h2> 
+<fieldset class="cbi-section">
+	<legend><%:Servers%></legend>
+	<textarea readonly="readonly" style="font-family:monospace;" wrap="off" rows="<%=ipvs_list:cmatch("\n")+1%>" id="syslog"><%=ipvs_list:pcdata()%>
+	</textarea>
+</fieldset>
+<fieldset class="cbi-section">
+	<legend><%:Connections%></legend>
+	<textarea readonly="readonly" style="font-family:monospace;" wrap="off" rows="<%=ipvs_conn:cmatch("\n")+1%>" id="syslog"><%=ipvs_conn:pcdata()%>
+	</textarea>
+</fieldset>
+<fieldset class="cbi-section">
+	<legend><%:Log%></legend>
+	<textarea readonly="readonly" style="font-family:monospace;" wrap="off" rows="<%=ipvs_log:cmatch("\n")%>" id="syslog"><%=ipvs_log:pcdata()%>
+	</textarea>
+</fieldset>
+<%+footer%>
+


### PR DESCRIPTION
Linux Virtual Server (ipvs) is used to set up and manage virtual server load balancers
This adds load balancer capabilities to LEDE/OpenWrt de-facto turning a small router into a powerful hardware load balancer

This change adds Luci configuration and monitoring pages for lede ipvsadm package

Signed-off-by: Mauro Mozzarelli <mauro@ezplanet.org>