### PR TITLE
luci-app-adblock: Fix package call from buildroot

### DIFF
--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -9,3 +9,5 @@ LUCI_DEPENDS:=+adblock
 LUCI_PKGARCH:=all
 
 include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
Cannot load this package in buildroot, so I fixed package call from
buildroot in the Makefile.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>