### PR TITLE
luci-mod-admin-full: auto-migrate ifnames when changing VLAN configuration

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -419,9 +419,6 @@ msgstr "Estacions associades"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Autenticació"
 
@@ -1449,6 +1446,9 @@ msgstr "Longitud de prefix IPv6"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "Adreça IPv6"
 
@@ -1554,6 +1554,9 @@ msgstr "Paquets instal·lats"
 
 msgid "Interface"
 msgstr "Interfície"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Configuració d'interfície"
@@ -1679,9 +1682,6 @@ msgstr "Duració de validitat d'arrendament"
 
 msgid "Leasefile"
 msgstr "Fitxer d'arrendament"
-
-msgid "Leasetime"
-msgstr "Duració d'arrendament"
 
 msgid "Leasetime remaining"
 msgstr "Duració d'arrendament restant"
@@ -2184,12 +2184,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3668,10 +3672,6 @@ msgstr "qualsevol"
 msgid "auto"
 msgstr "auto"
 
-#, fuzzy
-msgid "automatic"
-msgstr "estàtic"
-
 msgid "baseT"
 msgstr ""
 
@@ -3748,9 +3748,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "no"
 
@@ -3782,12 +3779,6 @@ msgid "routed"
 msgstr "encaminat"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3825,6 +3816,13 @@ msgstr "sí"
 
 msgid "« Back"
 msgstr "« Enrere"
+
+#~ msgid "Leasetime"
+#~ msgstr "Duració d'arrendament"
+
+#, fuzzy
+#~ msgid "automatic"
+#~ msgstr "estàtic"
 
 #~ msgid "AR Support"
 #~ msgstr "Suport AR"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -419,9 +419,6 @@ msgstr "Připojení klienti"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Autentizace"
 
@@ -1460,6 +1457,9 @@ msgstr "Délka IPv6 prefixu"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6 adresa"
 
@@ -1565,6 +1565,9 @@ msgstr "Nainstalované balíčky"
 
 msgid "Interface"
 msgstr "Rozhraní"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Konfigurace rozhraní"
@@ -1692,9 +1695,6 @@ msgstr "Doba platnosti zápůjčky"
 
 msgid "Leasefile"
 msgstr "Soubor zájpůjček"
-
-msgid "Leasetime"
-msgstr "Doba trvání zápůjčky"
 
 msgid "Leasetime remaining"
 msgstr "Zbývající doba trvání zápůjčky"
@@ -2205,12 +2205,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3738,9 +3742,6 @@ msgstr "libovolný"
 msgid "auto"
 msgstr "auto"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3817,9 +3818,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "ne"
 
@@ -3851,12 +3849,6 @@ msgid "routed"
 msgstr "směrované"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3894,6 +3886,9 @@ msgstr "ano"
 
 msgid "« Back"
 msgstr "« Zpět"
+
+#~ msgid "Leasetime"
+#~ msgstr "Doba trvání zápůjčky"
 
 #~ msgid "AR Support"
 #~ msgstr "Podpora AR"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -38,13 +38,13 @@ msgid "-- custom --"
 msgstr "-- benutzerdefiniert --"
 
 msgid "-- match by device --"
-msgstr ""
+msgstr "-- anhand Gerätedatei selektieren --"
 
 msgid "-- match by label --"
-msgstr ""
+msgstr "-- anhand Label selektieren --"
 
 msgid "-- match by uuid --"
-msgstr ""
+msgstr "-- UUID vergleichen --"
 
 msgid "1 Minute Load:"
 msgstr "Systemlast (1 Minute):"
@@ -53,7 +53,7 @@ msgid "15 Minute Load:"
 msgstr "Systemlast (15 Minuten):"
 
 msgid "4-character hexadecimal ID"
-msgstr ""
+msgstr "vierstellige hexadezimale ID"
 
 msgid "464XLAT (CLAT)"
 msgstr ""
@@ -62,25 +62,25 @@ msgid "5 Minute Load:"
 msgstr "Systemlast (5 Minuten):"
 
 msgid "6-octet identifier as a hex string - no colons"
-msgstr ""
+msgstr "sechstellige hexadezimale ID (ohne Doppelpunkte)"
 
 msgid "802.11r Fast Transition"
 msgstr ""
 
 msgid "802.11w Association SA Query maximum timeout"
-msgstr ""
+msgstr "Maximales Timeout für Quelladressprüfungen (SA Query)"
 
 msgid "802.11w Association SA Query retry timeout"
-msgstr ""
+msgstr "Wiederholungsintervall für Quelladressprüfungen (SA Query)"
 
 msgid "802.11w Management Frame Protection"
-msgstr ""
+msgstr "802.11w: Schutz von Management-Frames aktivieren"
 
 msgid "802.11w maximum timeout"
-msgstr ""
+msgstr "802.11w: Maximales Timeout"
 
 msgid "802.11w retry timeout"
-msgstr ""
+msgstr "802.11w: Wiederholungsintervall"
 
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
@@ -119,7 +119,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Gateway"
 msgstr "IPv6-Gateway"
 
 msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
-msgstr ""
+msgstr "IPv6-Suffix (hexadezimal)"
 
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "LED Konfiguration"
@@ -312,7 +312,7 @@ msgstr ""
 "genutzt wird"
 
 msgid "Allowed IPs"
-msgstr ""
+msgstr "Erlaubte IP-Adressen"
 
 msgid ""
 "Also see <a href=\"https://www.sixxs.net/faq/connectivity/?faq=comparison"
@@ -320,7 +320,7 @@ msgid ""
 msgstr ""
 
 msgid "Always announce default router"
-msgstr ""
+msgstr "Immer Defaultrouter ankündigen"
 
 msgid "Annex"
 msgstr ""
@@ -341,7 +341,7 @@ msgid "Annex A G.992.5"
 msgstr ""
 
 msgid "Annex B (all)"
-msgstr ""
+msgstr "Annex B (alle Arten)"
 
 msgid "Annex B G.992.1"
 msgstr ""
@@ -353,13 +353,13 @@ msgid "Annex B G.992.5"
 msgstr ""
 
 msgid "Annex J (all)"
-msgstr ""
+msgstr "Annex J (alle Arten)"
 
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
 msgid "Annex M (all)"
-msgstr ""
+msgstr "Annex M (alle Arten)"
 
 msgid "Annex M G.992.3"
 msgstr ""
@@ -369,21 +369,23 @@ msgstr ""
 
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
+"Kündigt im Netzwerk einen Defaultrouter an, auch wenn kein öffentlicher "
+"Adressbereich verfügbar ist."
 
 msgid "Announced DNS domains"
-msgstr ""
+msgstr "Angekündigte Suchdomains"
 
 msgid "Announced DNS servers"
-msgstr ""
+msgstr "Angekündigte DNS Server"
 
 msgid "Anonymous Identity"
-msgstr ""
+msgstr "Anonyme Identität"
 
 msgid "Anonymous Mount"
-msgstr ""
+msgstr "automatische Mountpunkte"
 
 msgid "Anonymous Swap"
-msgstr ""
+msgstr "automatische Swap-Aktivierung"
 
 msgid "Antenna 1"
 msgstr "Antenne 1"
@@ -406,6 +408,8 @@ msgstr "Änderungen werden angewandt"
 msgid ""
 "Assign a part of given length of every public IPv6-prefix to this interface"
 msgstr ""
+"Legt die Größe der dieser Schnittstelle zugewiesenen Partitionen der "
+"öffentlichen IPv6-Präfixe fest."
 
 msgid "Assign interfaces..."
 msgstr "Schnittstellen zuweisen..."
@@ -413,21 +417,20 @@ msgstr "Schnittstellen zuweisen..."
 msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
+"Der Schnittstelle zugewiesene Partitionen des Adressraums werden anhand "
+"dieser hexadezimalen ID gewählt."
 
 msgid "Associated Stations"
 msgstr "Assoziierte Clients"
 
 msgid "Auth Group"
-msgstr ""
-
-msgid "AuthGroup"
-msgstr ""
+msgstr "Berechtigungsgruppe"
 
 msgid "Authentication"
 msgstr "Authentifizierung"
 
 msgid "Authentication Type"
-msgstr ""
+msgstr "Authentifizierungstyp"
 
 msgid "Authoritative"
 msgstr "Authoritativ"
@@ -439,25 +442,25 @@ msgid "Auto Refresh"
 msgstr "Automatisches Neuladen"
 
 msgid "Automatic"
-msgstr ""
+msgstr "automatisch"
 
 msgid "Automatic Homenet (HNCP)"
-msgstr ""
+msgstr "automatisches Homenet-Protokoll (HNCP)"
 
 msgid "Automatically check filesystem for errors before mounting"
-msgstr ""
+msgstr "Dateisystem vor dem Einhängen automatisch auf Fehler prüfen"
 
 msgid "Automatically mount filesystems on hotplug"
-msgstr ""
+msgstr "Unkonfigurierte Dateisysteme automatisch einhängen"
 
 msgid "Automatically mount swap on hotplug"
-msgstr ""
+msgstr "Unkonfigurierte SWAP-Partitionen automatisch aktivieren"
 
 msgid "Automount Filesystem"
-msgstr ""
+msgstr "Dateisystem automatisch einhängen"
 
 msgid "Automount Swap"
-msgstr ""
+msgstr "SWAP automatisch aktivieren"
 
 msgid "Available"
 msgstr "Verfügbar"
@@ -508,10 +511,10 @@ msgid "Bad address specified!"
 msgstr "Ungültige Adresse angegeben!"
 
 msgid "Band"
-msgstr ""
+msgstr "Frequenztyp"
 
 msgid "Behind NAT"
-msgstr ""
+msgstr "NAT"
 
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -524,13 +527,15 @@ msgstr ""
 "benutzerdefinierte Dateiemuster betroffenen Dateien enthalten."
 
 msgid "Bind interface"
-msgstr ""
+msgstr "An Schnittstelle binden"
 
 msgid "Bind only to specific interfaces rather than wildcard address."
 msgstr ""
+"Nur auf angegebenen Schnittstellen reagieren, anstatt auf allen "
+"Schnittstellen zu antworten."
 
 msgid "Bind the tunnel to this interface (optional)."
-msgstr ""
+msgstr "Tunnelendpunkt an diese Schnittstelle binden (optional)"
 
 msgid "Bitrate"
 msgstr "Bitrate"
@@ -563,12 +568,16 @@ msgid ""
 "Build/distribution specific feed definitions. This file will NOT be "
 "preserved in any sysupgrade."
 msgstr ""
+"Konfiguriert die distributionsspezifischen Paket-Repositories. Diese "
+"Konfiguration wird bei Upgrades NICHT gesichert."
 
 msgid "Buttons"
 msgstr "Knöpfe"
 
 msgid "CA certificate; if empty it will be saved after the first connection."
 msgstr ""
+"CA-Zertifikat (wird beim ersten Verbindungsaufbau automatisch gespeichert "
+"wenn leer). "
 
 msgid "CPU usage (%)"
 msgstr "CPU-Nutzung (%)"
@@ -577,7 +586,7 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 msgid "Category"
-msgstr ""
+msgstr "Kategorie"
 
 msgid "Chain"
 msgstr "Kette"
@@ -598,10 +607,11 @@ msgid "Check"
 msgstr "Prüfen"
 
 msgid "Check fileystems before mount"
-msgstr ""
+msgstr "Dateisysteme prüfen"
 
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
+"Diese Option setzen um existierende Netzwerke auf dem Radio zu löschen."
 
 msgid "Checksum"
 msgstr "Prüfsumme"
@@ -611,7 +621,11 @@ msgid ""
 "<em>unspecified</em> to remove the interface from the associated zone or "
 "fill out the <em>create</em> field to define a new zone and attach the "
 "interface to it."
-msgstr "Diese Schnittstelle gehört bis jetzt zu keiner Firewallzone."
+msgstr ""
+"Ordnet dieser Schnittstelle eine Firewallzone zu. Den Wert "
+"<em>unspezifiziert</em> wählen um die Schnittstelle von der Zone zu lösen "
+"oder das <em>erstellen</em> Feld ausfüllen um eine neue Zone direkt "
+"anzulegen und zuzuweisen."
 
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
@@ -624,7 +638,7 @@ msgid "Cipher"
 msgstr "Verschlüsselungsalgorithmus"
 
 msgid "Cisco UDP encapsulation"
-msgstr ""
+msgstr "Cisco UDP-Kapselung"
 
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
@@ -683,7 +697,7 @@ msgid "Connection Limit"
 msgstr "Verbindungslimit"
 
 msgid "Connection to server fails when TLS cannot be used"
-msgstr ""
+msgstr "TLS zwingend vorraussetzen und abbrechen wenn TLS fehlschlägt."
 
 msgid "Connections"
 msgstr "Verbindungen"
@@ -719,15 +733,17 @@ msgid "Custom Interface"
 msgstr "benutzerdefinierte Schnittstelle"
 
 msgid "Custom delegated IPv6-prefix"
-msgstr ""
+msgstr "Delegierter IPv6-Präfix"
 
 msgid ""
 "Custom feed definitions, e.g. private feeds. This file can be preserved in a "
 "sysupgrade."
 msgstr ""
