### PR TITLE
luci-mod-admin-full: correct logic for dnsmasq boguspriv keyword

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -71,8 +71,7 @@ se.optional = true
 bp = s:taboption("advanced", Flag, "boguspriv",
 	translate("Filter private"),
 	translate("Do not forward reverse lookups for local networks"))
-bp.default = 1
-bp.rmempty = false
+bp.default = bp.enabled
 
 s:taboption("advanced", Flag, "filterwin2k",
 	translate("Filter useless"),

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -68,9 +68,11 @@ se = s:taboption("advanced", Flag, "sequential_ip",
 	translate("Allocate IP addresses sequentially, starting from the lowest available address"))
 se.optional = true
 
-s:taboption("advanced", Flag, "boguspriv",
+bp = s:taboption("advanced", Flag, "boguspriv",
 	translate("Filter private"),
 	translate("Do not forward reverse lookups for local networks"))
+bp.default = 1
+bp.rmempty = false
 
 s:taboption("advanced", Flag, "filterwin2k",
 	translate("Filter useless"),


### PR DESCRIPTION
Prevents deletion of the UCI dns boguspriv keyword and explicitly sets it to either 0 or 1 as the LEDE/Openwrt dnsmasq.conf default is 1 - not 0.  This allows boguspriv to be turned off from the GUI.

Signed-off-by: Warren Linton warren@linton.id.au