### PR TITLE
luci-app-adblock: Update Japanese translation

### DIFF
--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -8,7 +8,7 @@ msgstr ""
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.1\n"
+"X-Generator: Poedit 2.0.2\n"
 "Language: ja\n"
 
 msgid "Adblock"
@@ -54,6 +54,9 @@ msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup in manual mode."
 msgstr ""
+"圧縮されたブロックリストのバックアップを作成します。これは、リストのダウン"
+"ロードがエラーの場合、またはマニュアル モードでサービスを起動時に使用されま"
+"す。"
 
 msgid "DNS backend"
 msgstr "DNS バックエンド"
@@ -65,6 +68,8 @@ msgid ""
 "Do not automatically update blocklists during startup, use blocklist backups "
 "instead."
 msgstr ""
+"サービス起動時にブロックリストを自動的に更新せず、代わりにバックアップされた"
+"ブロックリストを使用します。"
 
 msgid "Download Utility (SSL Library)"
 msgstr "ダウンロード ユーティリティ（SSL ライブラリ）"
@@ -105,7 +110,7 @@ msgid ""
 "'libustream-ssl' or the wget 'built-in'."
 msgstr ""
 "SSLで保護されているブロックリストの取得には、適切なSSL ライブラリが必要です。"
-"例: 'libustream-ssl' または wget 'ビルトイン'"
+"例: 'libustream-ssl' または wget 'built-in'"
 
 msgid ""
 "For further information <a href=\"%s\" target=\"_blank\">see online "
@@ -133,7 +138,7 @@ msgid "Loading"
 msgstr "読込中"
 
 msgid "Manual mode"
-msgstr ""
+msgstr "マニュアル モード"
 
 msgid "No"
 msgstr "いいえ"
@@ -264,129 +269,3 @@ msgstr "ブロックされたドメインはありません"
 
 msgid "suspended"
 msgstr "一時停止中"
-
-#~ msgid "."
-#~ msgstr "。"
-
-#~ msgid "For further information"
-#~ msgstr "詳細な情報は"
-
-#~ msgid "see online documentation"
-#~ msgstr "オンライン ドキュメントを確認してください"
-
-#~ msgid "Backup options"
-#~ msgstr "バックアップ オプション"
-
-#~ msgid "Restrict interface reload trigger to certain interface(s)"
-#~ msgstr "リロード トリガを特定のインターフェースに限定する"
-
-#~ msgid ""
-#~ "Space separated list of interfaces that trigger a reload action. To "
-#~ "disable reload trigger at all remove all entries."
-#~ msgstr ""
-#~ "リロードのトリガとなる、スペースで区切られたインターフェースのリストです。"
-#~ "リロード トリガを無効にするには、全てのエントリーを削除して空欄にします。"
-
-#~ msgid ""
-#~ "Space separated list of interfaces that trigger a reload action. To "
-#~ "disable reload trigger at all set it to 'false'."
-#~ msgstr ""
-#~ "リロードのトリガとなる、スペースで区切られたインターフェースのリストで"
-#~ "す。'false' に設定した場合、全てのリロード トリガは無効になります。"
-
-#~ msgid ""
-#~ "Please add only one domain per line. Comments introduced with '#' are "
-#~ "allowed - ip addresses, wildcards & regex are not."
-#~ msgstr ""
-#~ "一行に一つのドメインを追加してください。'#' から始まるコメントを記述できま"
-#~ "すが、IPアドレスやワイルドカード、正規表現を設定値として使用することはでき"
-#~ "ません。"
-
-#~ msgid ""
-#~ "). Note that list URLs and Shallalist category selections are not "
-#~ "configurable via Luci."
-#~ msgstr ""
-#~ "）。これらのリストのURLおよびshallaリストの選択済みカテゴリーは、Luciを通"
-#~ "して設定することができません。"
-
-#~ msgid "Available blocklist sources ("
-#~ msgstr "利用可能なブロックリスト提供元です（"
-
-#~ msgid ""
-#~ "File with whitelisted hosts/domains that are allowed despite being on a "
-#~ "blocklist."
-#~ msgstr ""
-#~ "ホワイトリスト ファイル内のホスト/ドメインは、ブロックリストの登録に関わら"
-#~ "ず許可されます。"
-
-#~ msgid "Global options"
-#~ msgstr "一般設定"
-
-#~ msgid "Restrict reload trigger to certain interface(s)"
-#~ msgstr "リロードトリガを特定のインターフェースに限定する"
-
-#~ msgid ""
-#~ "Space separated list of wan interfaces that trigger reload action. To "
-#~ "disable reload trigger set it to 'false'. Default: empty"
-#~ msgstr ""
-#~ "リロード実行のトリガとなる、スペースで区切られたWANインターフェースのリス"
-#~ "トです。リロードトリガを無効にするには、 false を設定します。デフォルト:"
-#~ "（空）"
-
-#~ msgid "Whitelist file"
-#~ msgstr "ホワイトリスト ファイル"
-
-#~ msgid "see list details"
-#~ msgstr "リストの詳細を見る"
-
-#~ msgid "Count"
-#~ msgstr "カウント"
-
-#~ msgid "Do not write status info to flash"
-#~ msgstr "ステータス情報をフラッシュに書き込まない"
-
-#~ msgid "Last update of the blocklists"
-#~ msgstr "ブロックリストの最終更新日時"
-
-#~ msgid "List date/state"
-#~ msgstr "リスト日時/状態"
-
-#~ msgid "Name of the logical lan interface"
-#~ msgstr "論理LANインターフェース名"
-
-#~ msgid "Percentage of blocked packets (before last update, IPv4/IPv6)"
-#~ msgstr "ブロック済みパケットの割合（最終更新以前、IPv4/IPv6）"
-
-#~ msgid "Port of the adblock uhttpd instance"
-#~ msgstr "adblock uhttpdインスタンスのポート"
-
-#~ msgid "Port of the adblock uhttpd instance for https links"
-#~ msgstr "httpsリンク用adblock uhttpdインスタンスのポート"
-
-#~ msgid "Redirect all DNS queries to the local resolver"
-#~ msgstr "全てのDNSクエリをローカルリゾルバにリダイレクト"
-
-#~ msgid ""
-#~ "Skip writing update status information to the config file. Status fields "
-#~ "on this page will not be updated."
-#~ msgstr ""
-#~ "更新ステータス情報をコンフィグファイルに書き込まず、スキップします。この"
-#~ "ページのステータス画面は更新されなくなります。"
-
-#~ msgid "Statistics"
-#~ msgstr "ステータス"
-
-#~ msgid "Timeout for blocklist fetch (seconds)"
-#~ msgstr "ブロックリスト取得の制限時間（秒）"
-
-#~ msgid "Total count of blocked domains"
-#~ msgstr "ブロック済みドメインの合計"
-
-#~ msgid ""
-#~ "When adblock is active, all DNS queries are redirected to the local "
-#~ "resolver in this server by default. You can disable that to allow queries "
-#~ "to external DNS servers."
-#~ msgstr ""
-#~ "adblockがアクティブである時、全てのDNSクエリは既定でこのサーバー上のリゾル"
-#~ "バにリダイレクトされます。外部DNSサーバーへのクエリを許可する場合、この設"
-#~ "定を無効にすることもできます。"

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -50,11 +50,21 @@ msgstr ""
 "DNS の利用によって広告/不正ドメインをブロックする、Adblock パッケージの設定で"
 "す。"
 
+msgid ""
+"Create compressed blocklist backups, they will be used in case of download "
+"errors or during startup in manual mode."
+msgstr ""
+
 msgid "DNS backend"
 msgstr "DNS バックエンド"
 
 msgid "Description"
 msgstr "説明"
+
+msgid ""
+"Do not automatically update blocklists during startup, use blocklist backups "
+"instead."
+msgstr ""
 
 msgid "Download Utility (SSL Library)"
 msgstr "ダウンロード ユーティリティ（SSL ライブラリ）"
