### PR TITLE
Luci-app-fwknopd: add quotation marks to squash error

### DIFF
--- a/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
+++ b/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
@@ -4,10 +4,10 @@ if [ "$1" != "" ]; then
 entry_num=$1
 fi
 
-key_base64=$(uci get fwknopd.@access[$entry_num].KEY_BASE64)
-key=$(uci get fwknopd.@access[$entry_num].KEY)
-hmac_key_base64=$(uci get fwknopd.@access[$entry_num].HMAC_KEY_BASE64)
-hmac_key=$(uci get fwknopd.@access[$entry_num].HMAC_KEY)
+key_base64=$(uci -q get fwknopd.@access[$entry_num].KEY_BASE64)
+key=$(uci -q get fwknopd.@access[$entry_num].KEY)
+hmac_key_base64=$(uci -q get fwknopd.@access[$entry_num].HMAC_KEY_BASE64)
+hmac_key=$(uci -q get fwknopd.@access[$entry_num].HMAC_KEY)
 
 if [ "$key_base64" != "" ]; then
 qr="KEY_BASE64:$key_base64"

--- a/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
+++ b/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
@@ -9,17 +9,17 @@ key=$(uci get fwknopd.@access[$entry_num].KEY)
 hmac_key_base64=$(uci get fwknopd.@access[$entry_num].HMAC_KEY_BASE64)
 hmac_key=$(uci get fwknopd.@access[$entry_num].HMAC_KEY)
 
-if [ $key_base64 != "" ]; then
+if [ "$key_base64" != "" ]; then
 qr="KEY_BASE64:$key_base64"
 fi
-if [ $key != "" ]; then
+if [ "$key" != "" ]; then
 qr="$qr KEY:$key"
 
 fi
-if [ $hmac_key_base64 != "" ]; then
+if [ "$hmac_key_base64" != "" ]; then
 qr="$qr HMAC_KEY_BASE64:$hmac_key_base64"
 fi
-if [ $hmac_key != "" ]; then
+if [ "$hmac_key" != "" ]; then
 qr="$qr HMAC_KEY:$hmac_key"
 fi
 

--- a/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
+++ b/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
@@ -23,4 +23,4 @@ if [ "$hmac_key" != "" ]; then
 qr="$qr HMAC_KEY:$hmac_key"
 fi
 
-qrencode -o - "$qr"
+qrencode -t svg -o - "$qr"


### PR DESCRIPTION
In some cases, the missing quotation marks can cause error messages.  Although harmless, adding the quotation marks for correctness.

Signed-off-by: Jonathan Bennett <JBennett@Incomsystems.biz>