### PR TITLE
luci-mod-admin-full: Fix wrong icon when noise=0

### DIFF
--- a/applications/luci-app-samba/luasrc/model/cbi/samba.lua
+++ b/applications/luci-app-samba/luasrc/model/cbi/samba.lua
@@ -36,7 +36,8 @@ function tmpl.write(self, section, value)
 end
 
 
-s = m:section(TypedSection, "sambashare", translate("Shared Directories"))
+s = m:section(TypedSection, "sambashare", translate("Shared Directories")
+	, translate("Please add directories to share.  Each directory refers to a folder on a mounted device."))
 s.anonymous = true
 s.addremove = true
 s.template = "cbi/tblsection"

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -563,7 +563,7 @@
 						tr.className = 'cbi-section-table-row cbi-rowstyle-' + (1 + (i % 2));
 
 					var icon;
-					var q = (-1 * (assoclist[i].noise - assoclist[i].signal)) / 5;
+					var q = Math.abs((assoclist[i].noise - assoclist[i].signal)) / 5;
 					if (q < 1)
 						icon = "<%=resource%>/icons/signal-0.png";
 					else if (q < 2)


### PR DESCRIPTION
#1101 [The wireless client signal strength is not displayed](https://github.com/openwrt/luci/issues/1101)

The existing code depends on subtraction of two negatives being a positive.
However, sometimes noise comes into this code as 0.
This creates a negative subtraction result, which selects the wrong icon.
Changing the formula from a multiply by -1, to a Math.abs() 
ensures that the result is always a positive value.

Signed-off-by: Bob Meizlik <bobmseagithub@squakmt.com>