### PR TITLE
luci-app-simple-adblock: Add Japanese translation

### DIFF
--- a/applications/luci-app-simple-adblock/po/ja/simple-adblock.po
+++ b/applications/luci-app-simple-adblock/po/ja/simple-adblock.po
@@ -1,0 +1,91 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.12\n"
+"Last-Translator: INAGAKI Hiroshi <musashino.open@gmail.com>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: ja\n"
+
+msgid "Blacklisted Domain URLs"
+msgstr "ドメイン ブラックリストのURL"
+
+msgid "Blacklisted Domains"
+msgstr "ブラックリスト ドメイン"
+
+msgid "Blacklisted Hosts URLs"
+msgstr "hosts ブラックリストのURL"
+
+msgid "Controls system log and console output verbosity"
+msgstr "システム ログとコンソール出力の冗長性を設定します。"
+
+msgid "Enable/start service"
+msgstr "サービスの有効化/開始"
+
+msgid "Force Router DNS"
+msgstr "ルーターDNSの強制"
+
+msgid "Force Router DNS server to all local devices"
+msgstr "全ローカル デバイスにルーター DNSサーバーの使用を強制"
+
+msgid "Forces Router DNS use on local devices, also known as DNS Hijacking"
+msgstr "ローカル デバイスに対し、ルーター上のDNSサーバーの使用を強制します。これは、DNS ハイジャックとしても知られています。"
+
+msgid "Individual domains to be blacklisted"
+msgstr "ブラックリストに登録する、個々のドメインです。"
+
+msgid "Individual domains to be whitelisted"
+msgstr "ホワイトリストに登録する、個々のドメインです。"
+
+msgid "LED to indicate status"
+msgstr "ステータスを表示するLED"
+
+msgid "Let local devices use their own DNS servers if set"
+msgstr "DNSサーバーの使用を強制しない"
+
+msgid "Output Verbosity Setting"
+msgstr "出力詳細度の設定"
+
+msgid "Pick the LED not already used in"
+msgstr "右の設定で既に使用されていないLEDを選択します:"
+
+msgid "Simple AdBlock"
+msgstr "Simple AdBlock"
+
+msgid "Simple AdBlock Settings"
+msgstr "Simple AdBlock 設定"
+
+msgid "Some output"
+msgstr "軽量出力"
+
+msgid "Suppress output"
+msgstr "出力の抑制"
+
+msgid "System LED Configuration"
+msgstr "LED 設定"
+
+msgid "URLs to lists of domains to be blacklisted"
+msgstr "ブラックリストに登録するドメインのリストのURLです。"
+
+msgid "URLs to lists of domains to be whitelisted"
+msgstr "ホワイトリストに登録するドメインのリストのURLです。"
+
+msgid "URLs to lists of hosts to be blacklisted"
+msgstr "ブラックリストに登録するドメインが列挙された、hostsファイルのURLです。"
+
+msgid "Verbose output"
+msgstr "詳細出力"
+
+msgid "Whitelisted Domain URLs"
+msgstr "ドメイン ホワイトリストのURL"
+
+msgid "Whitelisted Domains"
+msgstr "ホワイトリスト ドメイン"
+
+msgid "none"
+msgstr "なし"


### PR DESCRIPTION
Added Japanese translations.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>