### PR TITLE
luci-app-dnscrypt-proxy: major update

### DIFF
--- a/applications/luci-app-dnscrypt-proxy/luasrc/controller/dnscrypt-proxy.lua
+++ b/applications/luci-app-dnscrypt-proxy/luasrc/controller/dnscrypt-proxy.lua
@@ -17,8 +17,8 @@ function index()
 	entry({"admin", "services", "dnscrypt-proxy", "advanced"}, firstchild(), _("Advanced"), 100)
 	entry({"admin", "services", "dnscrypt-proxy", "advanced", "configuration"}, cbi("dnscrypt-proxy/configuration_tab"), _("Edit DNSCrypt-Proxy Configuration"), 110).leaf = true
 	entry({"admin", "services", "dnscrypt-proxy", "advanced", "cfg_dnsmasq"}, cbi("dnscrypt-proxy/cfg_dnsmasq_tab"), _("Edit Dnsmasq Configuration"), 120).leaf = true
-	entry({"admin", "services", "dnscrypt-proxy", "advanced", "view_reslist"}, call("view_reslist"), _("View Resolver List"), 130).leaf = true
-
+	entry({"admin", "services", "dnscrypt-proxy", "advanced", "cfg_resolvcrypt"}, cbi("dnscrypt-proxy/cfg_resolvcrypt_tab"), _("Edit Resolvcrypt Configuration"), 130).leaf = true
+	entry({"admin", "services", "dnscrypt-proxy", "advanced", "view_reslist"}, call("view_reslist"), _("View Resolver List"), 140).leaf = true
 end
 
 function view_reslist()
@@ -27,6 +27,12 @@ function view_reslist()
 end
 
 function logread()
-	local logfile = util.trim(util.exec("logread -e 'dnscrypt-proxy'"))
+	local logfile
+
+	if nixio.fs.access("/var/log/messages") then
+		logfile = util.trim(util.exec("cat /var/log/messages | grep 'dnscrypt-proxy'"))
+	else
+		logfile = util.trim(util.exec("logread -e 'dnscrypt-proxy'"))
+	end
 	templ.render("dnscrypt-proxy/logread", {title = i18n.translate("DNSCrypt-Proxy Logfile"), content = logfile})
 end

--- a/applications/luci-app-dnscrypt-proxy/luasrc/model/cbi/dnscrypt-proxy/cfg_resolvcrypt_tab.lua
+++ b/applications/luci-app-dnscrypt-proxy/luasrc/model/cbi/dnscrypt-proxy/cfg_resolvcrypt_tab.lua
@@ -3,9 +3,9 @@
 
 local nxfs      = require("nixio.fs")
 local util      = require("luci.util")
-local uci_input = "/etc/config/dhcp"
+local res_input = "/etc/resolv-crypt.conf"
 
-if not nxfs.access(uci_input) then
+if not nxfs.access(res_input) then
 	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
 	m.reset = false
 	m.submit = false
@@ -18,18 +18,18 @@ m.submit = translate("Save")
 m.reset = false
 
 s = m:section(SimpleSection, nil,
-	translate("This form allows you to modify the content of the main Dnsmasq configuration file (/etc/config/dhcp)."))
+	translate("This form allows you to modify the content of the resolv-crypt configuration file (/etc/resolv-crypt.conf)."))
 
 f = s:option(TextValue, "data")
 f.rows = 20
 f.rmempty = true
 
 function f.cfgvalue()
-	return nxfs.readfile(uci_input) or ""
+	return nxfs.readfile(res_input) or ""
 end
 
 function f.write(self, section, data)
