### PR TITLE
luci-mod-admin-full,luci-theme-material: support for cached mem 

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -567,6 +567,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Ús de CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Cancel·la"
 

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -566,6 +566,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Vytížení CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Storno"
 

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -568,6 +568,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "CPU-Nutzung (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Abbrechen"
 

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -575,6 +575,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Χρήση CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Ακύρωση"
 

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -564,6 +564,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "CPU usage (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Cancel"
 

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -571,6 +571,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Uso de CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Cancelar"
 

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -576,6 +576,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Utilisation CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Annuler"
 

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -566,6 +566,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "שימוש מעבד (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "בטל"
 

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -570,6 +570,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Processzor használat (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Mégsem"
 

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -576,6 +576,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Uso CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Annulla"
 

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -569,6 +569,9 @@ msgstr "CA証明書（空白の場合、初回の接続後に保存されます�
 msgid "CPU usage (%)"
 msgstr "CPU使用率 (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "キャンセル"
 

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -560,6 +560,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "CPU 사용량 (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr ""
 

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -550,6 +550,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Penggunaan CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Batal"
 

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -562,6 +562,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "CPU forbruk (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Avbryt"
 

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -579,6 +579,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Użycie CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Anuluj"
 

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -611,6 +611,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Uso da CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Cancelar"
 

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -575,6 +575,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Uso da CPU (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Cancelar"
 

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -558,6 +558,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Utilizarea procesorului (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Anuleaza"
 

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -575,6 +575,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Загрузка ЦП (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Отменить"
 

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -544,6 +544,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr ""
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr ""
 

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -550,6 +550,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr ""
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr ""
 

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -537,6 +537,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr ""
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr ""
 

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -557,6 +557,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr ""
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr ""
 

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -584,6 +584,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "Завантаження ЦП, %"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Скасувати"
 

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -551,6 +551,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "CPU usage (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "Bỏ qua"
 

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -557,6 +557,9 @@ msgstr "CA 证书，如果留空的话证书将在第一次连接时被保存。
 msgid "CPU usage (%)"
 msgstr "CPU 使用率 (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "取消"
 

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -556,6 +556,9 @@ msgstr ""
 msgid "CPU usage (%)"
 msgstr "CPU 使用率 (%)"
 
+msgid "Cached"
+msgstr ""
+
 msgid "Cancel"
 msgstr "取消"
 

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -30,6 +30,9 @@
 		free = 0
 	}
 
+	local procmeminfo = fs.readfile("/proc/meminfo")
+	local cacheinfo = 1024 * tonumber(procmeminfo:match("Cached:%s+([0-9]+)%s+")) or 0
+
 	local has_dsl = fs.access("/etc/init.d/dsl_control")
 
 	if luci.http.formvalue("status") == "1" then
@@ -51,6 +54,7 @@
 			loadavg    = sysinfo.load or { 0, 0, 0 },
 			memory     = meminfo,
 			swap       = swapinfo,
+			cached     = cacheinfo,
 			connmax    = conn_max,
 			conncount  = conn_count,
 			leases     = stat.dhcp_leases(),
@@ -639,7 +643,13 @@
 
 			if (e = document.getElementById('memtotal'))
 				e.innerHTML = progressbar(
-					((info.memory.free + info.memory.buffered) / 1024) + " <%:kB%>",
+					((info.memory.free + info.memory.buffered + info.cached) / 1024) + " <%:kB%>",
+					(info.memory.total / 1024) + " <%:kB%>"
+				);
+
+			if (e = document.getElementById('memcache'))
+				e.innerHTML = progressbar(
+					(info.cached / 1024) + " <%:kB%>",
 					(info.memory.total / 1024) + " <%:kB%>"
 				);
 
@@ -698,6 +708,7 @@
 
 	<table width="100%" cellspacing="10">
 		<tr><td width="33%"><%:Total Available%></td><td id="memtotal">-</td></tr>
+		<tr><td width="33%"><%:Cached%></td><td id="memcache">-</td></tr>
 		<tr><td width="33%"><%:Free%></td><td id="memfree">-</td></tr>
 		<tr><td width="33%"><%:Buffered%></td><td id="membuff">-</td></tr>
 	</table>

--- a/themes/luci-theme-material/htdocs/luci-static/material/css/style.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/css/style.css
@@ -487,6 +487,7 @@ fieldset > table > tbody > tr:nth-of-type(2n) {
 #swaptotal > div,
 #swapfree > div,
 #memfree > div,
+#memcache > div,
 #membuff > div,
 #conns > div,
 #memtotal > div {
@@ -497,6 +498,7 @@ fieldset > table > tbody > tr:nth-of-type(2n) {
 #swaptotal > div > div,
 #swapfree > div > div,
 #memfree > div > div,
+#memcache > div > div,
 #membuff > div > div,
 #conns > div > div,
 #memtotal > div > div {


### PR DESCRIPTION
Fixes #1148 

I have gone ahead and implemented a fix for the total available memory calculations on the status page and it is only one additional string parsing operation. The page is now displaying proper values as per below. 

Memory
 Total Available	371028 kB / 479620 kB (77%)
 Cached	301992 kB / 479620 kB (62%)
 Free	62048 kB / 479620 kB (12%)
 Buffered	6988 kB / 479620 kB (1%)

The Status page was ignoring the amount of cached memory in calculations
and that resulted in wrong "Total Avalable" memory. sysinfo is not returning
cached memory, so getting it from /proc/meminfo