+"Selbst konfigurierte Paket-Repositories, z.B. private oder inoffizielle "
+"Quellen. Diese Konfiguration wird by Upgrades gesichert."
 
 msgid "Custom feeds"
-msgstr ""
+msgstr "Eigene Repositories"
 
 msgid ""
 "Customizes the behaviour of the device <abbr title=\"Light Emitting Diode"
@@ -753,7 +769,7 @@ msgid "DHCPv6 Leases"
 msgstr "DHCPv6-Leases"
 
 msgid "DHCPv6 client"
-msgstr ""
+msgstr "DHCPv6 Client"
 
 msgid "DHCPv6-Mode"
 msgstr ""
@@ -774,13 +790,13 @@ msgid "DNSSEC"
 msgstr ""
 
 msgid "DNSSEC check unsigned"
-msgstr ""
+msgstr "DNSSEC Signaturstatus prüfen"
 
 msgid "DPD Idle Timeout"
-msgstr ""
+msgstr "DPD Inaktivitätstimeout"
 
 msgid "DS-Lite AFTR address"
-msgstr ""
+msgstr "DS-Lite AFTR-Adresse"
 
 msgid "DSL"
 msgstr ""
@@ -789,13 +805,13 @@ msgid "DSL Status"
 msgstr ""
 
 msgid "DSL line mode"
-msgstr ""
+msgstr "DSL Leitungsmodus"
 
 msgid "DUID"
 msgstr "DUID"
 
 msgid "Data Rate"
-msgstr ""
+msgstr "Datenrate"
 
 msgid "Debug"
 msgstr "Debug"
@@ -807,10 +823,10 @@ msgid "Default gateway"
 msgstr "Default Gateway"
 
 msgid "Default is stateless + stateful"
-msgstr ""
+msgstr "Der Standardwert ist zustandslos und zustandsorientiert"
 
 msgid "Default route"
-msgstr ""
+msgstr "Default Route"
 
 msgid "Default state"
 msgstr "Ausgangszustand"
@@ -848,16 +864,16 @@ msgid "Device Configuration"
 msgstr "Gerätekonfiguration"
 
 msgid "Device is rebooting..."
-msgstr ""
+msgstr "Das Gerät startet neu..."
 
 msgid "Device unreachable"
-msgstr ""
+msgstr "Das Gerät ist nicht erreichbar"
 
 msgid "Diagnostics"
 msgstr "Diagnosen"
 
 msgid "Dial number"
-msgstr ""
+msgstr "Einwahlnummer"
 
 msgid "Directory"
 msgstr "Verzeichnis"
@@ -882,7 +898,7 @@ msgid "Disabled"
 msgstr "Deaktiviert"
 
 msgid "Disabled (default)"
-msgstr ""
+msgstr "Deaktiviert (Standard)"
 
 msgid "Discard upstream RFC1918 responses"
 msgstr "Eingehende RFC1918-Antworten verwerfen"
@@ -897,7 +913,7 @@ msgid "Distance to farthest network member in meters."
 msgstr "Distanz zum am weitesten entfernten Funkpartner in Metern."
 
 msgid "Distribution feeds"
-msgstr ""
+msgstr "Distributionsrepositories"
 
 msgid "Diversity"
 msgstr "Diversität"
@@ -934,7 +950,7 @@ msgid "Domain whitelist"
 msgstr "Domain-Whitelist"
 
 msgid "Don't Fragment"
-msgstr ""
+msgstr "Nicht fragmentieren"
 
 msgid ""
 "Don't forward <abbr title=\"Domain Name System\">DNS</abbr>-Requests without "
@@ -974,7 +990,7 @@ msgstr ""
 "Clients mit konfigurierten statischen Leases bedient"
 
 msgid "EA-bits length"
-msgstr ""
+msgstr "EA-Bitlänge"
 
 msgid "EAP-Method"
 msgstr "EAP-Methode"
@@ -986,6 +1002,8 @@ msgid ""
 "Edit the raw configuration data above to fix any error and hit \"Save\" to "
 "reload the page."
 msgstr ""
+"Um die Syntaxfehler zu beheben, bitte die obige unformatierte Konfiguration "
+"anpassen und \"Speichern\" klicken um die Seite neu zu laden."
 
 msgid "Edit this interface"
 msgstr "Diese Schnittstelle bearbeiten"
@@ -1006,7 +1024,7 @@ msgid "Enable HE.net dynamic endpoint update"
 msgstr "Dynamisches HE.net IP-Adress-Update aktivieren"
 
 msgid "Enable IPv6 negotiation"
-msgstr ""
+msgstr "IPv6 anfordern"
 
 msgid "Enable IPv6 negotiation on the PPP link"
 msgstr "Aushandeln von IPv6-Adressen auf der PPP-Verbindung aktivieren"
@@ -1018,7 +1036,7 @@ msgid "Enable NTP client"
 msgstr "Aktiviere NTP-Client"
 
 msgid "Enable Single DES"
-msgstr ""
+msgstr "Single-DES aktivieren"
 
 msgid "Enable TFTP server"
 msgstr "TFTP-Server aktivieren"
@@ -1027,19 +1045,19 @@ msgid "Enable VLAN functionality"
 msgstr "VLAN-Funktionalität aktivieren"
 
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr ""
+msgstr "WPS-via-Knopfdruck aktivieren, erfordert WPA(2)-PSK"
 
 msgid "Enable learning and aging"
 msgstr "Learning und Aging aktivieren"
 
 msgid "Enable mirroring of incoming packets"
-msgstr ""
+msgstr "Port-Mirroring für eingehende Pakete aktivieren"
 
 msgid "Enable mirroring of outgoing packets"
-msgstr ""
+msgstr "Port-Mirroring für ausgehende Pakete aktivieren"
 
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
-msgstr ""
+msgstr "Das DF-Bit (Nicht fragmentieren) auf gekapselten Paketen setzen."
 
 msgid "Enable this mount"
 msgstr "Diesen Mountpunkt aktivieren"
@@ -1057,6 +1075,8 @@ msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
 msgstr ""
+"Aktiviert schnelles Roaming zwischen Access-Points des selben "
+"Mobilitätsbereiches"
 
 msgid "Enables the Spanning Tree Protocol on this bridge"
 msgstr "Aktiviert das Spanning Tree Protokoll auf dieser Netzwerkbrücke"
@@ -1068,10 +1088,10 @@ msgid "Encryption"
 msgstr "Verschlüsselung"
 
 msgid "Endpoint Host"
-msgstr ""
+msgstr "Entfernter Server"
 
 msgid "Endpoint Port"
-msgstr ""
+msgstr "Entfernter Port"
 
 msgid "Erasing..."
 msgstr "Lösche..."
@@ -1080,7 +1100,7 @@ msgid "Error"
 msgstr "Fehler"
 
 msgid "Errored seconds (ES)"
-msgstr ""
+msgstr "Fehlersekunden (ES)"
 
 msgid "Ethernet Adapter"
 msgstr "Netzwerkschnittstelle"
@@ -1089,7 +1109,7 @@ msgid "Ethernet Switch"
 msgstr "Netzwerk Switch"
 
 msgid "Exclude interfaces"
-msgstr ""
+msgstr "Schnittstellen ausschließen"
 
 msgid "Expand hosts"
 msgstr "Hosts vervollständigen"
@@ -1105,13 +1125,13 @@ msgstr ""
 "(<code>2m</code>)."
 
 msgid "External"
-msgstr ""
+msgstr "Extern"
 
 msgid "External R0 Key Holder List"
-msgstr ""
+msgstr "Externe R0-Key-Holder-List"
 
 msgid "External R1 Key Holder List"
-msgstr ""
+msgstr "Externe R1-Key-Holder-List"
 
 msgid "External system log server"
 msgstr "Externer Protokollserver IP"
@@ -1120,10 +1140,10 @@ msgid "External system log server port"
 msgstr "Externer Protokollserver Port"
 
 msgid "External system log server protocol"
-msgstr ""
+msgstr "Externes Protokollserver Protokoll"
 
 msgid "Extra SSH command options"
-msgstr ""
+msgstr "Zusätzliche SSH-Kommando-Optionen"
 
 msgid "File"
 msgstr "Datei"
@@ -1147,6 +1167,9 @@ msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
 msgstr ""
+"Findet alle angeschlossenen Dateisysteme und SWAP-Partitionen und generiert "
+"die Konfiguration mit passenden Standardwerten für alle gefundenen Geräte "
+"neu."
 
 msgid "Find and join network"
 msgstr "Suchen und Verbinden von Netzwerken"
@@ -1161,7 +1184,7 @@ msgid "Firewall"
 msgstr "Firewall"
 
 msgid "Firewall Mark"
-msgstr ""
+msgstr "Firewall-Markierung"
 
 msgid "Firewall Settings"
 msgstr "Firewall Einstellungen"
@@ -1170,7 +1193,7 @@ msgid "Firewall Status"
 msgstr "Firewall-Status"
 
 msgid "Firmware File"
-msgstr ""
+msgstr "Firmware-Datei"
 
 msgid "Firmware Version"
 msgstr "Firmware Version"
@@ -1214,16 +1237,16 @@ msgid "Force link"
 msgstr "Erzwinge Verbindung"
 
 msgid "Force use of NAT-T"
-msgstr ""
+msgstr "Benutzung von NAT-T erzwingen"
 
 msgid "Form token mismatch"
-msgstr ""
+msgstr "Abweichendes Formular-Token"
 
 msgid "Forward DHCP traffic"
 msgstr "DHCP Traffic weiterleiten"
 
 msgid "Forward Error Correction Seconds (FECS)"
-msgstr ""
+msgstr "Fehlerkorrektursekunden (FECS)"
 
 msgid "Forward broadcast traffic"
 msgstr "Broadcasts weiterleiten"
@@ -1247,6 +1270,8 @@ msgid ""
 "Further information about WireGuard interfaces and peers at <a href=\"http://"
 "wireguard.io\">wireguard.io</a>."
 msgstr ""
+"Weitere Informationen zu WireGuard-Schnittstellen und Peers unter <a href="
+"\"http://wireguard.io\">wireguard.io</a>."
 
 msgid "GHz"
 msgstr "GHz"
@@ -1267,10 +1292,10 @@ msgid "General Setup"
 msgstr "Allgemeine Einstellungen"
 
 msgid "General options for opkg"
-msgstr ""
+msgstr "Allgemeine Optionen für Opkg."
 
 msgid "Generate Config"
-msgstr ""
+msgstr "Konfiguration generieren"
 
 msgid "Generate archive"
 msgstr "Sicherung erstellen"
@@ -1284,10 +1309,10 @@ msgstr ""
 "nicht geändert!"
 
 msgid "Global Settings"
-msgstr ""
+msgstr "Globale Einstellungen"
 
 msgid "Global network options"
-msgstr ""
+msgstr "Globale Netzwerkeinstellungen"
 
 msgid "Go to password configuration..."
 msgstr "Zur Passwortkonfiguration..."
@@ -1296,19 +1321,19 @@ msgid "Go to relevant configuration page"
 msgstr "Gehe zur entsprechenden Konfigurationsseite"
 
 msgid "Group Password"
-msgstr ""
+msgstr "Gruppenpasswort"
 
 msgid "Guest"
-msgstr ""
+msgstr "Gast"
 
 msgid "HE.net password"
 msgstr "HE.net Passwort"
 
 msgid "HE.net username"
-msgstr ""
+msgstr "HE.net Benutzername"
 
 msgid "HT mode (802.11n)"
-msgstr ""
+msgstr "HT-Modus (802.11n)"
 
 msgid "Handler"
 msgstr "Handler"
@@ -1317,7 +1342,7 @@ msgid "Hang Up"
 msgstr "Auflegen"
 
 msgid "Header Error Code Errors (HEC)"
-msgstr ""
+msgstr "Anzahl Header-Error-Code-Fehler (HEC)"
 
 msgid "Heartbeat"
 msgstr ""
@@ -1369,7 +1394,7 @@ msgid "IKE DH Group"
 msgstr ""
 
 msgid "IP Addresses"
-msgstr ""
+msgstr "IP-Adressen"
 
 msgid "IP address"
 msgstr "IP-Adresse"
@@ -1390,7 +1415,7 @@ msgid "IPv4 and IPv6"
 msgstr "IPv4 und IPv6"
 
 msgid "IPv4 assignment length"
-msgstr ""
+msgstr "IPv4 Zuweisungslänge"
 
 msgid "IPv4 broadcast"
 msgstr "IPv4 Broadcast"
@@ -1405,7 +1430,7 @@ msgid "IPv4 only"
 msgstr "nur IPv4"
 
 msgid "IPv4 prefix"
-msgstr ""
+msgstr "IPv4 Bereich"
 
 msgid "IPv4 prefix length"
 msgstr "Länge des IPv4 Präfix"
@@ -1423,13 +1448,13 @@ msgid "IPv6 Firewall"
 msgstr "IPv6 Firewall"
 
 msgid "IPv6 Neighbours"
-msgstr ""
+msgstr "IPv6 Nachbarn"
 
 msgid "IPv6 Settings"
-msgstr ""
+msgstr "IPv6 Einstellungen"
 
 msgid "IPv6 ULA-Prefix"
