### PR TITLE
luci-app-firewall: It is not possible to create 'Firewall …

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/rule-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/rule-details.lua
@@ -93,6 +93,7 @@ elseif rule_type == "redirect" then
 
 	o = s:option(Value, "src", translate("Source zone"))
 	o.nocreate = true
+	o.allownone = true
 	o.default = "wan"
 	o.template = "cbi/firewall_zonelist"
 
@@ -118,6 +119,7 @@ elseif rule_type == "redirect" then
 
 	o = s:option(Value, "dest", translate("Destination zone"))
 	o.nocreate = true
+	o.allownone = false
 	o.default = "lan"
 	o.template = "cbi/firewall_zonelist"
 
@@ -255,6 +257,7 @@ else
 	o = s:option(Value, "src", translate("Source zone"))
 	o.nocreate = true
 	o.allowany = true
+	o.allownone = true
 	o.default = "wan"
 	o.template = "cbi/firewall_zonelist"
 
@@ -286,6 +289,7 @@ else
 	o.nocreate = true
 	o.allowany = true
 	o.allowlocal = true
+	o.allownone = false
 	o.template = "cbi/firewall_zonelist"
 
 

--- a/modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm
+++ b/modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm
@@ -25,6 +25,16 @@
 -%>
 
 <ul style="margin:0; list-style-type:none; text-align:left">
+	<% if self.allownone then %>
+	<li style="padding:0.5em">
+		<input class="cbi-input-radio" data-update="click change"<%=attr("type", self.widget or "radio") .. attr("id", cbid .. "_empty") .. attr("name", cbid) .. attr("value", "") .. ifattr(checked[""], "checked", "checked")%> /> &#160;
+		<label<%=attr("for", cbid .. "_empty")%>></label>
+		<label<%=attr("for", cbid .. "_empty")%> style="background-color:<%=fwm.zone.get_color()%>" class="zonebadge">
+			<strong><%:None%></strong>
+			(output)
+		</label>
+	</li>
+	<% end %>
 	<% if self.allowlocal then %>
 	<li style="padding:0.5em">
 		<input class="cbi-input-radio" data-update="click change"<%=attr("type", self.widget or "radio") .. attr("id", cbid .. "_empty") .. attr("name", cbid) .. attr("value", "") .. ifattr(checked[""], "checked", "checked")%> /> &#160;


### PR DESCRIPTION
…- Traffic Rule' for OUTPUT chain

Fix the issue by adding 'None' source zone type which will instruct the
backend not to create 'src' record in the UCI config file.

Although it is Copy&Paste type fix, with little knowledge of LUCI
framework, I believe it may help someone.

The idea is taken from how the 'INPUT' chain is implemented.

This fixes #1457: