### PR TITLE
luci-app-mwan3: Fix luci tools cannot detect translate()

### DIFF
--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua
@@ -59,24 +59,24 @@ end
 function interfaceWarnings() -- display status and warning messages at the top of the page
 	local warnings = ""
 	if interfaceNumber <= 250 then
-		warnings = "<strong>There are currently " .. interfaceNumber .. " of 250 supported interfaces configured</strong>"
+		warnings = "<strong>" .. translatef("There are currently %d of 250 supported interfaces configured", interfaceNumber) .. "</strong>"
 	else
-		warnings = "<font color=\"ff0000\"><strong>WARNING: " .. interfaceNumber .. " interfaces are configured exceeding the maximum of 250!</strong></font>"
+		warnings = "<font color=\"ff0000\"><strong>" .. translatef("WARNING: %d interfaces are configured exceeding the maximum of 250!", interfaceNumber) .. "</strong></font>"
 	end
 	if errorReliabilityList ~= " " then
-		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>WARNING: some interfaces have a higher reliability requirement than there are tracking IP addresses!</strong></font>"
+		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>" .. translate("WARNING: some interfaces have a higher reliability requirement than there are tracking IP addresses!") .. "</strong></font>"
 	end
 	if errorRouteList ~= " " then
-		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>WARNING: some interfaces have no default route in the main routing table!</strong></font>"
+		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>" .. translate("WARNING: some interfaces have no default route in the main routing table!") .. "</strong></font>"
 	end
 	if errorNetConfigList ~= " " then
-		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>WARNING: some interfaces are configured incorrectly or not at all in /etc/config/network!</strong></font>"
+		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>" .. translate("WARNING: some interfaces are configured incorrectly or not at all in /etc/config/network!") .. "</strong></font>"
 	end
 	if errorNoMetricList ~= " " then
-		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>WARNING: some interfaces have no metric configured in /etc/config/network!</strong></font>"
+		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>" .. translate("WARNING: some interfaces have no metric configured in /etc/config/network!") .. "</strong></font>"
 	end
 	if errorDuplicateMetricList ~= " " then
-		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>WARNING: some interfaces have duplicate metrics configured in /etc/config/network!</strong></font>"
+		warnings = warnings .. "<br /><br /><font color=\"ff0000\"><strong>" .. translate("WARNING: some interfaces have duplicate metrics configured in /etc/config/network!") .. "</strong></font>"
 	end
 	return warnings
 end
@@ -99,7 +99,7 @@ interfaceCheck()
 
 
 m5 = Map("mwan3", translate("MWAN Interface Configuration"),
-	translate(interfaceWarnings()))
+	interfaceWarnings())
 	m5:append(Template("mwan/config_css"))
 
 

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua
@@ -50,21 +50,21 @@ end
 function interfaceWarnings() -- display warning messages at the top of the page
 	local warns, lineBreak = "", ""
 	if errorReliability == 1 then
-		warns = "<font color=\"ff0000\"><strong>WARNING: this interface has a higher reliability requirement than there are tracking IP addresses!</strong></font>"
+		warns = "<font color=\"ff0000\"><strong>" .. translate("WARNING: this interface has a higher reliability requirement than there are tracking IP addresses!") .. "</strong></font>"
 		lineBreak = "<br /><br />"
 	end
 	if errorRoute == 1 then
-		warns = warns .. lineBreak .. "<font color=\"ff0000\"><strong>WARNING: this interface has no default route in the main routing table!</strong></font>"
+		warns = warns .. lineBreak .. "<font color=\"ff0000\"><strong>" .. translate("WARNING: this interface has no default route in the main routing table!") .. "</strong></font>"
 		lineBreak = "<br /><br />"
 	end
 	if errorNetConfig == 1 then
-		warns = warns .. lineBreak .. "<font color=\"ff0000\"><strong>WARNING: this interface is configured incorrectly or not at all in /etc/config/network!</strong></font>"
+		warns = warns .. lineBreak .. "<font color=\"ff0000\"><strong>" .. translate("WARNING: this interface is configured incorrectly or not at all in /etc/config/network!") .. "</strong></font>"
 		lineBreak = "<br /><br />"
 	end
 	if errorNoMetric == 1 then
-		warns = warns .. lineBreak .. "<font color=\"ff0000\"><strong>WARNING: this interface has no metric configured in /etc/config/network!</strong></font>"
+		warns = warns .. lineBreak .. "<font color=\"ff0000\"><strong>" .. translate("WARNING: this interface has no metric configured in /etc/config/network!") .. "</strong></font>"
 	elseif errorDuplicateMetric == 1 then
