### PR TITLE
luci-app-hd-idle: removed dashes in menu items and text labels

### DIFF
--- a/applications/luci-app-hd-idle/luasrc/controller/hd_idle.lua
+++ b/applications/luci-app-hd-idle/luasrc/controller/hd_idle.lua
@@ -10,6 +10,6 @@ function index()
 
 	local page
 
-	page = entry({"admin", "services", "hd_idle"}, cbi("hd_idle"), _("hd-idle"), 60)
+	page = entry({"admin", "services", "hd_idle"}, cbi("hd_idle"), _("HDD Idle"), 60)
 	page.dependent = true
 end

--- a/applications/luci-app-hd-idle/luasrc/model/cbi/hd_idle.lua
+++ b/applications/luci-app-hd-idle/luasrc/model/cbi/hd_idle.lua
@@ -3,8 +3,8 @@
 
 require("nixio.fs")
 
-m = Map("hd-idle", "hd-idle",
-	translate("hd-idle is a utility program for spinning-down external " ..
+m = Map("hd-idle", translate("HDD Idle"),
+	translate("HDD Idle is a utility program for spinning-down external " ..
 		"disks after a period of idle time."))
 
 s = m:section(TypedSection, "hd-idle", translate("Settings"))
@@ -18,9 +18,9 @@ for dev in nixio.fs.glob("/dev/[sh]d[a-z]") do
 	disk:value(nixio.fs.basename(dev))
 end
 
-s:option(Value, "idle_time_interval", translate("Idle-time")).default = 10
+s:option(Value, "idle_time_interval", translate("Idle time")).default = 10
 s.rmempty = true
-unit = s:option(ListValue, "idle_time_unit", translate("Idle-time unit"))
+unit = s:option(ListValue, "idle_time_unit", translate("Idle time unit"))
 unit.default = "minutes"
 unit:value("minutes", translate("min"))
 unit:value("hours", translate("h"))

--- a/applications/luci-app-hd-idle/po/ca/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/ca/hd_idle.po
@@ -21,10 +21,10 @@ msgstr "Disc"
 msgid "Enable"
 msgstr "Habilita"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Temps d'inactivitat"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Unitat de temps d'inactivitat"
 
 msgid "Settings"
@@ -34,14 +34,14 @@ msgstr "Ajusts"
 msgid "h"
 msgstr "h"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle és un programa per ralentitzar els discos externs després d'un "
+"HDD Idle és un programa per ralentitzar els discos externs després d'un "
 "període de temps inactiu."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/cs/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/cs/hd_idle.po
@@ -21,10 +21,10 @@ msgstr "Disk"
 msgid "Enable"
 msgstr "Povolit"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Čas nečinnosti"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Čas nečinnosti - jednotka"
 
 msgid "Settings"
@@ -34,14 +34,14 @@ msgstr "Nastavení"
 msgid "h"
 msgstr "h"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle je utilita pro vypnutí externích pevných disků po určité době "
+"HDD Idle je utilita pro vypnutí externích pevných disků po určité době "
 "nečinnosti."
 
 # Minut (ne minimum)

--- a/applications/luci-app-hd-idle/po/de/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/de/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "Festplatte"
 msgid "Enable"
 msgstr "Aktivieren"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Leerlaufzeit"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Leerlaufzeiteinheit"
 
 msgid "Settings"
@@ -32,14 +32,14 @@ msgstr "Einstellungen"
 msgid "h"
 msgstr "Stunden"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle ist ein Hilfsprogramm um externe Festplatten nach einer festgelegten "
+"HDD Idle ist ein Hilfsprogramm um externe Festplatten nach einer festgelegten "
 "Leerlaufzeit herunter zu fahren."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/el/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/el/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "Δίσκος"
 msgid "Enable"
 msgstr "Ενεργοποίηση"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr ""
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr ""
 
 msgid "Settings"
@@ -32,11 +32,11 @@ msgstr "Ρυθμίσεις"
 msgid "h"
 msgstr "ω"
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr ""
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
 

--- a/applications/luci-app-hd-idle/po/en/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/en/hd_idle.po
@@ -17,11 +17,11 @@ msgstr "Disk"
 msgid "Enable"
 msgstr "Enable"
 
-msgid "Idle-time"
-msgstr "Idle-time"
+msgid "Idle time"
+msgstr "Idle time"
 
-msgid "Idle-time unit"
-msgstr "Idle-time unit"
+msgid "Idle time unit"
+msgstr "Idle time unit"
 
 msgid "Settings"
 msgstr "Settings"
@@ -30,14 +30,14 @@ msgstr "Settings"
 msgid "h"
 msgstr "h"
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr ""
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/es/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/es/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "Disco"
 msgid "Enable"
 msgstr "Activar"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Tiempo de inactividad"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Unidad de tiempo"
 
 msgid "Settings"
@@ -32,14 +32,14 @@ msgstr "Configuración"
 msgid "h"
 msgstr "h"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle es un programa que gestiona el reposo de discos externos tras un "
+"HDD Idle es un programa que gestiona el reposo de discos externos tras un "
 "tiempo de inactividad."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/fr/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/fr/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "Disque"
 msgid "Enable"
 msgstr "Activer"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Temps d'inactivité"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Unité de temps"
 
 msgid "Settings"
@@ -32,14 +32,14 @@ msgstr "Réglages"
 msgid "h"
 msgstr "h"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle est un utilitaire pour arrêter la rotation des disques externes "
+"HDD Idle est un utilitaire pour arrêter la rotation des disques externes "
 "après une période d'inactivité."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/he/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/he/hd_idle.po
@@ -21,10 +21,10 @@ msgstr "כונן"
 msgid "Enable"
 msgstr "אפשר"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "זמן חוסר פעילות"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "יחידת זמן חוסר פעילות"
 
 msgid "Settings"
@@ -34,14 +34,14 @@ msgstr "הגדרות"
 msgid "h"
 msgstr "ש'"
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr ""
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle הינה תוכנת שירות שמטרתה להקטין את מהירות הסיבוב של כוננים חיצוניים "
+"HDD Idle הינה תוכנת שירות שמטרתה להקטין את מהירות הסיבוב של כוננים חיצוניים "
 "לאחר זמן מסוים של חוסר פעילות."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/hu/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/hu/hd_idle.po
@@ -21,10 +21,10 @@ msgstr "Lemez"
 msgid "Enable"
 msgstr "Engedélyezés"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Üresjárati idő"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Üresjárati idő egysége"
 
 msgid "Settings"
@@ -34,14 +34,14 @@ msgstr "Beállítások"
 msgid "h"
 msgstr "óra"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle egy a külső lemezek adott üresjárati idő után történő leállítására "
+"HDD Idle egy a külső lemezek adott üresjárati idő után történő leállítására "
 "szolgáló segédprogram."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/it/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/it/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "Disco"
 msgid "Enable"
 msgstr "Abilita"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Tempo di inattività"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Unità di misura del tempo di inattività"
 
 msgid "Settings"
@@ -32,14 +32,14 @@ msgstr "Opzioni"
 msgid "h"
 msgstr "ora/e"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"HD-idle è un programma per mettere in standby i dischi esterni dopo un "
+"HDD Idle è un programma per mettere in standby i dischi esterni dopo un "
 "periodo di inattività."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/ja/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/ja/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "ディスク"
 msgid "Enable"
 msgstr "有効"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "アイドル時間"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "アイドル時間 (単位)"
 
 msgid "Settings"
@@ -32,14 +32,14 @@ msgstr "設定"
 msgid "h"
 msgstr "時"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idleはアイドル時に外部ディスクをスピンダウンさせるための、ユーティリティプ"
+"HDD Idleはアイドル時に外部ディスクをスピンダウンさせるための、ユーティリティプ"
 "ログラムです。"
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/ms/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/ms/hd_idle.po
@@ -18,10 +18,10 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr ""
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr ""
 
 msgid "Settings"
@@ -31,11 +31,11 @@ msgstr ""
 msgid "h"
 msgstr ""
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr ""
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
 

--- a/applications/luci-app-hd-idle/po/no/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/no/hd_idle.po
@@ -10,10 +10,10 @@ msgstr "Disk"
 msgid "Enable"
 msgstr "Aktiver"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Tid inaktiv"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Tidsenhet"
 
 msgid "Settings"
@@ -22,14 +22,14 @@ msgstr "Innstillinger"
 msgid "h"
 msgstr "timer"
 
-msgid "hd-idle"
-msgstr "Hd-Idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle er et verktøy for å spinne ned eksterne disker etter en periode med "
+"HDD Idle er et verktøy for å spinne ned eksterne disker etter en periode med "
 "inaktivitet."
 
 msgid "min"

--- a/applications/luci-app-hd-idle/po/pl/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/pl/hd_idle.po
@@ -20,10 +20,10 @@ msgstr "Dysk"
 msgid "Enable"
 msgstr "Włącz"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Czas bezczynności"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Jednostka czasu bezczynności"
 
 msgid "Settings"
@@ -33,14 +33,14 @@ msgstr "Ustawienia"
 msgid "h"
 msgstr "godz."
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle jest narzędziem do zwalniania obrotów zewnętrznych dysków po "
+"HDD Idle jest narzędziem do zwalniania obrotów zewnętrznych dysków po "
 "określonym czasie bezczynności."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/pt-br/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/pt-br/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "Disco"
 msgid "Enable"
 msgstr "Habilitar"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Tempo de ociosidade"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Unidade do tempo da ociosidade"
 
 msgid "Settings"
@@ -32,14 +32,14 @@ msgstr "Configurações"
 msgid "h"
 msgstr "horas"
 
-msgid "hd-idle"
-msgstr "Hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"Hd-idle é um programa utilitário para ativar o modo \"economia de energia"
+"HDD Idle é um programa utilitário para ativar o modo \"economia de energia"
 "\" (spinning-down) de discos externos após um período de ociosidade."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/pt/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/pt/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "Disco"
 msgid "Enable"
 msgstr "Ativar"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Tempo de ociosidade"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Unidade de tempo de ociosidade"
 
 msgid "Settings"
@@ -32,14 +32,14 @@ msgstr "Configurações"
 msgid "h"
 msgstr "h"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle é um programa utilitário para activar o modo \"economia de energia"
+"HDD Idle é um programa utilitário para activar o modo \"economia de energia"
 "\" (spinning-down) de discos externos após um período de ociosidade."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/ro/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/ro/hd_idle.po
@@ -22,10 +22,10 @@ msgstr "Disc"
 msgid "Enable"
 msgstr "Activeaza"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Timp de inactivitate"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Unitatea de timp pentru masurarea inactivitatii"
 
 msgid "Settings"
@@ -35,14 +35,14 @@ msgstr "Setari"
 msgid "h"
 msgstr "ore"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle este un utilitar pentru a oprit din rotatie hard disc-urile externe "
+"HDD Idle este un utilitar pentru a oprit din rotatie hard disc-urile externe "
 "dupa o anumita perioada de inactivitate."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/ru/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/ru/hd_idle.po
@@ -21,10 +21,10 @@ msgstr "Диск"
 msgid "Enable"
 msgstr "Включить"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Время бездействия"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Единицы времени бездействия"
 
 msgid "Settings"
@@ -34,14 +34,14 @@ msgstr "Настройки"
 msgid "h"
 msgstr "ч"
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"Утилита hd-idle позволяет замедлять внешние диски после определённого "
+"Утилита HDD Idle позволяет замедлять внешние диски после определённого "
 "времени бездействия."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/sk/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/sk/hd_idle.po
@@ -14,10 +14,10 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr ""
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr ""
 
 msgid "Settings"
@@ -26,11 +26,11 @@ msgstr ""
 msgid "h"
 msgstr ""
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr ""
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
 

--- a/applications/luci-app-hd-idle/po/sv/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/sv/hd_idle.po
@@ -15,10 +15,10 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr ""
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr ""
 
 msgid "Settings"
@@ -27,11 +27,11 @@ msgstr ""
 msgid "h"
 msgstr ""
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr ""
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
 

--- a/applications/luci-app-hd-idle/po/templates/hd_idle.pot
+++ b/applications/luci-app-hd-idle/po/templates/hd_idle.pot
@@ -7,10 +7,10 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr ""
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr ""
 
 msgid "Settings"
@@ -19,11 +19,11 @@ msgstr ""
 msgid "h"
 msgstr ""
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr ""
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
 

--- a/applications/luci-app-hd-idle/po/tr/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/tr/hd_idle.po
@@ -21,10 +21,10 @@ msgstr "Disk"
 msgid "Enable"
 msgstr "Kullanıma Aç"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Bekleme Zamanı"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "bekleme zamanı birimi"
 
 msgid "Settings"
@@ -34,11 +34,11 @@ msgstr "Ayarlar"
 msgid "h"
 msgstr "s"
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr "Harddisk-Park"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
 "Harddisk-Park belirli bir zaman sonra diskleri beklemeye alan bir yardımcı "

--- a/applications/luci-app-hd-idle/po/uk/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/uk/hd_idle.po
@@ -22,10 +22,10 @@ msgstr "Диск"
 msgid "Enable"
 msgstr "Активувати"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Час простою"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr ""
 
 msgid "Settings"
@@ -36,11 +36,11 @@ msgid "h"
 msgstr ""
 
 #, fuzzy
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr "HD-простій"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
 

--- a/applications/luci-app-hd-idle/po/vi/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/vi/hd_idle.po
@@ -21,11 +21,11 @@ msgid "Enable"
 msgstr "Kích hoạt debug"
 
 #, fuzzy
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "Thời gian Idle"
 
 #, fuzzy
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "Đơn vị thời gian Idle"
 
 msgid "Settings"
@@ -35,14 +35,14 @@ msgstr "Sắp đặt"
 msgid "h"
 msgstr ""
 
-msgid "hd-idle"
-msgstr "hd-idle"
+msgid "HDD Idle"
+msgstr "HDD Idle"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr ""
-"hd-idle là một chương trình tiện ích để quay các đĩa ngoài sau một khoảng "
+"HDD Idle là một chương trình tiện ích để quay các đĩa ngoài sau một khoảng "
 "thời gian idle."
 
 # Minutes (not minimum)

--- a/applications/luci-app-hd-idle/po/zh-cn/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/zh-cn/hd_idle.po
@@ -19,10 +19,10 @@ msgstr "硬盘"
 msgid "Enable"
 msgstr "开启"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "空闲时间"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "空闲时间单位"
 
 msgid "Settings"
@@ -32,11 +32,11 @@ msgstr "设置"
 msgid "h"
 msgstr "小时"
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr "硬盘休眠"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr "硬盘休眠是一个让硬盘在空闲一段时间后休眠的工具"
 

--- a/applications/luci-app-hd-idle/po/zh-tw/hd_idle.po
+++ b/applications/luci-app-hd-idle/po/zh-tw/hd_idle.po
@@ -17,10 +17,10 @@ msgstr "磁碟"
 msgid "Enable"
 msgstr "啟用"
 
-msgid "Idle-time"
+msgid "Idle time"
 msgstr "休眠時間"
 
-msgid "Idle-time unit"
+msgid "Idle time unit"
 msgstr "休眠時間單位"
 
 msgid "Settings"
@@ -29,11 +29,11 @@ msgstr "設定"
 msgid "h"
 msgstr "小時"
 
-msgid "hd-idle"
+msgid "HDD Idle"
 msgstr "硬碟休眠"
 
 msgid ""
-"hd-idle is a utility program for spinning-down external disks after a period "
+"HDD Idle is a utility program for spinning-down external disks after a period "
 "of idle time."
 msgstr "硬碟休眠是控制當硬碟閒置一段時間後進入休眠模式的工具"
 


### PR DESCRIPTION
The menu item and some text on the configuration page itself do not match the other pages. Now words in the menu are upper-cased and the dashes removed in the labels.

Fixes #1138 