### PR TITLE
luci-app-minidlna: add allow wide links option

### DIFF
--- a/applications/luci-app-minidlna/luasrc/model/cbi/minidlna.lua
+++ b/applications/luci-app-minidlna/luasrc/model/cbi/minidlna.lua
@@ -91,6 +91,10 @@ s:taboption("advanced", Flag, "enable_tivo", translate("Enable TIVO:"),
 	translate("Set this to enable support for streaming .jpg and .mp3 files to a TiVo supporting HMO."))
 o.rmempty = true
 
+s:taboption("advanced", Flag, "wide_links", translate("Allow wide links"),
+	translate("Set this to allow serving content outside the media root (via symlinks)."))
+o.rmempty = true
+
 o = s:taboption("advanced", Flag, "strict_dlna", translate("Strict to DLNA standard:"),
 	translate("Set this to strictly adhere to DLNA standards. This will allow server-side downscaling of very large JPEG images, which may hurt JPEG serving performance on (at least) Sony DLNA products."))
 o.rmempty = true

--- a/applications/luci-app-minidlna/po/ca/minidlna.po
+++ b/applications/luci-app-minidlna/po/ca/minidlna.po
@@ -17,6 +17,9 @@ msgstr "Ajusts avançats"
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/cs/minidlna.po
+++ b/applications/luci-app-minidlna/po/cs/minidlna.po
@@ -17,6 +17,9 @@ msgstr "Pokročilé nastavení"
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/de/minidlna.po
+++ b/applications/luci-app-minidlna/po/de/minidlna.po
@@ -17,6 +17,9 @@ msgstr "Erweiterte Einstellungen"
 msgid "Album art names:"
 msgstr "Dateinamen für Cover-Bilder:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Angekündigte Modellnummer:"
 

--- a/applications/luci-app-minidlna/po/el/minidlna.po
+++ b/applications/luci-app-minidlna/po/el/minidlna.po
@@ -14,6 +14,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/en/minidlna.po
+++ b/applications/luci-app-minidlna/po/en/minidlna.po
@@ -14,6 +14,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr "Album art names:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Announced model number:"
 

--- a/applications/luci-app-minidlna/po/es/minidlna.po
+++ b/applications/luci-app-minidlna/po/es/minidlna.po
@@ -17,6 +17,9 @@ msgstr "Configuración avanzada"
 msgid "Album art names:"
 msgstr "Imágenes de álbumes:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Número de modelo declarado:"
 

--- a/applications/luci-app-minidlna/po/fr/minidlna.po
+++ b/applications/luci-app-minidlna/po/fr/minidlna.po
@@ -14,6 +14,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/he/minidlna.po
+++ b/applications/luci-app-minidlna/po/he/minidlna.po
@@ -14,6 +14,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/hu/minidlna.po
+++ b/applications/luci-app-minidlna/po/hu/minidlna.po
@@ -17,6 +17,9 @@ msgstr "Haladó beállítások"
 msgid "Album art names:"
 msgstr "Borító album nevek:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Közölt modellszám:"
 

--- a/applications/luci-app-minidlna/po/it/minidlna.po
+++ b/applications/luci-app-minidlna/po/it/minidlna.po
@@ -17,6 +17,9 @@ msgstr "Opzioni avanzate"
 msgid "Album art names:"
 msgstr "Nome Copertina Album:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Numero modello annunciato:"
 

--- a/applications/luci-app-minidlna/po/ja/minidlna.po
+++ b/applications/luci-app-minidlna/po/ja/minidlna.po
@@ -17,6 +17,9 @@ msgstr "詳細設定"
 msgid "Album art names:"
 msgstr "アルバムアートワーク・ファイル名:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "通知するモデル番号:"
 

--- a/applications/luci-app-minidlna/po/ms/minidlna.po
+++ b/applications/luci-app-minidlna/po/ms/minidlna.po
@@ -13,6 +13,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/no/minidlna.po
+++ b/applications/luci-app-minidlna/po/no/minidlna.po
@@ -17,6 +17,9 @@ msgstr "Avanserte Innstillinger"
 msgid "Album art names:"
 msgstr "Albumbilder navn:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Annonsert modellnummer:"
 

--- a/applications/luci-app-minidlna/po/pl/minidlna.po
+++ b/applications/luci-app-minidlna/po/pl/minidlna.po
@@ -18,6 +18,9 @@ msgstr "Ustawienia zaawansowane"
 msgid "Album art names:"
 msgstr "Nazwy okładek albumów:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Rozgłaszany model:"
 

--- a/applications/luci-app-minidlna/po/pt-br/minidlna.po
+++ b/applications/luci-app-minidlna/po/pt-br/minidlna.po
@@ -14,6 +14,9 @@ msgstr "Configuração Avançada"
 msgid "Album art names:"
 msgstr "Nomes do Álbum artistico: "
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "numero de modelo anunciado:"
 

--- a/applications/luci-app-minidlna/po/pt/minidlna.po
+++ b/applications/luci-app-minidlna/po/pt/minidlna.po
@@ -17,6 +17,9 @@ msgstr "Definições Avançadas"
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Número modelo anunciado:"
 

--- a/applications/luci-app-minidlna/po/ro/minidlna.po
+++ b/applications/luci-app-minidlna/po/ro/minidlna.po
@@ -18,6 +18,9 @@ msgstr "Setări avansate"
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/ru/minidlna.po
+++ b/applications/luci-app-minidlna/po/ru/minidlna.po
@@ -20,6 +20,9 @@ msgstr "Расширенные настройки"
 msgid "Album art names:"
 msgstr "Имена обложек альбома:"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "Номер модели:"
 

--- a/applications/luci-app-minidlna/po/sk/minidlna.po
+++ b/applications/luci-app-minidlna/po/sk/minidlna.po
@@ -14,6 +14,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/sv/minidlna.po
+++ b/applications/luci-app-minidlna/po/sv/minidlna.po
@@ -15,6 +15,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/templates/minidlna.pot
+++ b/applications/luci-app-minidlna/po/templates/minidlna.pot
@@ -7,6 +7,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgstr ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/tr/minidlna.po
+++ b/applications/luci-app-minidlna/po/tr/minidlna.po
@@ -14,6 +14,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/uk/minidlna.po
+++ b/applications/luci-app-minidlna/po/uk/minidlna.po
@@ -15,6 +15,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/vi/minidlna.po
+++ b/applications/luci-app-minidlna/po/vi/minidlna.po
@@ -14,6 +14,9 @@ msgstr ""
 msgid "Album art names:"
 msgstr ""
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr ""
 

--- a/applications/luci-app-minidlna/po/zh-cn/minidlna.po
+++ b/applications/luci-app-minidlna/po/zh-cn/minidlna.po
@@ -17,6 +17,9 @@ msgstr "高级设置"
 msgid "Album art names:"
 msgstr "专辑封面名称："
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "通告型号："
 

--- a/applications/luci-app-minidlna/po/zh-tw/minidlna.po
+++ b/applications/luci-app-minidlna/po/zh-tw/minidlna.po
@@ -17,6 +17,9 @@ msgstr "進階設定值"
 msgid "Album art names:"
 msgstr "專輯名稱"
 
+msgid "Allow wide links:"
+msgid ""
+
 msgid "Announced model number:"
 msgstr "已宣告型號數量"
 


### PR DESCRIPTION
This option was added to minidlna in version 1.2.0
and is set to no by default.

Signed-off-by: James Christopher Adduono <jc@adduono.com>