-		warns = warns .. lineBreak .. "<font color=\"ff0000\"><strong>WARNING: this and other interfaces have duplicate metrics configured in /etc/config/network!</strong></font>"
+		warns = warns .. lineBreak .. "<font color=\"ff0000\"><strong>" .. translate("WARNING: this and other interfaces have duplicate metrics configured in /etc/config/network!") .. "</strong></font>"
 	end
 	return warns
 end
@@ -87,8 +87,8 @@ errorReliability = 0
 interfaceCheck()
 
 
-m5 = Map("mwan3", translate("MWAN Interface Configuration - " .. arg[1]),
-	translate(interfaceWarnings()))
+m5 = Map("mwan3", translatef("MWAN Interface Configuration - %s", arg[1]),
+	interfaceWarnings())
 	m5.redirect = dsp.build_url("admin", "network", "mwan", "configuration", "interface")
 
 

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua
@@ -14,7 +14,7 @@ dsp = require "luci.dispatcher"
 arg[1] = arg[1] or ""
 
 
-m5 = Map("mwan3", translate("MWAN Member Configuration - ") .. arg[1])
+m5 = Map("mwan3", translatef("MWAN Member Configuration - %s", arg[1]))
 	m5.redirect = dsp.build_url("admin", "network", "mwan", "configuration", "member")
 
 

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua
@@ -13,7 +13,7 @@ end
 
 function policyWarn() -- display status and warning messages at the top of the page
 	if nameTooLong == 1 then
-		return "<font color=\"ff0000\"><strong>WARNING: Some policies have names exceeding the maximum of 15 characters!</strong></font>"
+		return "<font color=\"ff0000\"><strong>" .. translate("WARNING: Some policies have names exceeding the maximum of 15 characters!") .. "</strong></font>"
 	else
 		return ""
 	end
@@ -30,7 +30,7 @@ policyCheck()
 
 
 m5 = Map("mwan3", translate("MWAN Policy Configuration"),
-	translate(policyWarn()))
+	policyWarn())
 	m5:append(Template("mwan/config_css"))
 
 

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua
@@ -9,7 +9,7 @@ end
 
 function policyWarn() -- display status and warning messages at the top of the page
 	if nameTooLong == 1 then
-		return "<font color=\"ff0000\"><strong>WARNING: this policy's name is " .. policyNameLength .. " characters exceeding the maximum of 15!</strong></font>"
+		return "<font color=\"ff0000\"><strong>" .. translatef("WARNING: this policy's name is %d characters exceeding the maximum of 15!", policyNameLength) .. "</strong></font>"
 	else
 		return ""
 	end
@@ -32,8 +32,8 @@ nameTooLong = 0
 policyCheck()
 
 
-m5 = Map("mwan3", translate("MWAN Policy Configuration - " .. arg[1]),
-	translate(policyWarn()))
+m5 = Map("mwan3", translatef("MWAN Policy Configuration - %s", arg[1]),
+	policyWarn())
 	m5.redirect = dsp.build_url("admin", "network", "mwan", "configuration", "policy")
 
 

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/rule.lua
@@ -17,7 +17,7 @@ end
 
 function ruleWarn() -- display warning messages at the top of the page
 	if error_protocol_list ~= " " then
-		return "<font color=\"ff0000\"><strong>WARNING: some rules have a port configured with no or improper protocol specified! Please configure a specific protocol!</strong></font>"
+		return "<font color=\"ff0000\"><strong>" .. translate("WARNING: some rules have a port configured with no or improper protocol specified! Please configure a specific protocol!") .. "</strong></font>"
 	else
 		return ""
 	end
@@ -34,7 +34,7 @@ ruleCheck()
 
 
 m5 = Map("mwan3", translate("MWAN Rule Configuration"),
-	translate(ruleWarn()))
+	ruleWarn())
 	m5:append(Template("mwan/config_css"))
 
 

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua
@@ -13,7 +13,7 @@ end
 
 function ruleWarn() -- display warning message at the top of the page
 	if error_protocol == 1 then
-		return "<font color=\"ff0000\"><strong>WARNING: this rule is incorrectly configured with no or improper protocol specified! Please configure a specific protocol!</strong></font>"
+		return "<font color=\"ff0000\"><strong>" .. translate("WARNING: this rule is incorrectly configured with no or improper protocol specified! Please configure a specific protocol!") .. "</strong></font>"
 	else
 		return ""
 	end
@@ -45,8 +45,8 @@ error_protocol = 0
 ruleCheck()
 
 
-m5 = Map("mwan3", translate("MWAN Rule Configuration - ") .. arg[1],
-	translate(ruleWarn()))
+m5 = Map("mwan3", translatef("MWAN Rule Configuration - %s", arg[1]),
+	ruleWarn())
 	m5.redirect = dsp.build_url("admin", "network", "mwan", "configuration", "rule")
 
 


### PR DESCRIPTION
Fixed strings in Lua sources where the LuCI i18n tools cannot be
detected. And also fixed some other problems.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>