-msgstr ""
+msgstr "IPv6 ULA-Präfix"
 
 msgid "IPv6 WAN Status"
 msgstr "IPv6 WAN Status"
@@ -1438,13 +1463,13 @@ msgid "IPv6 address"
 msgstr "IPv6 Adresse"
 
 msgid "IPv6 address delegated to the local tunnel endpoint (optional)"
-msgstr ""
+msgstr "Zum lokalen Tunnelendpunkt delegierte IPv6-Adresse (optional)"
 
 msgid "IPv6 assignment hint"
-msgstr ""
+msgstr "IPv6 Zuweisungshinweis"
 
 msgid "IPv6 assignment length"
-msgstr ""
+msgstr "IPv6 Zuweisungslänge"
 
 msgid "IPv6 gateway"
 msgstr "IPv6 Gateway"
@@ -1459,13 +1484,16 @@ msgid "IPv6 prefix length"
 msgstr "Länge des IPv6 Präfix"
 
 msgid "IPv6 routed prefix"
-msgstr ""
+msgstr "Gerouteter IPv6-Präfix"
+
+msgid "IPv6 suffix"
+msgstr "IPv6 Endung"
 
 msgid "IPv6-Address"
 msgstr "IPv6-Adresse"
 
 msgid "IPv6-PD"
-msgstr ""
+msgstr "IPv6 Präfixdelegation (PD)"
 
 msgid "IPv6-in-IPv4 (RFC4213)"
 msgstr "IPv6-in-IPv4 (RFC4213)"
@@ -1480,10 +1508,10 @@ msgid "Identity"
 msgstr "Identität"
 
 msgid "If checked, 1DES is enaled"
-msgstr ""
+msgstr "Aktiviert die Benutzung von 1DES, wenn ausgewählt"
 
 msgid "If checked, encryption is disabled"
-msgstr ""
+msgstr "Deaktiviert die Verschlüsselung, wenn ausgewählt"
 
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
@@ -1535,6 +1563,9 @@ msgid ""
 "In order to prevent unauthorized access to the system, your request has been "
 "blocked. Click \"Continue »\" below to return to the previous page."
 msgstr ""
+"Um unauthorisierte Zugriffe auf das System zu verhindern, wurde dieser "
+"Request blockiert. Auf \"Weiter\" klicken um zur vorherigen Seite "
+"zurückzukehren."
 
 msgid "Inactivity timeout"
 msgstr "Timeout bei Inaktivität"
@@ -1556,6 +1587,8 @@ msgstr "Installieren"
 
 msgid "Install iputils-traceroute6 for IPv6 traceroute"
 msgstr ""
+"Bitte \"iputils-traceroute6\" installieren um IPv6-Routenverfolgung nutzen "
+"zu können"
 
 msgid "Install package %q"
 msgstr "Installiere Paket %q"
@@ -1568,6 +1601,10 @@ msgstr "Installierte Pakete"
 
 msgid "Interface"
 msgstr "Schnittstelle"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
+"Das Gerät der Schnittstelle %q wurde automatisch von %q auf %q geändert."
 
 msgid "Interface Configuration"
 msgstr "Schnittstellenkonfiguration"
@@ -1582,7 +1619,7 @@ msgid "Interface is shutting down..."
 msgstr "Schnittstelle fährt herunter..."
 
 msgid "Interface name"
-msgstr ""
+msgstr "Schnittstellenname"
 
 msgid "Interface not present or not connected yet."
 msgstr "Schnittstelle existiert nicht oder ist nicht verbunden."
@@ -1597,7 +1634,7 @@ msgid "Interfaces"
 msgstr "Schnittstellen"
 
 msgid "Internal"
-msgstr ""
+msgstr "Intern"
 
 msgid "Internal Server Error"
 msgstr "Interner Serverfehler"
@@ -1616,7 +1653,7 @@ msgstr ""
 "Ungültiger Benutzername oder ungültiges Passwort! Bitte erneut versuchen. "
 
 msgid "Isolate Clients"
-msgstr ""
+msgstr "Clients isolieren"
 
 #, fuzzy
 msgid ""
@@ -1636,7 +1673,7 @@ msgid "Join Network: Wireless Scan"
 msgstr "Netzwerk beitreten: Suche nach Netzwerken"
 
 msgid "Joining Network: %q"
-msgstr ""
+msgstr "Trete Netzwerk %q bei"
 
 msgid "Keep settings"
 msgstr "Konfiguration behalten"
@@ -1681,22 +1718,19 @@ msgid "Language and Style"
 msgstr "Sprache und Aussehen"
 
 msgid "Latency"
-msgstr ""
+msgstr "Latenz"
 
 msgid "Leaf"
-msgstr ""
+msgstr "Zweigstelle"
 
 msgid "Lease time"
-msgstr ""
+msgstr "Laufzeit"
 
 msgid "Lease validity time"
 msgstr "Lease-Gültigkeitsdauer"
 
 msgid "Leasefile"
 msgstr "Leasedatei"
-
-msgid "Leasetime"
-msgstr "Laufzeit"
 
 msgid "Leasetime remaining"
 msgstr "Verbleibende Gültigkeit"
@@ -1715,21 +1749,23 @@ msgstr "Limit"
 
 msgid "Limit DNS service to subnets interfaces on which we are serving DNS."
 msgstr ""
+"DNS-Dienste auf direkte lokale Subnetze beschränken um Missbrauch durch "
+"Dritte zu verhindern."
 
 msgid "Limit listening to these interfaces, and loopback."
-msgstr ""
+msgstr "Dienste auf die angegeben Schnittstellen plus Loopback beschränken."
 
 msgid "Line Attenuation (LATN)"
-msgstr ""
+msgstr "Dämpfung (LATN)"
 
 msgid "Line Mode"
-msgstr ""
+msgstr "Verbindungsmodus"
 
 msgid "Line State"
-msgstr ""
+msgstr "Verbindungsstatus"
 
 msgid "Line Uptime"
-msgstr ""
+msgstr "Verbindungsdauer"
 
 msgid "Link On"
 msgstr "Verbindung hergestellt"
@@ -1758,7 +1794,7 @@ msgid ""
 msgstr ""
 
 msgid "List of SSH key files for auth"
-msgstr ""
+msgstr "Liste der SSH Schlüssel zur Authentifikation"
 
 msgid "List of domains to allow RFC1918 responses for"
 msgstr "Liste von Domains für welche RFC1918-Antworten erlaubt sind"
@@ -1767,10 +1803,10 @@ msgid "List of hosts that supply bogus NX domain results"
 msgstr "Liste von Servern die falsche \"NX Domain\" Antworten liefern"
 
 msgid "Listen Interfaces"
-msgstr ""
+msgstr "Aktive Schnittstellen"
 
 msgid "Listen Port"
-msgstr ""
+msgstr "Aktive Ports"
 
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
@@ -1790,7 +1826,7 @@ msgid "Loading"
 msgstr "Lade"
 
 msgid "Local IP address to assign"
-msgstr ""
+msgstr "Lokale IP-Adresse"
 
 msgid "Local IPv4 address"
 msgstr "Lokale IPv4 Adresse"
@@ -1799,7 +1835,7 @@ msgid "Local IPv6 address"
 msgstr "Lokale IPv6 Adresse"
 
 msgid "Local Service Only"
-msgstr ""
+msgstr "Nur lokale Dienste"
 
 msgid "Local Startup"
 msgstr "Lokales Startskript"
@@ -1838,7 +1874,7 @@ msgid "Localise queries"
 msgstr "Lokalisiere Anfragen"
 
 msgid "Locked to channel %s used by: %s"
-msgstr ""
+msgstr "Festgelegt auf Kanal %s, verwendet durch: %s"
 
 msgid "Log output level"
 msgstr "Protokolllevel"
@@ -1856,7 +1892,7 @@ msgid "Logout"
 msgstr "Abmelden"
 
 msgid "Loss of Signal Seconds (LOSS)"
-msgstr ""
+msgstr "Signalverlustsekunden (LOSS)"
 
 msgid "Lowest leased address as offset from the network address."
 msgstr "Kleinste vergebene Adresse (Netzwerkadresse + x)"
@@ -1891,13 +1927,13 @@ msgstr "MTU"
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
-msgstr ""
+msgstr "Das Root-Dateisystem muss mit folgenden Kommandsos vorbereitet werden:"
 
 msgid "Manual"
-msgstr ""
+msgstr "Manuell"
 
 msgid "Max. Attainable Data Rate (ATTNDR)"
-msgstr ""
+msgstr "Maximal erreichbare Datenrate (ATTNDR)"
 
 msgid "Maximum allowed number of active DHCP leases"
 msgstr "Maximal zulässige Anzahl von aktiven DHCP-Leases"
@@ -1918,6 +1954,9 @@ msgid ""
 "Maximum length of the name is 15 characters including the automatic protocol/"
 "bridge prefix (br-, 6in4-, pppoe- etc.)"
 msgstr ""
+"Die maximale Länge des Names ist auf 15 Zeichen beschränkt, abzüglich des "
+"automatischen Protokoll- oder Bridge-Prefixes wie \"br-\" oder \"pppoe-\" "
+"etc."
 
 msgid "Maximum number of leased addresses."
 msgstr "Maximal zulässige Anzahl von vergeben DHCP-Adressen"
@@ -1938,22 +1977,22 @@ msgid "Minimum hold time"
 msgstr "Minimalzeit zum Halten der Verbindung"
 
 msgid "Mirror monitor port"
-msgstr ""
+msgstr "Spiegel-Monitor-Port"
 
 msgid "Mirror source port"
-msgstr ""
+msgstr "Spiegel-Quell-Port"
 
 msgid "Missing protocol extension for proto %q"
 msgstr "Erweiterung für Protokoll %q fehlt"
 
 msgid "Mobility Domain"
-msgstr ""
+msgstr "Mobilitätsbereich"
 
 msgid "Mode"
 msgstr "Modus"
 
 msgid "Model"
-msgstr ""
+msgstr "Modell"
 
 msgid "Modem device"
 msgstr "Modemgerät"
@@ -1996,7 +2035,7 @@ msgid "Mount point"
 msgstr "Mountpunkt"
 
 msgid "Mount swap not specifically configured"
-msgstr ""
+msgstr "Unkonfigurierte SWAP-Partitionen aktivieren"
 
 msgid "Mounted file systems"
 msgstr "Eingehängte Dateisysteme"
@@ -2014,10 +2053,10 @@ msgid "NAS ID"
 msgstr "NAS ID"
 
 msgid "NAT-T Mode"
-msgstr ""
+msgstr "NAT-T Modus"
 
 msgid "NAT64 Prefix"
-msgstr ""
+msgstr "NAT64 Präfix"
 
 msgid "NCM"
 msgstr ""
@@ -2032,7 +2071,7 @@ msgid "NTP server candidates"
 msgstr "NTP Server Kandidaten"
 
 msgid "NTP sync time-out"
-msgstr ""
+msgstr "NTP Synchronisierungstimeout"
 
 msgid "Name"
 msgstr "Name"
@@ -2068,7 +2107,7 @@ msgid "No DHCP Server configured for this interface"
 msgstr "Kein DHCP Server auf dieser Schnittstelle eingerichtet"
 
 msgid "No NAT-T"
-msgstr ""
+msgstr "Kein NAT-T"
 
 msgid "No chains in this table"
 msgstr "Keine Ketten in dieser Tabelle"
@@ -2105,16 +2144,16 @@ msgid "Noise"
 msgstr "Rauschen"
 
 msgid "Noise Margin (SNR)"
-msgstr ""
+msgstr "Signal-Rausch-Abstand (SNR)"
 
 msgid "Noise:"
 msgstr "Noise:"
 
 msgid "Non Pre-emtive CRC errors (CRC_P)"
-msgstr ""
+msgstr "Nicht-präemptive CRC-Fehler (CRC_P)"
 
 msgid "Non-wildcard"
-msgstr ""
+msgstr "An Schnittstellen binden"
 
 msgid "None"
 msgstr "keine"
@@ -2135,7 +2174,7 @@ msgid "Note: Configuration files will be erased."
 msgstr "Warnung: Konfigurationsdateien werden gelöscht."
 
 msgid "Note: interface name length"
-msgstr ""
+msgstr "Hinweis: Länge des Namens beachten"
 
 msgid "Notice"
 msgstr "Notiz"
@@ -2150,10 +2189,10 @@ msgid "OPKG-Configuration"
 msgstr "OPKG-Konfiguration"
 
 msgid "Obfuscated Group Password"
-msgstr ""
+msgstr "Chiffriertes Gruppenpasswort"
 
 msgid "Obfuscated Password"
-msgstr ""
+msgstr "Chiffriertes Passwort"
 
 msgid "Off-State Delay"
 msgstr "Verzögerung für Ausschalt-Zustand"
@@ -2195,7 +2234,7 @@ msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
 msgid "Operating frequency"
-msgstr ""
+msgstr "Betriebsfrequenz"
 
 msgid "Option changed"
 msgstr "Option geändert"
@@ -2204,48 +2243,68 @@ msgid "Option removed"
 msgstr "Option entfernt"
 
 msgid "Optional"
