### PR TITLE
Use nf_conntrack_count instead of `wl -l`

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -38,8 +38,7 @@
 		local wan6 = ntm:get_wan6net()
 
 		local conn_count = tonumber((
-			luci.sys.exec("wc -l /proc/net/nf_conntrack") or
-			luci.sys.exec("wc -l /proc/net/ip_conntrack") or
+			luci.sys.exec("cat /proc/sys/net/netfilter/nf_conntrack_count") or
 			""):match("%d+")) or 0
 
 		local conn_max = tonumber((


### PR DESCRIPTION
Currently the summary page of LuCI calls `wc -l` on the entire list of connections (`/proc/net/nf_conntrack`) in order to get the current connection count. 

On thousands of active connections, this command could take several seconds or minutes to complete.

Instead, we can use the count provided by the kernel at `/proc/sys/net/netfilter/nf_conntrack_count`. The data is available instantly and will not hang the page.