### PR TITLE
luci-mod-admin-full: set 0 db DSL SNR offset by default

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/network.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/network.lua
@@ -56,6 +56,7 @@ if fs.access("/etc/init.d/dsl_control") then
 		line_mode:value("vdsl", translate("VDSL"))
 
 		ds_snr = dsl:option(ListValue, "ds_snr_offset", translate("Downstream SNR offset"))
+		ds_snr.default = "0"
 		for i = -100, 100, 5 do
 			ds_snr:value(i, translatef("%.1f dB", i / 10))
 		end


### PR DESCRIPTION
If no DSL SNR offset is set for the dsl line the first entry from the
dropdown list is pre-selected by default, which would apply a -10 db
offset by default.

Pre-select the 0 db option if nothing else is specified in the uci config
files.

Signed-off-by: Mathias Kresin <dev@kresin.me>