### PR TITLE
luci-app-travelmate: Update Japanese translation

### DIFF
--- a/applications/luci-app-travelmate/luasrc/view/travelmate/wifi_scan.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/wifi_scan.htm
@@ -17,7 +17,7 @@ This is free software, licensed under the Apache License, Version 2.0
         if info.wep == true then
             return translate("WEP")
         elseif info.wpa > 0 then
-            return translatef("%s (%s/%s)", (info.wpa == 3) and translate("WPA/WPA2") or (info.wpa == 2 and "WPA2" or "WPA"), table.concat(info.auth_suites), table.concat(info.group_ciphers))
+            return string.format("%s (%s/%s)", (info.wpa == 3 and translate("WPA/WPA2")) or (info.wpa == 2 and translate("WPA2")) or translate("WPA"), table.concat(info.auth_suites), table.concat(info.group_ciphers))
         elseif info.enabled then
             return translate("Unknown")
         else

--- a/applications/luci-app-travelmate/po/ja/travelmate.po
+++ b/applications/luci-app-travelmate/po/ja/travelmate.po
@@ -35,7 +35,7 @@ msgid "Authentication"
 msgstr "認証"
 
 msgid "Automatic"
-msgstr ""
+msgstr "自動"
 
 msgid "BSSID"
 msgstr "BSSID"
@@ -44,7 +44,7 @@ msgid "Back to overview"
 msgstr "概要へ戻る"
 
 msgid "Cipher"
-msgstr ""
+msgstr "暗号化方式"
 
 msgid ""
 "Configuration of the travelmate package to to enable travel router "
@@ -123,13 +123,13 @@ msgstr ""
 "確認してください。"
 
 msgid "Force CCMP (AES)"
-msgstr ""
+msgstr "CCMP (AES)"
 
 msgid "Force TKIP"
-msgstr ""
+msgstr "TKIP"
 
 msgid "Force TKIP and CCMP (AES)"
-msgstr ""
+msgstr "TKIP と CCMP (AES)"
 
 msgid "How long should travelmate wait for a successful wlan interface reload."
 msgstr ""
@@ -194,22 +194,22 @@ msgid "Overview"
 msgstr "概要"
 
 msgid "Passphrase"
-msgstr ""
+msgstr "パスフレーズ"
 
 msgid "Password"
 msgstr "パスワード"
 
 msgid "Password of Private Key"
-msgstr ""
+msgstr "秘密鍵のパスワード"
 
 msgid "Path to CA-Certificate"
-msgstr ""
+msgstr "CA 証明書へのパス"
 
 msgid "Path to Client-Certificate"
-msgstr ""
+msgstr "クライアント証明書へのパス"
 
 msgid "Path to Private Key"
-msgstr ""
+msgstr "秘密鍵へのパス"
 
 msgid ""
 "Provides an overview of all configured uplinks for the travelmate interface "
@@ -336,19 +336,19 @@ msgid "WEP"
 msgstr "WEP"
 
 msgid "WEP-Passphrase"
-msgstr ""
+msgstr "WEP パスフレーズ"
 
 msgid "WPA"
-msgstr ""
+msgstr "WPA"
 
 msgid "WPA-Passphrase"
-msgstr ""
+msgstr "WPA パスフレーズ"
 
 msgid "WPA/WPA2"
-msgstr ""
+msgstr "WPA/WPA2"
 
 msgid "WPA2"
-msgstr ""
+msgstr "WPA2"
 
 msgid "Wireless Scan"
 msgstr "無線スキャン"
@@ -373,18 +373,3 @@ msgstr "利用不可"
 
 msgid "not connected"
 msgstr "未接続"
-
-#~ msgid "Passphrase (%s)"
-#~ msgstr "暗号フレーズ (%s)"
-
-#~ msgid "Specify the secret encryption key here."
-#~ msgstr "暗号キーを設定します。"
-
-#~ msgid "WEP passphrase"
-#~ msgstr "WEP 暗号キー"
-
-#~ msgid "WPA passphrase"
-#~ msgstr "WPA 暗号キー"
-
-#~ msgid "WPA/WPA2 -"
-#~ msgstr "WPA/WPA2 -"

