### PR TITLE
luci-base: Remove request headers that are set automatically by browser

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/xhr.js
+++ b/modules/luci-base/htdocs/luci-static/resources/xhr.js
@@ -91,8 +91,6 @@ XHR = function()
 
 		xhr.open('POST', url, true);
 		xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-		xhr.setRequestHeader('Content-length', code.length);
-		xhr.setRequestHeader('Connection', 'close');
 		xhr.send(code);
 	}
 


### PR DESCRIPTION
Content-length and Connection should not be set in a JS request. Security issue when they are set. My browser throws two errors when they are set.

https://stackoverflow.com/questions/7210507/ajax-post-error-refused-to-set-unsafe-header-connection
https://stackoverflow.com/questions/2623963/webkit-refused-to-set-unsafe-header-content-length