### PR TITLE
luci-app-adblock: sync with 2.6.0-2

### DIFF
--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for Adblock
-LUCI_DEPENDS:=+adblock
+LUCI_DEPENDS:=+adblock +luci-lib-jsonc
 LUCI_PKGARCH:=all
 
 include ../../luci.mk

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
@@ -50,7 +50,7 @@ o2.rmempty = true
 
 o3 = s:option(Value, "adb_triggerdelay", translate("Trigger delay"),
 	translate("Additional trigger delay in seconds before adblock processing begins."))
-o3.default = 1
+o3.default = 2
 o3.datatype = "range(1,90)"
 o3.rmempty = false
 


### PR DESCRIPTION
* made default trigger delay more conservative to fix possible start up issues
* add luci-lib-jsonc dependency

Signed-off-by: Dirk Brenken <dev@brenken.org>