### PR TITLE
luci-mod-admin-full: fatab fix UUID "not present" in some device

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab.lua
@@ -19,7 +19,7 @@ repeat
 
 		for key, val in ln:gmatch([[(%w+)="(.-)"]]) do
 			e[key:lower()] = val
-			devices[val] = e
+			devices[val:lower()] = e
 		end
 
 		s = tonumber((fs.readfile("/sys/class/block/%s/size" % dev)))


### PR DESCRIPTION
Some device have a UUID with all Caps.

eg. /dev/sdb4: UUID="5247-4D54" LABEL="Device" VERSION="FAT32" TYPE="vfat"

Remove lower() to fix "not present" issue.

Signed-off-by: Hsing-Wang Liao <kuoruan@gmail.com>