### PR TITLE
luci-app-mwan3: Fix mismatched texts

### DIFF
--- a/applications/luci-app-mwan3/po/ja/mwan3.po
+++ b/applications/luci-app-mwan3/po/ja/mwan3.po
@@ -362,7 +362,7 @@ msgid "There are currently %d of 250 supported interfaces configured"
 msgstr "現在、250個中 %d 個のサポートされたインターフェースが設定済みです。"
 
 msgid ""
-"This Hostname or IP Address will be pinged to determine if the link is up or "
+"This hostname or IP address will be pinged to determine if the link is up or "
 "down. Leave blank to assume interface is always online"
 msgstr ""
 "リンクの Up または Down 状態を判定するために、このホスト名または IP アドレス"
@@ -406,7 +406,7 @@ msgstr ""
 "wan2, その他）<br />$DEVICE - インターフェースにアタッチされたデバイスの名前"
 "（eth0.1, eth1, その他）"
 
-msgid "Tracking Hostname or IP Address"
+msgid "Tracking hostname or IP address"
 msgstr "追跡ホスト名または IP アドレス"
 
 msgid "Tracking IP"

--- a/applications/luci-app-mwan3/po/templates/mwan3.pot
+++ b/applications/luci-app-mwan3/po/templates/mwan3.pot
@@ -312,7 +312,7 @@ msgid "There are currently %d of 250 supported interfaces configured"
 msgstr ""
 
 msgid ""
-"This Hostname or IP Address will be pinged to determine if the link is up or "
+"This hostname or IP address will be pinged to determine if the link is up or "
 "down. Leave blank to assume interface is always online"
 msgstr ""
 
@@ -340,7 +340,7 @@ msgid ""
 "device name attached to the interface (eth0.1, eth1, etc.)"
 msgstr ""
 
-msgid "Tracking Hostname or IP Address"
+msgid "Tracking hostname or IP address"
 msgstr ""
 
 msgid "Tracking IP"

--- a/applications/luci-app-mwan3/po/zh-cn/mwan3.po
+++ b/applications/luci-app-mwan3/po/zh-cn/mwan3.po
@@ -348,7 +348,7 @@ msgid "There are currently %d of 250 supported interfaces configured"
 msgstr ""
 
 msgid ""
-"This Hostname or IP Address will be pinged to determine if the link is up or "
+"This hostname or IP address will be pinged to determine if the link is up or "
 "down. Leave blank to assume interface is always online"
 msgstr ""
 
@@ -382,7 +382,7 @@ msgstr ""
 "$INTERFACE 是接口名称 (wan1、wan2 等)<br />$DEVICE 是连接到接口的设备名称 "
 "(eth0.1、eth1 等)"
 
-msgid "Tracking Hostname or IP Address"
+msgid "Tracking hostname or IP address"
 msgstr ""
 
 msgid "Tracking IP"


### PR DESCRIPTION
"hostname" and "address" in interfaceconfig.lua are mismatched with
the strings in po/pot files, and their translations are not applied.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>