### PR TITLE
luci-proto-ppp: add redial and redial_timeout options for L2TP

### DIFF
--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua
@@ -56,6 +56,23 @@ dns:depends("peerdns", "")
 dns.datatype = "ipaddr"
 dns.cast     = "string"
 
+
 mtu = section:taboption("advanced", Value, "mtu", translate("Override MTU"))
 mtu.placeholder = "1500"
 mtu.datatype    = "max(9200)"
+
+
+redial = section:taboption("advanced", Flag, "redial",
+	translate("Redial"),
+	translate("Redial the connection if it is disconnected"))
+
+redial.default = redial.enabled
+
+
+redial_timeout = section:taboption("advanced", Value, "redial_timeout",
+	translate("Redial timeout"),
+	translate("Wait for a certain number of seconds before attempting redial"))
+
+redial_timeout:depends("redial", "1")
+redial_timeout.placeholder = "15"
+redial_timeout.datatype    = "and(uinteger,min(0))"


### PR DESCRIPTION
This commit adds the `redial` and `redial_timeout` fields to enable redialing the connection (e.g. when
interrupted) on LT2P interfaces. It depends on https://github.com/openwrt/packages/pull/5125/commits/0aa9dc3a474ecd548449ec375266d669fb77896c

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>