### PR TITLE
luci-mod-admin-full: fix incorrect length of DUID-LL

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -297,7 +297,7 @@ time = s:option(Value, "leasetime", translate("Lease time"))
 time.rmempty  = true
 
 duid = s:option(Value, "duid", translate("<abbr title=\"The DHCP Unique Identifier\">DUID</abbr>"))
-duid.datatype = "and(rangelength(28,36),hexstring)"
+duid.datatype = "and(rangelength(20,36),hexstring)"
 fp = io.open("/var/hosts/odhcpd")
 if fp then
 	for line in fp:lines() do

--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/lease_status.htm
@@ -5,7 +5,7 @@
 			return duid.substr(16).replace(/(..)(?=..)/g, '$1:').toUpperCase();
 
 		// DUID-LL / Ethernet
-		if (duid.length === 24 && duid.substr(0, 8) === '00030001')
+		if (duid.length === 20 && duid.substr(0, 8) === '00030001')
 			return duid.substr(8).replace(/(..)(?=..)/g, '$1:').toUpperCase();
 
 		return null;

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -150,7 +150,7 @@
 			return duid.substr(16).replace(/(..)(?=..)/g, '$1:').toUpperCase();
 
 		// DUID-LL / Ethernet
-		if (duid.length === 24 && duid.substr(0, 8) === '00030001')
+		if (duid.length === 20 && duid.substr(0, 8) === '00030001')
 			return duid.substr(8).replace(/(..)(?=..)/g, '$1:').toUpperCase();
 
 		return null;


### PR DESCRIPTION
The length of DUID-LL is 80 bits (16 bit DUID type, 16 bit hardware type, 48 bit mac)
which corresponds to 20 nibbles. Also lower the minimum required length of DUID to
20 nibbles in order to allow entering a DUID-LL.

Signed-off-by: Arjen de Korte <build+github@de-korte.org>