-msgstr ""
+msgstr "Optional"
 
 msgid "Optional, specify to override default server (tic.sixxs.net)"
 msgstr ""
+"Optional, angeben um den Standardserver (tic.sixxs.net) zu überschreiben"
 
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
-
-msgid "Optional."
-msgstr ""
+"Optional, angeben wenn das SIXSS Konto mehr als einen Tunnel beinhaltet"
 
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
 msgstr ""
+"Optional. 32-Bit-Marke für ausgehende, verschlüsselte Pakete. Wert in "
+"hexadezimal mit führendem <code>0x</code> angeben."
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
+msgstr ""
+"Optional. Mögliche Werte: 'eui64', 'random' oder Suffixes wie '::1' oder "
+"'::1:2'. Wenn ein IPv6-Präfix (wie z.B. 'a:b:c:d::') von einem delegierendem "
+"Server empfangen wird, kombiniert das System das Suffix mit dem Präfix um "
+"eine IPv6-Adresse (z.B. 'a:b:c:d::1') für die Schnittstelle zu formen."
 
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
+"Optional. Base64-kodierter, vorhab ausgetauschter Schlüssel um eine weitere "
+"Ebene an symmetrischer Verschlüsselung für erhöhte Sicherheit hinzuzufügen."
 
 msgid "Optional. Create routes for Allowed IPs for this peer."
-msgstr ""
+msgstr "Optional. Routen für erlaubte IP-Adressen erzeugen."
 
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
+"Optional. Hostname oder Adresse des Verbindungspartners. Namen werden vor "
+"dem Verbindungsaufbau aufgelöst."
 
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
-msgstr ""
+msgstr "Optional. Maximale MTU für Tunnelschnittstellen."
 
 msgid "Optional. Port of peer."
-msgstr ""
+msgstr "Optional. Port-Nummer des Verbindungspartners."
 
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
+"Optional. Sekunden zwischen Keep-Alive-Nachrichten. Standardwert is 0 "
+"(deaktiviert). Der empfohlene Wert für Geräte hinter einem NAT sind 25 "
+"Sekunden."
 
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
+"Optional. Benutzte UDP-Port-Nummer für ausgehende und eingehende Pakete."
 
 msgid "Options"
 msgstr "Optionen"
@@ -2260,7 +2319,7 @@ msgid "Outbound:"
 msgstr "Ausgehend:"
 
 msgid "Output Interface"
-msgstr ""
+msgstr "Ausgehende Schnittstelle"
 
 msgid "Override MAC address"
 msgstr "MAC-Adresse überschreiben"
@@ -2269,13 +2328,13 @@ msgid "Override MTU"
 msgstr "MTU-Wert überschreiben"
 
 msgid "Override TOS"
-msgstr ""
+msgstr "TOS-Wert überschreiben"
 
 msgid "Override TTL"
-msgstr ""
+msgstr "TTL-Wert überschreiben"
 
 msgid "Override default interface name"
-msgstr ""
+msgstr "Standard Schnittstellennamen überschreiben"
 
 msgid "Override the gateway in DHCP responses"
 msgstr "Gateway-Adresse in DHCP-Antworten überschreiben"
@@ -2330,10 +2389,10 @@ msgid "PPtP"
 msgstr "PPtP"
 
 msgid "PSID offset"
-msgstr ""
+msgstr "PSID-Offset"
 
 msgid "PSID-bits length"
-msgstr ""
+msgstr "PSID-Bitlänge"
 
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
@@ -2360,10 +2419,10 @@ msgid "Password authentication"
 msgstr "Passwortanmeldung"
 
 msgid "Password of Private Key"
-msgstr "Passwort des Privaten Schlüssels"
+msgstr "Passwort des privaten Schlüssels"
 
 msgid "Password of inner Private Key"
-msgstr ""
+msgstr "Password des inneren, privaten Schlüssels"
 
 msgid "Password successfully changed!"
 msgstr "Passwort erfolgreich geändert!"
@@ -2381,22 +2440,22 @@ msgid "Path to executable which handles the button event"
 msgstr "Ausführbare Datei welche das Schalter-Ereignis verarbeitet"
 
 msgid "Path to inner CA-Certificate"
-msgstr ""
+msgstr "Pfad zum inneren CA-Zertifikat"
 
 msgid "Path to inner Client-Certificate"
-msgstr ""
+msgstr "Pfad zum inneren Client-Zertifikat"
 
 msgid "Path to inner Private Key"
-msgstr ""
+msgstr "Pfad zum inneren, privaten Schlüssel"
 
 msgid "Peak:"
 msgstr "Spitze:"
 
 msgid "Peer IP address to assign"
-msgstr ""
+msgstr "Entfernte IP-Adresse"
 
 msgid "Peers"
-msgstr ""
+msgstr "Verbindungspartner"
 
 msgid "Perfect Forward Secrecy"
 msgstr ""
@@ -2408,7 +2467,7 @@ msgid "Perform reset"
 msgstr "Reset durchführen"
 
 msgid "Persistent Keep Alive"
-msgstr ""
+msgstr "Persistentes Keep-Alive"
 
 msgid "Phy Rate:"
 msgstr "Phy-Rate:"
@@ -2435,22 +2494,22 @@ msgid "Port status:"
 msgstr "Port-Status:"
 
 msgid "Power Management Mode"
-msgstr ""
+msgstr "Energiesparmodus"
 
 msgid "Pre-emtive CRC errors (CRCP_P)"
-msgstr ""
+msgstr "Präemptive CRC-Fehler (CRCP_P)"
 
 msgid "Prefer LTE"
-msgstr ""
+msgstr "LTE bevorzugen"
 
 msgid "Prefer UMTS"
-msgstr ""
+msgstr "UMTS bevorzugen"
 
 msgid "Prefix Delegated"
-msgstr ""
+msgstr "Delegiertes Präfix"
 
 msgid "Preshared Key"
-msgstr ""
+msgstr "Gemeinsamer Schlüssel"
 
 msgid ""
 "Presume peer to be dead after given amount of LCP echo failures, use 0 to "
@@ -2460,7 +2519,7 @@ msgstr ""
 "Fehlschlägen, nutze den Wert 0 um Fehler zu ignorieren"
 
 msgid "Prevent listening on these interfaces."
-msgstr ""
+msgstr "Verhindert das Binden an diese Schnittstellen"
 
 msgid "Prevents client-to-client communication"
 msgstr "Unterbindet Client-Client-Verkehr"
@@ -2469,7 +2528,7 @@ msgid "Prism2/2.5/3 802.11b Wireless Controller"
 msgstr "Prism2/2.5/3 802.11b W-LAN Adapter"
 
 msgid "Private Key"
-msgstr ""
+msgstr "Privater Schlüssel"
 
 msgid "Proceed"
 msgstr "Fortfahren"
@@ -2478,7 +2537,7 @@ msgid "Processes"
 msgstr "Prozesse"
 
 msgid "Profile"
-msgstr ""
+msgstr "Profil"
 
 msgid "Prot."
 msgstr "Prot."
@@ -2505,10 +2564,12 @@ msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
 msgid "Public Key"
-msgstr ""
+msgstr "Öffentlicher Schlüssel"
 
 msgid "Public prefix routed to this device for distribution to clients."
 msgstr ""
+"Zu diesem Gerät geroutetes öffentliches Präfix zur Weiterverteilung an "
+"Clients."
 
 msgid "QMI Cellular"
 msgstr ""
@@ -2618,7 +2679,7 @@ msgid "Realtime Wireless"
 msgstr "Echtzeit-WLAN-Signal"
 
 msgid "Reassociation Deadline"
-msgstr ""
+msgstr "Reassoziierungsfrist"
 
 msgid "Rebind protection"
 msgstr "DNS-Rebind-Schutz"
@@ -2639,7 +2700,7 @@ msgid "Receiver Antenna"
 msgstr "Empfangsantenne"
 
 msgid "Recommended. IP addresses of the WireGuard interface."
-msgstr ""
+msgstr "Empfohlen. IP-Adresse der WireGuard-Schnittstelle."
 
 msgid "Reconnect this interface"
 msgstr "Diese Schnittstelle neu verbinden"
@@ -2666,7 +2727,7 @@ msgid "Remote IPv4 address"
 msgstr "Entfernte IPv4-Adresse"
 
 msgid "Remote IPv4 address or FQDN"
-msgstr ""
+msgstr "Entfernte IPv4-Adresse oder Hostname"
 
 msgid "Remove"
 msgstr "Entfernen"
@@ -2681,42 +2742,50 @@ msgid "Replace wireless configuration"
 msgstr "Drahtloskonfiguration ersetzen"
 
 msgid "Request IPv6-address"
-msgstr ""
+msgstr "IPv6-Adresse anfordern"
 
 msgid "Request IPv6-prefix of length"
-msgstr ""
+msgstr "IPv6-Präfix dieser Länge anfordern"
 
 msgid "Require TLS"
-msgstr ""
+msgstr "TLS erfordern"
 
 msgid "Required"
-msgstr ""
+msgstr "Benötigt"
 
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 "Wird von bestimmten Internet-Providern benötigt, z.B. Charter mit DOCSIS 3"
 
 msgid "Required. Base64-encoded private key for this interface."
-msgstr ""
+msgstr "Benötigt. Base64-kodierter privater Schlüssel für diese Schnittstelle"
 
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
+"Benötigt. Base64-kodierter öffentlicher Schlüssel für diese Schnittstelle"
 
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
+"Benötigt. IP-Adressen und Präfixe die der Verbindungspartner innerhalb des "
+"Tunnels nutzen darf. Entspricht üblicherweise der Tunnel-IP-Adresse des "
+"Verbindungspartners und den Netzwerken, die dieser durch den Tunnel routet."
 
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Feb 2017: ath9k and ath10k, in LEDE also mwlwifi and mt76)"
 msgstr ""
+"Benötigt die \"volle\" Variante des wpad oder hostapd Paketes und "
+"Unterstützung vom WLAN-Treiber."
 
 msgid ""
 "Requires upstream supports DNSSEC; verify unsigned domain responses really "
 "come from unsigned domains"
 msgstr ""
+"Setzt DNSSEC-Unterstützung im DNS-Zielserver vorraus; überprüft ob "
+"unsignierte Antworten wirklich von unsignierten Domains kommen."
 
 msgid "Reset"
 msgstr "Zurücksetzen"
@@ -2755,19 +2824,19 @@ msgid "Root directory for files served via TFTP"
 msgstr "Wurzelverzeichnis für über TFTP ausgelieferte Dateien "
 
 msgid "Root preparation"
-msgstr ""
+msgstr "Wurzelverzeichnis erzeugen"
 
 msgid "Route Allowed IPs"
-msgstr ""
+msgstr "Erlaubte IP-Addressen routen"
 
 msgid "Route type"
-msgstr ""
+msgstr "Routen-Typ"
 
 msgid "Routed IPv6 prefix for downstream interfaces"
-msgstr ""
+msgstr "Geroutetes IPv6-Präfix für nachgelagerte Schnittstellen"
 
 msgid "Router Advertisement-Service"
-msgstr ""
+msgstr "Router-Advertisement-Dienst"
 
 msgid "Router Password"
 msgstr "Routerpasswort"
@@ -2806,13 +2875,13 @@ msgid "SSH Access"
 msgstr "SSH-Zugriff"
 
 msgid "SSH server address"
-msgstr ""
+msgstr "SSH-Server-Adresse"
 
 msgid "SSH server port"
-msgstr ""
+msgstr "SSH-Server-Port"
 
 msgid "SSH username"
-msgstr ""
+msgstr "SSH Benutzername"
 
 msgid "SSH-Keys"
 msgstr "SSH-Schlüssel"
@@ -2858,15 +2927,17 @@ msgid "Server Settings"
 msgstr "Servereinstellungen"
 
 msgid "Server password"
-msgstr ""
+msgstr "Server Passwort"
 
 msgid ""
 "Server password, enter the specific password of the tunnel when the username "
 "contains the tunnel ID"
 msgstr ""
+"Server Passwort bzw. das tunnelspezifische Passwort wenn der Benutzername "
+"eine Tunnel-ID beinhaltet."
 
 msgid "Server username"
-msgstr ""
+msgstr "Server Benutzername"
 
 msgid "Service Name"
 msgstr "Service-Name"
@@ -2893,10 +2964,10 @@ msgid "Setup DHCP Server"
 msgstr "DHCP Server einrichten"
 
 msgid "Severely Errored Seconds (SES)"
-msgstr ""
+msgstr "schwerwiegende Fehlersekunden (SES)"
 
 msgid "Short GI"
-msgstr ""
+msgstr "kurzes Guardintervall"
 
 msgid "Show current backup file list"
 msgstr "Zeige aktuelle Liste der gesicherten Dateien"
@@ -2911,7 +2982,7 @@ msgid "Signal"
 msgstr "Signal"
 
 msgid "Signal Attenuation (SATN)"
-msgstr ""
+msgstr "Signaldämpfung (SATN)"
 
 msgid "Signal:"
 msgstr "Signal:"
@@ -2920,7 +2991,7 @@ msgid "Size"
 msgstr "Größe"
 
 msgid "Size (.ipk)"
