### PR TITLE
Firewall zones: Use "NAT" and "Adjust MTU" as description

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/zones.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/zones.lua
@@ -70,7 +70,7 @@ for i, v in ipairs(p) do
 	v:value("ACCEPT", translate("accept"))
 end
 
-s:option(Flag, "masq", translate("Masquerading"))
-s:option(Flag, "mtu_fix", translate("MSS clamping"))
+s:option(Flag, "masq", translate("NAT"))
+s:option(Flag, "mtu_fix", translate("Adjust MTU"))
 
 return m


### PR DESCRIPTION
This PR changes the description of "Masquerade" and "MSS clamping" in firewall/zones.lua to "NAT" and "Adjust MTU" which is more clear and widely used as descriptions in routers. In Addition the variable "mtu_fix" sounds like "bad network stack" so is is now labled as "Adjust MTU" which sounds better, shorter...

closes  #1129

![pr_nat](https://user-images.githubusercontent.com/2057932/36233641-46a79864-11e7-11e8-8f3a-fd1d1c015996.png)

Signed of by: LipkeGu@fblipke.de
