### PR TITLE
luci-app-dnscrypt-proxy: fix ssl dependency

### DIFF
--- a/applications/luci-app-dnscrypt-proxy/Makefile
+++ b/applications/luci-app-dnscrypt-proxy/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for DNSCrypt-Proxy
-LUCI_DEPENDS:=+libustream-mbedtls +dnscrypt-proxy
+LUCI_DEPENDS:=+uclient-fetch +dnscrypt-proxy
 LUCI_PKGARCH:=all
 
 include ../../luci.mk

--- a/applications/luci-app-dnscrypt-proxy/luasrc/model/cbi/dnscrypt-proxy/overview_tab.lua
+++ b/applications/luci-app-dnscrypt-proxy/luasrc/model/cbi/dnscrypt-proxy/overview_tab.lua
@@ -11,6 +11,13 @@ local plug_cnt  = tonumber(luci.sys.exec("env -i /usr/sbin/dnscrypt-proxy --vers
 local res_list  = {}
 local url       = "https://download.dnscrypt.org/dnscrypt-proxy/dnscrypt-resolvers.csv"
 
+if not fs.access("/lib/libustream-ssl.so") then
+	m = SimpleForm("error", nil, translate("SSL support not available, please install an libustream-ssl variant to use this package."))
+	m.submit = false
+	m.reset = false
+	return m
+end
+
 if not fs.access(res_input) then
 	luci.sys.call("env -i /bin/uclient-fetch --no-check-certificate -O " .. res_input .. " " .. url .. " >/dev/null 2>&1")
 end


### PR DESCRIPTION
* remove libustream-mbedtls dependency in makefile and check for
'libustream-ssl.so' in the app. (fix for #1310)
* add missing uclient-fetch dependency in makefile.

Signed-off-by: Dirk Brenken <dev@brenken.org>