-msgstr ""
+msgstr "Größe (.ipk)"
 
 msgid "Skip"
 msgstr "Überspringen"
@@ -2966,7 +3037,7 @@ msgid "Source"
 msgstr "Quelle"
 
 msgid "Source routing"
-msgstr ""
+msgstr "Quell-Routing"
 
 msgid "Specifies the button state to handle"
 msgstr "Gibt den zu behandelnden Tastenstatus an"
@@ -2992,17 +3063,21 @@ msgstr ""
 "werden"
 
 msgid "Specify a TOS (Type of Service)."
-msgstr ""
+msgstr "Setzt einen spezifischen TOS (Type of Service) Wert"
 
 msgid ""
 "Specify a TTL (Time to Live) for the encapsulating packet other than the "
 "default (64)."
 msgstr ""
+"Setzt eine spezifische TTL (Time to Live) für gekapselte Pakete, anstatt der "
+"standardmäßigen 64."
 
 msgid ""
 "Specify an MTU (Maximum Transmission Unit) other than the default (1280 "
 "bytes)."
 msgstr ""
+"Setzt eine spezifische MTU (Maximum Transmission Unit) abweichend von den "
+"standardmäßigen 1280 Bytes."
 
 msgid "Specify the secret encryption key here."
 msgstr "Geben Sie hier den geheimen Netzwerkschlüssel an"
@@ -3078,6 +3153,8 @@ msgstr "Switch %q (%s)"
 msgid ""
 "Switch %q has an unknown topology - the VLAN settings might not be accurate."
 msgstr ""
+"Der Switch %q hat eine unbekannte Struktur, die VLAN Settings könnten "
+"unpassend sein."
 
 msgid "Switch VLAN"
 msgstr ""
@@ -3156,10 +3233,13 @@ msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
 "username instead of the user ID!"
 msgstr ""
+"Die Updateprozedur für HE.net Tunnel-IP-Adrerssen hat sich geändert, statt "
+"der numerischen User-ID muss nun der normale Benutzername angegeben werden."
 
 msgid ""
 "The IPv4 address or the fully-qualified domain name of the remote tunnel end."
 msgstr ""
+"Die IPv4-Adresse oder der volle Domain Name des entfernten Tunnel-Endpunktes."
 
 msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
@@ -3176,6 +3256,8 @@ msgstr ""
 
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
+"Die Konfigurationsdatei konnte aufgrund der folgenden Fehler nicht geladen "
+"werden:"
 
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
@@ -3229,7 +3311,7 @@ msgid "The length of the IPv6 prefix in bits"
 msgstr "Länge des IPv6 Präfix in Bits"
 
 msgid "The local IPv4 address over which the tunnel is created (optional)."
-msgstr ""
+msgstr "Die lokale IPv4-Adresse über die der Tunnel aufgebaut wird (optional)."
 
 msgid ""
 "The network ports on this device can be combined to several <abbr title="
@@ -3253,6 +3335,7 @@ msgstr "Dem ausgewähltem Protokoll muss ein Gerät zugeordnet werden"
 
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
+"Das mitgesendete Sicherheits-Token ist ungültig oder bereits abgelaufen!"
 
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
@@ -3277,6 +3360,8 @@ msgid ""
 "The tunnel end-point is behind NAT, defaults to disabled and only applies to "
 "AYIYA"
 msgstr ""
+"Der lokale Tunnel-Endpunkt ist hinter einem NAT. Standard ist deaktiviert, "
+"nur auf AYIYA anwendbar."
 
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
@@ -3319,6 +3404,8 @@ msgid ""
 "'server=1.2.3.4' fordomain-specific or full upstream <abbr title=\"Domain "
 "Name System\">DNS</abbr> servers."
 msgstr ""
+"Diese Datei beinhaltet Zeilen in der Art 'server=/domain/1.2.3.4' oder "
+"'server=1.2.3.4' für domainspezifische oder komplette Ziel-DNS-Server."
 
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -3334,6 +3421,9 @@ msgid ""
 "This is either the \"Update Key\" configured for the tunnel or the account "
 "password if no update key has been configured"
 msgstr ""
+"Dies ist entweder der \"Update Key\" der für diesen Tunnel eingerichtet "
+"wurde oder das normale Account-Passwort wenn kein separater Schlüssel "
+"gesetzt wurde."
 
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
@@ -3355,11 +3445,13 @@ msgid ""
 msgstr "Dies ist der einzige DHCP im lokalen Netz"
 
 msgid "This is the plain username for logging into the account"
-msgstr ""
+msgstr "Das ist der normale Login-Name für den Account."
 
 msgid ""
 "This is the prefix routed to you by the tunnel broker for use by clients"
 msgstr ""
+"Dies ist das vom Tunnel-Broker geroutete öffentliche Präfix zur Verwendung "
+"durch nachgelagerte Clients."
 
 msgid "This is the system crontab in which scheduled tasks can be defined."
 msgstr ""
@@ -3405,7 +3497,7 @@ msgstr ""
 "Backup-Archiv hochgeladen werden."
 
 msgid "Tone"
-msgstr ""
+msgstr "Ton"
 
 msgid "Total Available"
 msgstr "Gesamt verfügbar"
@@ -3445,16 +3537,16 @@ msgid "Tunnel Interface"
 msgstr "Tunnelschnittstelle"
 
 msgid "Tunnel Link"
-msgstr ""
+msgstr "Basisschnittstelle"
 
 msgid "Tunnel broker protocol"
-msgstr ""
+msgstr "Tunnel-Boker-Protokoll"
 
 msgid "Tunnel setup server"
-msgstr ""
+msgstr "Tunnel-Setup-Server"
 
 msgid "Tunnel type"
-msgstr ""
+msgstr "Tunneltyp"
 
 msgid "Tx-Power"
 msgstr "Sendestärke"
@@ -3475,7 +3567,7 @@ msgid "USB Device"
 msgstr "USB-Gerät"
 
 msgid "USB Ports"
-msgstr ""
+msgstr "USB Anschlüsse"
 
 msgid "UUID"
 msgstr "UUID"
@@ -3484,7 +3576,7 @@ msgid "Unable to dispatch"
 msgstr "Kann Anfrage nicht zustellen"
 
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
+msgstr "Nicht verfügbare Sekunden (UAS)"
 
 msgid "Unknown"
 msgstr "Unbekannt"
@@ -3496,7 +3588,7 @@ msgid "Unmanaged"
 msgstr "Ignoriert"
 
 msgid "Unmount"
-msgstr ""
+msgstr "Aushängen"
 
 msgid "Unsaved Changes"
 msgstr "Ungespeicherte Änderungen"
@@ -3544,16 +3636,16 @@ msgid "Use TTL on tunnel interface"
 msgstr "Benutze TTL auf der Tunnelschnittstelle"
 
 msgid "Use as external overlay (/overlay)"
-msgstr ""
+msgstr "Als externes Overlay benutzen (/overlay)"
 
 msgid "Use as root filesystem (/)"
-msgstr ""
+msgstr "Als Root-Dateisystem benutzen (/)"
 
 msgid "Use broadcast flag"
 msgstr "Benutze Broadcast-Flag"
 
 msgid "Use builtin IPv6-management"
-msgstr ""
+msgstr "Eingebautes IPv6-Management nutzen"
 
 msgid "Use custom DNS servers"
 msgstr "Benutze eigene DNS-Server"
@@ -3589,12 +3681,14 @@ msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
 msgstr ""
+"Wird als RADIUS-NAS-ID und als 802.11r R0KH-ID verwendet. Nicht benötigt für "
+"WPA(2)-PSK."
 
 msgid "User certificate (PEM encoded)"
-msgstr ""
+msgstr "PEM-kodiertes Benutzerzertifikat"
 
 msgid "User key (PEM encoded)"
-msgstr ""
+msgstr "PEM-kodierter Benutzerschlüssel"
 
 msgid "Username"
 msgstr "Benutzername"
@@ -3612,34 +3706,34 @@ msgid "VLANs on %q (%s)"
 msgstr "VLANs auf %q (%s)"
 
 msgid "VPN Local address"
-msgstr ""
+msgstr "Lokale VPN-Adresse"
 
 msgid "VPN Local port"
-msgstr ""
+msgstr "Lokaler VPN-Port"
 
 msgid "VPN Server"
 msgstr "VPN-Server"
 
 msgid "VPN Server port"
-msgstr ""
+msgstr "VPN-Server Port"
 
 msgid "VPN Server's certificate SHA1 hash"
-msgstr ""
+msgstr "SHA1-Hash des VPN-Server-Zertifikates"
 
 msgid "VPNC (CISCO 3000 (and others) VPN)"
 msgstr ""
 
 msgid "Vendor"
-msgstr ""
+msgstr "Hersteller"
 
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Bei DHCP-Anfragen gesendete Vendor-Klasse"
 
 msgid "Verbose"
-msgstr ""
+msgstr "Umfangreiche Ausgaben"
 
 msgid "Verbose logging by aiccu daemon"
-msgstr ""
+msgstr "Aktiviert erweiterte Protokollierung durch den AICCU-Prozess"
 
 msgid "Verify"
 msgstr "Verifizieren"
@@ -3675,6 +3769,8 @@ msgstr ""
 msgid ""
 "Wait for NTP sync that many seconds, seting to 0 disables waiting (optional)"
 msgstr ""
+"Warte die angegebene Anzahl an Sekunden auf NTP-Synchronisierung, der Wert 0 "
+"deaktiviert das Warten (optional)"
 
 msgid "Waiting for changes to be applied..."
 msgstr "Änderungen werden angewandt..."
@@ -3683,22 +3779,25 @@ msgid "Waiting for command to complete..."
 msgstr "Der Befehl wird ausgeführt..."
 
 msgid "Waiting for device..."
-msgstr ""
+msgstr "Warte auf Gerät..."
 
 msgid "Warning"
 msgstr "Warnung"
 
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
+"Achtung: Es gibt ungespeicherte Änderungen die bei einem Neustart verloren "
+"gehen!"
 
 msgid "Whether to create an IPv6 default route over the tunnel"
 msgstr ""
+"Gibt an, ob eine IPv6-Default-Route durch den Tunnel etabliert werden soll"
 
 msgid "Whether to route only packets from delegated prefixes"
-msgstr ""
+msgstr "Gibt an, ob nur Pakete von delegierten Präfixen geroutet werden sollen"
 
 msgid "Width"
-msgstr ""
+msgstr "Breite"
 
 msgid "WireGuard VPN"
 msgstr ""
@@ -3740,7 +3839,7 @@ msgid "Write received DNS requests to syslog"
 msgstr "Empfangene DNS-Anfragen in das Systemprotokoll schreiben"
 
 msgid "Write system log to file"
-msgstr ""
+msgstr "Systemprotokoll in Datei schreiben"
 
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
@@ -3770,9 +3869,6 @@ msgstr "beliebig"
 msgid "auto"
 msgstr "auto"
 
-msgid "automatic"
-msgstr "automatisch"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3795,7 +3891,7 @@ msgid "disable"
 msgstr "deaktivieren"
 
 msgid "disabled"
-msgstr ""
+msgstr "deaktiviert"
 
 msgid "expired"
 msgstr "abgelaufen"
@@ -3821,7 +3917,7 @@ msgid "hidden"
 msgstr "versteckt"
 
 msgid "hybrid mode"
-msgstr ""
+msgstr "hybrider Modus"
 
 msgid "if target is a network"
 msgstr "falls Ziel ein Netzwerk ist"
@@ -3842,13 +3938,10 @@ msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "Lokale DNS-Datei"
 
 msgid "minimum 1280, maximum 1480"
-msgstr ""
+msgstr "Minimum 1280, Maximum 1480"
 
 msgid "minutes"
-msgstr ""
-
-msgid "navigation Navigation"
-msgstr ""
+msgstr "Minuten"
 
 msgid "no"
 msgstr "nein"
@@ -3860,7 +3953,7 @@ msgid "none"
 msgstr "keine"
 
 msgid "not present"
-msgstr ""
+msgstr "nicht vorhanden"
 
 msgid "off"
 msgstr "aus"
@@ -3872,37 +3965,31 @@ msgid "open"
 msgstr "offen"
 
 msgid "overlay"
-msgstr ""
+msgstr "Overlay"
 
 msgid "relay mode"
-msgstr ""
+msgstr "Relay-Modus"
 
 msgid "routed"
 msgstr "routed"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
-msgstr ""
+msgstr "Server-Modus"
 
 msgid "stateful-only"
-msgstr ""
+msgstr "nur zustandsorientiert"
 
 msgid "stateless"
-msgstr ""
+msgstr "nur zustandlos"
 
 msgid "stateless + stateful"
-msgstr ""
+msgstr "zustandslos + zustandsorientiert"
 
 msgid "tagged"
 msgstr "tagged"
 
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
-msgstr ""
+msgstr "Zeiteinheiten (TUs / 1024 ms) [1000-65535]"
 
 msgid "unknown"
 msgstr "unbekannt"
@@ -3924,6 +4011,18 @@ msgstr "ja"
 
 msgid "« Back"
 msgstr "« Zurück"
