### PR TITLE
luci-app-mwan3: fix uci-defaults script rename initial_source to loca…

### DIFF
--- a/applications/luci-app-mwan3/root/etc/uci-defaults/60_luci-mwan3
+++ b/applications/luci-app-mwan3/root/etc/uci-defaults/60_luci-mwan3
@@ -11,7 +11,7 @@ EOF
 uci -q get mwan3.globals >/dev/null || {
 	uci -q add mwan3 globals >/dev/null
 	uci -q rename mwan3.@globals[-1]="globals" >/dev/null
-	uci -q set mwan3.globals.initial_source="none" >/dev/null
+	uci -q set mwan3.globals.local_source="none" >/dev/null
 	uci commit mwan3
 }
 


### PR DESCRIPTION
Fix wrong config parameter. Which was introduced
in commit https://github.com/openwrt/luci/pull/1297/commits/5371f159da1806dc58671c6e1f519a3c9b9d120f
Signed-off-by: Florian Eckert <fe@dev.tdt.de>