### PR TITLE
Fix bad argument #1 to 'tonumber'

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -38,7 +38,7 @@
 		local wan6 = ntm:get_wan6net()
 
 		local conn_count = tonumber(
-			fs.readfile("/proc/sys/net/netfilter/nf_conntrack_count")) or 0
+			fs.readfile("/proc/sys/net/netfilter/nf_conntrack_count") or "") or 0
 
 		local conn_max = tonumber((
 			luci.sys.exec("sysctl net.nf_conntrack_max") or


### PR DESCRIPTION
Fixes [FS#1118](https://bugs.lede-project.org/index.php?do=details&task_id=1118)

Luci chokes on devices that do not have _iptables_ installed with:

```
/usr/lib/lua/luci/dispatcher.lua:460: Failed to execute function dispatcher target for entry '/'.
The called action terminated with an exception:
/usr/lib/lua/luci/dispatcher.lua:460: Failed to execute firstchild dispatcher target for entry '/admin'.
The called action terminated with an exception:
/usr/lib/lua/luci/dispatcher.lua:460: Failed to execute function dispatcher target for entry '/admin/status'.
The called action terminated with an exception:
/usr/lib/lua/luci/dispatcher.lua:460: Failed to execute template dispatcher target for entry '/admin/status/overview'.
The called action terminated with an exception:
/usr/lib/lua/luci/template.lua:97: Failed to execute template 'admin_status/index'.
A runtime error occured: [string "/usr/lib/lua/luci/view/admin_status/index.h..."]:34: bad argument #1 to 'tonumber' (string expected, got nil)
stack traceback:
	[C]: in function 'assert'
	/usr/lib/lua/luci/dispatcher.lua:460: in function 'dispatch'
	/usr/lib/lua/luci/dispatcher.lua:141: in function </usr/lib/lua/luci/dispatcher.lua:140>
```

The code should be more defensive.