+
+#~ msgid "Leasetime"
+#~ msgstr "Laufzeit"
+
+#~ msgid "Optional."
+#~ msgstr "Optional"
+
+#~ msgid "AuthGroup"
+#~ msgstr "Berechtigungsgruppe"
+
+#~ msgid "automatic"
+#~ msgstr "automatisch"
 
 #~ msgid "AR Support"
 #~ msgstr "AR-Unterstützung"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -426,9 +426,6 @@ msgstr "Συνδεδεμένοι Σταθμοί"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Εξουσιοδότηση"
 
@@ -1473,6 +1470,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1582,6 +1582,9 @@ msgstr "Εγκατεστημένα πακέτα"
 
 msgid "Interface"
 msgstr "Διεπαφή"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Παραμετροποίηση Διεπαφής"
@@ -1707,9 +1710,6 @@ msgstr ""
 
 msgid "Leasefile"
 msgstr "Αρχείο Leases"
-
-msgid "Leasetime"
-msgstr "Χρόνος Lease"
 
 msgid "Leasetime remaining"
 msgstr "Υπόλοιπο χρόνου Lease"
@@ -2214,12 +2214,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3689,10 +3693,6 @@ msgstr ""
 msgid "auto"
 msgstr "αυτόματα"
 
-#, fuzzy
-msgid "automatic"
-msgstr "στατικό"
-
 msgid "baseT"
 msgstr ""
 
@@ -3770,9 +3770,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "όχι"
 
@@ -3804,12 +3801,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3847,6 +3838,13 @@ msgstr "ναι"
 
 msgid "« Back"
 msgstr "« Πίσω"
+
+#~ msgid "Leasetime"
+#~ msgstr "Χρόνος Lease"
+
+#, fuzzy
+#~ msgid "automatic"
+#~ msgstr "στατικό"
 
 #~ msgid "AR Support"
 #~ msgstr "Υποστήριξη AR"

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -417,9 +417,6 @@ msgstr "Associated Stations"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Authentication"
 
@@ -1447,6 +1444,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1551,6 +1551,9 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Interface"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr ""
@@ -1676,9 +1679,6 @@ msgstr ""
 
 msgid "Leasefile"
 msgstr "Leasefile"
-
-msgid "Leasetime"
-msgstr "Leasetime"
 
 msgid "Leasetime remaining"
 msgstr "Leasetime remaining"
@@ -2181,12 +2181,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3647,9 +3651,6 @@ msgstr ""
 msgid "auto"
 msgstr "auto"
 
-msgid "automatic"
-msgstr "automatic"
-
 msgid "baseT"
 msgstr ""
 
@@ -3726,9 +3727,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr ""
 
@@ -3760,12 +3758,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3803,6 +3795,12 @@ msgstr ""
 
 msgid "« Back"
 msgstr "« Back"
+
+#~ msgid "Leasetime"
+#~ msgstr "Leasetime"
+
+#~ msgid "automatic"
+#~ msgstr "automatic"
 
 #~ msgid "AR Support"
 #~ msgstr "AR Support"

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -423,9 +423,6 @@ msgstr "Estaciones asociadas"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Autentificación"
 
@@ -1469,6 +1466,9 @@ msgstr "Longitud de prefijo IPv6"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "Dirección IPv6"
 
@@ -1580,6 +1580,9 @@ msgstr "Paquetes instalados"
 
 msgid "Interface"
 msgstr "Interfaz"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Configuración del interfaz"
@@ -1706,9 +1709,6 @@ msgstr "Tiempo de validación de cesión"
 
 msgid "Leasefile"
 msgstr "Archivo de cesiones"
-
-msgid "Leasetime"
-msgstr "Tiempo de cesión"
 
 msgid "Leasetime remaining"
 msgstr "Tiempo de cesión restante"
@@ -2219,12 +2219,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3765,10 +3769,6 @@ msgstr "cualquiera"
 msgid "auto"
 msgstr "auto"
 
-#, fuzzy
-msgid "automatic"
-msgstr "estático"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3845,9 +3845,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "no"
 
@@ -3879,12 +3876,6 @@ msgid "routed"
 msgstr "enrutado"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3922,6 +3913,13 @@ msgstr "sí"
 
 msgid "« Back"
 msgstr "« Volver"
+
+#~ msgid "Leasetime"
+#~ msgstr "Tiempo de cesión"
+
+#, fuzzy
+#~ msgid "automatic"
+#~ msgstr "estático"
 
 #~ msgid "AR Support"
 #~ msgstr "Soporte a AR"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -429,9 +429,6 @@ msgstr "Équipements associés"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Authentification"
 
@@ -1481,6 +1478,9 @@ msgstr "longueur du préfixe IPv6"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "Adresse IPv6"
 
@@ -1588,6 +1588,9 @@ msgstr "Paquets installés"
 
 msgid "Interface"
 msgstr "Interface"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Configuration de l'interface"
@@ -1717,9 +1720,6 @@ msgstr "Durée de validité d'un bail"
 
 msgid "Leasefile"
 msgstr "Fichier de baux"
-
-msgid "Leasetime"
-msgstr "Durée du bail"
 
 msgid "Leasetime remaining"
 msgstr "Durée de validité"
@@ -2232,12 +2232,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3785,10 +3789,6 @@ msgstr "n'importe lequel"
 msgid "auto"
 msgstr "auto"
 
-#, fuzzy
-msgid "automatic"
-msgstr "statique"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3863,9 +3863,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "non"
 
@@ -3897,12 +3894,6 @@ msgid "routed"
 msgstr "routé"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3940,6 +3931,13 @@ msgstr "oui"
 
 msgid "« Back"
 msgstr "« Retour"
+
+#~ msgid "Leasetime"
+#~ msgstr "Durée du bail"
+
+#, fuzzy
+#~ msgid "automatic"
+#~ msgstr "statique"
 
 #~ msgid "AR Support"
 #~ msgstr "Gestion du mode AR"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -418,9 +418,6 @@ msgstr "תחנות קשורות"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "אימות"
 
@@ -1430,6 +1427,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1528,6 +1528,9 @@ msgid "Installed packages"
 msgstr ""
 
 msgid "Interface"
+msgstr ""
+
+msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
 msgid "Interface Configuration"
@@ -1650,9 +1653,6 @@ msgid "Lease validity time"
 msgstr ""
 
 msgid "Leasefile"
-msgstr ""
-
-msgid "Leasetime"
 msgstr ""
 
 msgid "Leasetime remaining"
@@ -2148,12 +2148,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3600,9 +3604,6 @@ msgstr "כלשהו"
 msgid "auto"
 msgstr "אוטומטי"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr ""
 
@@ -3677,9 +3678,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "לא"
 
@@ -3711,12 +3709,6 @@ msgid "routed"
 msgstr "מנותב"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -422,9 +422,6 @@ msgstr "Kapcsolódó kliensek"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Hitelesítés"
 
@@ -1470,6 +1467,9 @@ msgstr "IPv6 prefix hossz"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6-cím"
 
@@ -1578,6 +1578,9 @@ msgstr "Telepített csomagok"
 
 msgid "Interface"
 msgstr "Interfész"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Interfész beállítások"
@@ -1706,9 +1709,6 @@ msgstr "Bérlet érvényességi ideje"
 
 msgid "Leasefile"
 msgstr "Bérlet fájl"
-
-msgid "Leasetime"
-msgstr "Bérlet időtartama"
 
 msgid "Leasetime remaining"
 msgstr "A bérletből hátralévő idő"
@@ -2222,12 +2222,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3772,9 +3776,6 @@ msgstr "bármelyik"
 msgid "auto"
 msgstr "automatikus"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3851,9 +3852,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "nem"
 
@@ -3885,12 +3883,6 @@ msgid "routed"
 msgstr "irányított"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3928,6 +3920,9 @@ msgstr "igen"
 
 msgid "« Back"
 msgstr "« Vissza"
+
+#~ msgid "Leasetime"
+#~ msgstr "Bérlet időtartama"
 
 #~ msgid "AR Support"
 #~ msgstr "AR Támogatás"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -429,9 +429,6 @@ msgstr "Dispositivi Wi-Fi connessi"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Autenticazione PEAP"
 
@@ -1473,6 +1470,9 @@ msgstr "Lunghezza prefisso IPv6"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "Indirizzo-IPv6"
 
@@ -1583,6 +1583,9 @@ msgstr "Pacchetti installati"
 
 msgid "Interface"
 msgstr "Interfaccia"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Configurazione Interfaccia"
@@ -1708,9 +1711,6 @@ msgstr "Periodo di Validità del Lease"
 
 msgid "Leasefile"
 msgstr "File di lease"
-
-msgid "Leasetime"
-msgstr "Tempo di lease"
 
 msgid "Leasetime remaining"
 msgstr "Tempo lease residuo"
@@ -2220,12 +2220,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3724,10 +3728,6 @@ msgstr "qualsiasi"
 msgid "auto"
 msgstr "auto"
 
-#, fuzzy
-msgid "automatic"
-msgstr "statico"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3804,9 +3804,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "no"
 
@@ -3838,12 +3835,6 @@ msgid "routed"
 msgstr "instradato"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3881,6 +3872,13 @@ msgstr "Sì"
 
 msgid "« Back"
 msgstr "« Indietro"
+
+#~ msgid "Leasetime"
+#~ msgstr "Tempo di lease"
+
+#, fuzzy
+#~ msgid "automatic"
+#~ msgstr "statico"
 
 #~ msgid "AR Support"
 #~ msgstr "Supporto AR"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -419,9 +419,6 @@ msgstr "認証済み端末"
 msgid "Auth Group"
 msgstr "認証グループ"
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "認証"
 
@@ -1469,6 +1466,9 @@ msgstr "IPv6 プレフィクス長"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6-アドレス"
 
@@ -1576,6 +1576,9 @@ msgstr "インストール済みパッケージ"
 
 msgid "Interface"
 msgstr "インターフェース"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "インターフェース設定"
@@ -1701,9 +1704,6 @@ msgstr "リース有効時間"
 
 msgid "Leasefile"
 msgstr "リースファイル"
-
-msgid "Leasetime"
-msgstr "リース時間"
 
 msgid "Leasetime remaining"
 msgstr "残りリース時間"
@@ -2216,12 +2216,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr "（オプション）"
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3756,9 +3760,6 @@ msgstr "全て"
 msgid "auto"
 msgstr "自動"
 
-msgid "automatic"
-msgstr "自動"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3835,9 +3836,6 @@ msgstr "最小値 1280、最大値 1480"
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "いいえ"
 
@@ -3870,12 +3868,6 @@ msgstr "routed"
 
 msgid "server mode"
 msgstr "サーバー モード"
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
-msgstr ""
 
 msgid "stateful-only"
 msgstr "ステートフルのみ"
@@ -3912,6 +3904,15 @@ msgstr "はい"
 
 msgid "« Back"
 msgstr "« 戻る"
+
+#~ msgid "Leasetime"
+#~ msgstr "リース時間"
+
+#~ msgid "Optional."
+#~ msgstr "（オプション）"
+
+#~ msgid "automatic"
+#~ msgstr "自動"
 
 #~ msgid "AR Support"
 #~ msgstr "ARサポート"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -411,9 +411,6 @@ msgstr "연결된 station 들"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr ""
 
@@ -1446,6 +1443,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6-주소"
 
@@ -1545,6 +1545,9 @@ msgstr "설치된 패키지"
 
 msgid "Interface"
 msgstr "인터페이스"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "인터페이스 설정"
@@ -1667,9 +1670,6 @@ msgstr ""
 
 msgid "Leasefile"
 msgstr ""
-
-msgid "Leasetime"
-msgstr "임대 시간"
 
 msgid "Leasetime remaining"
 msgstr "남아있는 임대 시간"
@@ -2172,12 +2172,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3656,9 +3660,6 @@ msgstr ""
 msgid "auto"
 msgstr ""
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr ""
 
@@ -3735,9 +3736,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr ""
 
@@ -3769,12 +3767,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3812,3 +3804,6 @@ msgstr ""
 
 msgid "« Back"
 msgstr ""
+
+#~ msgid "Leasetime"
+#~ msgstr "임대 시간"

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -406,9 +406,6 @@ msgstr "Associated Stesen"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Authentifizierung"
 
@@ -1417,6 +1414,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1521,6 +1521,9 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Interface"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr ""
@@ -1647,9 +1650,6 @@ msgstr ""
 
 msgid "Leasefile"
 msgstr "Sewa fail"
-
-msgid "Leasetime"
-msgstr "Masa penyewaan"
 
 msgid "Leasetime remaining"
 msgstr "Sisa masa penyewaan"
@@ -2153,12 +2153,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3620,9 +3624,6 @@ msgstr ""
 msgid "auto"
 msgstr "auto"
 
-msgid "automatic"
-msgstr "automatik"
-
 msgid "baseT"
 msgstr ""
 
@@ -3697,9 +3698,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr ""
 
@@ -3731,12 +3729,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3774,6 +3766,12 @@ msgstr ""
 
 msgid "« Back"
 msgstr "« Kembali"
+
+#~ msgid "Leasetime"
+#~ msgstr "Masa penyewaan"
+
+#~ msgid "automatic"
+#~ msgstr "automatik"
 
 #~ msgid "AR Support"
 #~ msgstr "AR-Penyokong"

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -415,9 +415,6 @@ msgstr "Tilkoblede Klienter"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Godkjenning"
 
