### PR TITLE
luci-base: fix langage missmatch on auto setting

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -206,6 +206,12 @@ function dispatch(request)
 			if conf.languages[lpat] then
 				lang = lpat
 				break
+			else
+				lpat = lpat and lpat:gsub("_.*", "")
+				if conf.languages[lpat] then
+					lang = lpat
+					break
+				end
 			end
 		end
 	end


### PR DESCRIPTION
missmatch laungage when auto settings.
It is a way to help things that are not perfect matches, but I would like to hear opinions.

example,
browser setting is ja-JP, I want you to selecting ja on auto setting.
In many cases, browser setting is ja-JP or ja-XX, not ja. Sadly.
fix to help these.

Signed-off-by: YuheiOKAWA <tochiro.srchack@gmail.com>