### PR TITLE
fix DHCPv6 hostname display

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
@@ -78,7 +78,7 @@
 						tr.className = 'cbi-section-table-row cbi-rowstyle-' + ((i % 2) + 1);
 
 					var host = hosts[duid2mac(st[1][i].duid)];
-					if (host)
+					if (!st[1][i].hostname && host)
 						tr.insertCell(-1).innerHTML = String.format(
 							'<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis">%s</div>',
 							((host.name && (host.ipv4 || host.ipv6))

--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
@@ -78,15 +78,13 @@
 						tr.className = 'cbi-section-table-row cbi-rowstyle-' + ((i % 2) + 1);
 
 					var host = hosts[duid2mac(st[1][i].duid)];
-					if (!st[1][i].hostname && host)
-						tr.insertCell(-1).innerHTML = String.format(
-							'<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis">%s</div>',
-							((host.name && (host.ipv4 || host.ipv6))
-								? '%h (%s)'.format(host.name, host.ipv4 || host.ipv6)
-								: '%h'.format(host.name || host.ipv4 || host.ipv6)).nobr()
-						);
+					if (!st[1][i].hostname)
+						tr.insertCell(-1).innerHTML =
+							(host && (host.name || host.ipv4 || host.ipv6))
+								? '<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space: nowrap">? (%h)</div>'.format(host.name || host.ipv4 || host.ipv6)
+								: '?';
 					else
-						tr.insertCell(-1).innerHTML = st[1][i].hostname ? st[1][i].hostname : '?';
+						tr.insertCell(-1).innerHTML = st[1][i].hostname;
 
 					tr.insertCell(-1).innerHTML = st[1][i].ip6addr;
 					tr.insertCell(-1).innerHTML = st[1][i].duid;

--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
@@ -84,7 +84,10 @@
 								? '<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space: nowrap">? (%h)</div>'.format(host.name || host.ipv4 || host.ipv6)
 								: '?';
 					else
-						tr.insertCell(-1).innerHTML = st[1][i].hostname;
+						tr.insertCell(-1).innerHTML =
+							(host && host.name && st[1][i].hostname != host.name)
+								? '<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space: nowrap">%h (%h)</div>'.format(st[1][i].hostname, host.name)
+								: st[1][i].hostname;
 
 					tr.insertCell(-1).innerHTML = st[1][i].ip6addr;
 					tr.insertCell(-1).innerHTML = st[1][i].duid;

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -423,7 +423,10 @@
 								? '<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space: nowrap">? (%h)</div>'.format(host.name || host.ipv4 || host.ipv6)
 								: '?';
 					else
-						tr.insertCell(-1).innerHTML = info.leases6[i].hostname;
+						tr.insertCell(-1).innerHTML =
+							(host && host.name && info.leases6[i].hostname != host.name)
+								? '<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space: nowrap">%h (%h)</div>'.format(info.leases6[i].hostname, host.name)
+								: info.leases6[i].hostname;
 
 					tr.insertCell(-1).innerHTML = info.leases6[i].ip6addr;
 					tr.insertCell(-1).innerHTML = info.leases6[i].duid;

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -417,15 +417,13 @@
 						tr.className = 'cbi-section-table-row cbi-rowstyle-' + ((i % 2) + 1);
 
 					var host = hosts[duid2mac(info.leases6[i].duid)];
-					if (!info.leases6[i].hostname && host)
-						tr.insertCell(-1).innerHTML = String.format(
-							'<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis">%s</div>',
-							((host.name && (host.ipv4 || host.ipv6))
-								? '%h (%s)'.format(host.name, host.ipv4 || host.ipv6)
-								: '%h'.format(host.name || host.ipv4 || host.ipv6)).nobr()
-						);
+					if (!info.leases6[i].hostname)
+						tr.insertCell(-1).innerHTML =
+							(host && (host.name || host.ipv4 || host.ipv6))
+								? '<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space: nowrap">? (%h)</div>'.format(host.name || host.ipv4 || host.ipv6)
+								: '?';
 					else
-						tr.insertCell(-1).innerHTML = info.leases6[i].hostname ? info.leases6[i].hostname : '?';
+						tr.insertCell(-1).innerHTML = info.leases6[i].hostname;
 
 					tr.insertCell(-1).innerHTML = info.leases6[i].ip6addr;
 					tr.insertCell(-1).innerHTML = info.leases6[i].duid;

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -417,7 +417,7 @@
 						tr.className = 'cbi-section-table-row cbi-rowstyle-' + ((i % 2) + 1);
 
 					var host = hosts[duid2mac(info.leases6[i].duid)];
-					if (host)
+					if (!info.leases6[i].hostname && host)
 						tr.insertCell(-1).innerHTML = String.format(
 							'<div style="max-width:200px;overflow:hidden;text-overflow:ellipsis">%s</div>',
 							((host.name && (host.ipv4 || host.ipv6))


### PR DESCRIPTION
LuCI tries to match the DUID send via DHCPv6 to an existing mac adress to displays already available informations next to the DHCPv6 supplied hostname. It was initial intended to make it easy to spot misconfigured DHCPv6 clients.

Unfortunately the display logic doesn't work as I would expect in case the DUID can be matches to an already known MAC-Address:

- if the DHCPv6 hostname matches an already known hostname, the IPv4 address is show after the DHCPv4 hostname for no reason
- the already known hostname is displayed instead of the one send via DHCPv6

It makes it hard/impossible to spot issues like DHCPv4/DHCPv6 hostname mismatch or missing DHCPv6 hostname. Furthermore, it will claim that a specific hostname has an IPv6 Address where it doesn't (due to different send hostname).

Find attached the  /tmp/dhcp.leases and /tmp/hosts/odhcpd files I used for testing all combinations I could thing of:

```
a0:48:1c:aa:aa:aa 000100011f7c1b79a0481caaaaaa mapSameHostname
a0:48:1c:bb:bb:bb 000100011bcae377a0481cbbbbbb mapDiffHostname4/mapDiffHostname6
a0:48:1c:cc:cc:cc 000100011ba9d71ba0481ccccccc mapNoHostname6 
a0:48:1c:dd:dd:dd 000100011f6b067fa0481cdddddd mapNoHostname4
a0:48:1c:ee:ee:ee 0001000120b5e146a0481ceeeeee mapNoHostname46


74:46:a0:aa:aa:aa 0004d58855727a24d7abbbfbaf0ccbd7b83d NoMapSameHostname
74:46:a0:bb:bb:bb 00041b3a3595b4b4b21303ddc7872a37439a NoMapDiffHostname4/NoMapDiffHostname6
74:46:a0:cc:cc:cc 000474a53b5674b5d66544767148acd434ab NoMapNoHostname6 
74:46:a0:dd:dd:dd 0004c5ceb825361d7bc95ad133af6391dcb8 NoMapNoHostname4
74:46:a0:ee:ee:ee 00049bc6fbc6c2c16b2e8feadbab2b06c779 NoMapNoHostname46
```

[dhcp.leases.txt](https://github.com/openwrt/luci/files/1502990/dhcp.leases.txt)
[odhcpd.txt](https://github.com/openwrt/luci/files/1502991/odhcpd.txt)

You might need to stop odhcpd and dnsmasq to ensure the files are not purged during testing.

Albeit this PR applies to lede-17.01 and the master branch, it is mainly intended for the lede-17.01 branch.

The DUID is generated by the DHCPv6 Client by one of the following ways:

- Link-layer address plus time (DUID-LLT)
- Vendor-assigned unique ID based on Enterprise Number (DUID-EN)
- Link-layer address (DUID-LL) _(note: contains the mac address)_
- UUID-Based DUID (DUID-UUID)

Matching a MAC-Address to the DUID can cause false/positives. RFC3315 is pretty clear about does and dont's regarding the DUID:

>   Clients and servers MUST treat DUIDs as opaque values and MUST only compare DUIDs for equality.  Clients and servers MUST NOT in any other way interpret DUIDs.

IMHO we should ask the odhcpd maintainer to expose the mac address in the lease file to do a proper matching. Opinions?