### PR TITLE
luci-app-vpnbypass: updated service start/enable logic.

### DIFF
--- a/applications/luci-app-vpnbypass/Makefile
+++ b/applications/luci-app-vpnbypass/Makefile
@@ -9,6 +9,7 @@ PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 LUCI_TITLE:=VPN Bypass Web UI
 LUCI_DEPENDS:=+vpnbypass
 LUCI_PKGARCH:=all
+PKG_RELEASE:=1
 
 include ../../luci.mk
 

--- a/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
+++ b/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
@@ -4,11 +4,11 @@ m = Map("vpnbypass", translate("VPN Bypass Settings"))
 s = m:section(NamedSection, "config", "vpnbypass")
 
 -- General options
-e = s:option(Flag, "enabled", translate("Enable VPN Bypass"))
+e = s:option(Flag, "enabled", translate("Enable/start service"))
 e.rmempty = false
 
 function e.cfgvalue(self, section)
-	return luci.sys.init.enabled("vpnbypass") and self.enabled or self.disabled
+	return self.map:get(section, "enabled") == "1" and luci.sys.init.enabled("vpnbypass") and self.enabled or self.disabled
 end
 
 function e.write(self, section, value)
@@ -17,35 +17,35 @@ function e.write(self, section, value)
 		luci.sys.call("/etc/init.d/vpnbypass start >/dev/null")
 	else
 		luci.sys.call("/etc/init.d/vpnbypass stop >/dev/null")
-		luci.sys.call("/etc/init.d/vpnbypass disable >/dev/null")
 	end
+	return Flag.write(self, section, value)
 end
 
 -- Local Ports
 p1 = s:option(DynamicList, "localport", translate("Local Ports to Bypass"), translate("Local ports to trigger VPN Bypass"))
 p1.datatype    = "portrange"
-p1.placeholder = "0-65535"
+-- p1.placeholder = "0-65535"
 p1.addremove = false
 p1.optional = false
 
 -- Remote Ports
 p2 = s:option(DynamicList, "remoteport", translate("Remote Ports to Bypass"), translate("Remote ports to trigger VPN Bypass"))
 p2.datatype    = "portrange"
-p2.placeholder = "0-65535"
+-- p2.placeholder = "0-65535"
 p2.addremove = false
 p2.optional = false
 
 -- Local Subnets
 r1 = s:option(DynamicList, "localsubnet", translate("Local IP Addresses to Bypass"), translate("Local IP addresses or subnets with direct internet access (outside of the VPN tunnel)"))
 r1.datatype    = "ip4addr"
-r1.placeholder = luci.ip.new(uci.cursor():get("network", "lan", "ipaddr") .. "/" .. uci.cursor():get("network", "lan", "netmask"))
+-- r1.placeholder = luci.ip.new(uci.cursor():get("network", "lan", "ipaddr") .. "/" .. uci.cursor():get("network", "lan", "netmask"))
 r1.addremove = false
 r1.optional = false
 
 -- Remote Subnets
 r2 = s:option(DynamicList, "remotesubnet", translate("Remote IP Addresses to Bypass"), translate("Remote IP addresses or subnets which will be accessed directly (outside of the VPN tunnel)"))
 r2.datatype    = "ip4addr"
-r2.placeholder = "0.0.0.0/0"
+-- r2.placeholder = "0.0.0.0/0"
 r2.addremove = false
 r2.optional = false
 

--- a/applications/luci-app-vpnbypass/po/templates/vpnbypass.pot
+++ b/applications/luci-app-vpnbypass/po/templates/vpnbypass.pot
@@ -7,7 +7,7 @@ msgstr ""
 msgid "Domains to be accessed directly (outside of the VPN tunnel), see"
 msgstr ""
 
-msgid "Enable VPN Bypass"
+msgid "Enable/start service"
 msgstr ""
 
 msgid "Local IP Addresses to Bypass"


### PR DESCRIPTION
Following up on the previous PR, this implementation respects the config's enable option, yet enables/starts or stops system service depending on UI switch.