@@ -1456,6 +1453,9 @@ msgstr "IPv6 prefikslengde"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6-Adresse"
 
@@ -1559,6 +1559,9 @@ msgstr "Installerte pakker"
 
 msgid "Interface"
 msgstr "Grensesnitt"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Grensesnitt Konfigurasjon"
@@ -1684,9 +1687,6 @@ msgstr "Gyldig leietid"
 
 msgid "Leasefile"
 msgstr "<abbr title=\"Leasefile\">Leie-fil</abbr>"
-
-msgid "Leasetime"
-msgstr "<abbr title=\"Leasetime\">Leietid</abbr>"
 
 msgid "Leasetime remaining"
 msgstr "Gjenværende leietid"
@@ -2197,12 +2197,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3738,9 +3742,6 @@ msgstr "enhver"
 msgid "auto"
 msgstr "auto"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3817,9 +3818,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "nei"
 
@@ -3851,12 +3849,6 @@ msgid "routed"
 msgstr "rutet"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3894,6 +3886,9 @@ msgstr "ja"
 
 msgid "« Back"
 msgstr "« Tilbake"
+
+#~ msgid "Leasetime"
+#~ msgstr "<abbr title=\"Leasetime\">Leietid</abbr>"
 
 #~ msgid "AR Support"
 #~ msgstr "AR Støtte"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -429,9 +429,6 @@ msgstr "Połączone stacje"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
@@ -1492,6 +1489,9 @@ msgstr "Długość prefiksu IPv6"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "Adres IPv6"
 
@@ -1601,6 +1601,9 @@ msgstr "Zainstalowane pakiety"
 
 msgid "Interface"
 msgstr "Interfejs"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Konfiguracja Interfejsu"
@@ -1728,9 +1731,6 @@ msgstr "Czas ważności dzierżawy"
 
 msgid "Leasefile"
 msgstr "Plik dzierżaw"
-
-msgid "Leasetime"
-msgstr "Czas dzierżawy"
 
 msgid "Leasetime remaining"
 msgstr "Pozostały czas dzierżawy"
@@ -2241,12 +2241,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3802,9 +3806,6 @@ msgstr "dowolny"
 msgid "auto"
 msgstr "auto"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3881,9 +3882,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "nie"
 
@@ -3916,12 +3914,6 @@ msgid "routed"
 msgstr "routowane"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3959,6 +3951,9 @@ msgstr "tak"
 
 msgid "« Back"
 msgstr "« Wróć"
+
+#~ msgid "Leasetime"
+#~ msgstr "Czas dzierżawy"
 
 # Wydaje mi się że brakuje litery R...
 #~ msgid "AR Support"

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -455,9 +455,6 @@ msgstr "Estações associadas"
 msgid "Auth Group"
 msgstr "Grupo de Autenticação"
 
-msgid "AuthGroup"
-msgstr "Grupo de Autenticação"
-
 msgid "Authentication"
 msgstr "Autenticação"
 
@@ -1540,6 +1537,9 @@ msgstr "Tamanho Prefixo IPv6"
 msgid "IPv6 routed prefix"
 msgstr "Prefixo roteável IPv6"
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "Endereço IPv6"
 
@@ -1653,6 +1653,9 @@ msgstr "Pacotes instalados"
 
 msgid "Interface"
 msgstr "Interface"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Configuração da Interface"
@@ -1781,9 +1784,6 @@ msgstr "Tempo de validade da atribuição"
 
 msgid "Leasefile"
 msgstr "Arquivo de atribuições"
-
-msgid "Leasetime"
-msgstr "Tempo de atribuição do DHCP"
 
 msgid "Leasetime remaining"
 msgstr "Tempo restante da atribuição"
@@ -2327,12 +2327,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr "Opcional, para usar quando a conta SIXXS tem mais de um túnel"
 
-msgid "Optional."
-msgstr "Opcional."
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3932,9 +3936,6 @@ msgstr "qualquer"
 msgid "auto"
 msgstr "automático"
 
-msgid "automatic"
-msgstr "automático"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -4012,9 +4013,6 @@ msgstr "mínimo 1280, máximo 1480"
 msgid "minutes"
 msgstr "minutos"
 
-msgid "navigation Navigation"
-msgstr "navegação Navegação"
-
 # Is this yes/no or no like in no one?
 msgid "no"
 msgstr "não"
@@ -4048,12 +4046,6 @@ msgstr "roteado"
 
 msgid "server mode"
 msgstr "modo servidor"
-
-msgid "skiplink1 Skip to navigation"
-msgstr "skiplink1 Pular para a navegação"
-
-msgid "skiplink2 Skip to content"
-msgstr "skiplink2 Pular para o conteúdo"
 
 msgid "stateful-only"
 msgstr "somente com estado"
@@ -4090,6 +4082,27 @@ msgstr "sim"
 
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "Leasetime"
+#~ msgstr "Tempo de atribuição do DHCP"
+
+#~ msgid "Optional."
+#~ msgstr "Opcional."
+
+#~ msgid "navigation Navigation"
+#~ msgstr "navegação Navegação"
+
+#~ msgid "skiplink1 Skip to navigation"
+#~ msgstr "skiplink1 Pular para a navegação"
+
+#~ msgid "skiplink2 Skip to content"
+#~ msgstr "skiplink2 Pular para o conteúdo"
+
+#~ msgid "AuthGroup"
+#~ msgstr "Grupo de Autenticação"
+
+#~ msgid "automatic"
+#~ msgstr "automático"
 
 #~ msgid "AR Support"
 #~ msgstr "Suporte AR"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -428,9 +428,6 @@ msgstr "Estações Associadas"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Autenticação"
 
@@ -1477,6 +1474,9 @@ msgstr "Comprimento do prefixo IPv6"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "Endereço-IPv6"
 
@@ -1582,6 +1582,9 @@ msgstr "Instalar pacotes"
 
 msgid "Interface"
 msgstr "Interface"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Configuração da Interface"
@@ -1708,9 +1711,6 @@ msgstr "Tempo de validade da concessão"
 
 msgid "Leasefile"
 msgstr "Ficheiro de concessões"
-
-msgid "Leasetime"
-msgstr "Tempo de concessão"
 
 msgid "Leasetime remaining"
 msgstr "Tempo de atribuição restante"
@@ -2221,12 +2221,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3733,10 +3737,6 @@ msgstr "qualquer"
 msgid "auto"
 msgstr "automático"
 
-#, fuzzy
-msgid "automatic"
-msgstr "estático"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3814,9 +3814,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "não"
 
@@ -3848,12 +3845,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3891,6 +3882,13 @@ msgstr "sim"
 
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "Leasetime"
+#~ msgstr "Tempo de concessão"
+
+#, fuzzy
+#~ msgid "automatic"
+#~ msgstr "estático"
 
 #~ msgid "AR Support"
 #~ msgstr "Suporte AR"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -414,9 +414,6 @@ msgstr "Statiile asociate"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Autentificare"
 
@@ -1424,6 +1421,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1523,6 +1523,9 @@ msgstr "Pachete instalate"
 
 msgid "Interface"
 msgstr "Interfata"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Configurarea interfetei"
@@ -1647,9 +1650,6 @@ msgid "Lease validity time"
 msgstr ""
 
 msgid "Leasefile"
-msgstr ""
-
-msgid "Leasetime"
 msgstr ""
 
 msgid "Leasetime remaining"
@@ -2145,12 +2145,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3593,9 +3597,6 @@ msgstr "oricare"
 msgid "auto"
 msgstr "auto"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr ""
 
@@ -3670,9 +3671,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "nu"
 
@@ -3704,12 +3702,6 @@ msgid "routed"
 msgstr "rutat"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -427,9 +427,6 @@ msgstr "Подключенные клиенты"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Аутентификация"
 
@@ -1476,6 +1473,9 @@ msgstr "Длина префикса IPv6"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6-адрес"
 
@@ -1585,6 +1585,9 @@ msgstr "Установленные пакеты"
 
 msgid "Interface"
 msgstr "Интерфейс"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Конфигурация интерфейса"
@@ -1712,9 +1715,6 @@ msgstr "Срок действия аренды"
 
 msgid "Leasefile"
 msgstr "Файл аренд"
-
-msgid "Leasetime"
-msgstr "Время аренды"
 
 msgid "Leasetime remaining"
 msgstr "Оставшееся время аренды"
@@ -2227,12 +2227,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3774,10 +3778,6 @@ msgstr "любой"
 msgid "auto"
 msgstr "авто"
 
-#, fuzzy
-msgid "automatic"
-msgstr "статический"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3855,9 +3855,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "нет"
 
@@ -3889,12 +3886,6 @@ msgid "routed"
 msgstr "маршрутизируемый"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3932,6 +3923,13 @@ msgstr "да"
 
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Leasetime"
+#~ msgstr "Время аренды"
+
+#, fuzzy
+#~ msgid "automatic"
+#~ msgstr "статический"
 
 #~ msgid "AR Support"
 #~ msgstr "Поддержка AR"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -400,9 +400,6 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr ""
 
@@ -1402,6 +1399,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1500,6 +1500,9 @@ msgid "Installed packages"
 msgstr ""
 
 msgid "Interface"
+msgstr ""
+
+msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
 msgid "Interface Configuration"
@@ -1622,9 +1625,6 @@ msgid "Lease validity time"
 msgstr ""
 
 msgid "Leasefile"
-msgstr ""
-
-msgid "Leasetime"
 msgstr ""
 
 msgid "Leasetime remaining"
@@ -2120,12 +2120,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3561,9 +3565,6 @@ msgstr ""
 msgid "auto"
 msgstr ""
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr ""
 
@@ -3638,9 +3639,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr ""
 
@@ -3672,12 +3670,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -406,9 +406,6 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr ""
 
@@ -1408,6 +1405,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1506,6 +1506,9 @@ msgid "Installed packages"
 msgstr ""
 
 msgid "Interface"
+msgstr ""
+
+msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
 msgid "Interface Configuration"
@@ -1628,9 +1631,6 @@ msgid "Lease validity time"
 msgstr ""
 
 msgid "Leasefile"
-msgstr ""
-
-msgid "Leasetime"
 msgstr ""
 
 msgid "Leasetime remaining"
@@ -2126,12 +2126,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3567,9 +3571,6 @@ msgstr ""
 msgid "auto"
 msgstr ""
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr ""
 
@@ -3644,9 +3645,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr ""
 
@@ -3678,12 +3676,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -393,9 +393,6 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr ""
 
@@ -1395,6 +1392,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1493,6 +1493,9 @@ msgid "Installed packages"
 msgstr ""
 
 msgid "Interface"
+msgstr ""
+
+msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
 msgid "Interface Configuration"
@@ -1615,9 +1618,6 @@ msgid "Lease validity time"
 msgstr ""
 
 msgid "Leasefile"
-msgstr ""
-
-msgid "Leasetime"
 msgstr ""
 
 msgid "Leasetime remaining"
@@ -2113,12 +2113,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3554,9 +3558,6 @@ msgstr ""
 msgid "auto"
 msgstr ""
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr ""
 
@@ -3631,9 +3632,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr ""
 
@@ -3665,12 +3663,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -413,9 +413,6 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Kimlik doğrulama"
 
@@ -1415,6 +1412,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1513,6 +1513,9 @@ msgid "Installed packages"
 msgstr ""
 
 msgid "Interface"
+msgstr ""
+
+msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
 msgid "Interface Configuration"
@@ -1635,9 +1638,6 @@ msgid "Lease validity time"
 msgstr ""
 
 msgid "Leasefile"
-msgstr ""
-
-msgid "Leasetime"
 msgstr ""
 
 msgid "Leasetime remaining"
@@ -2133,12 +2133,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3576,9 +3580,6 @@ msgstr "herhangi"
 msgid "auto"
 msgstr "otomatik"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr ""
 
@@ -3653,9 +3654,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "hayır"
 
@@ -3687,12 +3685,6 @@ msgid "routed"
 msgstr "yönlendirildi"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -437,9 +437,6 @@ msgstr "Приєднані станції"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Автентифікація"
 
@@ -1484,6 +1481,9 @@ msgstr "Довжина префікса IPv6"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6-адреса"
 
@@ -1593,6 +1593,9 @@ msgstr "Інстальовані пакети"
 
 msgid "Interface"
 msgstr "Інтерфейс"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "Конфігурація інтерфейсу"
@@ -1719,9 +1722,6 @@ msgstr "Час чинності оренди"
 
 msgid "Leasefile"
 msgstr "Файл оренд"
-
-msgid "Leasetime"
-msgstr "Час оренди"
 
 msgid "Leasetime remaining"
 msgstr "Час оренди, що лишився"
@@ -2235,12 +2235,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3789,9 +3793,6 @@ msgstr "будь-який"
 msgid "auto"
 msgstr "авто"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3870,9 +3871,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "ні"
 
@@ -3904,12 +3902,6 @@ msgid "routed"
 msgstr "спрямовано"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3947,6 +3939,9 @@ msgstr "так"
 
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Leasetime"
+#~ msgstr "Час оренди"
 
 #~ msgid "AR Support"
 #~ msgstr "Підтримка AR"

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -407,9 +407,6 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "Xác thực"
 
