### PR TITLE
luci-mod-admin-full: Fix default state for "enable_vlan"

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/vlan.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/vlan.lua
@@ -128,7 +128,8 @@ m.uci:foreach("network", "switch",
 		s.addremove = false
 
 		if has_vlan then
-			s:option(Flag, has_vlan, translate("Enable VLAN functionality"))
+			x = s:option(Flag, has_vlan, translate("Enable VLAN functionality"))
+			x.default = x.enabled
 		end
 
 		if has_learn then


### PR DESCRIPTION
swconfig sets the "enable_vlan" attribute to 1 by default[1], so we need
to match this or the user will not be able to disable VLAN functionality
via the web interface.

Before this change:

    [ ] Enable VLAN functionality   -- enable_vlan deleted
    [X] Enable VLAN functionality   -- enable_vlan=1

After this change:

    [ ] Enable VLAN functionality   -- enable_vlan=0
    [X] Enable VLAN functionality   -- enable_vlan deleted

This reverts a tiny part of the following commit:

    commit 76e5b68bb921fdbb95cec4a42cb3c69800e6ac41
    Author: Jo-Philipp Wich <jow@openwrt.org>
    Date:   Sun Jul 17 05:46:54 2011 +0000

        modules/admin-full: don't expose "reset" and "enable" options for
        switches, do not set any default state for "enable_vlan"

Tested manually on LEDE 17.01.2

[1] https://github.com/openwrt/openwrt/blob/484ecf816460f58fe589565ac88014f369db86ee/package/network/config/swconfig/src/uci.c#L50

Signed-off-by: Dwayne Litzenberger <dlitz@dlitz.net>