### PR TITLE
luci-app-travelmate: bugfixes

### DIFF
--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
@@ -90,7 +90,7 @@ end
 o3 = s:option(Value, "trm_iface", translate("Uplink / Trigger interface"),
 	translate("Name of the uplink interface that triggers travelmate processing in 'manual' mode."))
 o3.datatype = "and(uciname,rangelength(3,15))"
-o3.default = "trm_wwan"
+o3.default = trmiface
 o3.rmempty = false
 
 o4 = s:option(Value, "trm_triggerdelay", translate("Trigger delay"),

--- a/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
@@ -14,7 +14,7 @@ This is free software, licensed under the Apache License, Version 2.0
 <div class="cbi-map">
 <h2 name="content"><%:Wireless Stations%></h2>
 <div class="cbi-map-descr">
-  <%:Provides an overview of all configured uplinks for the travelmate interface (%><%=trmiface%><%:). You can edit, delete or re-order existing uplinks or scan for a new one. The currently used uplink is emphasized in blue.%>
+  <%=translatef("Provides an overview of all configured uplinks for the travelmate interface (%s). You can edit, delete or re-order existing uplinks or scan for a new one. The currently used uplink is emphasized in blue.", trmiface)%>
 </div>
 
 <fieldset class="cbi-section">
@@ -26,8 +26,11 @@ This is free software, licensed under the Apache License, Version 2.0
       <th class="cbi-section-table-cell" style="text-align:center" colspan="2"><%:Actions%></th>
     </tr>
 <%
-    local pos = 1
-    uci:foreach("wireless", "wifi-iface", function(s)
+  local pos = -1
+  uci:foreach("wireless", "wifi-device", function(s)
+    pos = pos + 1
+  end)
+  uci:foreach("wireless", "wifi-iface", function(s)
     pos = pos + 1
     local section = s['.name']
     local device = s.device or ""


### PR DESCRIPTION
* fix interface default value on overview page
* fix re-ordering of wireless stations

Signed-off-by: Dirk Brenken <dev@brenken.org>