### PR TITLE
luci-app-statistics: Voltage graphs - AC and DC

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
@@ -5,18 +5,34 @@ module("luci.statistics.rrdtool.definitions.apcups",package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
 
-	local voltages = {
-		title = "%H: Voltages on APC UPS ",
-		vlabel = "V",
+	local voltagesdc = {
+		title = "%H: Voltages on APC UPS - Battery",
+		vlabel = "Volts DC",
+    alt_autoscale = true,
 		number_format = "%5.1lfV",
 		data = {
 			instances = {
-				voltage = { "battery", "input", "output" }
+				voltage = { "battery" }
+			},
+
+			options = { 
+				voltage = { title = "Battery voltage", noarea=true }
+			}
+		}
+	}
+	
+	local voltages = {
+		title = "%H: Voltages on APC UPS - AC",
+		vlabel = "Volts AC",
+		alt_autoscale = true,
+		number_format = "%5.1lfV",
+		data = {
+			instances = {
+				voltage = {  "input", "output" }
 			},
 
 			options = {
 				voltage_output  = { color = "00e000", title = "Output voltage", noarea=true, overlay=true },
-				voltage_battery = { color = "0000ff", title = "Battery voltage", noarea=true, overlay=true },
 				voltage_input   = { color = "ffb000", title = "Input voltage", noarea=true, overlay=true }
 			}
 		}
@@ -97,5 +113,5 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		}
 	}
 
-	return { voltages, percentload, charge_percent, temperature, timeleft, frequency }
+	return { voltages, voltagesdc, percentload, charge_percent, temperature, timeleft, frequency }
 end


### PR DESCRIPTION
#1227 [luci-app-statistics: add support for apcups plugin](https://github.com/openwrt/luci/pull/1227)
The Voltage graph combines Battery, Input Voltage and Output Voltage.
The Y-Axis scale masks changes in Input/Output voltages over time.
This patch splits the graphs into 2 graphs.
This makes it possible to see variations in AC Input/Output voltages.

Signed-off-by: bobmseagithub <bobmseagithub@squakmt.com>