### PR TITLE
luci-mod-admin-full: Add mesh_fwding support

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -355,6 +355,10 @@ mode:value("adhoc", translate("Ad-Hoc"))
 
 meshid = s:taboption("general", Value, "mesh_id", translate("Mesh Id"))
 meshid:depends({mode="mesh"})
+meshfwd = s:taboption("advanced", Flag, "mesh_fwding", translate("internal forwarding of Mesh-peers"))
+meshfwd.rmempty = false
+meshfwd.default = "1"
+meshfwd:depends({mode="mesh"})
 
 ssid = s:taboption("general", Value, "ssid", translate("<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"))
 ssid.datatype = "maxlength(32)"


### PR DESCRIPTION
This further improves the support for 802.11s networks.
By default this should be enabled, as it is in OpenWRT.

