### PR TITLE
luci-base: reload log on uci system change

### DIFF
--- a/modules/luci-base/root/etc/config/ucitrack
+++ b/modules/luci-base/root/etc/config/ucitrack
@@ -36,6 +36,7 @@ config qos
 
 config system
 	option init led
+	option exec '/etc/init.d/log reload'
 	list affects luci_statistics
 	list affects dhcp
 


### PR DESCRIPTION
If log configuration get changed in uci system no new values are applied
until reboot. Add /etc/init.d/log reload to exec option will solve this
issue.

Signed-off-by: Florian Eckert <fe@dev.tdt.de>