### PR TITLE
luci-app-samba: add "Browsable" checkbox to each share

### DIFF
--- a/applications/luci-app-samba/luasrc/model/cbi/samba.lua
+++ b/applications/luci-app-samba/luasrc/model/cbi/samba.lua
@@ -53,6 +53,12 @@ ro.rmempty = false
 ro.enabled = "yes"
 ro.disabled = "no"
 
+br = s:option(Flag, "browseable", translate("Browseable"))
+br.rmempty = false
+br.default = "yes"
+br.enabled = "yes"
+br.disabled = "no"
+
 go = s:option(Flag, "guest_ok", translate("Allow guests"))
 go.rmempty = false
 go.enabled = "yes"


### PR DESCRIPTION
The current "Network Shares" page is missing a frequently used option: "browseable yes/no". When setting up a number of shares with different access levels this one was the only missing option on the page that I had to add manually. 
The default value for it is "yes" if it is missing for backwards compatibility, because that is the initial value in /etc/samba/smb.conf.template on a new samba install.
With this new checkbox, the page is still readable.