### PR TITLE
luci-app-travelmate: sync with travelmate 0.7.3

### DIFF
--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
@@ -16,6 +16,11 @@ m = Map("travelmate", translate("Travelmate"),
 	.. "<a href=\"%s\" target=\"_blank\">"
 	.. "see online documentation</a>", "https://github.com/openwrt/packages/blob/master/net/travelmate/files/README.md"))
 
+function m.on_after_commit(self)
+	luci.sys.call("/etc/init.d/travelmate restart >/dev/null 2>&1")
+	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "travelmate"))
+end
+
 -- Main travelmate options
 
 s = m:section(NamedSection, "global", "travelmate")


### PR DESCRIPTION
* Automatically refresh the overview page after button onclick event,
e.g. 'Save & Apply'

Signed-off-by: Dirk Brenken <dev@brenken.org>