### PR TITLE
luci-base: add hardening header

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -418,6 +418,13 @@ function dispatch(request)
 		ctx.authsession = sid
 		ctx.authtoken = sdat.token
 		ctx.authuser = sdat.username
+
+		if http.getenv("HTTPS") == "on" then
+			local forcehsts = conf.main.forcehsts
+			if forcehsts then
+				http.header("Strict-Transport-Security", 'max-age=%s' % forcehsts)
+			end
+		end
 	end
 
 	if c and require_post_security(c.target) then

--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -406,7 +406,7 @@ function dispatch(request)
 				return
 			end
 
-			http.header("Set-Cookie", 'sysauth=%s; path=%s' %{ sid, build_url() })
+			http.header("Set-Cookie", 'sysauth=%s; path=%s; HttpOnly; secure' %{ sid, build_url() })
 			http.redirect(build_url(unpack(ctx.requestpath)))
 		end
 


### PR DESCRIPTION
- expand "Set-Cookie" header: Send only cookies over HTTPS connections.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
- append "Strict-Transport-Security" header: Pin HTTPS connections. 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security