### PR TITLE
luci-app-mwan3: Fix "ip" command path

### DIFF
--- a/applications/luci-app-mwan3/luasrc/controller/mwan3.lua
+++ b/applications/luci-app-mwan3/luasrc/controller/mwan3.lua
@@ -3,7 +3,7 @@ module("luci.controller.mwan3", package.seeall)
 sys = require "luci.sys"
 ut = require "luci.util"
 
-ip = "/usr/bin/ip -4 "
+ip = "ip -4 "
 
 function index()
 	if not nixio.fs.access("/etc/config/mwan3") then


### PR DESCRIPTION
Fixed an issue that mwan3 fails to detect connection because "ip"
command was relocated.

This issue has been reported in #1166 .

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>