### PR TITLE
luci-app-travelmate: Fix translation issue

### DIFF
--- a/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
@@ -14,7 +14,7 @@ This is free software, licensed under the Apache License, Version 2.0
 <div class="cbi-map">
 <h2 name="content"><%:Wireless Stations%></h2>
 <div class="cbi-map-descr">
-  <%:Provides an overview of all configured uplinks for the travelmate interface (%><%=trmiface%><%:). You can edit, delete or re-order existing uplinks or scan for a new one. The currently used uplink is emphasized in blue.%>
+  <%=translatef("Provides an overview of all configured uplinks for the travelmate interface (%s). You can edit, delete or re-order existing uplinks or scan for a new one. The currently used uplink is emphasized in blue.", trmiface)%>
 </div>
 
 <fieldset class="cbi-section">


### PR DESCRIPTION
Since the position of variable "trmiface" in the sentence can not be changed, it
may become an unnatural translation (e.g. Japanese).

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>