### PR TITLE
wireguard: preshared-key is now an attribute of the peer

### DIFF
--- a/applications/luci-app-wireguard/luasrc/view/wireguard.htm
+++ b/applications/luci-app-wireguard/luasrc/view/wireguard.htm
@@ -17,22 +17,22 @@
         data[line[1]] = {
           name                 = line[1],
           public_key           = line[3],
-          listen_port          = line[5],
-          fwmark               = line[6],
+          listen_port          = line[4],
+          fwmark               = line[5],
           peers                = { }
         }
       else
         local peer = {
           public_key           = line[2],
-          endpoint             = line[3],
+          endpoint             = line[4],
           allowed_ips          = { },
-          latest_handshake     = line[5],
-          transfer_rx          = line[6],
-          transfer_tx          = line[7],
-          persistent_keepalive = line[8]
+          latest_handshake     = line[6],
+          transfer_rx          = line[7],
+          transfer_tx          = line[8],
+          persistent_keepalive = line[9]
         }
         if not (line[4] == '(none)') then
-          for ipkey, ipvalue in pairs(string.split(line[4], ",")) do
+          for ipkey, ipvalue in pairs(string.split(line[5], ",")) do
             if #ipvalue > 0 then
               table.insert(peer['allowed_ips'], ipvalue)
             end

--- a/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
+++ b/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
@@ -70,21 +70,6 @@ mtu.datatype = "range(1280,1420)"
 mtu.placeholder = "1420"
 mtu.optional = true
 
-
-preshared_key = section:taboption(
-  "advanced",
-  Value,
-  "preshared_key",
-  translate("Preshared Key"),
-  translate("Optional. Base64-encoded preshared key. " ..
-            "Adds in an additional layer of symmetric-key " ..
-            "cryptography for post-quantum resistance.")
-)
-preshared_key.password = true
-preshared_key.datatype = "and(base64,rangelength(44,44))"
-preshared_key.optional = true
-
-
 fwmark = section:taboption(
   "advanced",
   Value,
@@ -119,6 +104,19 @@ public_key = peers:option(
 )
 public_key.datatype = "and(base64,rangelength(44,44))"
 public_key.optional = false
+
+
+preshared_key = peers:option(
+  Value,
+  "preshared_key",
+  translate("Preshared Key"),
+  translate("Optional. Base64-encoded preshared key. " ..
+            "Adds in an additional layer of symmetric-key " ..
+            "cryptography for post-quantum resistance.")
+)
+preshared_key.password = true
+preshared_key.datatype = "and(base64,rangelength(44,44))"
+preshared_key.optional = true
 
 
 allowed_ips = peers:option(


### PR DESCRIPTION
Maintainer: @danrl 

This should only be merged when openwrt/packages#4341 is also merged.