@@ -1422,6 +1419,9 @@ msgstr ""
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr ""
 
@@ -1526,6 +1526,9 @@ msgstr ""
 
 msgid "Interface"
 msgstr "Giao diện "
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr ""
@@ -1651,9 +1654,6 @@ msgstr ""
 
 msgid "Leasefile"
 msgstr "Leasefile"
-
-msgid "Leasetime"
-msgstr "Leasetime"
 
 msgid "Leasetime remaining"
 msgstr "Leasetime còn lại"
@@ -2156,12 +2156,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3620,10 +3624,6 @@ msgstr ""
 msgid "auto"
 msgstr "tự động"
 
-#, fuzzy
-msgid "automatic"
-msgstr "thống kê"
-
 msgid "baseT"
 msgstr ""
 
@@ -3700,9 +3700,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr ""
 
@@ -3734,12 +3731,6 @@ msgid "routed"
 msgstr ""
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3777,6 +3768,13 @@ msgstr ""
 
 msgid "« Back"
 msgstr ""
+
+#~ msgid "Leasetime"
+#~ msgstr "Leasetime"
+
+#, fuzzy
+#~ msgid "automatic"
+#~ msgstr "thống kê"
 
 #~ msgid "AR Support"
 #~ msgstr "Hỗ trợ AR"

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -411,9 +411,6 @@ msgstr "已连接站点"
 msgid "Auth Group"
 msgstr "认证组"
 
-msgid "AuthGroup"
-msgstr "认证组"
-
 msgid "Authentication"
 msgstr "认证"
 
@@ -1430,6 +1427,9 @@ msgstr "IPv6 地址前缀长度"
 msgid "IPv6 routed prefix"
 msgstr "IPv6 路由前缀"
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6-地址"
 
@@ -1531,6 +1531,9 @@ msgstr "已安装软件包"
 
 msgid "Interface"
 msgstr "接口"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "接口配置"
@@ -1653,9 +1656,6 @@ msgstr "有效租期"
 
 msgid "Leasefile"
 msgstr "租约文件"
-
-msgid "Leasetime"
-msgstr "租用时间"
 
 msgid "Leasetime remaining"
 msgstr "剩余租期"
@@ -2163,14 +2163,18 @@ msgstr "可选，设置这个选项会覆盖默认设定的服务器 (tic.sixxs.
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr "可选，如果你的 SIXXS 账号拥有一个以上的隧道请设置此项."
 
-msgid "Optional."
-msgstr "可选。"
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
 msgstr ""
 "可选，传出加密数据包的 32 位标记。请输入十六进制值，以 <code>0x</code> 开头。"
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
+msgstr ""
 
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
@@ -3655,9 +3659,6 @@ msgstr "任意"
 msgid "auto"
 msgstr "自动"
 
-msgid "automatic"
-msgstr "自动"
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3732,9 +3733,6 @@ msgstr "最小值 1280，最大值 1480"
 msgid "minutes"
 msgstr "分钟"
 
-msgid "navigation Navigation"
-msgstr "导航"
-
 msgid "no"
 msgstr "否"
 
@@ -3767,12 +3765,6 @@ msgstr "已路由"
 
 msgid "server mode"
 msgstr "服务器模式"
-
-msgid "skiplink1 Skip to navigation"
-msgstr "skiplink1 跳转到导航"
-
-msgid "skiplink2 Skip to content"
-msgstr "skiplink2 跳到内容"
 
 msgid "stateful-only"
 msgstr "有状态的"
@@ -3809,6 +3801,27 @@ msgstr "是"
 
 msgid "« Back"
 msgstr "« 后退"
+
+#~ msgid "Leasetime"
+#~ msgstr "租用时间"
+
+#~ msgid "Optional."
+#~ msgstr "可选。"
+
+#~ msgid "navigation Navigation"
+#~ msgstr "导航"
+
+#~ msgid "skiplink1 Skip to navigation"
+#~ msgstr "skiplink1 跳转到导航"
+
+#~ msgid "skiplink2 Skip to content"
+#~ msgstr "skiplink2 跳到内容"
+
+#~ msgid "AuthGroup"
+#~ msgstr "认证组"
+
+#~ msgid "automatic"
+#~ msgstr "自动"
 
 #~ msgid "AR Support"
 #~ msgstr "AR支持"

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -410,9 +410,6 @@ msgstr "已連接站點"
 msgid "Auth Group"
 msgstr ""
 
-msgid "AuthGroup"
-msgstr ""
-
 msgid "Authentication"
 msgstr "認證"
 
@@ -1433,6 +1430,9 @@ msgstr "IPv6字首長度"
 msgid "IPv6 routed prefix"
 msgstr ""
 
+msgid "IPv6 suffix"
+msgstr ""
+
 msgid "IPv6-Address"
 msgstr "IPv6-位址"
 
@@ -1536,6 +1536,9 @@ msgstr "安裝軟體包"
 
 msgid "Interface"
 msgstr "介面"
+
+msgid "Interface %q device auto-migrated from %q to %q."
+msgstr ""
 
 msgid "Interface Configuration"
 msgstr "介面設定"
@@ -1659,9 +1662,6 @@ msgstr "租賃有效時間"
 
 msgid "Leasefile"
 msgstr "租賃檔案"
-
-msgid "Leasetime"
-msgstr "租賃時間"
 
 msgid "Leasetime remaining"
 msgstr "租賃保留時間"
@@ -2161,12 +2161,16 @@ msgstr ""
 msgid "Optional, use when the SIXXS account has more than one tunnel"
 msgstr ""
 
-msgid "Optional."
-msgstr ""
-
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
+msgstr ""
+
+msgid ""
+"Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or "
+"'::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating "
+"server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
+"for the interface."
 msgstr ""
 
 msgid ""
@@ -3657,9 +3661,6 @@ msgstr "任意"
 msgid "auto"
 msgstr "自動"
 
-msgid "automatic"
-msgstr ""
-
 msgid "baseT"
 msgstr "baseT"
 
@@ -3736,9 +3737,6 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
-msgid "navigation Navigation"
-msgstr ""
-
 msgid "no"
 msgstr "無"
 
@@ -3770,12 +3768,6 @@ msgid "routed"
 msgstr "路由"
 
 msgid "server mode"
-msgstr ""
-
-msgid "skiplink1 Skip to navigation"
-msgstr ""
-
-msgid "skiplink2 Skip to content"
 msgstr ""
 
 msgid "stateful-only"
@@ -3813,6 +3805,9 @@ msgstr "是的"
 
 msgid "« Back"
 msgstr "« 倒退"
+
+#~ msgid "Leasetime"
+#~ msgstr "租賃時間"
 
 #~ msgid "AR Support"
 #~ msgstr "AR支援"

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
@@ -445,7 +445,7 @@ if has_dnsmasq and net:proto() == "static" then
 		limit.datatype = "uinteger"
 		limit.default = "150"
 
-		local ltime = s:taboption("general", Value, "leasetime", translate("Leasetime"),
+		local ltime = s:taboption("general", Value, "leasetime", translate("Lease time"),
 			translate("Expiry time of leased addresses, minimum is 2 minutes (<code>2m</code>)."))
 		ltime.rmempty = true
 		ltime.default = "12h"

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/vlan.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/vlan.lua
@@ -12,6 +12,35 @@ nw.init(m.uci)
 
 local topologies = nw:get_switch_topologies() or {}
 
+local update_interfaces = function(old_ifname, new_ifname)
+	local info = { }
+
+	m.uci:foreach("network", "interface", function(section)
+		local old_ifnames = m.uci:get("network", section[".name"], "ifname")
+		local new_ifnames = { }
+		local cur_ifname
+		local changed = false
+		for cur_ifname in luci.util.imatch(old_ifnames) do
+			if cur_ifname == old_ifname then
+				new_ifnames[#new_ifnames+1] = new_ifname
+				changed = true
+			else
+				new_ifnames[#new_ifnames+1] = cur_ifname
+			end
+		end
+		if changed then
+			m.uci:set("network", section[".name"], "ifname", table.concat(new_ifnames, " "))
+
+			info[#info+1] = translatef("Interface %q device auto-migrated from %q to %q.",
+				section[".name"], old_ifname, new_ifname)
+		end
+	end)
+
+	if #info > 0 then
+		m.message = (m.message and m.message .. "\n" or "") .. table.concat(info, "\n")
+	end
+end
+
 m.uci:foreach("network", "switch",
 	function(x)
 		local sid         = x['.name']
@@ -259,16 +288,31 @@ m.uci:foreach("network", "switch",
 
 		-- When writing the "vid" or "vlan" option, serialize the port states
 		-- as well and write them as "ports" option to uci.
-		vid.write = function(self, section, value)
+		vid.write = function(self, section, new_vid)
 			local o
 			local p = { }
-
 			for _, o in ipairs(port_opts) do
-				local v = o:formvalue(section)
-				if v == "t" then
-					p[#p+1] = o.option .. v
-				elseif v == "u" then
+				local new_tag = o:formvalue(section)
+				if new_tag == "t" then
+					p[#p+1] = o.option .. new_tag
+				elseif new_tag == "u" then
 					p[#p+1] = o.option
+				end
+
+				if o.info and o.info.device then
+					local old_tag = o:cfgvalue(section)
+					local old_vid = self:cfgvalue(section)
+					if old_tag ~= new_tag or old_vid ~= new_vid then
+						local old_ifname = (old_tag == "u") and o.info.device
+							or "%s.%s" %{ o.info.device, old_vid }
+
+						local new_ifname = (new_tag == "u") and o.info.device
+							or "%s.%s" %{ o.info.device, new_vid }
+
+						if old_ifname ~= new_ifname then
+							update_interfaces(old_ifname, new_ifname)
+						end
+					end
 				end
 			end
 
@@ -277,7 +321,7 @@ m.uci:foreach("network", "switch",
 			end
 
 			m:set(section, "ports", table.concat(p, " "))
-			return Value.write(self, section, value)
+			return Value.write(self, section, new_vid)
 		end
 
 		-- Fallback to "vlan" option if "vid" option is supported but unset.
@@ -301,6 +345,7 @@ m.uci:foreach("network", "switch",
 			po.cfgvalue = portvalue
 			po.validate = portvalidate
 			po.write    = function() end
+			po.info     = pt
 
 			port_opts[#port_opts+1] = po
 		end

--- a/protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua
+++ b/protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua
@@ -14,7 +14,7 @@ o.default = "try"
 
 o = section:taboption("general", Value, "reqprefix",
 	translate("Request IPv6-prefix of length"))
-o:value("auto", translate("automatic"))
+o:value("auto", translate("Automatic"))
 o:value("no", translate("disabled"))
 o:value("48")
 o:value("52")

--- a/protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua
+++ b/protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua
@@ -38,7 +38,7 @@ metric:depends("defaultroute", defaultroute.enabled)
 
 section:taboption("general", Value, "serverhash", translate("VPN Server's certificate SHA1 hash"))
 
-section:taboption("general", Value, "authgroup", translate("AuthGroup"))
+section:taboption("general", Value, "authgroup", translate("Auth Group"))
 
 username = section:taboption("general", Value, "username", translate("Username"))
 password = section:taboption("general", Value, "password", translate("Password"))

--- a/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
+++ b/protocols/luci-proto-wireguard/luasrc/model/cbi/admin_network/proto_wireguard.lua
@@ -52,7 +52,7 @@ metric = section:taboption(
   Value,
   "metric",
   translate("Metric"),
-  translate("Optional.")
+  translate("Optional")
 )
 metric.datatype = "uinteger"
 metric.placeholder = "0"

--- a/themes/luci-theme-freifunk-generic/luasrc/view/themes/freifunk-generic/header.htm
+++ b/themes/luci-theme-freifunk-generic/luasrc/view/themes/freifunk-generic/header.htm
@@ -105,8 +105,8 @@
 <%- end -%>
 
 <p class="skiplink">
-<span id="skiplink1"><a href="#navigation"><%:skiplink1 Skip to navigation%></a></span>
-<span id="skiplink2"><a href="#content"><%:skiplink2 Skip to content%></a></span>
+<span id="skiplink1"><a href="#navigation"><%:Skip to navigation%></a></span>
+<span id="skiplink2"><a href="#content"><%:Skip to content%></a></span>
 </p>
 
 <div id="header">
@@ -163,7 +163,7 @@
 %>
 
 <div id="menubar">
-<h2 class="navigation"><a id="navigation" name="navigation"><%:navigation Navigation%></a></h2>
+<h2 class="navigation"><a id="navigation" name="navigation"><%:Navigation%></a></h2>
 <ul id="mainmenu" class="dropdowns">
 	<%
 		local childs = disp.node_childs(cattree)


### PR DESCRIPTION
This change extends the switch VLAN configuration page to automatically
adjust interface ifname options when altering VLAN settings.

For example "eth0" is changed to "eth0.1" when a previously untagged LAN
VLAN is switched to tagged on the CPU port and vice versa.

Notifications are displayed in the page header if an auto migration was
performed.

This change should make the switch configuration more user friendly and
less prone to soft bricking.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>