### PR TITLE
fix all graphs missing

### DIFF
--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -401,7 +401,7 @@ plugins = {
 
 	rrdtool	= {
 		{ "DataDir", "StepSize", "HeartBeat", "RRARows", "XFF", "CacheFlush", "CacheTimeout" },
-		{ "RRASingle" },
+		{ "RRASingle", "RRAMax" },
 		{ "RRATimespans" }
 	},
 


### PR DESCRIPTION
When both RRDTool's 'Only create average RRAs' and 'Show max values instead of averages' are changed at once (single to false and max to true), no graphs are rendered after restart due to 'RRAMax true' missing in '/etc/collectd.conf' and 'ERROR: the RRD does not contain an RRA matching the chosen CF' being logged