### PR TITLE
luci-app-adblock: Fix commented out translations

### DIFF
--- a/applications/luci-app-adblock/po/pt-br/adblock.po
+++ b/applications/luci-app-adblock/po/pt-br/adblock.po
@@ -25,7 +25,7 @@ msgid "Adblock Status"
 msgstr ""
 
 msgid "Adblock Version"
-msgstr ""
+msgstr "Versão do Adblock"
 
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
@@ -39,10 +39,10 @@ msgid "Available blocklist sources."
 msgstr "Fontes de listas de bloqueio disponíveis."
 
 msgid "Backup Directory"
-msgstr ""
+msgstr "Diretório da cópia de segurança"
 
 msgid "Blocklist Sources"
-msgstr ""
+msgstr "Fontes de listas de bloqueio"
 
 msgid ""
 "Caution: Please don't select big lists or many lists at once on low memory "
@@ -99,10 +99,10 @@ msgid "Edit Whitelist"
 msgstr "Editar Lista Permitida"
 
 msgid "Enable Adblock"
-msgstr ""
+msgstr "Habilitar adblock"
 
 msgid "Enable Blocklist Backup"
-msgstr ""
+msgstr "Habilitar cópia de segurança da lista de bloqueio"
 
 msgid ""
 "Enable memory intense overall sort / duplicate removal on low memory devices "
@@ -118,7 +118,7 @@ msgid "Enabled"
 msgstr "Habilitado"
 
 msgid "Extra Options"
-msgstr ""
+msgstr "Opções adicionais"
 
 msgid ""
 "For SSL protected blocklist sources you need a suitable SSL library, e.g. "
@@ -135,7 +135,7 @@ msgstr ""
 "online</a>"
 
 msgid "Force Local DNS"
-msgstr ""
+msgstr "Force o DNS local"
 
 msgid "Force Overall Sort"
 msgstr "Force Tipo Geral"
@@ -215,7 +215,7 @@ msgid "Resume"
 msgstr ""
 
 msgid "Runtime Information"
-msgstr ""
+msgstr "Informação de execução"
 
 msgid "SSL req."
 msgstr "req. de SSL"
@@ -230,7 +230,7 @@ msgid "Suspend"
 msgstr ""
 
 msgid "Suspend / Resume Adblock"
-msgstr ""
+msgstr "Suspender / Resumir adblock"
 
 msgid ""
 "Target directory for adblock backups. Please use only non-volatile disks, no "
@@ -285,7 +285,7 @@ msgid ""
 msgstr ""
 
 msgid "Trigger Delay"
-msgstr ""
+msgstr "Atraso no gatilho"
 
 msgid "Verbose Debug Logging"
 msgstr ""
@@ -314,35 +314,14 @@ msgstr "n/d"
 msgid "paused"
 msgstr ""
 
-#~ msgid "Adblock version"
-#~ msgstr "Versão do Adblock"
-
-#~ msgid "Backup directory"
-#~ msgstr "Diretório da cópia de segurança"
-
 #~ msgid "Blocked domains (overall)"
 #~ msgstr "Domínios bloqueados (total)"
-
-#~ msgid "Blocklist sources"
-#~ msgstr "Fontes de listas de bloqueio"
 
 #~ msgid "DNS backend"
 #~ msgstr "Porta dos fundos de DNS"
 
-#~ msgid "Enable adblock"
-#~ msgstr "Habilitar adblock"
-
-#~ msgid "Enable blocklist backup"
-#~ msgstr "Habilitar cópia de segurança da lista de bloqueio"
-
 #~ msgid "Enable verbose debug logging"
 #~ msgstr "Habilite registros detalhados para depuração"
-
-#~ msgid "Extra options"
-#~ msgstr "Opções adicionais"
-
-#~ msgid "Force local DNS"
-#~ msgstr "Force o DNS local"
 
 #~ msgid "Last rundate"
 #~ msgstr "Última data de execução"
@@ -363,17 +342,8 @@ msgstr ""
 #~ msgid "Resume adblock"
 #~ msgstr "Resumir adblock"
 
