### PR TITLE
luci-app-travelmate fixed

### DIFF
--- a/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
@@ -69,7 +69,7 @@ This is free software, licensed under the Apache License, Version 2.0
   <form class="inline" action="<%=luci.dispatcher.build_url('admin/services/travelmate/wifiscan')%>" method="post">
     <input type="hidden" name="device" value="<%=device%>"/>
     <input type="hidden" name="token" value="<%=token%>"/>
-    <input type="submit" class="cbi-button cbi-button-find" title="<%:Find and join network on %><%=device%>" value="<%:Scan %><%=device%>"/>
+    <input type="submit" class="cbi-button cbi-button-find" title="<%:Find and join network on%> <%=device%>" value="<%:Scan%> <%=device%>"/>
   </form>
 <%
   end)

--- a/applications/luci-app-travelmate/po/ru/travelmate.po
+++ b/applications/luci-app-travelmate/po/ru/travelmate.po
@@ -115,7 +115,7 @@ msgid "Extra options"
 msgstr "Дополнительные настройки"
 
 msgid "Find and join network on"
-msgstr "Найти сеть и подключится к ней"
+msgstr "Найти сеть для подключения используя"
 
 msgid ""
 "For further information <a href=\"%s\" target=\"_blank\">see online "


### PR DESCRIPTION
Signed-off-by: Vladimir <picfun@ya.ru>
There was no space:
![default](https://user-images.githubusercontent.com/28679841/35525903-ee46b02c-0536-11e8-94ec-c56e4e22b373.png)
Corrected, clarified the Russian text:
![4](https://user-images.githubusercontent.com/28679841/35525915-f771c0d8-0536-11e8-95c7-9b80afc2a381.png)

