### PR TITLE
luci-app-travelmate fixed

### DIFF
--- a/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
@@ -69,7 +69,7 @@ This is free software, licensed under the Apache License, Version 2.0
   <form class="inline" action="<%=luci.dispatcher.build_url('admin/services/travelmate/wifiscan')%>" method="post">
     <input type="hidden" name="device" value="<%=device%>"/>
     <input type="hidden" name="token" value="<%=token%>"/>
-    <input type="submit" class="cbi-button cbi-button-find" title="<%:Find and join network on %><%=device%>" value="<%:Scan %><%=device%>"/>
+    <input type="submit" class="cbi-button cbi-button-find" title="<%:Find and join network on%> <%=device%>" value="<%:Scan%> <%=device%>"/>
   </form>
 <%
   end)

--- a/applications/luci-app-travelmate/po/ru/travelmate.po
+++ b/applications/luci-app-travelmate/po/ru/travelmate.po
@@ -115,7 +115,7 @@ msgid "Extra options"
 msgstr "Дополнительные настройки"
 
 msgid "Find and join network on"
-msgstr "Найти сеть и подключится к ней"
+msgstr "Найти сеть для подключения используя"
 
 msgid ""
 "For further information <a href=\"%s\" target=\"_blank\">see online "
@@ -230,10 +230,10 @@ msgid "Radio selection"
 msgstr "Выбор Wi-Fi устройства"
 
 msgid "Repeat scan"
-msgstr "Повторить сканирование"
+msgstr "Повторить поиск"
 
 msgid "Rescan"
-msgstr "Повторить поиск"
+msgstr "Пересканировать"
 
 msgid "Restrict travelmate to a dedicated radio, e.g. 'radio0'."
 msgstr "Выделить TravelMate-у конкретное Wi-Fi устройство, например 'radio0'."


### PR DESCRIPTION
Signed-off-by: Vladimir <picfun@ya.ru>
There was no space:
![default](https://user-images.githubusercontent.com/28679841/35525180-d3165c82-0534-11e8-88e3-bde5e3d837b5.png)
Corrected, clarified the Russian text:
![4](https://user-images.githubusercontent.com/28679841/35525332-3e7bfad6-0535-11e8-9b75-6f9882ec2ec8.png)
