### PR TITLE
luci.mk: sort languages in lexical order

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -7,7 +7,7 @@
 LUCI_NAME?=$(notdir ${CURDIR})
 LUCI_TYPE?=$(word 2,$(subst -, ,$(LUCI_NAME)))
 LUCI_BASENAME?=$(patsubst luci-$(LUCI_TYPE)-%,%,$(LUCI_NAME))
-LUCI_LANGUAGES:=$(filter-out templates,$(notdir $(wildcard ${CURDIR}/po/*)))
+LUCI_LANGUAGES:=$(sort $(filter-out templates,$(notdir $(wildcard ${CURDIR}/po/*))))
 LUCI_DEFAULTS:=$(notdir $(wildcard ${CURDIR}/root/etc/uci-defaults/*))
 LUCI_PKGARCH?=$(if $(realpath src/Makefile),,all)
 


### PR DESCRIPTION
If you make a fresh build env the languages config tags `CONFIG_LUCI_LANG_*` are sometimes resorted in an undefined order.
I track my configuration with git this will mess my change tracking.
There are changes where no changes are!
This change will fix this


Signed-off-by: Florian Eckert <fe@dev.tdt.de>