### PR TITLE
luci-mod-admin-full: Add 802.11b legacy_rates option

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -228,6 +228,10 @@ if hwtype == "mac80211" then
 		s:taboption("advanced", Value, "country", translate("Country Code"), translate("Use ISO/IEC 3166 alpha2 country codes."))
 	end
 
+	legacyrates = s:taboption("advanced", Flag, "legacy_rates", translate("802.11b rates"))
+	legacyrates.rmempty = false
+	legacyrates.default = "1"
+
 	s:taboption("advanced", Value, "distance", translate("Distance Optimization"),
 		translate("Distance to farthest network member in meters."))
 


### PR DESCRIPTION
this was added to LEDE with ed62d91f4b5296a4aa883ce975d76f590ef4e910 and defaults to enable.

Signed-off-by: Sven Roederer <freifunk@it-solutions.geroedel.de>