### PR TITLE
Fix #1171: output rule not listed accordingly at traffic rules

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/rules.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/rules.lua
@@ -158,7 +158,7 @@ target = s:option(DummyValue, "target", translate("Action"))
 target.rawhtml = true
 target.width   = "20%"
 function target.cfgvalue(self, s)
-	local t = ft.fmt_target(self.map:get(s, "target"), self.map:get(s, "dest"))
+	local t = ft.fmt_target(self.map:get(s, "target"), self.map:get(s, "dest"), self.map:get(s, "src"))
 	local l = ft.fmt_limit(self.map:get(s, "limit"),
 		self.map:get(s, "limit_burst"))
 

--- a/applications/luci-app-firewall/luasrc/tools/firewall.lua
+++ b/applications/luci-app-firewall/luasrc/tools/firewall.lua
@@ -219,6 +219,7 @@ function fmt_target(x, dest, src)
 				return tr("Do not track output")
 			else --if x == "DROP" then
 				return tr("Discard output")
+			end
 		else
 			if x == "ACCEPT" then
 				return tr("Accept input")
@@ -228,6 +229,7 @@ function fmt_target(x, dest, src)
 				return tr("Do not track input")
 			else --if x == "DROP" then
 				return tr("Discard input")
+			end
 		end
 	end
 end

--- a/applications/luci-app-firewall/luasrc/tools/firewall.lua
+++ b/applications/luci-app-firewall/luasrc/tools/firewall.lua
@@ -198,8 +198,8 @@ function fmt_limit(limit, burst)
 	end
 end
 
-function fmt_target(x, dest)
-	if dest and #dest > 0 then
+function fmt_target(x, dest, src)
+    if dest and src and #dest > 0 then
 		if x == "ACCEPT" then
 			return tr("Accept forward")
 		elseif x == "REJECT" then
@@ -210,14 +210,24 @@ function fmt_target(x, dest)
 			return tr("Discard forward")
 		end
 	else
-		if x == "ACCEPT" then
-			return tr("Accept input")
-		elseif x == "REJECT" then
-			return tr("Refuse input")
-		elseif x == "NOTRACK" then
-			return tr("Do not track input")
-		else --if x == "DROP" then
-			return tr("Discard input")
+		if dest then
+			if x == "ACCEPT" then
+				return tr("Accept output")
+			elseif x == "REJECT" then
+				return tr("Refuse output")
+			elseif x == "NOTRACK" then
+				return tr("Do not track output")
+			else --if x == "DROP" then
+				return tr("Discard output")
+		else
+			if x == "ACCEPT" then
+				return tr("Accept input")
+			elseif x == "REJECT" then
+				return tr("Refuse input")
+			elseif x == "NOTRACK" then
+				return tr("Do not track input")
+			else --if x == "DROP" then
+				return tr("Discard input")
 		end
 	end
 end


### PR DESCRIPTION
Fix just extends function 'fmt_target' and adjusts caller to provide
required parameters.

The function itself is extended to properly print 'OUTPUT' chain rule.
