### PR TITLE
luci-mod-admin-full: DHCP and DNS: Add fields for dnsmasq ipsets

### DIFF
--- a/modules/luci-base/luasrc/util.lua
+++ b/modules/luci-base/luasrc/util.lua
@@ -649,24 +649,6 @@ function libpath()
 	return require "nixio.fs".dirname(ldebug.__file__)
 end
 
-function checklib(fullpathexe, wantedlib)
-	local fs = require "nixio.fs"
-	local haveldd = fs.access('/usr/bin/ldd')
-	if not haveldd then
-		return false
-	end
-	local libs = exec("/usr/bin/ldd " .. fullpathexe)
-	if not libs then
-		return false
-	end
-	for k, v in ipairs(split(libs)) do
-		if v:find(wantedlib) then
-			return true
-		end
-	end
-	return false
-end
-
 --
 -- Coroutine safe xpcall and pcall versions modified for Luci
 -- original version:

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -5,6 +5,12 @@ local ipc = require "luci.ip"
 local o
 require "luci.util"
 
+local features = {}
+local verstr = luci.util.exec("/usr/sbin/dnsmasq --version")
+if verstr then
+	features = (verstr:match("\nCompile time options: ([^\n]+)") or ""):split(" ")
+end
+
 m = Map("dhcp", translate("DHCP and DNS"),
 	translate("Dnsmasq is a combined <abbr title=\"Dynamic Host Configuration Protocol" ..
 		"\">DHCP</abbr>-Server and <abbr title=\"Domain Name System\">DNS</abbr>-" ..
@@ -82,9 +88,7 @@ s:taboption("advanced", Flag, "localise_queries",
 	translate("Localise queries"),
 	translate("Localise hostname depending on the requesting subnet if multiple IPs are available"))
 
-local have_dnssec_support = luci.util.checklib("/usr/sbin/dnsmasq", "libhogweed.so")
-
-if have_dnssec_support then
+if luci.util.contains(features, "DNSSEC") then
 	o = s:taboption("advanced", Flag, "dnssec",
 		translate("DNSSEC"))
 	o.optional = true

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -145,6 +145,16 @@ df.optional = true
 df.placeholder = "/example.org/10.1.2.3"
 
 
+if luci.util.contains(features, "ipset") then
+	is = s:taboption("general", DynamicList, "ipset",
+		translate("Domain IP Sets"),
+		translate("Places the resolved IP addresses of queries for " ..
+				"domains in the specified Netfilter IP Sets"))
+	is.optional = true
+	is.placeholder = "/example.org/ipset_ipv4,ipset_ipv6"
+end
+
+
 rp = s:taboption("general", Flag, "rebind_protection",
 	translate("Rebind protection"),
 	translate("Discard upstream RFC1918 responses"))


### PR DESCRIPTION
This allows easy user day-to-day administration of which domain IPs are added to IP Sets when dnsmasq is queried (useful for blacklists / whitelists).

Previously these domain lists could only be managed through the UI by using Domain Forwarding rules to a local ipset-dns instance, or by using third party packages (e.g. https://github.com/lvqier/luci-app-dnsmasq-ipset )

The IP Sets themselves and Firewall rules using them still need to be configured through uci.

This PR includes a necessary commit which simplifies the dnsmasq feature detection introduced in #679