### PR TITLE
luci-app-travelmate: sync with 1.0.1

### DIFF
--- a/applications/luci-app-travelmate/luasrc/controller/travelmate.lua
+++ b/applications/luci-app-travelmate/luasrc/controller/travelmate.lua
@@ -1,4 +1,4 @@
--- Copyright 2017 Dirk Brenken (dev@brenken.org)
+-- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
 module("luci.controller.travelmate", package.seeall)
@@ -33,9 +33,9 @@ function logread()
 	local logfile
 
 	if nixio.fs.access("/var/log/messages") then
-		logfile = util.trim(util.exec("cat /var/log/messages | grep 'travelmate'"))
+		logfile = util.trim(util.exec("cat /var/log/messages | grep 'travelmate-'"))
 	else
-		logfile = util.trim(util.exec("logread -e 'travelmate'"))
+		logfile = util.trim(util.exec("logread -e 'travelmate-'"))
 	end
 	templ.render("travelmate/logread", {title = i18n.translate("Travelmate Logfile"), content = logfile})
 end

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
@@ -1,4 +1,4 @@
--- Copyright 2017 Dirk Brenken (dev@brenken.org)
+-- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
 local fs       = require("nixio.fs")
@@ -34,7 +34,11 @@ else
 	wssid = m:field(Value, "ssid", translate("SSID (hidden)"))
 end
 
+nobssid = m:field(Flag, "no_bssid", translate("Ignore BSSID"))
+nobssid.default = nobssid.enabled
+
 bssid = m:field(Value, "bssid", translate("BSSID"))
+bssid:depends("no_bssid", 0)
 bssid.datatype = "macaddr"
 bssid.default = m.hidden.bssid or ""
 

--- a/applications/luci-app-travelmate/luasrc/view/travelmate/logread.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/logread.htm
@@ -1,5 +1,5 @@
 <%#
-Copyright 2017 Dirk Brenken (dev@brenken.org)
+Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 This is free software, licensed under the Apache License, Version 2.0
 -%>
 
@@ -11,5 +11,10 @@ This is free software, licensed under the Apache License, Version 2.0
 		<textarea id="logread_id" style="width: 100%; height: 450px; border: 1px solid #cccccc; padding: 5px; font-size: 12px; font-family: monospace; resize: none;" readonly="readonly" wrap="off" rows="<%=content:cmatch("\n")+2%>"><%=content:pcdata()%></textarea>
 	</fieldset>
 </div>
+
+<script type="text/javascript">
+	var textarea = document.getElementById('logread_id');
+	textarea.scrollTop = textarea.scrollHeight;
+</script>
 
 <%+footer%>


### PR DESCRIPTION
* LuCI: BSSID will be ignored by default in 'wireless add' dialog
* LuCI: Textarea 'autoscroll down' in logfile view
* LuCI: refine logfile search term

Signed-off-by: Dirk Brenken <dev@brenken.org>