### PR TITLE
luci-app-lxc: use images.linuxcontainers.org

### DIFF
--- a/applications/luci-app-lxc/Makefile
+++ b/applications/luci-app-lxc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LXC management Web UI
-LUCI_DEPENDS:=+luci-mod-admin-full +lxc +lxc-create +liblxc +rpcd-mod-lxc +getopt +xz
+LUCI_DEPENDS:=+luci-mod-admin-full +lxc +lxc-attach +lxc-console +lxc-create +liblxc +rpcd-mod-lxc +getopt
 LUCI_PKGARCH:=all
 
 PKG_MAINTAINER:=Petar Koretic <petar.koretic@sartura.hr>

--- a/applications/luci-app-lxc/luasrc/controller/lxc.lua
+++ b/applications/luci-app-lxc/luasrc/controller/lxc.lua
@@ -74,10 +74,9 @@ function lxc_get_downloadable()
 	luci.http.prepare_content("application/json")
 
 	local uci = require("uci").cursor()
+	local url = uci:get("lxc", "lxc", "url")
 
-        local url = uci:get("lxc", "lxc", "url")
-
-        local target = lxc_get_arch_target()
+	local target = lxc_get_arch_target()
 
 	local templates = {}
 
@@ -96,7 +95,6 @@ function lxc_create(lxc_name, lxc_template)
 	luci.http.prepare_content("text/plain")
 
 	local uci = require("uci").cursor()
-
 	local url = uci:get("lxc", "lxc", "url")
 
 	if not pcall(dofile, "/etc/openwrt_release") then
@@ -164,23 +162,21 @@ function lxc_configuration_set(lxc_name)
 end
 
 function lxc_get_arch_target()
-        local f = io.popen('uname -m', 'r')                                                                                                                                                                                                                                    
-        local target = f:read('*a')                                                                                                                                                                                                                                            
-        f:close()                                                                                                                                                                                                                                                              
+	local target = nixio.uname().machine
 
-        if string.find(target, 'armv5') or string.find(target, 'armv6') then
-                return 'armel'
-        end
+	if string.find(target, 'armv5') or string.find(target, 'armv6') then
+		return "armel"
+	end
 
-        if string.find(target, 'armv7') then
-                return 'armhf'
-        end
+	if string.find(target, 'armv7') then
+		return "armhf"
+	end
 
-        if string.find(target, 'armv8') then
-                return 'arm64'
-        end
+	if string.find(target, 'armv8') then
+		return "arm64"
+	end
 
-        if string.find(target, 'x86i%_64') then
-                return 'amd64'
-        end
+	if string.find(target, 'x86_64') then
+		return "amd64"
+	end
 end

--- a/applications/luci-app-lxc/root/etc/config/lxc
+++ b/applications/luci-app-lxc/root/etc/config/lxc
@@ -1,6 +1,3 @@
-#
-# lxc uci configuration
-#
 
 config lxc 'lxc'
-	option url 'virtualwrt.org/containers/'
+        option url 'images.linuxcontainers.org'

--- a/applications/luci-app-lxc/root/etc/config/lxc
+++ b/applications/luci-app-lxc/root/etc/config/lxc
@@ -1,3 +1,3 @@
 
 config lxc 'lxc'
-        option url 'images.linuxcontainers.org'
+	option url 'images.linuxcontainers.org'


### PR DESCRIPTION
Do luci-app-lxc functional out of the box using "images.linuxcontainers.org" as container image repository because "virtualwrt.org/containers/" seems dead.

Signed-off-by: Admin Localnet <localnet@users.noreply.github.com>