### PR TITLE
luci-app-adblock: Fix duplicated text

### DIFF
--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
@@ -8,7 +8,7 @@ local adbinput = uci.get("adblock", "blacklist", "adb_src" or "/etc/adblock/adbl
 
 if not nixio.fs.access(adbinput) then
 	m = SimpleForm("error", nil,
-		translate("Input file not found. Please check your configuration."))
+		translate("Input file not found, please check your configuration."))
 	m.reset = false
 	m.submit = false
 	return m

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -111,9 +111,6 @@ msgstr "ローカル DNS の強制"
 msgid "Input file not found, please check your configuration."
 msgstr "入力ファイルが見つかりません。設定を確認してください。"
 
-msgid "Input file not found. Please check your configuration."
-msgstr ""
-
 msgid "Invalid domain specified!"
 msgstr "無効なドメインが指定されています！"
 

--- a/applications/luci-app-adblock/po/pt-br/adblock.po
+++ b/applications/luci-app-adblock/po/pt-br/adblock.po
@@ -108,9 +108,6 @@ msgstr ""
 msgid "Input file not found, please check your configuration."
 msgstr ""
 
-msgid "Input file not found. Please check your configuration."
-msgstr ""
-
 msgid "Invalid domain specified!"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -55,7 +55,7 @@ msgid "Edit Blacklist"
 msgstr "Redigera svartlista"
 
 msgid "Edit Configuration"
-msgstr Redigerar konfigurationen""
+msgstr "Redigerar konfigurationen"
 
 msgid "Edit Whitelist"
 msgstr "Redigera vitlista"

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -1,9 +1,6 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8\n"
 
-msgid "."
-msgstr "."
-
 msgid "Adblock"
 msgstr "Adblock"
 
@@ -40,7 +37,8 @@ msgstr "Samlar in data..."
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS."
 msgstr ""
-"Konfiguration av paketet adblock för att blockera annons/otillåtna domäner genom att använda DNS."
+"Konfiguration av paketet adblock för att blockera annons/otillåtna domäner "
+"genom att använda DNS."
 
 msgid "DNS backend"
 msgstr "Bakände för DNS"
@@ -85,8 +83,10 @@ msgid ""
 "'libustream-ssl' or the wget 'built-in'."
 msgstr ""
 
-msgid "For further information"
-msgstr "För mer information"
+msgid ""
+"For further information <a href=\"%s\" target=\"_blank\">see online "
+"documentation</a>"
+msgstr ""
 
 msgid "Force Overall Sort"
 msgstr ""
@@ -95,7 +95,8 @@ msgid "Force local DNS"
 msgstr "Tvinga lokal DNS"
 
 msgid "Input file not found, please check your configuration."
-msgstr "Inmatningsfilen hittades inte, var vänlig och kontrollera din konfiguration."
+msgstr ""
+"Inmatningsfilen hittades inte, var vänlig och kontrollera din konfiguration."
 
 msgid "Invalid domain specified!"
 msgstr "Ogiltig domän angiven!"
@@ -124,6 +125,9 @@ msgstr "Översikt"
 msgid ""
 "Please add only one domain per line. Comments introduced with '#' are "
 "allowed - ip addresses, wildcards and regex are not."
+msgstr ""
+
+msgid "Please edit this file directly in a terminal session."
 msgstr ""
 
 msgid "Query"
@@ -160,6 +164,9 @@ msgstr "Upphäv / Återuppta adblock"
 
 msgid "Suspend adblock"
 msgstr "Upphäv adblock"
+
+msgid "The file size is too large for online editing in LuCI (&gt; 512 KB)."
+msgstr ""
 
 msgid ""
 "This form allows you to modify the content of the adblock blacklist (%s)."
@@ -207,11 +214,14 @@ msgstr "n/a"
 msgid "no domains blocked"
 msgstr "inga domäner blockerades"
 
-msgid "see online documentation"
-msgstr ""
-
 msgid "suspended"
 msgstr "upphävd"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "For further information"
+#~ msgstr "För mer information"
 
 #~ msgid "Backup options"
 #~ msgstr "Alternativ för säkerhetskopiering"

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -95,9 +95,6 @@ msgstr ""
 msgid "Input file not found, please check your configuration."
 msgstr ""
 
-msgid "Input file not found. Please check your configuration."
-msgstr ""
-
 msgid "Invalid domain specified!"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/zh-cn/adblock.po
+++ b/applications/luci-app-adblock/po/zh-cn/adblock.po
@@ -107,9 +107,6 @@ msgstr ""
 msgid "Input file not found, please check your configuration."
 msgstr ""
 
-msgid "Input file not found. Please check your configuration."
-msgstr ""
-
 msgid "Invalid domain specified!"
 msgstr "无效域名！"
 


### PR DESCRIPTION
Fixed some issues.

- Fix duplicated text in Lua source.

- Fix syntax error in sv/adblock.po

And synchronized translations.
