### PR TITLE
luci-app-adblock: sync with adblock 2.6.0

### DIFF
--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -1,4 +1,3 @@
-# Copyright 2016 Hannu Nyman
 # Copyright 2017 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the Apache License, Version 2.0
 

--- a/applications/luci-app-adblock/luasrc/controller/adblock.lua
+++ b/applications/luci-app-adblock/luasrc/controller/adblock.lua
@@ -1,4 +1,3 @@
--- Copyright 2016 Hannu Nyman
 -- Copyright 2017 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
@@ -1,11 +1,10 @@
--- Copyright 2016 Hannu Nyman
 -- Copyright 2017 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
 local fs = require("nixio.fs")
 local util = require("luci.util")
 local uci = require("uci")
-local adbinput = uci.get("adblock", "blacklist", "adb_src")
+local adbinput = uci.get("adblock", "blacklist", "adb_src" or "/etc/adblock/adblock.blacklist")
 
 if not nixio.fs.access(adbinput) then
 	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
@@ -13,27 +12,27 @@ if not nixio.fs.access(adbinput) then
 end
 
 m = SimpleForm("input", nil)
-	m:append(Template("adblock/config_css"))
+m:append(Template("adblock/config_css"))
 
 s = m:section(SimpleSection, nil,
 	translatef("This form allows you to modify the content of the adblock blacklist (%s).<br />", adbinput)
 	.. translate("Please add only one domain per line. Comments introduced with '#' are allowed - ip addresses, wildcards and regex are not."))
 
 f = s:option(TextValue, "data")
-	f.rmempty = true
-	f.datatype = "string"
-	f.rows = 20
+f.datatype = "string"
+f.rows = 20
+f.rmempty = true
 
-	function f.cfgvalue()
-		return nixio.fs.readfile(adbinput) or ""
-	end
+function f.cfgvalue()
+	return nixio.fs.readfile(adbinput) or ""
+end
 
-	function f.write(self, section, data)
-		return nixio.fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
-	end
+function f.write(self, section, data)
+	return nixio.fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+end
 
-	function s.handle(self, state, data)
-		return true
-	end
+function s.handle(self, state, data)
+	return true
+end
 
 return m

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/configuration_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/configuration_tab.lua
@@ -1,4 +1,3 @@
--- Copyright 2016 Hannu Nyman
 -- Copyright 2017 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
@@ -12,25 +11,25 @@ if not nixio.fs.access(adbinput) then
 end
 
 m = SimpleForm("input", nil)
-	m:append(Template("adblock/config_css"))
+m:append(Template("adblock/config_css"))
 
 s = m:section(SimpleSection, nil,
-translate("This form allows you to modify the content of the main adblock configuration file (/etc/config/adblock)."))
+	translate("This form allows you to modify the content of the main adblock configuration file (/etc/config/adblock)."))
 
 f = s:option(TextValue, "data")
-	f.rmempty = true
-	f.rows = 20
+f.rows = 20
+f.rmempty = true
 
-	function f.cfgvalue()
-		return nixio.fs.readfile(adbinput) or ""
-	end
+function f.cfgvalue()
+	return nixio.fs.readfile(adbinput) or ""
+end
 
-	function f.write(self, section, data)
-		return nixio.fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
-	end
+function f.write(self, section, data)
+	return nixio.fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+end
 
-	function s.handle(self, state, data)
-		return true
-	end
+function s.handle(self, state, data)
+	return true
+end
 
 return m

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
@@ -1,12 +1,14 @@
--- Copyright 2016 Hannu Nyman
 -- Copyright 2017 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
+local fs = require("nixio.fs")
+local uci = require("uci")
 local sys = require("luci.sys")
