### PR TITLE
luci-app-mwan3: add service hint

### DIFF
--- a/applications/luci-app-mwan3/luasrc/view/admin_status/index/mwan.htm
+++ b/applications/luci-app-mwan3/luasrc/view/admin_status/index/mwan.htm
@@ -1,1 +1,3 @@
+<%if require("luci.sys").init.enabled("mwan3") then%>
 <%+mwan/overview_status_interface%>
+<%end%>

--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm
@@ -28,6 +28,9 @@
 
 <div class="cbi-map">
 	<h2 name="content"><%:MWAN Status - Detail%></h2>
+	<%if not require("luci.sys").init.enabled("mwan3") then%>
+	<div><strong><%:INFO: MWAN not running%></strong></div>
+	<%end%>
 	<fieldset class="cbi-section">
 		<legend id="diag-rc-legend"><%:Collecting data...%></legend>
 		<span id="diag-rc-output">

--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm
@@ -55,7 +55,9 @@
 <form method="post" action="<%=url('admin/network/diagnostics')%>">
 	<div class="cbi-map">
 		<h2 name="content"><%:MWAN Status - Diagnostics%></h2>
-
+		<%if not require("luci.sys").init.enabled("mwan3") then%>
+		<div><strong><%:INFO: MWAN not running%></strong></div>
+		<%end%>
 		<fieldset class="cbi-section">
 			<br />
 

--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_interface.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_interface.htm
@@ -66,6 +66,9 @@
 
 <div class="cbi-map">
 	<h2 name="content"><%:MWAN Status - Interface%></h2>
+	<%if not require("luci.sys").init.enabled("mwan3") then%>
+	<div><strong><%:INFO: MWAN not running%></strong></div>
+	<%end%>
 	<fieldset class="cbi-section">
 		<legend id="diag-rc-legend"><%:Collecting data...%></legend>
 		<span id="diag-rc-output">

--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_interface.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_interface.htm
@@ -18,7 +18,9 @@
 	XHR.poll(5, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "interface_status")%>', null,
 		function(x, status)
 		{
-			var statusDiv = document.getElementById('mwan_status_text');
+			var legend = document.getElementById('diag-rc-legend');
+			var statusDiv = document.getElementById('diag-rc-output');
+			legend.style.display = 'none';
 			if (status.interfaces)
 			{
 				var statusview = '';
@@ -62,10 +64,13 @@
 	);
 //]]></script>
 
-<div id="mwan_interface_status">
-	<fieldset id="interface_field" class="cbi-section">
-		<legend><%:MWAN status - Interface Live Status%></legend>
-		<div id="mwan_status_text"><img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle" /><%:Collecting data...%></div>
+<div class="cbi-map">
+	<h2 name="content"><%:MWAN Status - Interface%></h2>
+	<fieldset class="cbi-section">
+		<legend id="diag-rc-legend"><%:Collecting data...%></legend>
+		<span id="diag-rc-output">
+			<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align: middle;" />
+		</span>
 	</fieldset>
 </div>
 

--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_troubleshooting.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_troubleshooting.htm
@@ -28,6 +28,9 @@
 
 <div class="cbi-map">
 	<h2 name="content"><%:MWAN Status - Troubleshooting%></h2>
+	<%if not require("luci.sys").init.enabled("mwan3") then%>
+	<div><strong><%:INFO: MWAN not running%></strong></div>
+	<%end%>
 	<fieldset class="cbi-section">
 		<legend id="diag-rc-legend"><%:Collecting data...%></legend>
 		<span id="diag-rc-output">

--- a/applications/luci-app-mwan3/root/etc/uci-defaults/60_luci-mwan3
+++ b/applications/luci-app-mwan3/root/etc/uci-defaults/60_luci-mwan3
@@ -4,7 +4,7 @@
 uci -q batch <<-EOF >/dev/null
 	del ucitrack.@mwan3[-1]
 	add ucitrack mwan3
-	set ucitrack.@mwan3[-1].exec="/usr/sbin/mwan3 restart"
+	set ucitrack.@mwan3[-1].exec="/etc/init.d/mwan3 reload"
 	commit ucitrack
 EOF
 


### PR DESCRIPTION
Service changes
- update uci track to call "/etc/init.d/mwan3 reload"
- Do not show interface status on Overview page if mwan3 is not global enabled
- Add hint if service is not enabled globally

Look and feel changes
- change look and fell interface status page