### PR TITLE
luci-app-travelmate: sync with travelmate 1.0.2

### DIFF
--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
@@ -1,4 +1,4 @@
--- Copyright 2017 Dirk Brenken (dev@brenken.org)
+-- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
 local fs       = require("nixio.fs")
@@ -113,17 +113,21 @@ end
 
 ds = m:section(NamedSection, "global", "travelmate", translate("Runtime Information"))
 
-dv1 = ds:option(DummyValue, "status", translate("Online Status"))
+dv1 = ds:option(DummyValue, "status", translate("Travelmate Status"))
 dv1.template = "travelmate/runtime"
 if parse == nil then
 	dv1.value = translate("n/a")
-elseif parse.data.station_connection == "true" then
+elseif parse.data.travelmate_status == "connected" then
 	dv1.value = translate("connected")
-else
+elseif parse.data.travelmate_status == "not connected" then
 	dv1.value = translate("not connected")
+elseif parse.data.travelmate_status == "running" then
+	dv1.value = translate("running")
+elseif parse.data.travelmate_status == "error" then
+	dv1.value = translate("error")
 end
 
-dv2 = ds:option(DummyValue, "travelmate_version", translate("Travelmate version"))
+dv2 = ds:option(DummyValue, "travelmate_version", translate("Travelmate Version"))
 dv2.template = "travelmate/runtime"
 if parse ~= nil then
 	dv2.value = parse.data.travelmate_version or translate("n/a")

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
@@ -101,6 +101,8 @@ elseif (tonumber(m.hidden.wpa_version) or 0) > 0 then
 		authentication:value("EAP-MD5")
 		authentication:value("EAP-MSCHAPV2")
 		authentication:value("EAP-TLS")
+		authentication:value("auth=PAP")
+		authentication:value("auth=MSCHAPV2")
 		authentication.default = "EAP-MSCHAPV2"
 
 		ident = m:field(Value, "identity", translate("Identity"))

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua
@@ -1,4 +1,4 @@
--- Copyright 2017 Dirk Brenken (dev@brenken.org)
+-- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
 local fs   = require("nixio.fs")
@@ -92,6 +92,8 @@ if s ~= nil then
 			authentication:value("EAP-MD5")
 			authentication:value("EAP-MSCHAPV2")
 			authentication:value("EAP-TLS")
+			authentication:value("auth=PAP")
+			authentication:value("auth=MSCHAPV2")
 			authentication.default = s.auth or "EAP-MSCHAPV2"
 
 			ident = m:field(Value, "identity", translate("Identity"))

--- a/applications/luci-app-travelmate/luasrc/view/travelmate/runtime.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/runtime.htm
@@ -1,10 +1,10 @@
 <%#
-Copyright 2017 Dirk Brenken (dev@brenken.org)
+Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 This is free software, licensed under the Apache License, Version 2.0
 -%>
 
 <%+cbi/valueheader%>
 
-<input name="runtime" id="runtime" type="text" class="cbi-input-text" style="border:none; box-shadow:none; background-color:#ffffff; color:#0069d6;" value="<%=self:cfgvalue(section)%>" disabled="disabled" />
+<input name="runtime" id="runtime" type="text" class="cbi-input-text" style="outline:none;border:none;box-shadow:none;background:transparent;color:#0069d6;font-weight:bold;line-height:30px;height:30px;" value="<%=self:cfgvalue(section)%>" disabled="disabled" />
 
 <%+cbi/valuefooter%>

--- a/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
@@ -1,5 +1,5 @@
 <%#
-Copyright 2017 Dirk Brenken (dev@brenken.org)
+Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 This is free software, licensed under the Apache License, Version 2.0
 -%>
 
@@ -36,21 +36,21 @@ This is free software, licensed under the Apache License, Version 2.0
       local bssid = s.bssid or "-"
       local encryption = s.encryption or "-"
       local disabled = s.disabled or ""
-      local style = "color:#000000"
+      local style = "text-align:left;color:#000000"
       if disabled == "0" then
-        style = "color:#0069d6;font-weight:bold"
+        style = "text-align:left;color:#0069d6;font-weight:bold"
       end
 %>
     <tr class="cbi-section-table-row cbi-rowstyle-1" style="<%=style%>">
-      <td style="text-align:left"><%=device%></td>
-      <td style="text-align:left"><%=ssid%></td>
-      <td style="text-align:left"><%=bssid%></td>
-      <td style="text-align:left"><%=encryption%></td>
-      <td class="cbi-value-field" style="width:70px;text-align:right">
+      <td style="<%=style%>"><%=device%></td>
+      <td style="<%=style%>"><%=ssid%></td>
+      <td style="<%=style%>"><%=bssid%></td>
+      <td style="<%=style%>"><%=encryption%></td>
+      <td class="cbi-value-field" style="width:80px">
         <input class="cbi-button cbi-button-up" type="button" value="" onclick="location.href='<%=luci.dispatcher.build_url('admin/services/travelmate/wifiorder')%>?cfg=<%=section%>;dir=up'" alt="<%:Move up%>" title="<%:Move up%>"/>
         <input class="cbi-button cbi-button-down" type="button" value="" onclick="location.href='<%=luci.dispatcher.build_url('admin/services/travelmate/wifiorder')%>?cfg=<%=section%>;dir=down'" alt="<%:Move down%>" title="<%:Move down%>"/>
       </td>
-      <td class="cbi-value-field" style="width:150px;text-align:right">
+      <td class="cbi-value-field" style="width:150px">
         <input type="button" class="cbi-button cbi-button-edit" onclick="location.href='<%=luci.dispatcher.build_url('admin/services/travelmate/wifiedit')%>?cfg=<%=section%>'" title="<%:Edit this Uplink%>" value="<%:Edit%>"/>
         <input type="button" class="cbi-button cbi-button-remove" onclick="location.href='<%=luci.dispatcher.build_url('admin/services/travelmate/wifidelete')%>?cfg=<%=section%>'" title="<%:Delete this Uplink%>" value="<%:Delete%>"/>
       </td>


### PR DESCRIPTION
* refine status view
* add two missing eap auth variants
* small visual fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>