### PR TITLE
luci-app-attendedsysupgrade: add missing dep

### DIFF
--- a/applications/luci-app-attendedsysupgrade/Makefile
+++ b/applications/luci-app-attendedsysupgrade/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for attended sysupgrades
-LUCI_DEPENDS:=+luci-base +rpcd-mod-attendedsysupgrade
+LUCI_DEPENDS:=+luci-base +uhttpd-mod-ubus +rpcd-mod-attendedsysupgrade
 
 include ../../luci.mk
 


### PR DESCRIPTION
uhttpd-mod-ubus is missing on some devices where rpcd is installed.
the luci app fundamentally depends on /ubus

Signed-off-by: Paul Spooren <paul@spooren.de>