### PR TITLE
luci-mod-admin-full: Add Hardware chipset information on status page

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -681,6 +681,7 @@
 
 	<table width="100%" cellspacing="10">
 		<tr><td width="33%"><%:Hostname%></td><td><%=luci.sys.hostname() or "?"%></td></tr>
+		<tr><td width="33%"><%:Hardware%></td><td><%=luci.sys.exec("cat /proc/cpuinfo | grep -inr 'system type' | sed 's/.*://'")%></td></tr>
 		<tr><td width="33%"><%:Model%></td><td><%=pcdata(boardinfo.model or boardinfo.system or "?")%></td></tr>
 		<tr><td width="33%"><%:Firmware Version%></td><td>
 			<%=pcdata(ver.distname)%> <%=pcdata(ver.distversion)%> /


### PR DESCRIPTION
Chipset(hardware) information is something that was missing on status page from long time.

![hardware_openwrt](https://user-images.githubusercontent.com/10448833/30478096-2e3646a4-9a2d-11e7-97b3-420f15e830f9.png)

Signed-off-by: Kishan Gondaliya <kishanpgondaliya@gmail.com>