### PR TITLE
luci-mod-admin-full: prefer IPv6 lease hostname

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
@@ -78,16 +78,16 @@
 						tr.className = 'cbi-section-table-row cbi-rowstyle-' + ((i % 2) + 1);
 
 					var host = hosts[duid2mac(st[1][i].duid)];
-					if (host)
-						tr.insertCell(-1).innerHTML = String.format(
-							'<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis">%s</div>',
-							((host.name && (host.ipv4 || host.ipv6))
-								? '%h (%s)'.format(host.name, host.ipv4 || host.ipv6)
-								: '%h'.format(host.name || host.ipv4 || host.ipv6)).nobr()
-						);
-					else
-						tr.insertCell(-1).innerHTML = st[1][i].hostname ? st[1][i].hostname : '?';
+					var hoststr = st[1][i].hostname
+							? st[1][i].hostname
+							: (host ? host.name : '?');
 
+					if (host && (host.ipv4 || host.ipv6))
+						hoststr = String.format(
+							'<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis">%h (%s)</div>',
+							hoststr, host.ipv4 || host.ipv6);
+
+					tr.insertCell(-1).innerHTML = hoststr;
 					tr.insertCell(-1).innerHTML = st[1][i].ip6addr;
 					tr.insertCell(-1).innerHTML = st[1][i].duid;
 					tr.insertCell(-1).innerHTML = timestr;

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -417,16 +417,16 @@
 						tr.className = 'cbi-section-table-row cbi-rowstyle-' + ((i % 2) + 1);
 
 					var host = hosts[duid2mac(info.leases6[i].duid)];
-					if (host)
-						tr.insertCell(-1).innerHTML = String.format(
-							'<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis">%s</div>',
-							((host.name && (host.ipv4 || host.ipv6))
-								? '%h (%s)'.format(host.name, host.ipv4 || host.ipv6)
-								: '%h'.format(host.name || host.ipv4 || host.ipv6)).nobr()
-						);
-					else
-						tr.insertCell(-1).innerHTML = info.leases6[i].hostname ? info.leases6[i].hostname : '?';
+					var hoststr = info.leases6[i].hostname
+							? info.leases6[i].hostname
+							: (host ? host.name : '?');
 
+					if (host && (host.ipv4 || host.ipv6))
+						hoststr = String.format(
+							'<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis">%h (%s)</div>',
+							hoststr, host.ipv4 || host.ipv6);
+
+					tr.insertCell(-1).innerHTML = hoststr;
 					tr.insertCell(-1).innerHTML = info.leases6[i].ip6addr;
 					tr.insertCell(-1).innerHTML = info.leases6[i].duid;
 					tr.insertCell(-1).innerHTML = timestr;


### PR DESCRIPTION
Instead of showing hostname from IPv4 information prefer the
hostname from the IPv6 lease. This also avoids that only a
question mark is shown in case no IPv4 hostname is available
while a IPv6 hostname is (e.g. static assigned IPv4, DHCPv6).

Signed-off-by: Stefan Agner <stefan@agner.ch>