### PR TITLE
luci-proto-ipv6: fix patterns in proto_4x6.lua

### DIFF
--- a/protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua
+++ b/protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua
@@ -54,10 +54,10 @@ for _, p in ipairs({"dslite", "map", "464xlat"}) do
 	end
 
 	if p == "dslite" then
-		netmod:register_pattern_virtual("^ds-%w")
+		netmod:register_pattern_virtual("^ds%-%w")
 	elseif p == "map" then
-		netmod:register_pattern_virtual("^map-%w")
+		netmod:register_pattern_virtual("^map%-%w")
 	elseif p == "464xlat" then
-		netmod:register_pattern_virtual("^464-%w")
+		netmod:register_pattern_virtual("^464%-%w")
 	end
 end


### PR DESCRIPTION
The dash '-' needs to be escaped by a '%', otherwise it will
be interpreted as minus, which means '0 or more repetitions'.

This fixes LEDE FS#1157.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>