### PR TITLE
luci-app-dnscrypt-proxy: Update Japanese translation

### DIFF
--- a/applications/luci-app-dnscrypt-proxy/po/ja/dnscrypt-proxy.po
+++ b/applications/luci-app-dnscrypt-proxy/po/ja/dnscrypt-proxy.po
@@ -34,6 +34,17 @@ msgstr ""
 msgid "Configuration of the DNSCrypt-Proxy package."
 msgstr "DNSCrypt-Proxy パッケージの設定です。"
 
+msgid ""
+"Create '/etc/resolv-crypt.conf' with 'options timeout:1' to reduce DNS "
+"upstream timeouts with multiple DNSCrypt instances."
+msgstr ""
+
+msgid "Create Config File"
+msgstr ""
+
+msgid "Create custom config file"
+msgstr ""
+
 msgid "DNS Query Logfile"
 msgstr "DNS クエリ ログファイル"
 
@@ -63,6 +74,9 @@ msgstr "DNSCrypt-Proxy の高速化のため、キャッシュ機能を有効化
 
 msgid "Ephemeral Keys"
 msgstr "一時的なキー"
+
+msgid "Extra options"
+msgstr ""
 
 msgid "File Checksum"
 msgstr "ファイル チェックサム"
@@ -115,6 +129,10 @@ msgstr ""
 msgid "Name of the remote DNS service for resolving queries."
 msgstr "クエリの名前解決を行う、リモートの DNS サービス名です。"
 
+msgid ""
+"Options for further tweaking in case the defaults are not suitable for you."
+msgstr ""
+
 msgid "Overview"
 msgstr "概要"
 
@@ -149,8 +167,10 @@ msgstr "スタートアップ トリガ"
 msgid "The listening port for DNS queries."
 msgstr "DNS クエリを待ち受けるポートです。"
 
-msgid "The local IP address."
-msgstr "ローカル IP アドレスです。"
+msgid ""
+"The local IPv4 or IPv6 address. The latter one should be specified within "
+"brackets, e.g. '[::1]'."
+msgstr ""
 
 msgid ""
 "The value for this property is the blocklist type and path to the file, e."
@@ -205,3 +225,6 @@ msgstr "ログファイルの確認"
 
 msgid "View Resolver List"
 msgstr "リゾルバ リストの確認"
+
+#~ msgid "The local IP address."
+#~ msgstr "ローカル IP アドレスです。"

--- a/applications/luci-app-dnscrypt-proxy/po/ja/dnscrypt-proxy.po
+++ b/applications/luci-app-dnscrypt-proxy/po/ja/dnscrypt-proxy.po
@@ -38,12 +38,15 @@ msgid ""
 "Create '/etc/resolv-crypt.conf' with 'options timeout:1' to reduce DNS "
 "upstream timeouts with multiple DNSCrypt instances."
 msgstr ""
+"複数の DNSCrypt インスタンスで DNS アップストリーム タイムアウトの設定値を共"
+"用するため、 'options timeout:1' を含めた '/etc/resolv-crypt.conf' を作成しま"
+"す。"
 
 msgid "Create Config File"
-msgstr ""
+msgstr "設定ファイルの作成"
 
 msgid "Create custom config file"
-msgstr ""
+msgstr "カスタム設定ファイルの作成"
 
 msgid "DNS Query Logfile"
 msgstr "DNS クエリ ログファイル"
@@ -76,7 +79,7 @@ msgid "Ephemeral Keys"
 msgstr "一時的なキー"
 
 msgid "Extra options"
-msgstr ""
+msgstr "拡張オプション"
 
 msgid "File Checksum"
 msgstr "ファイル チェックサム"
@@ -131,7 +134,7 @@ msgstr "クエリの名前解決を行う、リモートの DNS サービス名�
 
 msgid ""
 "Options for further tweaking in case the defaults are not suitable for you."
-msgstr ""
+msgstr "デフォルト設定が適切でない場合、追加で設定するためのオプションです。"
 
 msgid "Overview"
 msgstr "概要"
@@ -171,6 +174,8 @@ msgid ""
 "The local IPv4 or IPv6 address. The latter one should be specified within "
 "brackets, e.g. '[::1]'."
 msgstr ""
+"ローカルの IPv4 または IPv6 アドレスです。 IPv6 アドレスの場合、ブラケット "
+"\"[ ]\" を含めて記述される必要があります（例: '[::1]'）。"
 
 msgid ""
 "The value for this property is the blocklist type and path to the file, e."
@@ -225,6 +230,3 @@ msgstr "ログファイルの確認"
 
 msgid "View Resolver List"
 msgstr "リゾルバ リストの確認"
-
-#~ msgid "The local IP address."
-#~ msgstr "ローカル IP アドレスです。"

--- a/applications/luci-app-dnscrypt-proxy/po/templates/dnscrypt-proxy.pot
+++ b/applications/luci-app-dnscrypt-proxy/po/templates/dnscrypt-proxy.pot
@@ -21,6 +21,17 @@ msgstr ""
 msgid "Configuration of the DNSCrypt-Proxy package."
 msgstr ""
 
+msgid ""
+"Create '/etc/resolv-crypt.conf' with 'options timeout:1' to reduce DNS "
+"upstream timeouts with multiple DNSCrypt instances."
+msgstr ""
+
+msgid "Create Config File"
+msgstr ""
+
+msgid "Create custom config file"
+msgstr ""
+
 msgid "DNS Query Logfile"
 msgstr ""
 
@@ -49,6 +60,9 @@ msgid "Enable Caching to speed up DNSCcrypt-Proxy."
 msgstr ""
 
 msgid "Ephemeral Keys"
+msgstr ""
+
+msgid "Extra options"
 msgstr ""
 
 msgid "File Checksum"
@@ -95,6 +109,10 @@ msgstr ""
 msgid "Name of the remote DNS service for resolving queries."
 msgstr ""
 
+msgid ""
+"Options for further tweaking in case the defaults are not suitable for you."
+msgstr ""
+
 msgid "Overview"
 msgstr ""
 
@@ -127,7 +145,9 @@ msgstr ""
 msgid "The listening port for DNS queries."
 msgstr ""
 
-msgid "The local IP address."
+msgid ""
+"The local IPv4 or IPv6 address. The latter one should be specified within "
+"brackets, e.g. '[::1]'."
 msgstr ""
 
 msgid ""


### PR DESCRIPTION
Updated Japanese translations.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>