### PR TITLE
fixed dynapoint.lua, there was no translation

### DIFF
--- a/applications/luci-app-dynapoint/luasrc/model/cbi/dynapoint.lua
+++ b/applications/luci-app-dynapoint/luasrc/model/cbi/dynapoint.lua
@@ -41,11 +41,10 @@ if (a.installed("curl") == true) then
   curl_interface:depends("use_curl","1")
   curl_interface.placeholder = "eth0"
 else
-  use_curl = s:option(Flag, "use_curl", translate("Use curl instead of wget"), translate("Curl is currently not installed.")
-  .." Please install the package in the "
-  ..[[<a href="]] .. DISP.build_url("admin", "system", "packages")
+  use_curl = s:option(Flag, "use_curl", translate("Use curl instead of wget"), translate("Curl is currently not installed. Please install the package in the")
+  ..[[ <a href="]] .. DISP.build_url("admin", "system", "packages")
   .. "?display=available&query=curl"..[[">]]
-  .. "Software Section" .. [[</a>]]
+  .. translate ("Software Section") .. [[</a>]]
   .. "."
   )
   use_curl.rmempty = false

--- a/applications/luci-app-dynapoint/po/de/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/de/dynapoint.po
@@ -26,8 +26,8 @@ msgstr "Testen der Internetverfügbarkeit via HTTP header download"
 msgid "Configuration"
 msgstr "Konfiguration"
 
-msgid "Curl is currently not installed."
-msgstr "Curl ist momentan nicht installiert."
+msgid "Curl is currently not installed. Please install the package in the"
+msgstr "Curl ist momentan nicht installiert. Bitte installieren Sie das Paket im"
 
 msgid "Device"
 msgstr "Gerät"
@@ -48,7 +48,8 @@ msgid ""
 "Failure counter after how many failed download attempts, the state is "
 "considered as offline"
 msgstr ""
-"Anzahl der fehlgeschlagenen Downloadversuche, nach denen die Verbindung als offline angesehen wird"
+"Anzahl der fehlgeschlagenen Downloadversuche, nach denen die Verbindung als "
+"offline angesehen wird"
 
 msgid "List of Wireless Virtual Interfaces (wVIF)"
 msgstr "Liste der Drahtlosen virtuellen Schnittstellen"
@@ -73,6 +74,9 @@ msgid "Online"
 msgstr "Online"
 
 msgid "SSID"
+msgstr ""
+
+msgid "Software Section"
 msgstr ""
 
 msgid "Switch_to_offline threshold"
@@ -104,3 +108,5 @@ msgstr ""
 msgid "WiFi Status"
 msgstr ""
 
+#~ msgid "Curl is currently not installed."
+#~ msgstr "Curl ist momentan nicht installiert."

--- a/applications/luci-app-dynapoint/po/ja/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/ja/dynapoint.po
@@ -28,8 +28,9 @@ msgstr ""
 msgid "Configuration"
 msgstr "設定"
 
-msgid "Curl is currently not installed."
-msgstr "curl は現在インストールされていません。"
+msgid "Curl is currently not installed. Please install the package in the"
+msgstr ""
+"curl は現在インストールされていません。パッケージをインストールしてください。"
 
 msgid "Device"
 msgstr "デバイス"
@@ -78,6 +79,9 @@ msgstr "オンライン"
 msgid "SSID"
 msgstr "SSID"
 
+msgid "Software Section"
+msgstr ""
+
 msgid "Switch_to_offline threshold"
 msgstr "オフライン化閾値"
 
@@ -106,3 +110,6 @@ msgstr ""
 
 msgid "WiFi Status"
 msgstr "無線ステータス"
+
+#~ msgid "Curl is currently not installed."
+#~ msgstr "curl は現在インストールされていません。"

--- a/applications/luci-app-dynapoint/po/pt-br/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/pt-br/dynapoint.po
@@ -29,8 +29,8 @@ msgstr "Cerifique a conectividade com a internet baixando o cabeçalho HTTP "
 msgid "Configuration"
 msgstr "Configuração"
 
-msgid "Curl is currently not installed."
-msgstr "O cURL não está instalado."
+msgid "Curl is currently not installed. Please install the package in the"
+msgstr "O cURL não está instalado. Por favor instale o pacote no"
 
 msgid "Device"
 msgstr "Dispositivo"
@@ -79,6 +79,9 @@ msgstr "Conectado"
 msgid "SSID"
 msgstr "SSID"
 
+msgid "Software Section"
+msgstr ""
+
 msgid "Switch_to_offline threshold"
 msgstr "Limiar para mudar para desconectado"
 
@@ -105,3 +108,6 @@ msgstr "Qual dispositivo o cURL deve usar. (Use ifconfig para listá-las)"
 
 msgid "WiFi Status"
 msgstr "Estado da WiFi"
+
+#~ msgid "Curl is currently not installed."
+#~ msgstr "O cURL não está instalado."

--- a/applications/luci-app-dynapoint/po/ru/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/ru/dynapoint.po
@@ -32,8 +32,8 @@ msgstr "Проверка подключения к интернету, с пом
 msgid "Configuration"
 msgstr "Настройка config файла"
 
-msgid "Curl is currently not installed."
-msgstr "Curl в настоящее время не установлен."
+msgid "Curl is currently not installed. Please install the package in the"
+msgstr "Curl в настоящее время не установлен. Установите пакет на странице"
 
 msgid "Device"
 msgstr "Устройство"
@@ -83,6 +83,9 @@ msgstr "Онлайн"
 
 msgid "SSID"
 msgstr "SSID"
+
+msgid "Software Section"
+msgstr "'Программное обеспечение'"
 
 msgid "Switch_to_offline threshold"
 msgstr "Кол-во попыток"

--- a/applications/luci-app-dynapoint/po/templates/dynapoint.pot
+++ b/applications/luci-app-dynapoint/po/templates/dynapoint.pot
@@ -16,7 +16,7 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-msgid "Curl is currently not installed."
+msgid "Curl is currently not installed. Please install the package in the"
 msgstr ""
 
 msgid "Device"
@@ -62,6 +62,9 @@ msgid "Online"
 msgstr ""
 
 msgid "SSID"
+msgstr ""
+
+msgid "Software Section"
 msgstr ""
 
 msgid "Switch_to_offline threshold"


### PR DESCRIPTION
Signed-off-by: Vladimir <picfun@ya.ru>
Corrected script: applications/luci-app-dynapoint/luasrc/model/cbi/dynapoint.lua
There was no translation - "Please install the package in the"
I put screenshots it was so:
![936b48ff4287](https://user-images.githubusercontent.com/28679841/35294458-a916dfc6-0087-11e8-947d-4830de0690e7.png)
now:
![dy](https://user-images.githubusercontent.com/28679841/35294553-e87fa846-0087-11e8-9f8f-31eef9776cf4.png)