-#~ msgid "Runtime information"
-#~ msgstr "Informação de execução"
-
 #~ msgid "Status"
 #~ msgstr "Estado"
-
-#~ msgid "Suspend / Resume adblock"
-#~ msgstr "Suspender / Resumir adblock"
-
-#~ msgid "Trigger delay"
-#~ msgstr "Atraso no gatilho"
 
 #~ msgid "active"
 #~ msgstr "ativo"

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -14,7 +14,7 @@ msgid "Adblock Status"
 msgstr ""
 
 msgid "Adblock Version"
-msgstr ""
+msgstr "Version för Adblock"
 
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
@@ -26,10 +26,10 @@ msgid "Available blocklist sources."
 msgstr "Tillgängliga källor för blockeringslistor"
 
 msgid "Backup Directory"
-msgstr ""
+msgstr "Säkerhetskopiera mapp"
 
 msgid "Blocklist Sources"
-msgstr ""
+msgstr "Källor för blockeringslistor"
 
 msgid ""
 "Caution: Please don't select big lists or many lists at once on low memory "
@@ -84,10 +84,10 @@ msgid "Edit Whitelist"
 msgstr "Redigera vitlista"
 
 msgid "Enable Adblock"
-msgstr ""
+msgstr "Aktivera adblock"
 
 msgid "Enable Blocklist Backup"
-msgstr ""
+msgstr "Aktivera säkerhetskopiering av blockeringslistan"
 
 msgid ""
 "Enable memory intense overall sort / duplicate removal on low memory devices "
@@ -101,7 +101,7 @@ msgid "Enabled"
 msgstr "Aktiverad"
 
 msgid "Extra Options"
-msgstr ""
+msgstr "Extra alternativ"
 
 msgid ""
 "For SSL protected blocklist sources you need a suitable SSL library, e.g. "
@@ -116,7 +116,7 @@ msgstr ""
 "internet</a>"
 
 msgid "Force Local DNS"
-msgstr ""
+msgstr "Tvinga lokal DNS"
 
 msgid "Force Overall Sort"
 msgstr ""
@@ -195,7 +195,7 @@ msgid "Resume"
 msgstr ""
 
 msgid "Runtime Information"
-msgstr ""
+msgstr "Information om körtid"
 
 msgid "SSL req."
 msgstr "SSL-rek."
@@ -210,7 +210,7 @@ msgid "Suspend"
 msgstr ""
 
 msgid "Suspend / Resume Adblock"
-msgstr ""
+msgstr "Upphäv / Återuppta adblock"
 
 msgid ""
 "Target directory for adblock backups. Please use only non-volatile disks, no "
@@ -289,35 +289,14 @@ msgstr "n/a"
 msgid "paused"
 msgstr ""
 
-#~ msgid "Adblock version"
-#~ msgstr "Version för Adblock"
-
-#~ msgid "Backup directory"
-#~ msgstr "Säkerhetskopiera mapp"
-
 #~ msgid "Blocked domains (overall)"
 #~ msgstr "Blockerade domäner (övergripande)"
-
-#~ msgid "Blocklist sources"
-#~ msgstr "Källor för blockeringslistor"
 
 #~ msgid "DNS backend"
 #~ msgstr "Bakände för DNS"
 
-#~ msgid "Enable adblock"
-#~ msgstr "Aktivera adblock"
-
-#~ msgid "Enable blocklist backup"
-#~ msgstr "Aktivera säkerhetskopiering av blockeringslistan"
-
 #~ msgid "Enable verbose debug logging"
 #~ msgstr "Aktivera utförlig loggning för avlusning"
-
-#~ msgid "Extra options"
-#~ msgstr "Extra alternativ"
-
-#~ msgid "Force local DNS"
-#~ msgstr "Tvinga lokal DNS"
 
 #~ msgid "Last rundate"
 #~ msgstr "Senaste kördatum"
@@ -328,14 +307,8 @@ msgstr ""
 #~ msgid "Resume adblock"
 #~ msgstr "Återuppta adblock"
 
