### PR TITLE
luci-mod-admin-full: add SNR tweak option for DSL

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/network.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/network.lua
@@ -46,6 +46,11 @@ if fs.access("/etc/init.d/dsl_control") then
 	line_mode:value("adsl", translate("ADSL"))
 	line_mode:value("vdsl", translate("VDSL"))
 
+	ds_snr = dsl:option(ListValue, "ds_snr_offset", translate("Downstream SNR offset"))
+	for i=-50,50,5 do
+	   ds_snr:value(i, translate("%.1f dB" %{ i / 10} ))
+	end
+
 	firmware = dsl:option(Value, "firmware", translate("Firmware File"))
 
 	m.pageaction = true


### PR DESCRIPTION
Since 860e053b29a77897d635c1e33007552561062961 I've added to LEDE the ability of tweaking  downstream SNR margin on Lantiq DSL chips via UCI.

This patch adds this option to LUCI. AFAIK Lantiq modems are the only supported by LEDE, so I'm adding the option to the UI unconditionally.

Note: currently the LEDE patch affects only ADSL (not VDSL - regardless of the chipset type), but it will probably be extended; so I didn't care about disabling the option in UI when the modem is in VDSL mode.