### PR TITLE
 luci-mod-admin-full: dnsmasq clarify non-wildcard mode

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -240,21 +240,19 @@ o.rmempty = false
 
 o = s:taboption("general", Flag, "nonwildcard",
 	translate("Non-wildcard"),
-	translate("Bind only to specific interfaces rather than wildcard address."))
+	translate("Bind dynamically to interfaces rather than wildcard address (recommended as linux default)"))
 o.optional = false
-o.rmempty = false
+o.rmempty = true
 
 o = s:taboption("general", DynamicList, "interface",
 	translate("Listen Interfaces"),
 	translate("Limit listening to these interfaces, and loopback."))
 o.optional = true
-o:depends("nonwildcard", true)
 
 o = s:taboption("general", DynamicList, "notinterface",
 	translate("Exclude interfaces"),
 	translate("Prevent listening on these interfaces."))
 o.optional = true
-o:depends("nonwildcard", true)
 
 m:section(SimpleSection).template = "admin_network/lease_status"
 


### PR DESCRIPTION
'non-wildcard' interfaces enables dnsmasq's '--bind-dynamic' mode.
This binds to interfaces rather than wildcard addresses *and* keeps track
of interface comings/goings via a unique Linux api.

Quoting dnsmasq's author "bind-dynamic (bind individual addresses,
keep up with changes in interface config) ... On linux, there's actually
no sane reason not to use --bind-dynamic, and it's only not the default
for historical reasons."

Removed the dependency of 'nonwildcard' enabling access to
'listen/exclude' interfaces.  This was bogus anyway, dnsmasq has no
requirement for 'bind dynamic' to enable include/exclude interfaces.
In fact the dnsmasq init script takes notice of include/exclude
interfaces irrespective of the 'nonwildcard' parameter.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>