### PR TITLE
luci-app-adblock: fix XHTML/HTML5 markup

### DIFF
--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
@@ -17,7 +17,7 @@ m = SimpleForm("input", nil)
 
 s = m:section(SimpleSection, nil,
 	translatef("This form allows you to modify the content of the adblock blacklist (%s).<br />", adbinput)
-	.. translate("Please add only one domain per line. Comments introduced with '#' are allowed - ip addresses, wildcards & regex are not."))
+	.. translate("Please add only one domain per line. Comments introduced with '#' are allowed - ip addresses, wildcards and regex are not."))
 
 f = s:option(TextValue, "data")
 	f.rmempty = true

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/whitelist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/whitelist_tab.lua
@@ -17,7 +17,7 @@ m = SimpleForm("input", nil)
 
 s = m:section(SimpleSection, nil,
 	translatef("This form allows you to modify the content of the adblock whitelist (%s).<br />", adbinput)
-	.. translate("Please add only one domain per line. Comments introduced with '#' are allowed - ip addresses, wildcards & regex are not."))
+	.. translate("Please add only one domain per line. Comments introduced with '#' are allowed - ip addresses, wildcards and regex are not."))
 
 f = s:option(TextValue, "data")
 	f.rmempty = true

--- a/applications/luci-app-adblock/luasrc/view/adblock/runtime.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/runtime.htm
@@ -6,6 +6,6 @@ This is free software, licensed under the Apache License, Version 2.0
 
 <%+cbi/valueheader%>
 
-<input name="runtime" id="runtime" type="text" class="cbi-input-text" style="border: none; box-shadow: none; background-color: #ffffff; color: #0069d6;" value="<%=self:cfgvalue(section)%>" disabled />
+<input name="runtime" id="runtime" type="text" class="cbi-input-text" style="border: none; box-shadow: none; background-color: #ffffff; color: #0069d6;" value="<%=self:cfgvalue(section)%>" disabled="disabled" />
 
 <%+cbi/valuefooter%>


### PR DESCRIPTION
* fix XHTML parsing errors in openwrt theme
* tested with openwrt, bootstrap & material theme

Signed-off-by: Dirk Brenken <dev@brenken.org>