### PR TITLE
luci-mod-admin-full: support customized domains using dnsmasq's --address option

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -141,6 +141,14 @@ df.optional = true
 df.placeholder = "/example.org/10.1.2.3"
 
 
+ad = s:taboption("general", DynamicList, "address",
+	translate("Local defined domains"),
+	translate("List of customized domains resolved locally and never forwarded to upstream"))
+
+ad.optional = true
+ad.placeholder = "/myservice.lan/192.168.1.123"
+
+
 rp = s:taboption("general", Flag, "rebind_protection",
 	translate("Rebind protection"),
 	translate("Discard upstream RFC1918 responses"))


### PR DESCRIPTION
This commit adds the luci configuration for customized domains under "DHCP and DNS". With this config, users can easily define their own DNS records or intercept certain public domains to their own favor. 

The backends already have the option in:
  /etc/config/dhcp:  list address '/myservice.lan/192.168.1.123'
  dnsmasq:  --address=/myservice.lan/192.168.1.123