### PR TITLE
luci-app-fwknop: add inline option to qrencode usage

### DIFF
--- a/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
+++ b/applications/luci-app-fwknopd/root/usr/sbin/gen-qr.sh
@@ -23,4 +23,4 @@ if [ "$hmac_key" != "" ]; then
 qr="$qr HMAC_KEY:$hmac_key"
 fi
 
-qrencode -t svg -o - "$qr"
+qrencode -t svg -I -o - "$qr"


### PR DESCRIPTION
The qrencode update in the packages repo includes a patch that
adds the --inline option.  We use that option to generate a
proper inline SVG image.
Signed-off-by: Jonathan Bennett <JBennett@Incomsystems.biz>

This PR depends on the qrencode update to 4.0.0.