### PR TITLE
luci-app-statistics: add support for apcups plugin

### DIFF
--- a/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
+++ b/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
@@ -23,6 +23,7 @@ function index()
 		s_general	= _("General plugins"),
 		s_network	= _("Network plugins"),
 
+		apcups		= _("APC UPS"),
 		conntrack	= _("Conntrack"),
 		contextswitch	= _("Context Switches"),
 		cpu			= _("Processor"),
@@ -59,8 +60,8 @@ function index()
 	-- our collectd menu
 	local collectd_menu = {
 		output  = { "csv", "network", "rrdtool", "unixsock" },
-		general = { "contextswitch", "cpu", "cpufreq", "df", "disk", "email",
-			"entropy", "exec", "irq", "load", "memory",
+		general = { "apcups", "contextswitch", "cpu", "cpufreq", "df",
+			"disk", "email", "entropy", "exec", "irq", "load", "memory",
 			"nut", "processes", "sensors", "thermal", "uptime" },
 		network = { "conntrack", "dns", "interface", "iptables",
 			"netlink", "olsrd", "openvpn", "ping",

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua
@@ -1,0 +1,28 @@
+-- Copyright 2015 Jo-Philipp Wich <jow@openwrt.org>
+-- Licensed to the public under the Apache License 2.0.
+
+m = Map("luci_statistics",
+	translate("APCUPS Plugin Configuration"),
+	translate(
+		"The APCUPS plugin collects statistics about the APC UPS."
+	))
+
+-- collectd_apcups config section
+s = m:section( NamedSection, "collectd_apcups", "luci_statistics" )
+
+-- collectd_apcups.enable
+enable = s:option( Flag, "enable", translate("Enable this plugin") )
+enable.default = 0
+
+-- collectd_apcups.host (Host)
+host = s:option( Value, "Host", translate("Monitor host"), translate ("Add multiple hosts separated by space."))
+host.default = "localhost"
+host:depends( "enable", 1 )
+
+-- collectd_apcups.port (Port)
+port = s:option( Value, "Port", translate("Port for apcupsd communication") )
+port.isinteger = true
+port.default   = 3551
+port:depends( "enable", 1 )
+
+return m

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
@@ -1,0 +1,101 @@
+-- Copyright 2015 Jo-Philipp Wich <jow@openwrt.org>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.statistics.rrdtool.definitions.apcups",package.seeall)
+
+function rrdargs( graph, plugin, plugin_instance, dtype )
+
+	local voltages = {
+		title = "%H: Voltages on APC UPS ",
+		vlabel = "V",
+		number_format = "%5.1lfV",
+		data = {
+			instances = {
+				voltage = { "battery", "input", "output" }
+			},
+
+			options = {
+				voltage_output  = { color = "00e000", title = "Output voltage", noarea=true, overlay=true },
+				voltage_battery = { color = "0000ff", title = "Battery voltage", noarea=true, overlay=true },
+				voltage_input   = { color = "ffb000", title = "Input voltage", noarea=true, overlay=true }
+			}
+		}
+	}
+
+	local percentload = {
+		title = "%H: Load on APC UPS ",
+		vlabel = "Percent",
+		y_min = "0",
+		y_max = "100",
+		number_format = "%5.1lf%%",
+		data = {
+			sources = {
+				percent_load = { "value" }
+			},
+			instances = {
+				percent = "load"
+			},
+			options = {
+				percent_load = { color = "00ff00", title = "Load level"  }
+			}
+		}
+	}
+
+	local charge_percent = {
+		title = "%H: Battery charge on APC UPS ",
+		vlabel = "Percent",
+		y_min = "0",
+		y_max = "100",
+		number_format = "%5.1lf%%",
+		data = {
+			types = { "charge" },
+			options = {
+				charge = { color = "00ff0b", title = "Charge level"  }
+			}
+		}
+	}
+
+	local temperature = {
+		title = "%H: Battery temperature on APC UPS ",
+		vlabel = "\176C",
+		number_format = "%5.1lf\176C",
+		data = {
+			types = { "temperature" },
+			options = {
+				temperature = { color = "ffb000", title = "Battery temperature" } }
+		}
+	}
+
+	local timeleft = {
+		title = "%H: Time left on APC UPS ",
+		vlabel = "Minutes",
+		number_format = "%.1lfm",
+		data = {
+			sources = {
+				timeleft = { "value" }
+			},
+			options = {
+				timeleft = { color = "0000ff", title = "Time left" }
+			}
+		}
+	}
+
+	local frequency = {
+		title = "%H: Incoming line frequency on APC UPS ",
+		vlabel = "Hz",
+		number_format = "%5.0lfhz",
+		data = {
+			sources = {
+				frequency_input = { "value" }
+			},
+			instances = {
+				frequency = "frequency"
+			},
+			options = {
+				frequency_frequency = { color = "000fff", title = "Line frequency" }
+			}
+		}
+	}
+
+	return { voltages, percentload, charge_percent, temperature, timeleft, frequency }
+end

--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -49,6 +49,11 @@ config statistics 'collectd_unixsock'
 
 # input plugins
 
+config statistics 'collectd_apcups'
+	option enable '0'
+	option Host 'localhost'
+	option Port '3551'
+
 config statistics 'collectd_conntrack'
 	option enable '0'
 

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -255,6 +255,12 @@ end
 
 
 plugins = {
+	apcups = {
+		{ "Host", "Port" },
+		{ },
+		{ }
+	},
+
 	collectd = {
 		{ "BaseDir", "Include", "PIDFile", "PluginDir", "TypesDB", "Interval", "ReadThreads", "Hostname" },
 		{ },


### PR DESCRIPTION
OpenWRT/LEDE support for APC UPSes is only partial: although the collectd apcups plugin is included, related lua/luci code is missing. These changes add the lua side and have been used for ~2 years, both on OpenWRT and LEDE.

Reworked from patches submitted by James Klaas to the luci development listin 2015.

EDIT: clarified text as requested.