### PR TITLE
luci-mod-admin-full: "isolate" option is missing for mac80211

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -461,6 +461,11 @@ if hwtype == "mac80211" then
 	wmm:depends({mode="ap-wds"})
 	wmm.default = wmm.enabled
 	
+	isolate = s:taboption("advanced", Flag, "isolate", translate("Isolate Clients"),
+	 translate("Prevents client-to-client communication"))
+	isolate:depends({mode="ap"})
+	isolate:depends({mode="ap-wds"})
+
 	ifname = s:taboption("advanced", Value, "ifname", translate("Interface name"), translate("Override default interface name"))
 	ifname.optional = true
 end


### PR DESCRIPTION
Not sure why, but the "isolate" option is only available for broadcom, but it works for mac80211 (tested in Netgear R7800). This commit makes it available in LUCI.
I suspect it is available for other chip sets as well, because this should be standard functionality...