-#~ msgid "Runtime information"
-#~ msgstr "Information om körtid"
-
 #~ msgid "Status"
 #~ msgstr "Status"
-
-#~ msgid "Suspend / Resume adblock"
-#~ msgstr "Upphäv / Återuppta adblock"
 
 #~ msgid "Suspend adblock"
 #~ msgstr "Upphäv adblock"

--- a/applications/luci-app-adblock/po/zh-cn/adblock.po
+++ b/applications/luci-app-adblock/po/zh-cn/adblock.po
@@ -26,7 +26,7 @@ msgid "Adblock Status"
 msgstr ""
 
 msgid "Adblock Version"
-msgstr ""
+msgstr "Adblock 版本"
 
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
@@ -38,10 +38,10 @@ msgid "Available blocklist sources."
 msgstr "可用的 blocklist 来源"
 
 msgid "Backup Directory"
-msgstr ""
+msgstr "备份目录"
 
 msgid "Blocklist Sources"
-msgstr ""
+msgstr "拦截列表来源"
 
 msgid ""
 "Caution: Please don't select big lists or many lists at once on low memory "
@@ -92,10 +92,10 @@ msgid "Edit Whitelist"
 msgstr "编辑白名单"
 
 msgid "Enable Adblock"
-msgstr ""
+msgstr "启用Adblock"
 
 msgid "Enable Blocklist Backup"
-msgstr ""
+msgstr "启用拦截规则备份"
 
 msgid ""
 "Enable memory intense overall sort / duplicate removal on low memory devices "
@@ -109,7 +109,7 @@ msgid "Enabled"
 msgstr "启用"
 
 msgid "Extra Options"
-msgstr ""
+msgstr "额外选项"
 
 msgid ""
 "For SSL protected blocklist sources you need a suitable SSL library, e.g. "
@@ -200,7 +200,7 @@ msgid "Resume"
 msgstr ""
 
 msgid "Runtime Information"
-msgstr ""
+msgstr "运行信息"
 
 msgid "SSL req."
 msgstr ""
@@ -215,7 +215,7 @@ msgid "Suspend"
 msgstr ""
 
 msgid "Suspend / Resume Adblock"
-msgstr ""
+msgstr "暂停/恢复 Adblock"
 
 msgid ""
 "Target directory for adblock backups. Please use only non-volatile disks, no "
@@ -259,7 +259,7 @@ msgid ""
 msgstr ""
 
 msgid "Trigger Delay"
-msgstr ""
+msgstr "触发延迟"
 
 msgid "Verbose Debug Logging"
 msgstr ""
@@ -288,47 +288,20 @@ msgstr ""
 msgid "paused"
 msgstr ""
 
-#~ msgid "Adblock version"
-#~ msgstr "Adblock 版本"
-
-#~ msgid "Backup directory"
-#~ msgstr "备份目录"
-
-#~ msgid "Blocklist sources"
-#~ msgstr "拦截列表来源"
-
 #~ msgid "DNS backend"
 #~ msgstr "DNS 后端"
-
-#~ msgid "Enable adblock"
-#~ msgstr "启用Adblock"
-
-#~ msgid "Enable blocklist backup"
-#~ msgstr "启用拦截规则备份"
 
 #~ msgid "Enable verbose debug logging"
 #~ msgstr "启用详细调试输出"
 
-#~ msgid "Extra options"
-#~ msgstr "额外选项"
-
 #~ msgid "Resume adblock"
 #~ msgstr "恢复 Adblock"
-
-#~ msgid "Runtime information"
-#~ msgstr "运行信息"
 
 #~ msgid "Status"
 #~ msgstr "状态"
 
-#~ msgid "Suspend / Resume adblock"
-#~ msgstr "暂停/恢复 Adblock"
-
 #~ msgid "Suspend adblock"
 #~ msgstr "暂停 Adblock"
-
-#~ msgid "Trigger delay"
-#~ msgstr "触发延迟"
 
 #~ msgid "active"
 #~ msgstr "已启用"


### PR DESCRIPTION
Fixed translations that commented out due to difference of letter-case
in msgid.

Related: #1361 

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>