### PR TITLE
luci-mod-admin-full: change backup file name to date prefixed

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
@@ -304,9 +304,9 @@ function action_backup()
 	local reader = ltn12_popen("sysupgrade --create-backup - 2>/dev/null")
 
 	luci.http.header(
-		'Content-Disposition', 'attachment; filename="backup-%s-%s.tar.gz"' %{
-			luci.sys.hostname(),
-			os.date("%Y-%m-%d")
+		'Content-Disposition', 'attachment; filename="%s-backup-%s.tar.gz"' %{
+			os.date("%Y-%m-%d"),
+			luci.sys.hostname()
 		})
 
 	luci.http.prepare_content("application/x-targz")


### PR DESCRIPTION
Useful if the user has more than one file.
File will get sorted by date and hostname.

Signed-off-by: Florian Eckert <fe@dev.tdt.de>