### PR TITLE
luci-app-uhttpd: Fix certificate configuration and improve strings

### DIFF
--- a/applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua
+++ b/applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua
@@ -1,4 +1,5 @@
 -- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2017 Alexander Schlarb <alexander@ninetailed.ninja>
 -- Licensed to the public under the Apache License 2.0.
 
 local fs = require("nixio.fs")
@@ -16,10 +17,10 @@ local cert_file = nil
 local key_file = nil
 
 ucs:tab("general", translate("General Settings"))
-ucs:tab("server", translate("Full Web Server Settings"), translate("For settings primarily geared to serving more than the web UI"))
-ucs:tab("advanced", translate("Advanced Settings"), translate("Settings which are either rarely needed or which affect serving the WebUI"))
+ucs:tab("server", translate("Web Server Settings"), translate("Settings primarily geared towards serving more than the web UI"))
+ucs:tab("advanced", translate("Advanced Settings"), translate("Rarely needed settings that can affect serving the WebUI"))
 
-lhttp = ucs:taboption("general", DynamicList, "listen_http", translate("HTTP listeners (address:port)"), translate("Bind to specific interface:port (by specifying interface address"))
+lhttp = ucs:taboption("general", DynamicList, "listen_http", translate("HTTP Server-Addresses (Address:Port)"), translate("Bind to specific interface:port (by specifying interface address)"))
 lhttp.datatype = "list(ipaddrport(1))"
 
 function lhttp.validate(self, value, section)
@@ -47,7 +48,7 @@ function lhttp.validate(self, value, section)
 	return DynamicList.validate(self, value, section)
 end
 
-lhttps = ucs:taboption("general", DynamicList, "listen_https", translate("HTTPS listener (address:port)"), translate("Bind to specific interface:port (by specifying interface address"))
+lhttps = ucs:taboption("general", DynamicList, "listen_https", translate("HTTPS Server-Addresses (Address:Port)"), translate("Bind to specific interface:port (by specifying interface address)"))
 lhttps.datatype = "list(ipaddrport(1))"
 lhttps:depends("cert")
 lhttps:depends("key")
@@ -83,20 +84,20 @@ function lhttps.validate(self, value, section)
 	return DynamicList.validate(self, value, section)
 end
 
-o = ucs:taboption("general", Flag, "redirect_https", translate("Redirect all HTTP to HTTPS"))
+o = ucs:taboption("general", Flag, "redirect_https", translate("Redirect all HTTP requests to HTTPS"))
 o.default = o.enabled
 o.rmempty = false
 
-o = ucs:taboption("general", Flag, "rfc1918_filter", translate("Ignore private IPs on public interface"), translate("Prevent access from private (RFC1918) IPs on an interface if it has an public IP address"))
+o = ucs:taboption("general", Flag, "rfc1918_filter", translate("Ignore private IP addresses on public interfaces"), translate("Prevent access from private (RFC1918) IPs on an interface if it has an public IP address"))
 o.default = o.enabled
 o.rmempty = false
 
-cert_file = ucs:taboption("general", FileUpload, "cert", translate("HTTPS Certificate (DER Encoded)"))
+cert_file = ucs:taboption("general", FileUpload, "cert", translate("HTTPS Certificate (DER encoded)"))
 
-key_file = ucs:taboption("general", FileUpload, "key", translate("HTTPS Private Key (DER Encoded)"))
+key_file = ucs:taboption("general", FileUpload, "key", translate("HTTPS Private Key (DER encoded)"))
 
-o = ucs:taboption("general", Button, "remove_old", translate("Remove old certificate and key"),
-		  translate("uHTTPd will generate a new self-signed certificate using the configuration shown below."))
+o = ucs:taboption("general", Button, "remove_old", translate("Generate new certificate and key"),
+		  translate("uHTTPd will generate a new self-signed certificate using the configuration shown below"))
 o.inputstyle = "remove"
 
 function o.write(self, section)
@@ -106,8 +107,8 @@ function o.write(self, section)
 	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "uhttpd"))
 end
 
-o = ucs:taboption("general", Button, "remove_conf", translate("Remove configuration for certificate and key"),
-	translate("This permanently deletes the cert, key, and configuration to use same."))
+o = ucs:taboption("general", Button, "remove_conf", translate("Remove certificate and key configuration"),
+	translate("Permanently delete the certificate and key, as well as the configuration to use them"))
 o.inputstyle = "remove"
 
 function o.write(self, section)
@@ -119,17 +120,17 @@ function o.write(self, section)
 	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "uhttpd"))
 end
 
-o = ucs:taboption("server", DynamicList, "index_page", translate("Index page(s)"), translate("E.g specify with index.html and index.php when using PHP"))
+o = ucs:taboption("server", DynamicList, "index_page", translate("Index page(s)"), translate("e.g.: enter index.html and index.php when using PHP"))
 o.optional = true
 o.placeholder = "index.html"
 
 o = ucs:taboption("server", DynamicList, "interpreter", translate("CGI filetype handler"), translate("Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/usr/bin/php-cgi')"))
 o.optional = true
 
-o = ucs:taboption("server", Flag, "no_symlinks", translate("Do not follow symlinks outside document root"))
+o = ucs:taboption("server", Flag, "no_symlinks", translate("Do not follow symlinks outside of the document root"))
 o.optional = true
 
-o = ucs:taboption("server", Flag, "no_dirlists", translate("Do not generate directory listings."))
+o = ucs:taboption("server", Flag, "no_dirlists", translate("Do not generate directory listings"))
 o.default = o.disabled
 
 o = ucs:taboption("server", DynamicList, "alias", translate("Aliases"), translate("(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"))
@@ -139,10 +140,10 @@ o = ucs:taboption("server", Value, "realm", translate("Realm for Basic Auth"))
 o.optional = true
 o.placeholder = luci.sys.hostname() or "OpenWrt"
 
-local httpconfig = ucs:taboption("server", Value, "config", translate("Config file (e.g. for credentials for Basic Auth)"), translate("Will not use HTTP authentication if not present"))
+local httpconfig = ucs:taboption("server", Value, "config", translate("Config file (e.g. for Basic Auth credentials)"), translate("HTTP authentication will not be available if empty"))
 httpconfig.optional = true
 