-local util = require("luci.util")
-local data = util.ubus("service", "get_data", "name", "adblock") or { }
-local dnsFile1 = sys.exec("find '/tmp/dnsmasq.d' -maxdepth 1 -type f -name 'adb_list*' -print 2>/dev/null")
-local dnsFile2 = sys.exec("find '/var/lib/unbound' -maxdepth 1 -type f -name 'adb_list*' -print 2>/dev/null")
+local json = require("luci.jsonc")
+local adbinput = uci.get("adblock", "global", "adb_rtfile") or "/tmp/adb_runtime.json"
+local parse = json.parse(fs.readfile(adbinput) or "")
+local dnsFile1 = sys.exec("find '/tmp/dnsmasq.d/.adb_hidden' -maxdepth 1 -type f -name 'adb_list*' -print 2>/dev/null")
+local dnsFile2 = sys.exec("find '/var/lib/unbound/.adb_hidden' -maxdepth 1 -type f -name 'adb_list*' -print 2>/dev/null")
 
 m = Map("adblock", translate("Adblock"),
 	translate("Configuration of the adblock package to block ad/abuse domains by using DNS. ")
@@ -21,87 +23,99 @@ m = Map("adblock", translate("Adblock"),
 s = m:section(NamedSection, "global", "adblock")
 
 o1 = s:option(Flag, "adb_enabled", translate("Enable adblock"))
+o1.default = o1.enabled
 o1.rmempty = false
-o1.default = 0
 
 btn = s:option(Button, "", translate("Suspend / Resume adblock"))
-if data.adblock == nil then
-	btn.inputtitle = "n/a"
-	btn.inputstyle = nil
-	btn.disabled = true
-elseif dnsFile1 ~= "" or dnsFile2 ~= "" then
-	btn.inputtitle = translate("Suspend adblock")
-	btn.inputstyle = "reset"
-	btn.disabled = false
-	function btn.write()
-		luci.sys.call("/etc/init.d/adblock suspend >/dev/null 2>&1")
-	end
-else
+if dnsFile1 ~= "" or dnsFile2 ~= "" then
 	btn.inputtitle = translate("Resume adblock")
 	btn.inputstyle = "apply"
 	btn.disabled = false
 	function btn.write()
 		luci.sys.call("/etc/init.d/adblock resume >/dev/null 2>&1")
 	end
+else
+	btn.inputtitle = translate("Suspend adblock")
+	btn.inputstyle = "reset"
+	btn.disabled = false
+	function btn.write()
+		luci.sys.call("/etc/init.d/adblock suspend >/dev/null 2>&1")
+	end
 end
 
-o2 = s:option(Flag, "adb_debug", translate("Enable verbose debug logging"))
-o2.default = o2.disabled
-o2.rmempty = false
+o2 = s:option(Value, "adb_iface", translate("Restrict interface trigger to certain interface(s)"),
+	translate("Space separated list of interfaces that trigger adblock processing. "..
+	"To disable event driven (re-)starts remove all entries."))
+o2.rmempty = true
 
-o3 = s:option(Value, "adb_iface", translate("Restrict interface reload trigger to certain interface(s)"),
-	translate("Space separated list of interfaces that trigger a reload action. "..
-	"To disable reload trigger at all remove all entries."))
-o3.rmempty =true
+o3 = s:option(Value, "adb_triggerdelay", translate("Trigger delay"),
+	translate("Additional trigger delay in seconds before adblock processing begins."))
+o3.default = 1
+o3.datatype = "range(1,90)"
+o3.rmempty = false
+
+o4 = s:option(Flag, "adb_debug", translate("Enable verbose debug logging"))
+o4.default = o4.disabled
+o4.rmempty = false
 
 -- Runtime information
 
-	ds = s:option(DummyValue, "_dummy", translate("Runtime information"))
-	ds.template = "cbi/nullsection"
+ds = s:option(DummyValue, "_dummy", translate("Runtime information"))
+ds.template = "cbi/nullsection"
 
-	dv1 = s:option(DummyValue, "adblock_version", translate("Adblock version"))
-	dv1.template = "adblock/runtime"
-	if data.adblock ~= nil then
-		dv1.value = data.adblock.adblock.adblock_version or "n/a"
-	else
-		dv1.value = "n/a"
-	end
+dv1 = s:option(DummyValue, "status", translate("Status"))
+dv1.template = "adblock/runtime"
+if parse == nil then
+	dv1.value = translate("n/a")
+elseif parse.data.blocked_domains == "0" then
+	dv1.value = translate("no domains blocked")
+elseif dnsFile1 ~= "" or dnsFile2 ~= "" then
+	dv1.value = translate("suspended")
+else
+	dv1.value = translate("active")
+end
+dv2 = s:option(DummyValue, "adblock_version", translate("Adblock version"))
+dv2.template = "adblock/runtime"
+if parse ~= nil then
+	dv2.value = parse.data.adblock_version or translate("n/a")
+else
+	dv2.value = translate("n/a")
+end
 
-	dv2 = s:option(DummyValue, "status", translate("Status"))
-	dv2.template = "adblock/runtime"
-	if data.adblock == nil then
-		dv2.value = "n/a"
-	elseif dnsFile1 ~= "" or dnsFile2 ~= "" then
-		dv2.value = "active"
-	else
-		dv2.value = "suspended"
-	end
+dv3 = s:option(DummyValue, "fetch_info", translate("Download Utility (SSL Library)"),
+	translate("For SSL protected blocklist sources you need a suitable SSL library, e.g. 'libustream-ssl' or the wget 'built-in'."))
+dv3.template = "adblock/runtime"
+if parse ~= nil then
+	dv3.value = parse.data.fetch_info or translate("n/a")
+else
+	dv3.value = translate("n/a")
+end
 
-	dv3 = s:option(DummyValue, "dns_backend", translate("DNS backend"))
-	dv3.template = "adblock/runtime"
-	if data.adblock ~= nil then
-		dv3.value = data.adblock.adblock.dns_backend or "n/a"
-	else
-		dv3.value = "n/a"
-	end
+dv4 = s:option(DummyValue, "dns_backend", translate("DNS backend"))
+dv4.template = "adblock/runtime"
+if parse ~= nil then
+	dv4.value = parse.data.dns_backend or translate("n/a")
+else
+	dv4.value = translate("n/a")
+end
 
-	dv4 = s:option(DummyValue, "blocked_domains", translate("Blocked domains (overall)"))
-	dv4.template = "adblock/runtime"
-	if data.adblock ~= nil then
-		dv4.value = data.adblock.adblock.blocked_domains or "n/a"
-	else
-		dv4.value = "n/a"
-	end
+dv5 = s:option(DummyValue, "blocked_domains", translate("Blocked domains (overall)"))
+dv5.template = "adblock/runtime"
+if parse ~= nil then
+	dv5.value = parse.data.blocked_domains or translate("n/a")
+else
+	dv5.value = translate("n/a")
+end
 
-	dv5 = s:option(DummyValue, "last_rundate", translate("Last rundate"))
-	dv5.template = "adblock/runtime"
-	if data.adblock ~= nil then
-		dv5.value = data.adblock.adblock.last_rundate or "n/a"
-	else
-		dv5.value = "n/a"
-	end
+dv6 = s:option(DummyValue, "last_rundate", translate("Last rundate"))
+dv6.template = "adblock/runtime"
+if parse ~= nil then
+	dv6.value = parse.data.last_rundate or translate("n/a")
+else
+	dv6.value = translate("n/a")
+end
 
--- Blocklist options
+-- Blocklist table
 
 bl = m:section(TypedSection, "source", translate("Blocklist sources"),
 	translate("Available blocklist sources. ")
@@ -109,7 +123,17 @@ bl = m:section(TypedSection, "source", translate("Blocklist sources"),
 bl.template = "cbi/tblsection"
 
 name = bl:option(Flag, "enabled", translate("Enabled"))
-name.rmempty  = false
+name.rmempty = false
+
+ssl = bl:option(DummyValue, "adb_src", translate("SSL req."))
+function ssl.cfgvalue(self, section)
+	local source = self.map:get(section, "adb_src")
+	if source and source:match("https://") then
+		return translate("Yes")
+	else
+		return translate("No")
+	end
+end
 
 des = bl:option(DummyValue, "adb_src_desc", translate("Description"))
 
@@ -117,12 +141,12 @@ des = bl:option(DummyValue, "adb_src_desc", translate("Description"))
 
 s = m:section(NamedSection, "global", "adblock", translate("Backup options"))
 
-o4 = s:option(Flag, "adb_backup", translate("Enable blocklist backup"))
-o4.rmempty = false
-o4.default = 0
-
-o5 = s:option(Value, "adb_backupdir", translate("Backup directory"))
+o5 = s:option(Flag, "adb_backup", translate("Enable blocklist backup"))
+o5.default = o5.disabled
 o5.rmempty = false
-o5.datatype = "directory"
+
+o6 = s:option(Value, "adb_backupdir", translate("Backup directory"))
+o6.datatype = "directory"
+o6.rmempty = false
 
 return m

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/whitelist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/whitelist_tab.lua
@@ -1,11 +1,10 @@
--- Copyright 2016 Hannu Nyman
 -- Copyright 2017 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
 local fs = require("nixio.fs")
 local util = require("luci.util")
 local uci = require("uci")
-local adbinput = uci.get("adblock", "global", "adb_whitelist") or " "
+local adbinput = uci.get("adblock", "global", "adb_whitelist") or "/etc/adblock/adblock.whitelist"
 
 if not nixio.fs.access(adbinput) then
 	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
@@ -13,27 +12,27 @@ if not nixio.fs.access(adbinput) then
 end
 
 m = SimpleForm("input", nil)
-	m:append(Template("adblock/config_css"))
+m:append(Template("adblock/config_css"))
 
 s = m:section(SimpleSection, nil,
 	translatef("This form allows you to modify the content of the adblock whitelist (%s).<br />", adbinput)
 	.. translate("Please add only one domain per line. Comments introduced with '#' are allowed - ip addresses, wildcards and regex are not."))
 
 f = s:option(TextValue, "data")
-	f.rmempty = true
-	f.datatype = "string"
-	f.rows = 20
+f.datatype = "string"
+f.rows = 20
+f.rmempty = true
 
-	function f.cfgvalue()
-		return nixio.fs.readfile(adbinput) or ""
-	end
+function f.cfgvalue()
+	return nixio.fs.readfile(adbinput) or ""
+end
 
-	function f.write(self, section, data)
-		return nixio.fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
-	end
+function f.write(self, section, data)
+	return nixio.fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+end
 
-	function s.handle(self, state, data)
-		return true
-	end
+function s.handle(self, state, data)
+	return true
+end
 
 return m

--- a/applications/luci-app-adblock/luasrc/view/adblock/logread.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/logread.htm
@@ -1,5 +1,4 @@
 <%#
-Copyright 2016 Hannu Nyman
 Copyright 2017 Dirk Brenken (dev@brenken.org)
 This is free software, licensed under the Apache License, Version 2.0
 -%>

--- a/applications/luci-app-adblock/luasrc/view/adblock/query.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/query.htm
@@ -1,5 +1,4 @@
 <%#
-Copyright 2016 Hannu Nyman
 Copyright 2017 Dirk Brenken (dev@brenken.org)
 This is free software, licensed under the Apache License, Version 2.0
 -%>

--- a/applications/luci-app-adblock/luasrc/view/adblock/runtime.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/runtime.htm
@@ -1,5 +1,4 @@
 <%#
-Copyright 2016 Hannu Nyman
 Copyright 2017 Dirk Brenken (dev@brenken.org)
 This is free software, licensed under the Apache License, Version 2.0
 -%>


### PR DESCRIPTION
* add new trigger timeout input field
* the download utility plus SSL Library will be listed in runtime
  information and the blocklist source table contains an additional 
  "SSL req." column
* various small fixes
* changed copyright notice

Signed-off-by: Dirk Brenken <dev@brenken.org>