### PR TITLE
luci-base: add missing conffiles

### DIFF
--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -26,6 +26,7 @@ include $(INCLUDE_DIR)/host-build.mk
 define Package/luci-base/conffiles
 /etc/luci-uploads
 /etc/config/luci
+/etc/config/ucitrack
 endef
 
 include ../../luci.mk


### PR DESCRIPTION
When the `/etc/config/ucitrack` is modified, it should not be overwritten when luci-base is upgraded.