### PR TITLE
luci-app-attendedsysupgrade: remove leading slash

### DIFF
--- a/applications/luci-app-attendedsysupgrade/luasrc/view/attendedsysupgrade.htm
+++ b/applications/luci-app-attendedsysupgrade/luasrc/view/attendedsysupgrade.htm
@@ -178,7 +178,7 @@ function image_request() {
 	request_dict = {}
 	request_dict.version = latest_version;
 	request_dict.board = data.board_name
-	server_request(request_dict, "/image-request", image_request_handler)
+	server_request(request_dict, "image-request", image_request_handler)
 }
 
 function image_request_handler(response) {


### PR DESCRIPTION
the slash leads to // redirecting to /. The redirecting causes problems
with CORS [1].

[1]: http://enable-cors.org/

Signed-off-by: Paul Spooren <paul@spooren.de>