-	return nxfs.writefile(uci_input, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+	return nxfs.writefile(res_input, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
 end
 
 function s.handle(self, state, data)

--- a/applications/luci-app-dnscrypt-proxy/luasrc/model/cbi/dnscrypt-proxy/overview_tab.lua
+++ b/applications/luci-app-dnscrypt-proxy/luasrc/model/cbi/dnscrypt-proxy/overview_tab.lua
@@ -11,15 +11,16 @@ local plug_cnt  = tonumber(luci.sys.exec("env -i /usr/sbin/dnscrypt-proxy --vers
 local res_list  = {}
 local url       = "https://download.dnscrypt.org/dnscrypt-proxy/dnscrypt-resolvers.csv"
 
-if not fs.access("/lib/libustream-ssl.so") then
-	m = SimpleForm("error", nil, translate("SSL support not available, please install an libustream-ssl variant to use this package."))
-	m.submit = false
-	m.reset = false
-	return m
-end
-
 if not fs.access(res_input) then
-	luci.sys.call("env -i /bin/uclient-fetch --no-check-certificate -O " .. res_input .. " " .. url .. " >/dev/null 2>&1")
+	if not fs.access("/lib/libustream-ssl.so") then
+		m = SimpleForm("error", nil, translate("No default resolver list and no SSL support available.<br />")
+			.. translate("Please install a resolver list to '/usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv' to use this package."))
+		m.submit = false
+		m.reset = false
+		return m
+	else
+		luci.sys.call("env -i /bin/uclient-fetch --no-check-certificate -O " .. res_input .. " " .. url .. " >/dev/null 2>&1")
+	end
 end
 
 if not uci:get_first("dnscrypt-proxy", "global") then
@@ -29,23 +30,53 @@ if not uci:get_first("dnscrypt-proxy", "global") then
 end
 
 for line in io.lines(res_input) do
-	local name = line:match("^[%w_.-]*")
-	res_list[#res_list + 1] = { name = name }
+	local name,
+	location,
+	dnssec,
+	nolog = line:match("^([^,]+),.-,\".-\",\"(.-)\",.-,[0-9],([yesno]+),([yesno]+)")
+	res_list[#res_list + 1] = { name = name, location = location, dnssec = dnssec, nolog = nolog }
 end
 
 m = Map("dnscrypt-proxy", translate("DNSCrypt-Proxy"),
 	translate("Configuration of the DNSCrypt-Proxy package. ")
-	.. translate("Keep in mind to configure Dnsmasq as well. ")
 	.. translatef("For further information "
 	.. "<a href=\"%s\" target=\"_blank\">"
 	.. "see the wiki online</a>", "https://wiki.openwrt.org/inbox/dnscrypt"))
+m:chain("dhcp")
 
 function m.on_after_commit(self)
-	luci.sys.call("env -i /etc/init.d/dnsmasq restart >/dev/null 2>&1")
+	function d1.validate(self, value, s1)
+		if value == "1" then
+			uci:commit("dnscrypt-proxy")
+			uci:set("dhcp", s1, "noresolv", 1)
+			if not fs.access("/etc/resolv-crypt.conf") or nixio.fs.stat("/etc/resolv-crypt.conf").size == 0 then
+				uci:set("dhcp", s1, "resolvfile", "/tmp/resolv.conf.auto")
+			else
+				uci:set("dhcp", s1, "resolvfile", "/etc/resolv-crypt.conf")
+			end
+			local server_list = {}
+			local cnt = 1
+			uci:foreach("dnscrypt-proxy", "dnscrypt-proxy", function(s)
+				server_list[cnt] = s['address'] .. "#" .. s['port']
+				cnt = cnt + 1
+			end)
+			server_list[cnt] = "/pool.ntp.org/8.8.8.8"
+			uci:set_list("dhcp", s1, "server", server_list)
+			if cnt > 2 then
+				uci:set("dhcp", s1, "allservers", 1)
+			else
+				uci:set("dhcp", s1, "allservers", 0)
+			end
+			uci:save("dhcp")
+			uci:commit("dhcp")
+		end
+		return value
+	end
 	luci.sys.call("env -i /etc/init.d/dnscrypt-proxy restart >/dev/null 2>&1")
+	luci.sys.call("env -i /etc/init.d/dnsmasq restart >/dev/null 2>&1")
 end
 
-s = m:section(TypedSection, "global", translate("General options"))
+s = m:section(TypedSection, "global", translate("General Options"))
 s.anonymous = true
 
 -- Main dnscrypt-proxy resource list
@@ -62,21 +93,53 @@ o3 = s:option(DummyValue, "", translate("File Checksum"))
 o3.template = "dnscrypt-proxy/res_options"
 o3.value = luci.sys.exec("sha256sum " .. res_input .. " | awk '{print $1}'")
 
-btn = s:option(Button, "", translate("Refresh Resolver List"))
-btn.inputtitle = translate("Refresh List")
-btn.inputstyle = "apply"
-btn.disabled = false
-function btn.write(self, section, value)
-	luci.sys.call("env -i /bin/uclient-fetch --no-check-certificate -O " .. res_input .. " " .. url .. " >/dev/null 2>&1")
-	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "dnscrypt-proxy"))
+if fs.access("/lib/libustream-ssl.so") then
+	btn1 = s:option(Button, "", translate("Refresh Resolver List"),
+		translate("Download the current resolver list from 'download.dnscrypt.org'."))
+	btn1.inputtitle = translate("Refresh List")
+	btn1.inputstyle = "apply"
+	btn1.disabled = false
+	function btn1.write()
+		luci.sys.call("env -i /bin/uclient-fetch --no-check-certificate -O " .. res_input .. " " .. url .. " >/dev/null 2>&1")
+		luci.http.redirect(luci.dispatcher.build_url("admin", "services", "dnscrypt-proxy"))
+	end
+else
+	btn1 = s:option(Button, "", translate("Refresh Resolver List"),
+		translate("No SSL support available.<br />")
+		.. translate("Please install a 'libustream-ssl' library to download the current resolver list from 'download.dnscrypt.org'."))
+	btn1.inputtitle = translate("-------")
+	btn1.inputstyle = "button"
+	btn1.disabled = true
+end
+
+if not fs.access("/etc/resolv-crypt.conf") or nixio.fs.stat("/etc/resolv-crypt.conf").size == 0 then
+	btn2 = s:option(Button, "", translate("Create Custom Config File"),
+		translate("Create '/etc/resolv-crypt.conf' with 'options timeout:1' to reduce DNS upstream timeouts with multiple DNSCrypt instances.<br />")
+		.. translatef("For further information "
+		.. "<a href=\"%s\" target=\"_blank\">"
+		.. "see the wiki online</a>", "https://wiki.openwrt.org/inbox/dnscrypt"))
+	btn2.inputtitle = translate("Create Config File")
+	btn2.inputstyle = "apply"
+	btn2.disabled = false
+	function btn2.write()
+		luci.sys.call("env -i echo 'options timeout:1' > '/etc/resolv-crypt.conf'")
+		luci.http.redirect(luci.dispatcher.build_url("admin", "services", "dnscrypt-proxy"))
+	end
+else
+	btn2 = s:option(Button, "", translate("Create Custom Config File"),
+		translate("The config file '/etc/resolv-crypt.conf' already exist.<br />")
+		.. translate("Please edit the file manually in the 'Advanced' section."))
+	btn2.inputtitle = translate("-------")
+	btn2.inputstyle = "button"
+	btn2.disabled = true
 end
 
 -- Trigger settings
 
-t = s:option(DynamicList, "procd_trigger", translate("Startup Trigger"),
-	translate("By default the DNSCrypt-Proxy startup will be triggered by ifup events of multiple network interfaces. ")
-	.. translate("To restrict the trigger, add only the relevant network interface(s). ")
-	.. translate("Usually the 'wan' interface should work for most users."))
+t = s:option(ListValue, "procd_trigger", translate("Startup Trigger"),
+	translate("By default the DNSCrypt-Proxy startup will be triggered by ifup events of 'All' available network interfaces.<br />")
+	.. translate("To restrict the trigger, select only the relevant network interface. Usually the 'wan' interface should work for most users."))
+t:value("", "All")
 if dump then
 	local i, v
 	for i, v in ipairs(dump.interface) do
@@ -85,57 +148,38 @@ if dump then
 		end
 	end
 end
+t.default = procd_trigger or "All"
 t.rmempty = true
-
--- Extra options
-
-ds = s:option(DummyValue, "_dummy", translate("Extra options"),
-	translate("Options for further tweaking in case the defaults are not suitable for you."))
-ds.template = "cbi/nullsection"
-
-btn = s:option(Button, "", translate("Create custom config file"),
-	translate("Create '/etc/resolv-crypt.conf' with 'options timeout:1' to reduce DNS upstream timeouts with multiple DNSCrypt instances. ")
-	.. translatef("For further information "
-	.. "<a href=\"%s\" target=\"_blank\">"
-	.. "see the wiki online</a>", "https://wiki.openwrt.org/inbox/dnscrypt"))
-btn.inputtitle = translate("Create Config File")
-btn.inputstyle = "apply"
-btn.disabled = false
-function btn.write(self, section, value)
-	if not fs.access("/etc/resolv-crypt.conf") then
-		luci.sys.call("env -i echo 'options timeout:1' > '/etc/resolv-crypt.conf'")
-	end
-end
 
 -- Mandatory options per instance
 
-s = m:section(TypedSection, "dnscrypt-proxy", translate("Instance options"))
+s = m:section(TypedSection, "dnscrypt-proxy", translate("Instance Options"))
 s.anonymous = true
 s.addremove = true
 
-o1 = s:option(Value, "address", translate("IP Address"),
+i1 = s:option(Value, "address", translate("IP Address"),
 	translate("The local IPv4 or IPv6 address. The latter one should be specified within brackets, e.g. '[::1]'."))
-o1.default = address or "127.0.0.1"
-o1.rmempty = false
+i1.default = address or "127.0.0.1"
+i1.rmempty = false
 
-o2 = s:option(Value, "port", translate("Port"),
+i2 = s:option(Value, "port", translate("Port"),
 	translate("The listening port for DNS queries."))
-o2.datatype = "port"
-o2.default = port
-o2.rmempty = false
+i2.datatype = "port"
+i2.default = port
+i2.rmempty = false
 
-o3 = s:option(ListValue, "resolver", translate("Resolver"),
-	translate("Name of the remote DNS service for resolving queries."))
-o3.datatype = "hostname"
-o3.widget = "select"
+i3 = s:option(ListValue, "resolver", translate("Resolver (LOC/SEC/NOLOG)"),
+	translate("Name of the remote DNS service for resolving queries incl. Location, DNSSEC- and NOLOG-Flag."))
+i3.datatype = "hostname"
+i3.widget = "select"
 local i, v
 for i, v in ipairs(res_list) do
-	if v.name ~= "Name" then
-		o3:value(v.name)
+	if v.name and v.location and v.dnssec and v.nolog and v.name ~= "Name" then
+		i3:value(v.name, v.name .. " (" .. v.location .. "/" .. v.dnssec .. "/" .. v.nolog .. ")")
 	end
 end
-o3.default = resolver
-o3.rmempty = false
+i3.default = resolver
+i3.rmempty = false
 
 -- Extra options per instance
 
@@ -174,4 +218,17 @@ if plug_cnt > 0 then
 	e6.optional = true
 end
 
-return m
+-- Dnsmasq options
+
+m1 = Map("dhcp")
+
+s1 = m1:section(TypedSection, "dnsmasq", translate("Dnsmasq Options"))
+s1.anonymous = true
+
+d1 = s1:option(Flag, "", translate("Transfer Options To Dnsmasq"),
+	translate("Apply DNSCrypt-Proxy specific settings to the Dnsmasq configuration.<br />")
+	.. translate("Please note: This may change the values for 'noresolv', 'resolvfile', 'allservers' and the list 'server' settings."))
+d1.default = d1.enabled
+d1.rmempty = false
+
+return m, m1


### PR DESCRIPTION
* automatically transfer dnscrypt specific settings to dnsmasq as well,
  This may change the values for 'noresolv', 'resolvfile',
  'allservers' and the list 'server' settings (enabled by default)
* parse/show the resolver, Location, DNSSEC- and NOLOG-Flag
  in the resolver select box
* make buttons for resolver list download & file creation
  (resolv-crypt.conf) more descriptive & responsive
* ease the startup trigger handling
* add an edit tab for 'resolv-crypt.conf' in the 'Advanced' section

Signed-off-by: Dirk Brenken <dev@brenken.org>