### PR TITLE
luci-app-advanced-reboot: 2 new routers + error reporting

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -7,13 +7,13 @@ PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
-LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot supported Linksys routers to\
+LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot supported Linksys and ZyXEL routers to\
 	an altnerative partition. Also provides Web UI to shut down (power off) your device. 	Supported dual-partition\
 	routers are listed at https://github.com/stangri/openwrt-luci/blob/luci-app-advanced-reboot/applications/luci-app-advanced-reboot/README.md
 
 LUCI_DEPENDS:=+luci
 LUCI_PKGARCH:=all
-PKG_RELEASE:=23
+PKG_RELEASE:=25
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/README.md
+++ b/applications/luci-app-advanced-reboot/README.md
@@ -5,15 +5,16 @@ This package allows you to reboot to an alternative partition on supported (dual
 
 ## Supported Devices
 Currently supported dual-partition devices include:
+- Linksys EA3500
+- Linksys E4200v2
+- Linksys EA4500
+- Linksys EA8500
 - Linksys WRT1200AC
 - Linksys WRT1900AC
 - Linksys WRT1900ACv2
 - Linksys WRT1900ACS
 - Linksys WRT3200ACM
-- Linksys E4200v2
-- Linksys EA4500
-- Linksys EA8500
-
+- ZyXEL NBG6817
 If you're interested in having your device supported, please post in [LEDE Project Forum Support Thread](https://forum.lede-project.org/t/web-ui-to-reboot-to-another-partition-dual-partition-routers/3423).
 
 ## Screenshot (luci-app-advanced-reboot)
@@ -28,8 +29,8 @@ opkg install luci-app-advanced-reboot
 
 ## Notes/Known Issues
 - When you reboot to a different partition, your current settings (WiFi SSID/password, etc.) will not apply to a different partition. Different partitions might have completely different settings and even firmware.
-- If you reboot to a partition which doesn't allow you to switch boot partitions (like stock Linksys firmware), you might not be able to boot back to OpenWrt/LEDE Project unless you reflash it, loosing all the settings.
+- If you reboot to a partition which doesn't allow you to switch boot partitions (like stock vendor firmware), you might not be able to boot back to OpenWrt/LEDE Project unless you reflash it, loosing all the settings.
 - Some devices allow you to trigger reboot to alternative partition by interrupting boot 3 times in a row (by resetting/switching off the device or pulling power). As these methods might be different for different devices, do your own homework.
 
 ## Thanks
-I'd like to thank everyone who helped create, test and troubleshoot this package. Without contributions from [@hnyman](https://github.com/hnyman) and [@jpstyves](https://github.com/jpstyves) it wouldn't have been possible.
+I'd like to thank everyone who helped create, test and troubleshoot this package. Without contributions from [@hnyman](https://github.com/hnyman), [@jpstyves](https://github.com/jpstyves) and [@slh](https://github.com/pkgadd) it wouldn't have been possible.

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm
@@ -14,6 +14,10 @@
 	<p class="alert-message warning"><%:Warning: There are unsaved changes that will get lost on reboot!%></p>
 <%- end -%>
 
+<%- if errorMessage and errorMessage ~= "" then -%>
+	<p class="alert-message warning"><%:ERROR: %><%=errorMessage%></p>
+<%- end -%>
+
 <%- if device_name then -%>
 <fieldset class="cbi-section">
   <legend><%=device_name%><%: Partitions%></legend>
@@ -26,7 +30,7 @@
     </tr>
     <tr class="cbi-section-table-row">
       <td>
-        <%=boot_envvar1_partition_one%>
+        <%=string.format("%X", boot_envvar1_partition_one)%>
       </td>
       <td>
         <%- if boot_envvar1_partition_one == current_partition then -%><%:Current%><%- else -%><%:Alternative%><%- end -%>
@@ -50,7 +54,7 @@
     </tr>
     <tr class="cbi-section-table-row">
       <td>
-        <%=boot_envvar1_partition_two%>
+        <%=string.format("%X", boot_envvar1_partition_two)%>
       </td>
       <td>
         <%- if boot_envvar1_partition_two == current_partition then -%><%:Current%><%- else -%><%:Alternative%><%- end -%>


### PR DESCRIPTION
Added support for: Linksys EA3500 and ZyXEL NBG6817.
Added error reporting to both system log and WebUI on errors.

Tested on Linksys EA8500 by @stangri; on ZyXEL NBG6817 by @pkgadd.

Please back-port to current release tree.

Signed-off-by: Stan Grishin <stangri@melmac.net>