### PR TITLE
luci-app-fwknopd: fix multiple errors in gen-qr.sh

### DIFF
--- a/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
+++ b/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
@@ -4,23 +4,23 @@ if [ "$1" != "" ]; then
 entry_num=$1
 fi
 
-key_base64=$(uci get fwknopd.@access[$entry_num].KEY_BASE64)
-key=$(uci get fwknopd.@access[$entry_num].KEY)
-hmac_key_base64=$(uci get fwknopd.@access[$entry_num].HMAC_KEY_BASE64)
-hmac_key=$(uci get fwknopd.@access[$entry_num].HMAC_KEY)
+key_base64=$(uci -q get fwknopd.@access[$entry_num].KEY_BASE64)
+key=$(uci -q get fwknopd.@access[$entry_num].KEY)
+hmac_key_base64=$(uci -q get fwknopd.@access[$entry_num].HMAC_KEY_BASE64)
+hmac_key=$(uci -q get fwknopd.@access[$entry_num].HMAC_KEY)
 
-if [ $key_base64 != "" ]; then
+if [ "$key_base64" != "" ]; then
 qr="KEY_BASE64:$key_base64"
 fi
-if [ $key != "" ]; then
+if [ "$key" != "" ]; then
 qr="$qr KEY:$key"
 
 fi
-if [ $hmac_key_base64 != "" ]; then
+if [ "$hmac_key_base64" != "" ]; then
 qr="$qr HMAC_KEY_BASE64:$hmac_key_base64"
 fi
-if [ $hmac_key != "" ]; then
+if [ "$hmac_key" != "" ]; then
 qr="$qr HMAC_KEY:$hmac_key"
 fi
 
-qrencode -o - "$qr"
+qrencode -o - "$qr" |sed '1d'


### PR DESCRIPTION
Add '-q' to uci get to make "uci: Entry not found" errors quiet
Quote variables in if statements to get rid of "sh: : unknown operand"
Remove first line of qrencode output to get rid of xml declaration error

Signed-off-by: Erin Quinlan <spacezorro@gmail.com>