### PR TITLE
luci.mk: Update language name for Chinese

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -36,7 +36,7 @@ LUCI_LANG.sv=Svenska (Swedish)
 LUCI_LANG.tr=Türkçe (Turkish)
 LUCI_LANG.uk=украї́нська (Ukrainian)
 LUCI_LANG.vi=Tiếng Việt (Vietnamese)
-LUCI_LANG.zh-cn=普通话 (Chinese)
+LUCI_LANG.zh-cn=中文 (Chinese)
 LUCI_LANG.zh-tw=臺灣華語 (Taiwanese)
 
 # Submenu titles


### PR DESCRIPTION
Rectification of non-standard name for language Chinese.
Signed-off-by: Angus Ding angus.ding@gmail.com