### PR TITLE
community-profiles: remove dependency on freifunk-common

### DIFF
--- a/contrib/package/community-profiles/Makefile
+++ b/contrib/package/community-profiles/Makefile
@@ -15,7 +15,6 @@ define Package/community-profiles
   CATEGORY:=LuCI
   SUBMENU:=9. Freifunk
   TITLE:=Community profiles
-  DEPENDS:=freifunk-common
 endef
 
 define Package/community-profiles/description


### PR DESCRIPTION
The configuration files provided by the community-profiles package do
not depend on files and code form the freifunk-common package. There is
no reason to create a artifical dependency in the Makefile.

Signed-off-by: Philipp Borgers <borgers@mi.fu-berlin.de>