### PR TITLE
luci-app-dnscrypt-proxy: Add Japanese translation

### DIFF
--- a/applications/luci-app-dnscrypt-proxy/luasrc/model/cbi/dnscrypt-proxy/overview_tab.lua
+++ b/applications/luci-app-dnscrypt-proxy/luasrc/model/cbi/dnscrypt-proxy/overview_tab.lua
@@ -41,7 +41,7 @@ end
 
 -- Trigger selection
 
-s = m:section(TypedSection, "global", "General options")
+s = m:section(TypedSection, "global", translate("General options"))
 s.anonymous = true
 
 -- Main dnscrypt-proxy resource list
@@ -69,7 +69,7 @@ end
 
 -- Trigger settings
 
-t = s:option(DynamicList, "procd_trigger", "Startup Trigger",
+t = s:option(DynamicList, "procd_trigger", translate("Startup Trigger"),
 	translate("By default the DNSCrypt-Proxy startup will be triggered by ifup events of multiple network interfaces. ")
 	.. translate("To restrict the trigger, add only the relevant network interface(s). ")
 	.. translate("Usually the 'wan' interface should work for most users."))
@@ -85,7 +85,7 @@ t.rmempty = true
 
 -- Mandatory options per instance
 
-s = m:section(TypedSection, "dnscrypt-proxy", "Instance options")
+s = m:section(TypedSection, "dnscrypt-proxy", translate("Instance options"))
 s.anonymous = true
 s.addremove = true
 

--- a/applications/luci-app-dnscrypt-proxy/po/ja/dnscrypt-proxy.po
+++ b/applications/luci-app-dnscrypt-proxy/po/ja/dnscrypt-proxy.po
@@ -1,0 +1,207 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.3\n"
+"Last-Translator: INAGAKI Hiroshi <musashino.open@gmail.com>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: ja\n"
+
+msgid "Advanced"
+msgstr "詳細"
+
+msgid "Alternate Resolver List"
+msgstr "代替 リゾルバ リスト"
+
+msgid "Blacklist"
+msgstr "ブラックリスト"
+
+msgid "Block IPv6"
+msgstr "IPv6 のブロック"
+
+msgid ""
+"By default the DNSCrypt-Proxy startup will be triggered by ifup events of "
+"multiple network interfaces."
+msgstr ""
+"デフォルトでは、 DNSCrypt-Proxy は全ネットワーク インターフェースの ifup イベ"
+"ントによりトリガされ起動します。"
+
+msgid "Configuration of the DNSCrypt-Proxy package."
+msgstr "DNSCrypt-Proxy パッケージの設定です。"
+
+msgid "DNS Query Logfile"
+msgstr "DNS クエリ ログファイル"
+
+msgid "DNSCrypt-Proxy"
+msgstr "DNSCrypt-Proxy"
+
+msgid "DNSCrypt-Proxy Logfile"
+msgstr "DNSCrypt-Proxy ログファイル"
+
+msgid "DNSCrypt-Proxy Resolver List"
+msgstr "DNSCrypt-Proxy リゾルバ リスト"
+
+msgid "Default Resolver List"
+msgstr "デフォルト リゾルバ リスト"
+
+msgid "Disable IPv6 to speed up DNSCrypt-Proxy."
+msgstr "DNSCrypt-Proxy の高速化のため、IPv6 を無効化します。"
+
+msgid "Edit DNSCrypt-Proxy Configuration"
+msgstr "DNSCrypt-Proxy 設定の編集"
+
+msgid "Edit Dnsmasq Configuration"
+msgstr "Dnsmasq 設定の編集"
+
+msgid "Enable Caching to speed up DNSCcrypt-Proxy."
+msgstr "DNSCrypt-Proxy の高速化のため、キャッシュ機能を有効化します。"
+
+msgid "Ephemeral Keys"
+msgstr "一時的なキー"
+
+msgid "File Checksum"
+msgstr "ファイル チェックサム"
+
+msgid "File Date"
+msgstr "ファイル日付"
+
+msgid ""
+"For further information <a href=\"%s\" target=\"_blank\">see the wiki "
+"online</a>"
+msgstr ""
+"詳細な情報は <a href=\"%s\" target=\"_blank\">オンライン Wiki</a> を確認して"
+"ください。"
+
+msgid "General options"
+msgstr "全般設定"
+
+msgid "IP Address"
+msgstr "IP アドレス"
+
+msgid "Improve privacy by using an ephemeral public key for each query."
+msgstr ""
+"クエリ毎に一時的な公開鍵を使用することにより、プライバシーを向上します。"
+
+msgid "Input file not found, please check your configuration."
+msgstr "入力ファイルが見つかりません。設定を確認してください。"
+
+msgid "Instance options"
+msgstr "インスタンス オプション"
+
+msgid "Keep in mind to configure Dnsmasq as well."
+msgstr "Dnsmasq を適切に設定する必要があることに留意してください。"
+
+msgid "Local Cache"
+msgstr "ローカル キャッシュ"
+
+msgid ""
+"Local blacklists allow you to block abuse sites by domains or ip addresses."
+msgstr ""
+"ローカル ブラックリストは、不正なサイトをドメイン名または IP アドレスによって"
+"ブロックすることが可能です。"
+
+msgid ""
+"Log the received DNS queries to a file, so you can watch in real-time what "
+"is happening on the network."
+msgstr ""
+"受信した DNS クエリをファイルに記録します。これにより、ネットワークで何が起き"
+"ているかをリアルタイムに把握することが可能です。"
+
+msgid "Name of the remote DNS service for resolving queries."
+msgstr "クエリの名前解決を行う、リモートの DNS サービス名です。"
+
+msgid "Overview"
+msgstr "概要"
+
+msgid "Port"
+msgstr "ポート"
+
+msgid "Refresh List"
+msgstr "リストのリフレッシュ"
+
+msgid "Refresh Resolver List"
+msgstr "リゾルバ リストのリフレッシュ"
+
+msgid "Resolver"
+msgstr "リゾルバ"
+
+msgid ""
+"SSL support not available, please install an libustream-ssl variant to use "
+"this package."
+msgstr ""
+"SSL サポートが利用できません。このパッケージを使用するには libustream-ssl 等"
+"をインストールし、 SSL サポートを有効にしてください。"
+
+msgid "Save"
+msgstr "保存"
+
+msgid "Specify a non-default Resolver List."
+msgstr "デフォルトとは異なるリゾルバ リストを設定します。"
+
+msgid "Startup Trigger"
+msgstr "スタートアップ トリガ"
+
+msgid "The listening port for DNS queries."
+msgstr "DNS クエリを待ち受けるポートです。"
+
+msgid "The local IP address."
+msgstr "ローカル IP アドレスです。"
+
+msgid ""
+"The value for this property is the blocklist type and path to the file, e."
+"g.'domains:/path/to/dbl.txt' or 'ips:/path/to/ipbl.txt'."
+msgstr ""
+"このプロパティの値は、ブロックリストのタイプ及びファイルへのパスの組み合わせ"
+"です。（例: 'domains:/path/to/domainlist.txt' または 'ips:/path/to/iplist."
+"txt'）"
+
+msgid ""
+"This form allows you to modify the content of the main DNSCrypt-Proxy "
+"configuration file (/etc/config/dnscrypt-proxy)."
+msgstr ""
+"このフォームでは、メインの DNSCrypt-Proxy 設定ファイル (/etc/config/dnscrypt-"
+"proxy) の内容を変更することができます。"
+
+msgid ""
+"This form allows you to modify the content of the main Dnsmasq configuration "
+"file (/etc/config/dhcp)."
+msgstr ""
+"このフォームでは、メインの Dnsmasq 設定ファイル (/etc/config/dhcp) の内容を変"
+"更することができます。"
+
+msgid "This form shows the content of the current DNSCrypt Resolver List."
+msgstr ""
+"このフォームには、現在の DNSCrypt リゾルバ リストの内容が表示されます。"
+
+msgid ""
+"This form shows the syslog output, pre-filtered for DNSCrypt-Proxy related "
+"messages only."
+msgstr ""
+"このフォームには、システムログ内の DNSCrypt-Proxy に関連するメッセージのみが"
+"表示されます。"
+
+msgid ""
+"This option requires extra CPU cycles and is useless with most DNSCrypt "
+"server."
+msgstr ""
+"このオプションは、通常よりも CPU リソースを多く使用するほか、ほとんどの "
+"DNSCrypt サーバーでは不要なものです。"
+
+msgid "To restrict the trigger, add only the relevant network interface(s)."
+msgstr ""
+"トリガを限定するには、適切なネットワーク インターフェースのみを追加してくださ"
+"い。"
+
+msgid "Usually the 'wan' interface should work for most users."
+msgstr "通常、 'wan' インターフェースがほとんどのユーザーに適しています。"
+
+msgid "View Logfile"
+msgstr "ログファイルの確認"
+
+msgid "View Resolver List"
+msgstr "リゾルバ リストの確認"

--- a/applications/luci-app-dnscrypt-proxy/po/templates/dnscrypt-proxy.pot
+++ b/applications/luci-app-dnscrypt-proxy/po/templates/dnscrypt-proxy.pot
@@ -1,0 +1,171 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "Advanced"
+msgstr ""
+
+msgid "Alternate Resolver List"
+msgstr ""
+
+msgid "Blacklist"
+msgstr ""
+
+msgid "Block IPv6"
+msgstr ""
+
+msgid ""
+"By default the DNSCrypt-Proxy startup will be triggered by ifup events of "
+"multiple network interfaces."
+msgstr ""
+
+msgid "Configuration of the DNSCrypt-Proxy package."
+msgstr ""
+
+msgid "DNS Query Logfile"
+msgstr ""
+
+msgid "DNSCrypt-Proxy"
+msgstr ""
+
+msgid "DNSCrypt-Proxy Logfile"
+msgstr ""
+
+msgid "DNSCrypt-Proxy Resolver List"
+msgstr ""
+
+msgid "Default Resolver List"
+msgstr ""
+
+msgid "Disable IPv6 to speed up DNSCrypt-Proxy."
+msgstr ""
+
+msgid "Edit DNSCrypt-Proxy Configuration"
+msgstr ""
+
+msgid "Edit Dnsmasq Configuration"
+msgstr ""
+
+msgid "Enable Caching to speed up DNSCcrypt-Proxy."
+msgstr ""
+
+msgid "Ephemeral Keys"
+msgstr ""
+
+msgid "File Checksum"
+msgstr ""
+
+msgid "File Date"
+msgstr ""
+
+msgid ""
+"For further information <a href=\"%s\" target=\"_blank\">see the wiki "
+"online</a>"
+msgstr ""
+
+msgid "General options"
+msgstr ""
+
+msgid "IP Address"
+msgstr ""
+
+msgid "Improve privacy by using an ephemeral public key for each query."
+msgstr ""
+
+msgid "Input file not found, please check your configuration."
+msgstr ""
+
+msgid "Instance options"
+msgstr ""
+
+msgid "Keep in mind to configure Dnsmasq as well."
+msgstr ""
+
+msgid "Local Cache"
+msgstr ""
+
+msgid ""
+"Local blacklists allow you to block abuse sites by domains or ip addresses."
+msgstr ""
+
+msgid ""
+"Log the received DNS queries to a file, so you can watch in real-time what "
+"is happening on the network."
+msgstr ""
+
+msgid "Name of the remote DNS service for resolving queries."
+msgstr ""
+
+msgid "Overview"
+msgstr ""
+
+msgid "Port"
+msgstr ""
+
+msgid "Refresh List"
+msgstr ""
+
+msgid "Refresh Resolver List"
+msgstr ""
+
+msgid "Resolver"
+msgstr ""
+
+msgid ""
+"SSL support not available, please install an libustream-ssl variant to use "
+"this package."
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Specify a non-default Resolver List."
+msgstr ""
+
+msgid "Startup Trigger"
+msgstr ""
+
+msgid "The listening port for DNS queries."
+msgstr ""
+
+msgid "The local IP address."
+msgstr ""
+
+msgid ""
+"The value for this property is the blocklist type and path to the file, e."
+"g.'domains:/path/to/dbl.txt' or 'ips:/path/to/ipbl.txt'."
+msgstr ""
+
+msgid ""
+"This form allows you to modify the content of the main DNSCrypt-Proxy "
+"configuration file (/etc/config/dnscrypt-proxy)."
+msgstr ""
+
+msgid ""
+"This form allows you to modify the content of the main Dnsmasq configuration "
+"file (/etc/config/dhcp)."
+msgstr ""
+
+msgid "This form shows the content of the current DNSCrypt Resolver List."
+msgstr ""
+
+msgid ""
+"This form shows the syslog output, pre-filtered for DNSCrypt-Proxy related "
+"messages only."
+msgstr ""
+
+msgid ""
+"This option requires extra CPU cycles and is useless with most DNSCrypt "
+"server."
+msgstr ""
+
+msgid "To restrict the trigger, add only the relevant network interface(s)."
+msgstr ""
+
+msgid "Usually the 'wan' interface should work for most users."
+msgstr ""
+
+msgid "View Logfile"
+msgstr ""
+
+msgid "View Resolver List"
+msgstr ""


### PR DESCRIPTION
- Added translate() functions for some UI texts.
- Added po templates and po for Japanese translations.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>