--- a/applications/luci-app-travelmate/po/ja/travelmate.po
+++ b/applications/luci-app-travelmate/po/ja/travelmate.po
@@ -34,11 +34,17 @@ msgstr "詳細設定"
 msgid "Authentication"
 msgstr "認証"
 
+msgid "Automatic"
+msgstr ""
+
 msgid "BSSID"
 msgstr "BSSID"
 
 msgid "Back to overview"
 msgstr "概要へ戻る"
+
+msgid "Cipher"
+msgstr ""
 
 msgid ""
 "Configuration of the travelmate package to to enable travel router "
@@ -116,6 +122,15 @@ msgstr ""
 "詳細な情報は <a href=\"%s\" target=\"_blank\">オンライン ドキュメント</a> を"
 "確認してください。"
 
+msgid "Force CCMP (AES)"
+msgstr ""
+
+msgid "Force TKIP"
+msgstr ""
+
+msgid "Force TKIP and CCMP (AES)"
+msgstr ""
+
 msgid "How long should travelmate wait for a successful wlan interface reload."
 msgstr ""
 "無線LAN インターフェースのリロードが成功するまでの、Travelmate の待機時間で"
@@ -178,11 +193,23 @@ msgstr "実行間隔"
 msgid "Overview"
 msgstr "概要"
 
-msgid "Passphrase (%s)"
-msgstr "暗号フレーズ (%s)"
+msgid "Passphrase"
+msgstr ""
 
 msgid "Password"
 msgstr "パスワード"
+
+msgid "Password of Private Key"
+msgstr ""
+
+msgid "Path to CA-Certificate"
+msgstr ""
+
+msgid "Path to Client-Certificate"
+msgstr ""
+
+msgid "Path to Private Key"
+msgstr ""
 
 msgid ""
 "Provides an overview of all configured uplinks for the travelmate interface "
@@ -223,9 +250,6 @@ msgstr "スキャン:"
 
 msgid "Signal strength"
 msgstr "信号強度"
-
-msgid "Specify the secret encryption key here."
-msgstr "暗号キーを設定します。"
 
 msgid "Station ID (SSID/BSSID)"
 msgstr "ステーション ID (SSID / BSSID)"
@@ -311,14 +335,20 @@ msgstr "ログファイルの確認"
 msgid "WEP"
 msgstr "WEP"
 
-msgid "WEP passphrase"
-msgstr "WEP 暗号キー"
+msgid "WEP-Passphrase"
+msgstr ""
 
-msgid "WPA passphrase"
-msgstr "WPA 暗号キー"
+msgid "WPA"
+msgstr ""
 
-msgid "WPA/WPA2 -"
-msgstr "WPA/WPA2 -"
+msgid "WPA-Passphrase"
+msgstr ""
+
+msgid "WPA/WPA2"
+msgstr ""
+
+msgid "WPA2"
+msgstr ""
 
 msgid "Wireless Scan"
 msgstr "無線スキャン"
@@ -343,3 +373,18 @@ msgstr "利用不可"
 
 msgid "not connected"
 msgstr "未接続"
+
+#~ msgid "Passphrase (%s)"
+#~ msgstr "暗号フレーズ (%s)"
+
+#~ msgid "Specify the secret encryption key here."
+#~ msgstr "暗号キーを設定します。"
+
+#~ msgid "WEP passphrase"
+#~ msgstr "WEP 暗号キー"
+
+#~ msgid "WPA passphrase"
+#~ msgstr "WPA 暗号キー"
+
+#~ msgid "WPA/WPA2 -"
+#~ msgstr "WPA/WPA2 -"

--- a/applications/luci-app-travelmate/po/pt-br/travelmate.po
+++ b/applications/luci-app-travelmate/po/pt-br/travelmate.po
@@ -34,10 +34,16 @@ msgstr ""
 msgid "Authentication"
 msgstr ""
 
+msgid "Automatic"
+msgstr ""
+
 msgid "BSSID"
 msgstr ""
 
 msgid "Back to overview"
+msgstr ""
+
+msgid "Cipher"
 msgstr ""
 
 msgid ""
