### PR TITLE
luci-proto-wireguard: make PSK a per-peer option

### DIFF
--- a/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
+++ b/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
@@ -71,20 +71,6 @@ mtu.placeholder = "1420"
 mtu.optional = true
 
 
-preshared_key = section:taboption(
-  "advanced",
-  Value,
-  "preshared_key",
-  translate("Preshared Key"),
-  translate("Optional. Base64-encoded preshared key. " ..
-            "Adds in an additional layer of symmetric-key " ..
-            "cryptography for post-quantum resistance.")
-)
-preshared_key.password = true
-preshared_key.datatype = "and(base64,rangelength(44,44))"
-preshared_key.optional = true
-
-
 fwmark = section:taboption(
   "advanced",
   Value,
@@ -119,6 +105,18 @@ public_key = peers:option(
 )
 public_key.datatype = "and(base64,rangelength(44,44))"
 public_key.optional = false
+
+
+preshared_key = peers:option(
+  Value,
+  "preshared_key",
+  translate("Preshared Key"),
+  translate("Optional. Base64-encoded preshared key. " ..
+            "Adds in an additional layer of symmetric-key " ..
+            "cryptography for post-quantum resistance.")
+)
+preshared_key.password = true
+preshared_key.datatype = "and(base64,rangelength(44,44))"
 
 
 allowed_ips = peers:option(


### PR DESCRIPTION
This reflects the latest changes of the wireguard package.

Signed-off-by: Dan Luedtke <mail@danrl.com>

See https://github.com/openwrt/packages/pull/4341