-o = ucs:taboption("server", Value, "error_page", translate("404 Error"), translate("Virtual URL or CGI script to display on status '404 Not Found'.  Must begin with '/'"))
+o = ucs:taboption("server", Value, "error_page", translate("404 Error Page"), translate("URL or CGI script to display on status '404 Not Found'; must begin with a '/'"))
 o.optional = true
 
 o = ucs:taboption("advanced", Value, "home", translate("Document root"),
@@ -150,27 +151,27 @@ o = ucs:taboption("advanced", Value, "home", translate("Document root"),
 o.default = "/www"
 o.datatype = "directory"
 
-o = ucs:taboption("advanced", Value, "cgi_prefix", translate("Path prefix for CGI scripts"), translate("CGI is disabled if not present."))
+o = ucs:taboption("advanced", Value, "cgi_prefix", translate("Path prefix for CGI scripts"), translate("CGI support will be disabled if empty"))
 o.optional = true
 
-o = ucs:taboption("advanced", Value, "lua_prefix", translate("Virtual path prefix for Lua scripts"))
+o = ucs:taboption("advanced", Value, "lua_prefix", translate("URL path prefix for Lua scripts"))
 o.placeholder = "/lua"
 o.optional = true
 
-o = ucs:taboption("advanced", Value, "lua_handler", translate("Full real path to handler for Lua scripts"), translate("Embedded Lua interpreter is disabled if not present."))
+o = ucs:taboption("advanced", Value, "lua_handler", translate("Filesystem path of Lua runtime initialization script"), translate("Embedded Lua interpreter will be disabled if empty"))
 o.optional = true
 
-o = ucs:taboption("advanced", Value, "ubus_prefix", translate("Virtual path prefix for ubus via JSON-RPC integration"), translate("ubus integration is disabled if not present"))
+o = ucs:taboption("advanced", Value, "ubus_prefix", translate("URL path prefix for ubus JSON-RPC"), translate("ubus integration will be disabled if empty"))
 o.optional = true
 
 o = ucs:taboption("advanced", Value, "ubus_socket", translate("Override path for ubus socket"))
 o.optional = true
 
-o = ucs:taboption("advanced", Flag, "ubus_cors", translate("Enable JSON-RPC Cross-Origin Resource Support"))
+o = ucs:taboption("advanced", Flag, "ubus_cors", translate("Enable JSON-RPC Cross-Origin Resource Sharing"))
 o.default = o.disabled
 o.optional = true
 
-o = ucs:taboption("advanced", Flag, "no_ubusauth", translate("Disable JSON-RPC authorization via ubus session API"))
+o = ucs:taboption("advanced", Flag, "no_ubusauth", translate("Disable JSON-RPC authorization when using the ubus session API"))
 o.optional= true
 o.default = o.disabled
 
@@ -184,7 +185,7 @@ o.placeholder = 30
 o.datatype = "uinteger"
 o.optional = true
 
-o = ucs:taboption("advanced", Value, "http_keepalive", translate("Connection reuse"))
+o = ucs:taboption("advanced", Value, "http_keepalive", translate("HTTP Keepalive"))
 o.placeholder = 20
 o.datatype = "uinteger"
 o.optional = true
@@ -202,12 +203,12 @@ o = ucs:taboption("advanced", Value, "max_requests", translate("Maximum number o
 o.optional = true
 o.datatype = "uinteger"
 
-local s = m:section(TypedSection, "cert", translate("uHTTPd Self-signed Certificate Parameters"))
+local s = m:section(TypedSection, "cert", translate("Parameters for Generating Certificates"))
 
 s.template  = "cbi/tsection"
 s.anonymous = true
 
-o = s:option(Value, "days", translate("Valid for # of Days"))
+o = s:option(Value, "days", translate("Validity (days)"))
 o.default = 730
 o.datatype = "uinteger"
 
@@ -215,7 +216,7 @@ o = s:option(Value, "bits", translate("Length of key in bits"))
 o.default = 2048
 o.datatype = "min(1536)"
 
-o = s:option(Value, "commonname", translate("Server Hostname"), translate("a.k.a CommonName"))
+o = s:option(Value, "commonname", translate("Server Hostname"), translate("X.509 CommonName field"))
 o.default = luci.sys.hostname()
 
 o = s:option(Value, "country", translate("Country"))
@@ -224,7 +225,7 @@ o.default = "ZZ"
 o = s:option(Value, "state", translate("State"))
 o.default = "Unknown"
 
-o = s:option(Value, "location", translate("Location"))
-o.default = "Unknown"
+o = s:option(Value, "location", translate("Locality (i.e. nearby city)"))
+o.default = "Somewhere"
 
 return m

--- a/applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua
+++ b/applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua
@@ -212,8 +212,8 @@ o.default = 730
 o.datatype = "uinteger"
 
 o = s:option(Value, "bits", translate("Length of key in bits"))
-o.default = 1024
-o.datatype = "min(1024)"
+o.default = 2048
+o.datatype = "min(1536)"
 
 o = s:option(Value, "commonname", translate("Server Hostname"), translate("a.k.a CommonName"))
 o.default = luci.sys.hostname()
@@ -225,6 +225,6 @@ o = s:option(Value, "state", translate("State"))
 o.default = "Unknown"
 
 o = s:option(Value, "location", translate("Location"))
-o.default = "Somewhere"
+o.default = "Unknown"
 
 return m

--- a/applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua
+++ b/applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua
@@ -202,7 +202,10 @@ o = ucs:taboption("advanced", Value, "max_requests", translate("Maximum number o
 o.optional = true
 o.datatype = "uinteger"
 
-local s = m:section(NamedSection, "px5g", "cert", translate("uHTTPd Self-signed Certificate Parameters"))
+local s = m:section(TypedSection, "cert", translate("uHTTPd Self-signed Certificate Parameters"))
+
+s.template  = "cbi/tsection"
+s.anonymous = true
 
 o = s:option(Value, "days", translate("Valid for # of Days"))
 o.default = 730

--- a/applications/luci-app-uhttpd/po/de/uhttpd.po
+++ b/applications/luci-app-uhttpd/po/de/uhttpd.po
@@ -1,0 +1,281 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/openwrt/luci/\n"
+"POT-Creation-Date: 2017-08-19 22:33+0200\n"
+"PO-Revision-Date: \n"
+"Last-Translator: Alexander Schlarb <alexander@ninetailed.ninja>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.3\n"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:6
+msgid "uHTTPd"
+msgstr "uHTTPd"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:7
+msgid "A lightweight single-threaded HTTP(S) server"
+msgstr "Ein einfach aufgebauter HTTP(S)-Server"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:18
+msgid "General Settings"
+msgstr "Allgemeine Einstellungen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:19
+msgid "Web Server Settings"
+msgstr "Web-Server Einstellungen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:19
+msgid "Settings primarily geared towards serving more than the web UI"
+msgstr ""
+"Einstellungen die nützlich sind um andere Dienste neben der Web-Oberfläche "
+"bereitzustellen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:20
+msgid "Advanced Settings"
+msgstr "Erweiterte Einstellungen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:20
+msgid "Rarely needed settings that can affect serving the WebUI"
+msgstr ""
+"Selten genutzte Einstellungen die sich negativ auf die Web-Oberfläche "
+"auswirken könnten"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:22
+msgid "HTTP Server-Addresses (Address:Port)"
+msgstr "HTTP-Server-Adressen (Adresse:Port)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:22 luasrc/model/cbi/uhttpd/uhttpd.lua:50
+msgid "Bind to specific interface:port (by specifying interface address)"
+msgstr ""
+"Liste der HTTP Schnittstellen-Adressen und Ports an denen der Server "
+"lauschen soll"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:50
+msgid "HTTPS Server-Addresses (Address:Port)"
+msgstr "HTTPS-Server-Adressen (Adresse:Port)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:86
+msgid "Redirect all HTTP requests to HTTPS"
+msgstr "Alle HTTP-Anfragen an HTTPS weiterleiten"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:90
+msgid "Ignore private IP addresses on public interfaces"
+msgstr "Private IP-Adressen auf öffentlichen Schnittstellen ignorieren"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:90
+msgid ""
+"Prevent access from private (RFC1918) IPs on an interface if it has an "
+"public IP address"
+msgstr ""
+"Zugriff von privaten (RFC 1918) IP-Adressen auf Netzwerkschnittstellen mit "
+"öffentlichen Adressen verhindern"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:94
+msgid "HTTPS Certificate (DER encoded)"
+msgstr "HTTPS-Zertifikat (DER kodiert)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:96
+msgid "HTTPS Private Key (DER encoded)"
+msgstr "Privater HTTPS-Schlüssel (DER kodiert)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:98
+msgid "Generate new certificate and key"
+msgstr "Neues Zertifikat generieren"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:99
+msgid ""
+"uHTTPd will generate a new self-signed certificate using the configuration "
+"shown below"
+msgstr ""
+"uHTPd will ein neues, selbst-signiertes Zertifikat mit den unten gewählten "
+"Einstellungen generieren"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:109
+msgid "Remove certificate and key configuration"
+msgstr "Zertifikatskonfiguration zurücksetzten"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:110
+msgid ""
+"Permanently delete the certificate and key, as well as the configuration to "
+"use them"
+msgstr ""
+"Das Zertifikat, sowie dessen Schlüssel und verwendete Konfiguration, "
+"endgültig löschen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:122
+msgid "Index page(s)"
+msgstr "Indexdateien"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:122
+msgid "e.g.: enter index.html and index.php when using PHP"
+msgstr "z.B. index.html und index.php um PHP zu verwenden"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid "CGI filetype handler"
+msgstr "CGI Datei-Handler"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid ""
+"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
+"usr/bin/php-cgi')"
+msgstr ""
+"Interpreter für Dateiendungen ('Suffix=Programmpfad', z.B.: '.php=/usr/bin/"
+"php-cgi')"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:129
+msgid "Do not follow symlinks outside of the document root"
+msgstr ""
+"Symbolischen Verknüpfungen nicht außerhalb des Basis-Verzeichnisses folgen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:132
+msgid "Do not generate directory listings"
+msgstr "Keine Verzeichnis-Auflistungen erzeugen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid "Aliases"
+msgstr "Alternativnamen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid ""
+"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
+msgstr ""
+"(/alter/Pfad=/neuer/Pfad) oder (nur /alter/Pfad um /CGI-Präfix/alter/Pfad "
+"als neuen Pfad zu verwenden)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:138
+msgid "Realm for Basic Auth"
+msgstr "Realm-Wert für HTTP-Basic-Authentifizierung"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:142
+msgid "Config file (e.g. for Basic Auth credentials)"
+msgstr ""
+"Konfigurationsdatei (z.B. Anmeldedaten für HTTP-Basic-Authentifizierung)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:142
+msgid "HTTP authentication will not be available if empty"
+msgstr ""
+"Die HTTP-Authentifizierung wird nicht verfügbar sein, wenn das Feld leer "
+"gelassen wird"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:145
+msgid "404 Error Page"
+msgstr "404 Error-Seite"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:145
+msgid ""
+"URL or CGI script to display on status '404 Not Found'; must begin with a '/'"
+msgstr ""
+"URL oder CGI-Skript das bei einem '404 Seite nicht gefunden'-Fehler "
+"angezeigt werden soll; muss mit '/' beginnen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:148
+msgid "Document root"
+msgstr "Basis-Verzeichnis"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:149
+msgid "Base directory for files to be served"
+msgstr "Basis-Verzeichnis für Dateien die vom Web-Server bereitgestellt werden"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "Path prefix for CGI scripts"
+msgstr "Pfadpräfix für CGI-Skripte"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "CGI support will be disabled if empty"
+msgstr "CGI-Unterstützung wird deaktiviert, wenn dieses Feld leergelassen wird"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:156
+msgid "URL path prefix for Lua scripts"
+msgstr "URL Pfadpräfix für Lua-Skripte"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:160
+msgid "Filesystem path of Lua runtime initialization script"
+msgstr "Vollständiger Pfad zum Interpreter für Lua-Skripte"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:160
+msgid "Embedded Lua interpreter will be disabled if empty"
+msgstr ""
+"Der integrierte Lua-Interpreter wird deaktiviert wenn das Feld leer gelassen "
+"wird"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:163
+msgid "URL path prefix for ubus JSON-RPC"
+msgstr "URL Pfadpräfix für UBus JSON-RPC"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:163
+msgid "ubus integration will be disabled if empty"
+msgstr ""
+"Die UBus-Integration wird deaktiviert, wenn das Feld leer gelassen wird"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:166
+msgid "Override path for ubus socket"
+msgstr "Pfad für UBus-Socket überschreiben"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:169
+msgid "Enable JSON-RPC Cross-Origin Resource Sharing"
+msgstr "JSON-RPC von fremden Domains (Cross-Origin Resource Sharing) erlauben"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:173
+msgid "Disable JSON-RPC authorization when using the ubus session API"
+msgstr ""
+"JSON-RPC-Authentifizierung bei Verwendung der UBus-Session-API deaktivieren"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:177
+msgid "Maximum wait time for Lua, CGI, or ubus execution"
+msgstr "Maximale Wartezeit beim Ausführen von Lua, CGI oder UBus"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:182
+msgid "Maximum wait time for network activity"
+msgstr "Maximale Wartezeit auf Netzwerkaktivität"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:187
+msgid "HTTP Keepalive"
+msgstr "HTTP keep-alive"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:192
+msgid "TCP Keepalive"
+msgstr "TCP Keep-alive"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:197
+msgid "Maximum number of connections"
+msgstr "Maximale Anzahl an Verbindungen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:201
+msgid "Maximum number of script requests"
+msgstr "Maximale Anzahl an Skript-Anfragen"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:205
+msgid "Parameters for Generating Certificates"
+msgstr "Parameter für das Generieren von Zertifikaten"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:210
+msgid "Validity (days)"
+msgstr "Gültigkeit (Tage)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:214
+msgid "Length of key in bits"
+msgstr "Schlüssellänge in Bits"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:218
+msgid "Server Hostname"
+msgstr "Server-Hostname"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:218
+msgid "X.509 CommonName field"
+msgstr "X.509 CommonName-Feld"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:221
+msgid "Country"
+msgstr "Staat"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:224
+msgid "State"
+msgstr "Bundesland"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:227
+msgid "Locality (i.e. nearby city)"
+msgstr "Lokalität (z.B.: nahe gelegene Stadt)"

--- a/applications/luci-app-uhttpd/po/ja/uhttpd.po
+++ b/applications/luci-app-uhttpd/po/ja/uhttpd.po
@@ -1,141 +1,87 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: 2017-01-01 18:11+0900\n"
+"Report-Msgid-Bugs-To: https://github.com/openwrt/luci/\n"
+"POT-Creation-Date: 2017-08-19 22:33+0200\n"
+"PO-Revision-Date: 2017-08-19 23:13+0200\n"
 "Last-Translator: INAGAKI Hiroshi <musashino.open@gmail.com>\n"
 "Language-Team: \n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.11\n"
+"X-Generator: Poedit 2.0.3\n"
 "X-Poedit-Basepath: .\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid ""
-"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
-msgstr ""
-"(/old/path=/new/path) または (just /old/path which becomes /cgi-prefix/old/"
-"path)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:6
+msgid "uHTTPd"
+msgstr "uHTTPd"
 
-msgid "404 Error"
-msgstr "404 エラー"
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:7
 msgid "A lightweight single-threaded HTTP(S) server"
 msgstr "軽量なシングル スレッド HTTP(S) サーバーです。"
 
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:18
+msgid "General Settings"
+msgstr "一般設定"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:19
+#, fuzzy
+#| msgid "Full Web Server Settings"
+msgid "Web Server Settings"
+msgstr "完全なWebサーバー設定"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:19
+#, fuzzy
+#| msgid "For settings primarily geared to serving more than the web UI"
+msgid "Settings primarily geared towards serving more than the web UI"
+msgstr "主に、Web UI以上のものを提供することを対象とした設定です。"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:20
 msgid "Advanced Settings"
 msgstr "詳細設定"
 
-msgid "Aliases"
-msgstr "エイリアス"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:20
+#, fuzzy
+#| msgid ""
+#| "Settings which are either rarely needed or which affect serving the WebUI"
+msgid "Rarely needed settings that can affect serving the WebUI"
+msgstr "まれに必要とされる設定、またはWeb UIに影響する設定です。"
 
-msgid "Base directory for files to be served"
-msgstr "サーバーがホストするファイルのベースディレクトリです。"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:22
+#, fuzzy
+#| msgid "HTTP listeners (address:port)"
+msgid "HTTP Server-Addresses (Address:Port)"
+msgstr "HTTP 待ち受け（アドレス:ポート）"
 
-msgid "Bind to specific interface:port (by specifying interface address"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:22 luasrc/model/cbi/uhttpd/uhttpd.lua:50
+#, fuzzy
+#| msgid "Bind to specific interface:port (by specifying interface address"
+msgid "Bind to specific interface:port (by specifying interface address)"
 msgstr ""
 "インターフェースのアドレスを使用して、特定のインターフェースとポートに関連付"
 "けます。"
 
-msgid "CGI filetype handler"
-msgstr "CGIファイル形式 ハンドラー"
-
-msgid "CGI is disabled if not present."
-msgstr "指定しない場合、CGIは無効になります。"
-
-msgid "Config file (e.g. for credentials for Basic Auth)"
-msgstr "設定ファイル（例: 基本認証用の資格情報）"
-
-msgid "Connection reuse"
-msgstr "接続の再使用"
-
-msgid "Country"
-msgstr "国"
-
-msgid "Disable JSON-RPC authorization via ubus session API"
-msgstr "ubus セッションAPI経由のJSON-RPC認証を無効にする"
-
-msgid "Do not follow symlinks outside document root"
-msgstr "ドキュメント ルート外へのシンボリックリンクを追随しない"
-
-msgid "Do not generate directory listings."
-msgstr "ディレクトリの待ち受けを生成しない"
-
-msgid "Document root"
-msgstr "ドキュメント ルート"
-
-msgid "E.g specify with index.html and index.php when using PHP"
-msgstr "index.html や、PHPを使用しているときは index.php を設定します。"
-
-msgid "Embedded Lua interpreter is disabled if not present."
-msgstr "指定しない場合、組込みLua インタープリタは無効になります。"
-
-msgid "Enable JSON-RPC Cross-Origin Resource Support"
-msgstr ""
-
-msgid "For settings primarily geared to serving more than the web UI"
-msgstr "主に、Web UI以上のものを提供することを対象とした設定です。"
-
-msgid "Full Web Server Settings"
-msgstr "完全なWebサーバー設定"
-
-msgid "Full real path to handler for Lua scripts"
-msgstr "Lua スクリプトへの絶対パス"
-
-msgid "General Settings"
-msgstr "一般設定"
-
-msgid "HTTP listeners (address:port)"
-msgstr "HTTP 待ち受け（アドレス:ポート）"
-
-msgid "HTTPS Certificate (DER Encoded)"
-msgstr "HTTPS 証明書（DER エンコード）"
-
-msgid "HTTPS Private Key (DER Encoded)"
-msgstr "HTTPS 秘密鍵（DER エンコード）"
-
-msgid "HTTPS listener (address:port)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:50
+#, fuzzy
+#| msgid "HTTPS listener (address:port)"
+msgid "HTTPS Server-Addresses (Address:Port)"
 msgstr "HTTPS 待ち受け（アドレス:ポート）"
 
-msgid "Ignore private IPs on public interface"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:86
+#, fuzzy
+#| msgid "Redirect all HTTP to HTTPS"
+msgid "Redirect all HTTP requests to HTTPS"
+msgstr "全てのHTTPをHTTPSにリダイレクトする"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:90
+#, fuzzy
+#| msgid "Ignore private IPs on public interface"
+msgid "Ignore private IP addresses on public interfaces"
 msgstr "公開側インターフェースでのプライベートIPを無視する"
 
-msgid "Index page(s)"
-msgstr "インデックス ページ"
-
-msgid ""
-"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
-"usr/bin/php-cgi')"
-msgstr ""
-"ファイル拡張子に関連付けるインタープリタです。（'suffix=handler'、例: '.php=/"
-"usr/bin/php-cgi')"
-
-msgid "Length of key in bits"
-msgstr "鍵のビット数"
-
-msgid "Location"
-msgstr "場所"
-
-msgid "Maximum number of connections"
-msgstr "最大接続数"
-
-msgid "Maximum number of script requests"
-msgstr "スクリプトの最大リクエスト数"
-
-msgid "Maximum wait time for Lua, CGI, or ubus execution"
-msgstr "LuaやCGI、ubus実行の最大待機時間"
-
-msgid "Maximum wait time for network activity"
-msgstr "ネットワークアクティビティの最大待機時間"
-
-msgid "Override path for ubus socket"
-msgstr "ubus ソケットのパスを上書きする"
-
-msgid "Path prefix for CGI scripts"
-msgstr "CGI スクリプトのパスプレフィクス"
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:90
 msgid ""
 "Prevent access from private (RFC1918) IPs on an interface if it has an "
 "public IP address"
@@ -143,71 +89,256 @@ msgstr ""
 "グローバル IPアドレスを持つインターフェースでは、プライベート IP (RFC1918) か"
 "らのアクセスをブロックします。"
 
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:94
+#, fuzzy
+#| msgid "HTTPS Certificate (DER Encoded)"
+msgid "HTTPS Certificate (DER encoded)"
+msgstr "HTTPS 証明書（DER エンコード）"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:96
+#, fuzzy
+#| msgid "HTTPS Private Key (DER Encoded)"
+msgid "HTTPS Private Key (DER encoded)"
+msgstr "HTTPS 秘密鍵（DER エンコード）"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:98
+#, fuzzy
+#| msgid "Remove old certificate and key"
+msgid "Generate new certificate and key"
+msgstr "古い証明書と鍵を削除する"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:99
+#, fuzzy
+#| msgid ""
+#| "uHTTPd will generate a new self-signed certificate using the "
+#| "configuration shown below."
+msgid ""
+"uHTTPd will generate a new self-signed certificate using the configuration "
+"shown below"
+msgstr "uHTTPd は、以下に表示した設定で新しい自己署名証明書を生成します。"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:109
+#, fuzzy
+#| msgid "Remove old certificate and key"
+msgid "Remove certificate and key configuration"
+msgstr "古い証明書と鍵を削除する"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:110
+msgid ""
+"Permanently delete the certificate and key, as well as the configuration to "
+"use them"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:122
+msgid "Index page(s)"
+msgstr "インデックス ページ"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:122
+#, fuzzy
+#| msgid "E.g specify with index.html and index.php when using PHP"
+msgid "e.g.: enter index.html and index.php when using PHP"
+msgstr "index.html や、PHPを使用しているときは index.php を設定します。"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid "CGI filetype handler"
+msgstr "CGIファイル形式 ハンドラー"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid ""
+"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
+"usr/bin/php-cgi')"
+msgstr ""
+"ファイル拡張子に関連付けるインタープリタです。（'suffix=handler'、例: '.php=/"
+"usr/bin/php-cgi')"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:129
+#, fuzzy
+#| msgid "Do not follow symlinks outside document root"
+msgid "Do not follow symlinks outside of the document root"
+msgstr "ドキュメント ルート外へのシンボリックリンクを追随しない"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:132
+#, fuzzy
+#| msgid "Do not generate directory listings."
+msgid "Do not generate directory listings"
+msgstr "ディレクトリの待ち受けを生成しない"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid "Aliases"
+msgstr "エイリアス"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid ""
+"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
+msgstr ""
+"(/old/path=/new/path) または (just /old/path which becomes /cgi-prefix/old/"
+"path)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:138
 msgid "Realm for Basic Auth"
 msgstr "基本認証の領域名"
 
-msgid "Redirect all HTTP to HTTPS"
-msgstr "全てのHTTPをHTTPSにリダイレクトする"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:142
+#, fuzzy
+#| msgid "Config file (e.g. for credentials for Basic Auth)"
+msgid "Config file (e.g. for Basic Auth credentials)"
+msgstr "設定ファイル（例: 基本認証用の資格情報）"
 
-msgid "Remove configuration for certificate and key"
-msgstr "証明書と鍵の設定を削除する"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:142
+msgid "HTTP authentication will not be available if empty"
+msgstr ""
 
-msgid "Remove old certificate and key"
-msgstr "古い証明書と鍵を削除する"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:145
+#, fuzzy
+#| msgid "404 Error"
+msgid "404 Error Page"
+msgstr "404 エラー"
 
-msgid "Server Hostname"
-msgstr "サーバー ホスト名"
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:145
+#, fuzzy
+#| msgid ""
+#| "Virtual URL or CGI script to display on status '404 Not Found'.  Must "
+#| "begin with '/'"
 msgid ""
-"Settings which are either rarely needed or which affect serving the WebUI"
-msgstr "まれに必要とされる設定、またはWeb UIに影響する設定です。"
+"URL or CGI script to display on status '404 Not Found'; must begin with a '/'"
+msgstr ""
+"'404 Not Found' ステータスを表示する、仮想URLまたはCGIスクリプトです。'/' か"
+"ら始まる必要があります。"
 
-msgid "State"
-msgstr "ステータス"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:148
+msgid "Document root"
+msgstr "ドキュメント ルート"
 
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:149
+msgid "Base directory for files to be served"
+msgstr "サーバーがホストするファイルのベースディレクトリです。"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "Path prefix for CGI scripts"
+msgstr "CGI スクリプトのパスプレフィクス"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "CGI support will be disabled if empty"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:156
+#, fuzzy
+#| msgid "Virtual path prefix for Lua scripts"
+msgid "URL path prefix for Lua scripts"
+msgstr "Lua スクリプトへの仮想パスプレフィクス"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:160
+msgid "Filesystem path of Lua runtime initialization script"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:160
+#, fuzzy
+#| msgid "Embedded Lua interpreter is disabled if not present."
+msgid "Embedded Lua interpreter will be disabled if empty"
+msgstr "指定しない場合、組込みLua インタープリタは無効になります。"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:163
+msgid "URL path prefix for ubus JSON-RPC"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:163
+msgid "ubus integration will be disabled if empty"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:166
+msgid "Override path for ubus socket"
+msgstr "ubus ソケットのパスを上書きする"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:169
+msgid "Enable JSON-RPC Cross-Origin Resource Sharing"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:173
+#, fuzzy
+#| msgid "Disable JSON-RPC authorization via ubus session API"
+msgid "Disable JSON-RPC authorization when using the ubus session API"
+msgstr "ubus セッションAPI経由のJSON-RPC認証を無効にする"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:177
+msgid "Maximum wait time for Lua, CGI, or ubus execution"
+msgstr "LuaやCGI、ubus実行の最大待機時間"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:182
+msgid "Maximum wait time for network activity"
+msgstr "ネットワークアクティビティの最大待機時間"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:187
+#, fuzzy
+#| msgid "TCP Keepalive"
+msgid "HTTP Keepalive"
+msgstr "TCP キープアライブ"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:192
 msgid "TCP Keepalive"
 msgstr "TCP キープアライブ"
 
-msgid "This permanently deletes the cert, key, and configuration to use same."
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:197
+msgid "Maximum number of connections"
+msgstr "最大接続数"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:201
+msgid "Maximum number of script requests"
+msgstr "スクリプトの最大リクエスト数"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:205
+msgid "Parameters for Generating Certificates"
 msgstr ""
 
-msgid "Valid for # of Days"
-msgstr "有効日数"
-
-msgid ""
-"Virtual URL or CGI script to display on status '404 Not Found'. Must begin "
-"with '/'"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:210
+msgid "Validity (days)"
 msgstr ""
 
-msgid "Virtual path prefix for Lua scripts"
-msgstr "Lua スクリプトへの仮想パスプレフィクス"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:214
+msgid "Length of key in bits"
+msgstr "鍵のビット数"
 
-msgid "Virtual path prefix for ubus via JSON-RPC integration"
-msgstr ""
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:218
+msgid "Server Hostname"
+msgstr "サーバー ホスト名"
 
-msgid "Will not use HTTP authentication if not present"
-msgstr "指定しない場合、HTTP 認証は使用されません。"
-
-msgid "a.k.a CommonName"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:218
+#, fuzzy
+#| msgid "a.k.a CommonName"
+msgid "X.509 CommonName field"
 msgstr "共通名"
 
-msgid "uHTTPd"
-msgstr "uHTTPd"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:221
+msgid "Country"
+msgstr "国"
 
-msgid "uHTTPd Self-signed Certificate Parameters"
-msgstr "uHTTPd 自己署名証明書 パラメーター"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:224
+msgid "State"
+msgstr "ステータス"
 
-msgid ""
-"uHTTPd will generate a new self-signed certificate using the configuration "
-"shown below."
-msgstr "uHTTPd は、以下に表示した設定で新しい自己署名証明書を生成します。"
-
-msgid "ubus integration is disabled if not present"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:227
+msgid "Locality (i.e. nearby city)"
 msgstr ""
 
-#~ msgid ""
-#~ "Virtual URL or CGI script to display on status '404 Not Found'.  Must "
-#~ "begin with '/'"
-#~ msgstr ""
-#~ "'404 Not Found' ステータスを表示する、仮想URLまたはCGIスクリプトです。'/' "
-#~ "から始まる必要があります。"
+#~ msgid "Remove configuration for certificate and key"
+#~ msgstr "証明書と鍵の設定を削除する"
+
+#~ msgid "Will not use HTTP authentication if not present"
+#~ msgstr "指定しない場合、HTTP 認証は使用されません。"
+
+#~ msgid "CGI is disabled if not present."
+#~ msgstr "指定しない場合、CGIは無効になります。"
+
+#~ msgid "Full real path to handler for Lua scripts"
+#~ msgstr "Lua スクリプトへの絶対パス"
+
+#~ msgid "Connection reuse"
+#~ msgstr "接続の再使用"
+
+#~ msgid "uHTTPd Self-signed Certificate Parameters"
+#~ msgstr "uHTTPd 自己署名証明書 パラメーター"
+
+#~ msgid "Valid for # of Days"
+#~ msgstr "有効日数"
+
+#~ msgid "Location"
+#~ msgstr "場所"

--- a/applications/luci-app-uhttpd/po/pt-br/uhttpd.po
+++ b/applications/luci-app-uhttpd/po/pt-br/uhttpd.po
@@ -1,139 +1,85 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
-"POT-Creation-Date: \n"
+"Report-Msgid-Bugs-To: https://github.com/openwrt/luci/\n"
+"POT-Creation-Date: 2017-08-19 22:33+0200\n"
 "PO-Revision-Date: \n"
-"Language-Team: \n"
-"MIME-Version: 1.0\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.11\n"
 "Last-Translator: Luiz Angelo Daros de Luca <luizluca@gmail.com>\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language-Team: \n"
 "Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.3\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-msgid ""
-"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
-msgstr ""
-"(/old/path=/new/path) ou (just /old/path que se torna /cgi-prefix/old/path)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:6
+msgid "uHTTPd"
+msgstr "uHTTPd"
 
-msgid "404 Error"
-msgstr "Erro 404"
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:7
 msgid "A lightweight single-threaded HTTP(S) server"
 msgstr "Um servidor HTTP(S) leve de únida thread."
 
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:18
+msgid "General Settings"
+msgstr "Configurações Gerais"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:19
+#, fuzzy
+msgid "Web Server Settings"
+msgstr "Configurações Completas do Servidor Web"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:19
+#, fuzzy
+#| msgid "For settings primarily geared to serving more than the web UI"
+msgid "Settings primarily geared towards serving more than the web UI"
+msgstr "Para ajustes envolvidos com mais do que prover a interface web"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:20
 msgid "Advanced Settings"
 msgstr "Opções Avançadas"
 
-msgid "Aliases"
-msgstr "Pseudônimos (Aliases)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:20
+#, fuzzy
+#| msgid ""
+#| "Settings which are either rarely needed or which affect serving the WebUI"
+msgid "Rarely needed settings that can affect serving the WebUI"
+msgstr "Ajustes que são raramente usadas ou que afetam a interface web"
 
-msgid "Base directory for files to be served"
-msgstr "Diretório Base para publicar arquivos"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:22
+#, fuzzy
+#| msgid "HTTP listeners (address:port)"
+msgid "HTTP Server-Addresses (Address:Port)"
+msgstr "Escutas do HTTP (endereço:porta)"
 
-msgid "Bind to specific interface:port (by specifying interface address"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:22 luasrc/model/cbi/uhttpd/uhttpd.lua:50
+#, fuzzy
+#| msgid "Bind to specific interface:port (by specifying interface address"
+msgid "Bind to specific interface:port (by specifying interface address)"
 msgstr ""
 "Escute em uma interface:porta específica (especificando o endereço da "
 "interface"
 
-msgid "CGI filetype handler"
-msgstr "Interpretador de tipo de arquivo CGI"
-
-msgid "CGI is disabled if not present."
-msgstr "O CGI estará desabilitado se não presente."
-
-msgid "Config file (e.g. for credentials for Basic Auth)"
-msgstr "Arquivo de configuração (ex: credenciais para autenticação básica)"
-
-msgid "Connection reuse"
-msgstr "Reutilizar conexão"
-
-msgid "Country"
-msgstr "País"
-
-msgid "Disable JSON-RPC authorization via ubus session API"
-msgstr "Desabilita a autorização JSON-RPC através da API de sessão ubus"
-
-msgid "Do not follow symlinks outside document root"
-msgstr "Não siga ligações simbólicas (symlinks) para fora do documento raiz"
-
-msgid "Do not generate directory listings."
-msgstr "Não gere listagens de diretórios"
-
-msgid "Document root"
-msgstr "Documento Raiz"
-
-msgid "E.g specify with index.html and index.php when using PHP"
-msgstr "Ex: use index.html e index.php quando usar PHP"
-
-msgid "Embedded Lua interpreter is disabled if not present."
-msgstr "O interpretador Lua embutido será desabilitado se não presente."
-
-msgid "Enable JSON-RPC Cross-Origin Resource Support"
-msgstr "Habilite o suporte para recursos JSON-RPC de origem cruzada"
-
-msgid "For settings primarily geared to serving more than the web UI"
-msgstr "Para ajustes envolvidos com mais do que prover a interface web"
-
-msgid "Full Web Server Settings"
-msgstr "Configurações Completas do Servidor Web"
-
-msgid "Full real path to handler for Lua scripts"
-msgstr "Caminho completo para o interpretador de scripts Lua"
-
-msgid "General Settings"
-msgstr "Configurações Gerais"
-
-msgid "HTTP listeners (address:port)"
-msgstr "Escutas do HTTP (endereço:porta)"
-
-msgid "HTTPS Certificate (DER Encoded)"
-msgstr "Certificado do HTTPS (codificado em formato PEM)"
-
-msgid "HTTPS Private Key (DER Encoded)"
-msgstr "Chave Privada do HTTPS (codificado como DER)"
-
-msgid "HTTPS listener (address:port)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:50
+#, fuzzy
+#| msgid "HTTPS listener (address:port)"
+msgid "HTTPS Server-Addresses (Address:Port)"
 msgstr "Escuta do HTTPS (endereço:porta)"
 
-msgid "Ignore private IPs on public interface"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:86
+#, fuzzy
+#| msgid "Redirect all HTTP to HTTPS"
+msgid "Redirect all HTTP requests to HTTPS"
+msgstr "Redirecionar todo tráfego HTTP para HTTPS"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:90
+#, fuzzy
+#| msgid "Ignore private IPs on public interface"
+msgid "Ignore private IP addresses on public interfaces"
 msgstr "Ignore endereços IP privados na interface pública"
 
-msgid "Index page(s)"
-msgstr "Página(s) Índice(s)"
-
-msgid ""
-"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
-"usr/bin/php-cgi')"
-msgstr ""
-"Interpretador para associar com extensões de arquivos "
-"('extensão=interpretador', ex: '.php=/usr/bin/php-cgi')"
-
-msgid "Length of key in bits"
-msgstr "Comprimento da chave em bits"
-
-msgid "Location"
-msgstr "Localização"
-
-msgid "Maximum number of connections"
-msgstr "Número máximo de requisições para script"
-
-msgid "Maximum number of script requests"
-msgstr "Número máximo de requisições para script"
-
-msgid "Maximum wait time for Lua, CGI, or ubus execution"
-msgstr "Tempo máximo de espera para execuções de Lua, CGI ou ubus"
-
-msgid "Maximum wait time for network activity"
-msgstr "Tempo máximo de espera para atividade na rede"
-
-msgid "Override path for ubus socket"
-msgstr "Sobrescrever o caminho do socket ubus"
-
-msgid "Path prefix for CGI scripts"
-msgstr "Prefixo do caminho para scripts CGI"
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:90
 msgid ""
 "Prevent access from private (RFC1918) IPs on an interface if it has an "
 "public IP address"
@@ -141,68 +87,266 @@ msgstr ""
 "Evite acesso de endereços privados (RFC1918) na interface que tem um "
 "endereço IP público"
 
-msgid "Realm for Basic Auth"
-msgstr "Reino para Autenticação Simples"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:94
+#, fuzzy
+#| msgid "HTTPS Certificate (DER Encoded)"
+msgid "HTTPS Certificate (DER encoded)"
+msgstr "Certificado do HTTPS (codificado em formato PEM)"
 
-msgid "Redirect all HTTP to HTTPS"
-msgstr "Redirecionar todo tráfego HTTP para HTTPS"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:96
+#, fuzzy
+#| msgid "HTTPS Private Key (DER Encoded)"
+msgid "HTTPS Private Key (DER encoded)"
+msgstr "Chave Privada do HTTPS (codificado como DER)"
 
-msgid "Remove configuration for certificate and key"
-msgstr "Remove a configuração para o certificado e chave"
-
-msgid "Remove old certificate and key"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:98
+#, fuzzy
+#| msgid "Remove old certificate and key"
+msgid "Generate new certificate and key"
 msgstr "Remove os certificados e chaves antigas"
 
-msgid "Server Hostname"
-msgstr "Nome do Servidor"
-
-msgid ""
-"Settings which are either rarely needed or which affect serving the WebUI"
-msgstr "Ajustes que são raramente usadas ou que afetam a interface web"
-
-msgid "State"
-msgstr "Estado"
-
-msgid "TCP Keepalive"
-msgstr "Manter conexões TCP abertas (Keepalive)"
-
-msgid "This permanently deletes the cert, key, and configuration to use same."
-msgstr "Isto apaga permanentemente o certificado, a chave e a configuração."
-
-msgid "Valid for # of Days"
-msgstr "Valido por # dias"
-
-msgid ""
-"Virtual URL or CGI script to display on status '404 Not Found'. Must begin "
-"with '/'"
-msgstr ""
-"URL virtual ou script CGI para mostrar quando ocorrer erro '404 Não "
-"Encontrado'. Deve começar com '/'"
-
-msgid "Virtual path prefix for Lua scripts"
-msgstr "Prefixo do caminho virtual para scripts Lua"
-
-msgid "Virtual path prefix for ubus via JSON-RPC integration"
-msgstr "Prefixo do caminho virtual para o ubus através da integração JSON-RPC"
-
-msgid "Will not use HTTP authentication if not present"
-msgstr "Não usar autenticação HTTP se não presente"
-
-msgid "a.k.a CommonName"
-msgstr "também conhecido como Nome Comum"
-
-msgid "uHTTPd"
-msgstr "uHTTPd"
-
-msgid "uHTTPd Self-signed Certificate Parameters"
-msgstr "Parâmetros do Certificado Auto-assinado do uHTTPd"
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:99
+#, fuzzy
+#| msgid ""
+#| "uHTTPd will generate a new self-signed certificate using the "
+#| "configuration shown below."
 msgid ""
 "uHTTPd will generate a new self-signed certificate using the configuration "
-"shown below."
+"shown below"
 msgstr ""
 "o uHTTPd gerará um certificado auto-assinado usando a configuração mostrada "
 "abaixo."
 
-msgid "ubus integration is disabled if not present"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:109
+#, fuzzy
+#| msgid "Remove old certificate and key"
+msgid "Remove certificate and key configuration"
+msgstr "Remove os certificados e chaves antigas"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:110
+#, fuzzy
+#| msgid ""
+#| "This permanently deletes the cert, key, and configuration to use same."
+msgid ""
+"Permanently delete the certificate and key, as well as the configuration to "
+"use them"
+msgstr "Isto apaga permanentemente o certificado, a chave e a configuração."
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:122
+msgid "Index page(s)"
+msgstr "Página(s) Índice(s)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:122
+#, fuzzy
+#| msgid "E.g specify with index.html and index.php when using PHP"
+msgid "e.g.: enter index.html and index.php when using PHP"
+msgstr "Ex: use index.html e index.php quando usar PHP"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid "CGI filetype handler"
+msgstr "Interpretador de tipo de arquivo CGI"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid ""
+"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
+"usr/bin/php-cgi')"
+msgstr ""
+"Interpretador para associar com extensões de arquivos "
+"('extensão=interpretador', ex: '.php=/usr/bin/php-cgi')"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:129
+#, fuzzy
+#| msgid "Do not follow symlinks outside document root"
+msgid "Do not follow symlinks outside of the document root"
+msgstr "Não siga ligações simbólicas (symlinks) para fora do documento raiz"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:132
+#, fuzzy
+#| msgid "Do not generate directory listings."
+msgid "Do not generate directory listings"
+msgstr "Não gere listagens de diretórios"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid "Aliases"
+msgstr "Pseudônimos (Aliases)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid ""
+"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
+msgstr ""
+"(/old/path=/new/path) ou (just /old/path que se torna /cgi-prefix/old/path)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:138
+msgid "Realm for Basic Auth"
+msgstr "Reino para Autenticação Simples"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:142
+#, fuzzy
+#| msgid "Config file (e.g. for credentials for Basic Auth)"
+msgid "Config file (e.g. for Basic Auth credentials)"
+msgstr "Arquivo de configuração (ex: credenciais para autenticação básica)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:142
+msgid "HTTP authentication will not be available if empty"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:145
+#, fuzzy
+#| msgid "404 Error"
+msgid "404 Error Page"
+msgstr "Erro 404"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:145
+#, fuzzy
+#| msgid ""
+#| "Virtual URL or CGI script to display on status '404 Not Found'. Must "
+#| "begin with '/'"
+msgid ""
+"URL or CGI script to display on status '404 Not Found'; must begin with a '/'"
+msgstr ""
+"URL virtual ou script CGI para mostrar quando ocorrer erro '404 Não "
+"Encontrado'. Deve começar com '/'"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:148
+msgid "Document root"
+msgstr "Documento Raiz"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:149
+msgid "Base directory for files to be served"
+msgstr "Diretório Base para publicar arquivos"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "Path prefix for CGI scripts"
+msgstr "Prefixo do caminho para scripts CGI"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "CGI support will be disabled if empty"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:156
+#, fuzzy
+#| msgid "Virtual path prefix for Lua scripts"
+msgid "URL path prefix for Lua scripts"
+msgstr "Prefixo do caminho virtual para scripts Lua"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:160
+msgid "Filesystem path of Lua runtime initialization script"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:160
+#, fuzzy
+#| msgid "Embedded Lua interpreter is disabled if not present."
+msgid "Embedded Lua interpreter will be disabled if empty"
+msgstr "O interpretador Lua embutido será desabilitado se não presente."
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:163
+#, fuzzy
+#| msgid "Virtual path prefix for ubus via JSON-RPC integration"
+msgid "URL path prefix for ubus JSON-RPC"
+msgstr "Prefixo do caminho virtual para o ubus através da integração JSON-RPC"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:163
+#, fuzzy
+#| msgid "ubus integration is disabled if not present"
+msgid "ubus integration will be disabled if empty"
 msgstr "A integração com o ubus será desativada se não presente"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:166
+msgid "Override path for ubus socket"
+msgstr "Sobrescrever o caminho do socket ubus"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:169
+#, fuzzy
+#| msgid "Enable JSON-RPC Cross-Origin Resource Support"
+msgid "Enable JSON-RPC Cross-Origin Resource Sharing"
+msgstr "Habilite o suporte para recursos JSON-RPC de origem cruzada"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:173
+#, fuzzy
+#| msgid "Disable JSON-RPC authorization via ubus session API"
+msgid "Disable JSON-RPC authorization when using the ubus session API"
+msgstr "Desabilita a autorização JSON-RPC através da API de sessão ubus"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:177
+msgid "Maximum wait time for Lua, CGI, or ubus execution"
+msgstr "Tempo máximo de espera para execuções de Lua, CGI ou ubus"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:182
+msgid "Maximum wait time for network activity"
+msgstr "Tempo máximo de espera para atividade na rede"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:187
+#, fuzzy
+#| msgid "TCP Keepalive"
+msgid "HTTP Keepalive"
+msgstr "Manter conexões TCP abertas (Keepalive)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:192
+msgid "TCP Keepalive"
+msgstr "Manter conexões TCP abertas (Keepalive)"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:197
+msgid "Maximum number of connections"
+msgstr "Número máximo de requisições para script"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:201
+msgid "Maximum number of script requests"
+msgstr "Número máximo de requisições para script"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:205
+msgid "Parameters for Generating Certificates"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:210
+msgid "Validity (days)"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:214
+msgid "Length of key in bits"
+msgstr "Comprimento da chave em bits"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:218
+msgid "Server Hostname"
+msgstr "Nome do Servidor"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:218
+#, fuzzy
+#| msgid "a.k.a CommonName"
+msgid "X.509 CommonName field"
+msgstr "também conhecido como Nome Comum"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:221
+msgid "Country"
+msgstr "País"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:224
+msgid "State"
+msgstr "Estado"
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:227
+msgid "Locality (i.e. nearby city)"
+msgstr ""
+
+#~ msgid "Remove configuration for certificate and key"
+#~ msgstr "Remove a configuração para o certificado e chave"
+
+#~ msgid "Will not use HTTP authentication if not present"
+#~ msgstr "Não usar autenticação HTTP se não presente"
+
+#~ msgid "CGI is disabled if not present."
+#~ msgstr "O CGI estará desabilitado se não presente."
+
+#~ msgid "Full real path to handler for Lua scripts"
+#~ msgstr "Caminho completo para o interpretador de scripts Lua"
+
+#~ msgid "Connection reuse"
+#~ msgstr "Reutilizar conexão"
+
+#~ msgid "uHTTPd Self-signed Certificate Parameters"
+#~ msgstr "Parâmetros do Certificado Auto-assinado do uHTTPd"
+
+#~ msgid "Valid for # of Days"
+#~ msgstr "Valido por # dias"
+
+#~ msgid "Location"
+#~ msgstr "Localização"

--- a/applications/luci-app-uhttpd/po/templates/uhttpd.pot
+++ b/applications/luci-app-uhttpd/po/templates/uhttpd.pot
@@ -1,186 +1,256 @@
+# Copyright (C) 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+# Copyright (C) 2017 Alexander Schlarb <alexander@ninetailed.ninja>
+# This file is distributed under the Apache License 2.0.
+#
+#, fuzzy
 msgid ""
-msgstr "Content-Type: text/plain; charset=UTF-8"
+msgstr ""
+"Project-Id-Version: luci-app-uhttpd\n"
+"Report-Msgid-Bugs-To: https://github.com/openwrt/luci/\n"
+"POT-Creation-Date: 2017-08-19 22:33+0200\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
 
-msgid ""
-"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:6
+msgid "uHTTPd"
 msgstr ""
 
-msgid "404 Error"
-msgstr ""
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:7
 msgid "A lightweight single-threaded HTTP(S) server"
 msgstr ""
 
-msgid "Advanced Settings"
-msgstr ""
-
-msgid "Aliases"
-msgstr ""
-
-msgid "Base directory for files to be served"
-msgstr ""
-
-msgid "Bind to specific interface:port (by specifying interface address"
-msgstr ""
-
-msgid "CGI filetype handler"
-msgstr ""
-
-msgid "CGI is disabled if not present."
-msgstr ""
-
-msgid "Config file (e.g. for credentials for Basic Auth)"
-msgstr ""
-
-msgid "Connection reuse"
-msgstr ""
-
-msgid "Country"
-msgstr ""
-
-msgid "Disable JSON-RPC authorization via ubus session API"
-msgstr ""
-
-msgid "Do not follow symlinks outside document root"
-msgstr ""
-
-msgid "Do not generate directory listings."
-msgstr ""
-
-msgid "Document root"
-msgstr ""
-
-msgid "E.g specify with index.html and index.php when using PHP"
-msgstr ""
-
-msgid "Embedded Lua interpreter is disabled if not present."
-msgstr ""
-
-msgid "Enable JSON-RPC Cross-Origin Resource Support"
-msgstr ""
-
-msgid "For settings primarily geared to serving more than the web UI"
-msgstr ""
-
-msgid "Full Web Server Settings"
-msgstr ""
-
-msgid "Full real path to handler for Lua scripts"
-msgstr ""
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:18
 msgid "General Settings"
 msgstr ""
 
-msgid "HTTP listeners (address:port)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:19
+msgid "Web Server Settings"
 msgstr ""
 
-msgid "HTTPS Certificate (DER Encoded)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:19
+msgid "Settings primarily geared towards serving more than the web UI"
 msgstr ""
 
-msgid "HTTPS Private Key (DER Encoded)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:20
+msgid "Advanced Settings"
 msgstr ""
 
-msgid "HTTPS listener (address:port)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:20
+msgid "Rarely needed settings that can affect serving the WebUI"
 msgstr ""
 
-msgid "Ignore private IPs on public interface"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:22
+msgid "HTTP Server-Addresses (Address:Port)"
 msgstr ""
 
-msgid "Index page(s)"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:22 luasrc/model/cbi/uhttpd/uhttpd.lua:50
+msgid "Bind to specific interface:port (by specifying interface address)"
 msgstr ""
 
-msgid ""
-"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
-"usr/bin/php-cgi')"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:50
+msgid "HTTPS Server-Addresses (Address:Port)"
 msgstr ""
 
-msgid "Length of key in bits"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:86
+msgid "Redirect all HTTP requests to HTTPS"
 msgstr ""
 
-msgid "Location"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:90
+msgid "Ignore private IP addresses on public interfaces"
 msgstr ""
 
-msgid "Maximum number of connections"
-msgstr ""
-
-msgid "Maximum number of script requests"
-msgstr ""
-
-msgid "Maximum wait time for Lua, CGI, or ubus execution"
-msgstr ""
-
-msgid "Maximum wait time for network activity"
-msgstr ""
-
-msgid "Override path for ubus socket"
-msgstr ""
-
-msgid "Path prefix for CGI scripts"
-msgstr ""
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:90
 msgid ""
 "Prevent access from private (RFC1918) IPs on an interface if it has an "
 "public IP address"
 msgstr ""
 
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:94
+msgid "HTTPS Certificate (DER encoded)"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:96
+msgid "HTTPS Private Key (DER encoded)"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:98
+msgid "Generate new certificate and key"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:99
+msgid ""
+"uHTTPd will generate a new self-signed certificate using the configuration "
+"shown below"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:109
+msgid "Remove certificate and key configuration"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:110
+msgid ""
+"Permanently delete the certificate and key, as well as the configuration to "
+"use them"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:122
+msgid "Index page(s)"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:122
+msgid "e.g.: enter index.html and index.php when using PHP"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid "CGI filetype handler"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid ""
+"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
+"usr/bin/php-cgi')"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:129
+msgid "Do not follow symlinks outside of the document root"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:132
+msgid "Do not generate directory listings"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid "Aliases"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid ""
+"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:138
 msgid "Realm for Basic Auth"
 msgstr ""
 
-msgid "Redirect all HTTP to HTTPS"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:142
+msgid "Config file (e.g. for Basic Auth credentials)"
 msgstr ""
 
-msgid "Remove configuration for certificate and key"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:142
+msgid "HTTP authentication will not be available if empty"
 msgstr ""
 
-msgid "Remove old certificate and key"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:145
+msgid "404 Error Page"
 msgstr ""
 
-msgid "Server Hostname"
-msgstr ""
-
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:145
 msgid ""
-"Settings which are either rarely needed or which affect serving the WebUI"
+"URL or CGI script to display on status '404 Not Found'; must begin with a '/'"
 msgstr ""
 
-msgid "State"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:148
+msgid "Document root"
 msgstr ""
 
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:149
+msgid "Base directory for files to be served"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "Path prefix for CGI scripts"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "CGI support will be disabled if empty"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:156
+msgid "URL path prefix for Lua scripts"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:160
+msgid "Filesystem path of Lua runtime initialization script"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:160
+msgid "Embedded Lua interpreter will be disabled if empty"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:163
+msgid "URL path prefix for ubus JSON-RPC"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:163
+msgid "ubus integration will be disabled if empty"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:166
+msgid "Override path for ubus socket"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:169
+msgid "Enable JSON-RPC Cross-Origin Resource Sharing"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:173
+msgid "Disable JSON-RPC authorization when using the ubus session API"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:177
+msgid "Maximum wait time for Lua, CGI, or ubus execution"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:182
+msgid "Maximum wait time for network activity"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:187
+msgid "HTTP Keepalive"
+msgstr ""
+
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:192
 msgid "TCP Keepalive"
 msgstr ""
 
-msgid "This permanently deletes the cert, key, and configuration to use same."
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:197
+msgid "Maximum number of connections"
 msgstr ""
 
-msgid "Valid for # of Days"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:201
+msgid "Maximum number of script requests"
 msgstr ""
 
-msgid ""
-"Virtual URL or CGI script to display on status '404 Not Found'. Must begin "
-"with '/'"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:205
+msgid "Parameters for Generating Certificates"
 msgstr ""
 
-msgid "Virtual path prefix for Lua scripts"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:210
+msgid "Validity (days)"
 msgstr ""
 
-msgid "Virtual path prefix for ubus via JSON-RPC integration"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:214
+msgid "Length of key in bits"
 msgstr ""
 
-msgid "Will not use HTTP authentication if not present"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:218
+msgid "Server Hostname"
 msgstr ""
 
-msgid "a.k.a CommonName"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:218
+msgid "X.509 CommonName field"
 msgstr ""
 
-msgid "uHTTPd"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:221
+msgid "Country"
 msgstr ""
 
-msgid "uHTTPd Self-signed Certificate Parameters"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:224
+msgid "State"
 msgstr ""
 
-msgid ""
-"uHTTPd will generate a new self-signed certificate using the configuration "
-"shown below."
-msgstr ""
-
-msgid "ubus integration is disabled if not present"
+#: luasrc/model/cbi/uhttpd/uhttpd.lua:227
+msgid "Locality (i.e. nearby city)"
 msgstr ""


### PR DESCRIPTION
Sorry for the noise on updating the translations with the new msgids, but I don't know how else to do this. At least they are in source-code order now…

Explanation of each patch:

  1. Without this patch the *uHTTPd Self-signed Certificate Parameters* section towards the bottom of the page is missing and it is not possible to generate any certificates with reasonable values
  2. Bump default key size to 2048 (which took about 8 seconds to generate on my *TP-Link Archer C5 v1*), and set the lower key size limit to 1536 bits, which is the [absolute lower limit to using RSA TLS](https://www.keylength.com/en/compare/) securely
  3. Update many source translation strings to improve consistancy and readablity
  4. Add German translation