### PR TITLE
luci-app-adblock: sync with adblock 2.6.3

### DIFF
--- a/applications/luci-app-adblock/luasrc/controller/adblock.lua
+++ b/applications/luci-app-adblock/luasrc/controller/adblock.lua
@@ -13,7 +13,7 @@ function index()
 		return
 	end
 	entry({"admin", "services", "adblock"}, firstchild(), _("Adblock"), 30).dependent = false
-	entry({"admin", "services", "adblock", "tab_from_cbi"}, cbi("adblock/overview_tab"), _("Overview"), 10).leaf = true
+	entry({"admin", "services", "adblock", "tab_from_cbi"}, cbi("adblock/overview_tab", {hideresetbtn=true, hidesavebtn=true}), _("Overview"), 10).leaf = true
 	entry({"admin", "services", "adblock", "logfile"}, call("logread"), _("View Logfile"), 20).leaf = true
 	entry({"admin", "services", "adblock", "advanced"}, firstchild(), _("Advanced"), 100)
 	entry({"admin", "services", "adblock", "advanced", "blacklist"}, cbi("adblock/blacklist_tab"), _("Edit Blacklist"), 110).leaf = true

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
@@ -7,7 +7,19 @@ local uci = require("uci")
 local adbinput = uci.get("adblock", "blacklist", "adb_src" or "/etc/adblock/adblock.blacklist")
 
 if not nixio.fs.access(adbinput) then
-	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
+	m = SimpleForm("error", nil,
+		translate("Input file not found. Please check your configuration."))
+	m.reset = false
+	m.submit = false
+	return m
+end
+
+if nixio.fs.stat(adbinput).size > 524288 then
+	m = SimpleForm("error", nil,
+		translate("The file size is too large for online editing in LuCI (&gt; 512 KB). ")
+		.. translate("Please edit this file directly in a terminal session."))
+	m.reset = false
+	m.submit = false
 	return m
 end
 

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/configuration_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/configuration_tab.lua
@@ -7,6 +7,8 @@ local adbinput = "/etc/config/adblock"
 
 if not nixio.fs.access(adbinput) then
 	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
+	m.reset = false
+	m.submit = false
 	return m
 end
 

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
@@ -12,12 +12,14 @@ local dnsFile2 = sys.exec("find '/var/lib/unbound/.adb_hidden' -maxdepth 1 -type
 
 m = Map("adblock", translate("Adblock"),
 	translate("Configuration of the adblock package to block ad/abuse domains by using DNS. ")
-	.. translate("For further information ")
-	.. [[<a href="https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md" target="_blank">]]
-	.. translate("see online documentation")
-	.. [[</a>]]
-	.. translate("."))
-m.reset = false
+	.. translatef("For further information "
+	.. "<a href=\"%s\" target=\"_blank\">"
+	.. "see online documentation</a>", "https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md"))
+
+function m.on_after_commit(self)
+	luci.sys.call("/etc/init.d/adblock reload >/dev/null 2>&1")
+	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "adblock"))
+end
 
 -- Main adblock options
 
@@ -34,6 +36,7 @@ if dnsFile1 ~= "" or dnsFile2 ~= "" then
 	btn.disabled = false
 	function btn.write()
 		luci.sys.call("/etc/init.d/adblock resume >/dev/null 2>&1")
+		luci.http.redirect(luci.dispatcher.build_url("admin", "services", "adblock"))
 	end
 else
 	btn.inputtitle = translate("Suspend adblock")
@@ -41,6 +44,7 @@ else
 	btn.disabled = false
 	function btn.write()
 		luci.sys.call("/etc/init.d/adblock suspend >/dev/null 2>&1")
+		luci.http.redirect(luci.dispatcher.build_url("admin", "services", "adblock"))
 	end
 end
 

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/whitelist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/whitelist_tab.lua
@@ -8,6 +8,17 @@ local adbinput = uci.get("adblock", "global", "adb_whitelist") or "/etc/adblock/
 
 if not nixio.fs.access(adbinput) then
 	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
+	m.reset = false
+	m.submit = false
+	return m
+end
+
+if nixio.fs.stat(adbinput).size > 524288 then
+	m = SimpleForm("error", nil,
+	translate("The file size is too large for online editing in LuCI (&gt; 512 KB). ")
+	.. translate("Please edit this file directly in a terminal session."))
+	m.reset = false
+	m.submit = false
 	return m
 end
 


### PR DESCRIPTION
* Limit Blacklist/Whitelist Online editing to max. 512 KB, approx.
20.000 domains per list
* Automatically refresh the overview page after button onclick event,
e.g. 'Suspend/Resume' or 'Save & Apply'
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>