### PR TITLE
luci-base: relieve langage ja_JP, ja_.., on auto setting.

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -206,6 +206,12 @@ function dispatch(request)
 			if conf.languages[lpat] then
 				lang = lpat
 				break
+			else
+				lpat = lpat and lpat:gsub("_.*", "")
+				if conf.languages[lpat] then
+					lang = lpat
+					break
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Rescue cases that can not be rescue by automatic language selection.
example ja_JP.
ja_JP is mismatch, 1st try "ja_JP", next try "ja".

Signed-off-by: YuheiOKAWA <tochiro.srchack@gmail.com>