### PR TITLE
luci-app-openvpn: fix proto param selection in basic

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua
@@ -24,7 +24,7 @@ local basicParams = {
 	{ ListValue,"comp_lzo",{"yes","no","adaptive"}, translate("Use fast LZO compression") },
 	{ Value,"keepalive","10 60", translate("Helper directive to simplify the expression of --ping and --ping-restart in server mode configurations") },
 
-	{ ListValue,"proto",{ "udp", "udp6", "tcp", "tcp6" }, translate("Use protocol") },
+	{ ListValue,"proto",{ "udp", "tcp-client", "tcp-server" }, translate("Use protocol") },
 
 	{ Flag,"client",0, translate("Configure client mode") },
 	{ Flag,"client_to_client",0, translate("Allow client-to-client traffic") },


### PR DESCRIPTION
Modified `proto` Parameter values to match extended `config` view.
Accepted values for proto are udp, tcp-server and tcp-client as written in openvpn 2.4 manual
https://community.openvpn.net/openvpn/wiki/Openvpn24ManPage

Bug description:
If you select in advanced view tcp-server/tcp-client and switch to basic-view then the param is set to `--delete` because the values tcp-server/tcp-client are unknown

Signed-off-by: Florian Eckert <fe@dev.tdt.de>