### PR TITLE
Fixed typos

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -263,7 +263,7 @@ s = m:section(TypedSection, "host", translate("Static Leases"),
 		"DHCP clients. They are also required for non-dynamic interface configurations where " ..
 		"only hosts with a corresponding lease are served.") .. "<br />" ..
 	translate("Use the <em>Add</em> Button to add a new lease entry. The <em>MAC-Address</em> " ..
-		"indentifies the host, the <em>IPv4-Address</em> specifies to the fixed address to " ..
+		"indentifies the host, the <em>IPv4-Address</em> specifies the fixed address to " ..
 		"use and the <em>Hostname</em> is assigned as symbolic name to the requesting host. " ..
 		"The optional <em>Lease time</em> can be used to set non-standard host-specific " ..
 		"lease time, e.g. 12h, 3d or infinite."))

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -264,7 +264,7 @@ s = m:section(TypedSection, "host", translate("Static Leases"),
 		"only hosts with a corresponding lease are served.") .. "<br />" ..
 	translate("Use the <em>Add</em> Button to add a new lease entry. The <em>MAC-Address</em> " ..
 		"indentifies the host, the <em>IPv4-Address</em> specifies the fixed address to " ..
-		"use and the <em>Hostname</em> is assigned as symbolic name to the requesting host. " ..
+		"use, and the <em>Hostname</em> is assigned as a symbolic name to the requesting host. " ..
 		"The optional <em>Lease time</em> can be used to set non-standard host-specific " ..
 		"lease time, e.g. 12h, 3d or infinite."))
 


### PR DESCRIPTION
There was a small typo in the DHCP static lease text.

> The MAC-Address indentifies the host, the IPv4-Address specifies **to** the fixed address to use and the Hostname is assigned as symbolic name to the requesting host.
Changed to:
> The MAC-Address indentifies the host, the IPv4-Address specifies the fixed address to use, and the Hostname is assigned as a symbolic name to the requesting host.