### PR TITLE
luci-app-mwan3: fix member metric allowed values

### DIFF
--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/memberconfig.lua
@@ -27,8 +27,8 @@ interface = mwan_member:option(Value, "interface", translate("Interface"))
 	cbi_add_interface(interface)
 
 metric = mwan_member:option(Value, "metric", translate("Metric"),
-	translate("Acceptable values: 1-1000. Defaults to 1 if not set"))
-	metric.datatype = "range(1, 1000)"
+	translate("Acceptable values: 1-256. Defaults to 1 if not set"))
+	metric.datatype = "range(1, 256)"
 
 weight = mwan_member:option(Value, "weight", translate("Weight"),
 	translate("Acceptable values: 1-1000. Defaults to 1 if not set"))

--- a/applications/luci-app-mwan3/po/ja/mwan3.po
+++ b/applications/luci-app-mwan3/po/ja/mwan3.po
@@ -34,6 +34,9 @@ msgstr ""
 "利用可能な値: 1-100。上記の追跡 IP の合計個数のうち、Up 状態と判定するために"
 "に必要な、レスポンスが返された追跡 IP アドレスの個数です。"
 
+msgid "Acceptable values: 1-256. Defaults to 1 if not set"
+msgstr "利用可能な値: 1-256。空欄の場合のデフォルトは1です。"
+
 msgid "Acceptable values: 1-1000. Defaults to 1 if not set"
 msgstr "利用可能な値: 1-1000。空欄の場合のデフォルトは1です。"
 

--- a/applications/luci-app-mwan3/po/templates/mwan3.pot
+++ b/applications/luci-app-mwan3/po/templates/mwan3.pot
@@ -21,6 +21,9 @@ msgid ""
 "the link to be deemed up"
 msgstr ""
 
+msgid "Acceptable values: 1-256. Defaults to 1 if not set"
+msgstr ""
+
 msgid "Acceptable values: 1-1000. Defaults to 1 if not set"
 msgstr ""
 

--- a/applications/luci-app-mwan3/po/zh-cn/mwan3.po
+++ b/applications/luci-app-mwan3/po/zh-cn/mwan3.po
@@ -32,8 +32,11 @@ msgid ""
 msgstr ""
 "取值范围：1-100。这个设置项指定了当多少个 IP 地址能够连通时接口会被认为在线"
 
+msgid "Acceptable values: 1-256. Defaults to 1 if not set"
+msgstr "取值范围：1-256。如果不填写，默认值为 1"
+
 msgid "Acceptable values: 1-1000. Defaults to 1 if not set"
-msgstr "取值范围：1-100。如果不填写，默认值为 1"
+msgstr "取值范围：1-1000。如果不填写，默认值为 1"
 
 msgid "Advanced"
 msgstr "高级"

--- a/applications/luci-app-mwan3/po/zh-tw/mwan3.po
+++ b/applications/luci-app-mwan3/po/zh-tw/mwan3.po
@@ -32,8 +32,11 @@ msgid ""
 msgstr ""
 "取值範圍：1-100。這個設定項指定了當多少個 IP 位址能夠連通時介面會被認為線上"
 
+msgid "Acceptable values: 1-256. Defaults to 1 if not set"
+msgstr "取值範圍：1-256。如果不填寫，預設值為 1"
+
 msgid "Acceptable values: 1-1000. Defaults to 1 if not set"
-msgstr "取值範圍：1-100。如果不填寫，預設值為 1"
+msgstr "取值範圍：1-1000。如果不填寫，預設值為 1"
 
 msgid "Advanced"
 msgstr "高階"


### PR DESCRIPTION
mwan3 accepts only 1-256 metric of member, if it is more, member is ignored.
This patch fix translations and allowed values of member metric input.

This is second part of issue https://github.com/openwrt/packages/issues/4428