@@ -111,6 +117,15 @@ msgid ""
 "documentation</a>"
 msgstr ""
 
+msgid "Force CCMP (AES)"
+msgstr ""
+
+msgid "Force TKIP"
+msgstr ""
+
+msgid "Force TKIP and CCMP (AES)"
+msgstr ""
+
 msgid "How long should travelmate wait for a successful wlan interface reload."
 msgstr ""
 
@@ -167,10 +182,22 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-msgid "Passphrase (%s)"
+msgid "Passphrase"
 msgstr ""
 
 msgid "Password"
+msgstr ""
+
+msgid "Password of Private Key"
+msgstr ""
+
+msgid "Path to CA-Certificate"
+msgstr ""
+
+msgid "Path to Client-Certificate"
+msgstr ""
+
+msgid "Path to Private Key"
 msgstr ""
 
 msgid ""
@@ -207,9 +234,6 @@ msgid "Scan"
 msgstr ""
 
 msgid "Signal strength"
-msgstr ""
-
-msgid "Specify the secret encryption key here."
 msgstr ""
 
 msgid "Station ID (SSID/BSSID)"
@@ -285,13 +309,19 @@ msgstr ""
 msgid "WEP"
 msgstr ""
 
-msgid "WEP passphrase"
+msgid "WEP-Passphrase"
 msgstr ""
 
-msgid "WPA passphrase"
+msgid "WPA"
 msgstr ""
 
-msgid "WPA/WPA2 -"
+msgid "WPA-Passphrase"
+msgstr ""
+
+msgid "WPA/WPA2"
+msgstr ""
+
+msgid "WPA2"
 msgstr ""
 
 msgid "Wireless Scan"

--- a/applications/luci-app-travelmate/po/templates/travelmate.pot
+++ b/applications/luci-app-travelmate/po/templates/travelmate.pot
@@ -23,10 +23,16 @@ msgstr ""
 msgid "Authentication"
 msgstr ""
 
+msgid "Automatic"
+msgstr ""
+
 msgid "BSSID"
 msgstr ""
 
 msgid "Back to overview"
+msgstr ""
+
+msgid "Cipher"
 msgstr ""
 
 msgid ""
@@ -100,6 +106,15 @@ msgid ""
 "documentation</a>"
 msgstr ""
 
+msgid "Force CCMP (AES)"
+msgstr ""
+
+msgid "Force TKIP"
+msgstr ""
+
+msgid "Force TKIP and CCMP (AES)"
+msgstr ""
+
 msgid "How long should travelmate wait for a successful wlan interface reload."
 msgstr ""
 
@@ -156,10 +171,22 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-msgid "Passphrase (%s)"
+msgid "Passphrase"
 msgstr ""
 
 msgid "Password"
+msgstr ""
+
+msgid "Password of Private Key"
+msgstr ""
+
+msgid "Path to CA-Certificate"
+msgstr ""
+
+msgid "Path to Client-Certificate"
+msgstr ""
+
+msgid "Path to Private Key"
 msgstr ""
 
 msgid ""
@@ -196,9 +223,6 @@ msgid "Scan"
 msgstr ""
 
 msgid "Signal strength"
-msgstr ""
-
-msgid "Specify the secret encryption key here."
 msgstr ""
 
 msgid "Station ID (SSID/BSSID)"
@@ -274,13 +298,19 @@ msgstr ""
 msgid "WEP"
 msgstr ""
 
-msgid "WEP passphrase"
+msgid "WEP-Passphrase"
 msgstr ""
 
-msgid "WPA passphrase"
+msgid "WPA"
 msgstr ""
 
-msgid "WPA/WPA2 -"
+msgid "WPA-Passphrase"
+msgstr ""
+
+msgid "WPA/WPA2"
+msgstr ""
+
+msgid "WPA2"
 msgstr ""
 
 msgid "Wireless Scan"


### PR DESCRIPTION
- Fixed translation markup issues
  - LuCI i18n-tools cannot detects UI-text from format specifier. I modified translatef() to string.format() and added translate() to each UI texts. cc @dibdot 
- Synchronized translations
- Updated Japanese translations

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>