### PR TITLE
luci-app-advanced-reboot: support for new board names for ea8500 and nbg6817

### DIFF
--- a/applications/luci-app-advanced-reboot/README.md
+++ b/applications/luci-app-advanced-reboot/README.md
@@ -1,7 +1,7 @@
 # Advanced Reboot Web UI (luci-app-advanced-reboot)
 
 ## Description
-This package allows you to reboot to an alternative partition on supported (dual-partition) routers and to power off (power down) your OpenWrt/LEDE Project device.
+This package allows you to reboot to an alternative partition on the supported (dual-partition) routers and to power off (power down) your OpenWrt/LEDE Project device.
 
 ## Supported Devices
 Currently supported dual-partition devices include:
@@ -15,6 +15,7 @@ Currently supported dual-partition devices include:
 - Linksys WRT1900ACS
 - Linksys WRT3200ACM
 - ZyXEL NBG6817
+
 If you're interested in having your device supported, please post in [LEDE Project Forum Support Thread](https://forum.lede-project.org/t/web-ui-to-reboot-to-another-partition-dual-partition-routers/3423).
 
 ## Screenshot (luci-app-advanced-reboot)
@@ -29,8 +30,8 @@ opkg install luci-app-advanced-reboot
 
 ## Notes/Known Issues
 - When you reboot to a different partition, your current settings (WiFi SSID/password, etc.) will not apply to a different partition. Different partitions might have completely different settings and even firmware.
-- If you reboot to a partition which doesn't allow you to switch boot partitions (like stock vendor firmware), you might not be able to boot back to OpenWrt/LEDE Project unless you reflash it, loosing all the settings.
-- Some devices allow you to trigger reboot to alternative partition by interrupting boot 3 times in a row (by resetting/switching off the device or pulling power). As these methods might be different for different devices, do your own homework.
+- If you reboot to a partition which doesn't allow you to switch boot partitions (like stock vendor firmware), you might not be able to boot back to OpenWrt/LEDE Project unless you reflash it, losing all the settings.
+- Some devices allow you to trigger reboot to an alternative partition by interrupting boot 3 times in a row (by resetting/switching off the device or pulling power). As these methods might be different for different devices, do your own homework.
 
 ## Thanks
 I'd like to thank everyone who helped create, test and troubleshoot this package. Without contributions from [@hnyman](https://github.com/hnyman), [@jpstyves](https://github.com/jpstyves) and [@slh](https://github.com/pkgadd) it wouldn't have been possible.

--- a/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
@@ -19,7 +19,7 @@ devices = {
 errorMessage = ""
 board_name = luci.util.trim(luci.sys.exec("cat /tmp/sysinfo/board_name"))
 for i=1, #devices do
-  if board_name and devices[i][2] == board_name then
+  if board_name and string.match(board_name, devices[i][2]) then
     device_name = devices[i][1]
     partition_one_mtd = devices[i][3] or nil
     partition_two_mtd = devices[i][4] or nil


### PR DESCRIPTION
* added support for new board names for ea8500 and nbg6817
* updated README

Signed-off-by: Stan Grishin <stangri@melmac.net>

Tested on nbg6817 by @pkgadd, on ea8500 by @stangri.

PS. Please back-port to 17.01.x, as far as I understood @pkgadd, the new board names will be a part of the 17.01.5 release.
