### PR TITLE
luci-proto-openconnect: allow setting no_cert_check, password2, mtu

### DIFF
--- a/protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua
+++ b/protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua
@@ -19,8 +19,6 @@ port = section:taboption("general", Value, "port", translate("VPN Server port"))
 port.placeholder = "443"
 port.datatype    = "port"
 
-ifname = section:taboption("general", Value, "interface", translate("Output Interface"))
-ifname.template = "cbi/network_netlist"
 
 defaultroute = section:taboption("advanced", Flag, "defaultroute",
 	translate("Use default gateway"),

--- a/protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua
+++ b/protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua
@@ -43,6 +43,8 @@ section:taboption("general", Value, "authgroup", translate("Auth Group"))
 username = section:taboption("general", Value, "username", translate("Username"))
 password = section:taboption("general", Value, "password", translate("Password"))
 password.password = true
+password2 = section:taboption("general", Value, "password2", translate("Password2"))
+password2.password = true
 
 
 cert = section:taboption("advanced", Value, "usercert", translate("User certificate (PEM encoded)"))
@@ -84,3 +86,7 @@ function ca.write(self, section, value)
 	value = value:gsub("\r\n?", "\n")
 	nixio.fs.writefile(oc_ca_file, value)
 end
+
+mtu = section:taboption("advanced", Value, "mtu", translate("Override MTU"))
+mtu.placeholder = "1406"
+mtu.datatype    = "max(9200)"


### PR DESCRIPTION
Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>

This depends on https://github.com/openwrt/packages/pull/4315

I plan to backport this also to lede-17.01 branch.