### PR TITLE
luci-mod-admin-full: add 'auto' xfer_mode to dsl configuration

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/network.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/network.lua
@@ -38,6 +38,7 @@ if fs.access("/etc/init.d/dsl_control") then
 	tone:value("bv", translate("B43 + B43C + V43"))
 
 	xfer_mode = dsl:option(ListValue, "xfer_mode", translate("Encapsulation mode"))
+	xfer_mode:value("", translate("auto"))
 	xfer_mode:value("atm", translate("ATM (Asynchronous Transfer Mode)"))
 	xfer_mode:value("ptm", translate("PTM/EFM (Packet Transfer Mode)"))
 


### PR DESCRIPTION
This change is needed to support the new default 'auto' xfer_mode
setting.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>