@@ -121,6 +131,9 @@ msgstr "最終実行日時"
 
 msgid "Loading"
 msgstr "読込中"
+
+msgid "Manual mode"
+msgstr ""
 
 msgid "No"
 msgstr "いいえ"

--- a/applications/luci-app-adblock/po/pt-br/adblock.po
+++ b/applications/luci-app-adblock/po/pt-br/adblock.po
@@ -51,11 +51,21 @@ msgstr ""
 "Configuração do pacote adblock para bloquear, usando o DNS, domínios que "
 "distribuem propagandas abusivas."
 
+msgid ""
+"Create compressed blocklist backups, they will be used in case of download "
+"errors or during startup in manual mode."
+msgstr ""
+
 msgid "DNS backend"
 msgstr ""
 
 msgid "Description"
 msgstr "Descrição"
+
+msgid ""
+"Do not automatically update blocklists during startup, use blocklist backups "
+"instead."
+msgstr ""
 
 msgid "Download Utility (SSL Library)"
 msgstr ""
@@ -115,6 +125,9 @@ msgid "Last rundate"
 msgstr ""
 
 msgid "Loading"
+msgstr ""
+
+msgid "Manual mode"
 msgstr ""
 
 msgid "No"

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -40,11 +40,21 @@ msgstr ""
 "Konfiguration av paketet adblock för att blockera annons/otillåtna domäner "
 "genom att använda DNS."
 
+msgid ""
+"Create compressed blocklist backups, they will be used in case of download "
+"errors or during startup in manual mode."
+msgstr ""
+
 msgid "DNS backend"
 msgstr "Bakände för DNS"
 
 msgid "Description"
 msgstr "Beskrivning"
+
+msgid ""
+"Do not automatically update blocklists during startup, use blocklist backups "
+"instead."
+msgstr ""
 
 msgid "Download Utility (SSL Library)"
 msgstr "Nerladdningsprogram (SSL-bibliotek)"
@@ -106,6 +116,9 @@ msgstr ""
 
 msgid "Loading"
 msgstr "Laddar"
+
+msgid "Manual mode"
+msgstr ""
 
 msgid "No"
 msgstr "Nej"

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -38,10 +38,20 @@ msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS."
 msgstr ""
 
+msgid ""
+"Create compressed blocklist backups, they will be used in case of download "
+"errors or during startup in manual mode."
+msgstr ""
+
 msgid "DNS backend"
 msgstr ""
 
 msgid "Description"
+msgstr ""
+
+msgid ""
+"Do not automatically update blocklists during startup, use blocklist backups "
+"instead."
 msgstr ""
 
 msgid "Download Utility (SSL Library)"
@@ -102,6 +112,9 @@ msgid "Last rundate"
 msgstr ""
 
 msgid "Loading"
+msgstr ""
+
+msgid "Manual mode"
 msgstr ""
 
 msgid "No"

--- a/applications/luci-app-adblock/po/zh-cn/adblock.po
+++ b/applications/luci-app-adblock/po/zh-cn/adblock.po
@@ -50,11 +50,21 @@ msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS."
 msgstr "Adblock 配置工具，通过 DNS 来拦截广告和阻止域名。"
 
+msgid ""
+"Create compressed blocklist backups, they will be used in case of download "
+"errors or during startup in manual mode."
+msgstr ""
+
 msgid "DNS backend"
 msgstr "DNS 后端"
 
 msgid "Description"
 msgstr "描述"
+
+msgid ""
+"Do not automatically update blocklists during startup, use blocklist backups "
+"instead."
+msgstr ""
 
 msgid "Download Utility (SSL Library)"
 msgstr ""
@@ -115,6 +125,9 @@ msgstr ""
 
 msgid "Loading"
 msgstr "加载中"
+
+msgid "Manual mode"
+msgstr ""
 
 msgid "No"
 msgstr "否"


### PR DESCRIPTION
Updated Japanese translations, and cleaned up old translations.

Most of old translations in Japanese po file were replaced with different strings or removed, and I decided that all of them were unnecessary and deleted.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>