### PR TITLE
luci-mod-admin-full: Add force link option in interfaces advanced settings section

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -1193,6 +1193,9 @@ msgstr "Força el TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Força el TKIP i el CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2807,6 +2810,11 @@ msgstr "Tipus de servei"
 
 msgid "Services"
 msgstr "Serveis"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -1205,6 +1205,9 @@ msgstr "Vynutit TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Vynutit TKIP a CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2847,6 +2850,11 @@ msgstr "Typ služby"
 
 msgid "Services"
 msgstr "Služby"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -1205,6 +1205,9 @@ msgstr "Erzwinge TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Erzwinge TKIP und CCMP (AES)"
 
+msgid "Force link"
+msgstr "Erzwinge Verbindung"
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2856,6 +2859,13 @@ msgstr "Service-Typ"
 
 msgid "Services"
 msgstr "Dienste"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
+"Schnittstelleneigenschaften werden unabhängig vom Link gesetzt (ist die "
+"Option ausgewählt, so werden die Hotplug-Skripte bei Änderung nicht aufgerufen)"
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -1219,6 +1219,9 @@ msgstr "Επιβολή TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Επιβολή TKIP και CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2840,6 +2843,11 @@ msgstr "Είδος Υπηρεσίας"
 
 msgid "Services"
 msgstr "Υπηρεσίες"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr ""

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -1194,6 +1194,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2804,6 +2807,11 @@ msgstr ""
 
 msgid "Services"
 msgstr "Services"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr ""

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -1212,6 +1212,9 @@ msgstr "Forzar TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forzar TKIP y CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2860,6 +2863,11 @@ msgstr "Tipo de servicio"
 
 msgid "Services"
 msgstr "Servicios"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -1224,6 +1224,9 @@ msgstr "Forcer TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forcer TKIP et CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2874,6 +2877,11 @@ msgstr "Type du service"
 
 msgid "Services"
 msgstr "Services"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -1179,6 +1179,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2770,6 +2773,11 @@ msgstr ""
 
 msgid "Services"
 msgstr "שירותים"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -1215,6 +1215,9 @@ msgstr "TKIP kényszerítése"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "TKIP és CCMP (AES) kényszerítése"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2865,6 +2868,11 @@ msgstr "Szolgáltatás típusa"
 
 msgid "Services"
 msgstr "Szolgáltatások"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -1215,6 +1215,9 @@ msgstr "Forza TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forza TKIP e CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2846,6 +2849,11 @@ msgstr ""
 
 msgid "Services"
 msgstr "Servizi"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr ""

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -1215,6 +1215,9 @@ msgstr "TKIP を使用"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "TKIP 及びCCMP (AES) を使用"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr "NAT-Tの強制使用"
 
@@ -2864,6 +2867,11 @@ msgstr "サービスタイプ"
 
 msgid "Services"
 msgstr "サービス"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr "時刻同期設定"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -1192,6 +1192,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2799,6 +2802,11 @@ msgstr ""
 
 msgid "Services"
 msgstr "서비스"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr ""

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -1164,6 +1164,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2775,6 +2778,11 @@ msgstr ""
 
 msgid "Services"
 msgstr "Perkhidmatan"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr ""

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -1201,6 +1201,9 @@ msgstr "Bruk TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Bruk TKIP og CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2838,6 +2841,11 @@ msgstr "Tjeneste type"
 
 msgid "Services"
 msgstr "Tjenester"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -1232,6 +1232,9 @@ msgstr "Wymuś TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Wymuś TKIP i CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2888,6 +2891,11 @@ msgstr "Typ serwisu"
 
 msgid "Services"
 msgstr "Serwisy"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -1268,6 +1268,9 @@ msgstr "Forçar TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forçar TKIP e CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr "Force o uso do NAT-T"
 
@@ -2993,6 +2996,11 @@ msgstr "Tipo do Serviço"
 
 msgid "Services"
 msgstr "Serviços"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr "Configurar a Sincronização do Horário"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -1218,6 +1218,9 @@ msgstr "Forçar TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forçar TKIP e CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2856,6 +2859,11 @@ msgstr "Tipo de Serviço"
 
 msgid "Services"
 msgstr "Serviços"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -1171,6 +1171,9 @@ msgstr "Forteaza TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forteaza TKIP si CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2766,6 +2769,11 @@ msgstr "Tip de serviciu"
 
 msgid "Services"
 msgstr "Servicii"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -1220,6 +1220,9 @@ msgstr "Требовать TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "TKIP или CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2868,6 +2871,11 @@ msgstr "Тип службы"
 
 msgid "Services"
 msgstr "Сервисы"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -1151,6 +1151,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2738,6 +2741,11 @@ msgid "Service Type"
 msgstr ""
 
 msgid "Services"
+msgstr ""
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
 msgstr ""
 
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -1157,6 +1157,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2744,6 +2747,11 @@ msgid "Service Type"
 msgstr ""
 
 msgid "Services"
+msgstr ""
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
 msgstr ""
 
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -1144,6 +1144,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2731,6 +2734,11 @@ msgid "Service Type"
 msgstr ""
 
 msgid "Services"
+msgstr ""
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
 msgstr ""
 
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -1164,6 +1164,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2751,6 +2754,11 @@ msgid "Service Type"
 msgstr ""
 
 msgid "Services"
+msgstr ""
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
 msgstr ""
 
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -1227,6 +1227,9 @@ msgstr "Примусово TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Примусово TKIP та CCMP (AES)"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2881,6 +2884,11 @@ msgstr "Тип сервісу"
 
 msgid "Services"
 msgstr "Сервіси"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -1169,6 +1169,9 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2779,6 +2782,11 @@ msgstr ""
 
 msgid "Services"
 msgstr "Dịch vụ "
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr ""

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -1171,6 +1171,9 @@ msgstr "强制使用TKIP加密"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "TKIP和CCMP(AES)混合加密"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr "强制使用NAT-T"
 
@@ -2777,6 +2780,11 @@ msgstr "服务类型"
 
 msgid "Services"
 msgstr "服务"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 msgid "Set up Time Synchronization"
 msgstr "设置时间同步"

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -1182,6 +1182,9 @@ msgstr "強制TKIP加密"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "強制TKIP+CCMP (AES)加密"
 
+msgid "Force link"
+msgstr ""
+
 msgid "Force use of NAT-T"
 msgstr ""
 
@@ -2791,6 +2794,11 @@ msgstr "服務型態"
 
 msgid "Services"
 msgstr "各服務"
+
+msgid ""
+"Set interface properties regardless of the link carrier (If set, carrier "
+"sense events do not invoke hotplug handlers)."
+msgstr ""
 
 #, fuzzy
 msgid "Set up Time Synchronization"

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
@@ -220,6 +220,12 @@ auto.default = (net:proto() == "none") and auto.disabled or auto.enabled
 delegate = s:taboption("advanced", Flag, "delegate", translate("Use builtin IPv6-management"))
 delegate.default = delegate.enabled
 
+force_link = s:taboption("advanced", Flag, "force_link",
+	translate("Force link"),
+	translate("Set interface properties regardless of the link carrier (If set, carrier sense events do not invoke hotplug handlers)."))
+
+force_link.default = (net:proto() == "static") and force_link.enabled or force_link.disabled
+
 
 if not net:is_virtual() then
 	br = s:taboption("physical", Flag, "type", translate("Bridge interfaces"), translate("creates a bridge over specified interface(s)"))


### PR DESCRIPTION
If `proto` option is `static` then `force_link` will be enabled by default and the hotplug-scripts will `not` be invoked. The behaviour for the proto `static` should be configurable in luci. The config option `force_link` manage this.