### PR TITLE
freifunk-policyrouting: do not run init-script in imagebuilder

### DIFF
--- a/contrib/package/freifunk-policyrouting/files/etc/init.d/freifunk-policyrouting
+++ b/contrib/package/freifunk-policyrouting/files/etc/init.d/freifunk-policyrouting
@@ -1,5 +1,8 @@
 #!/bin/sh /etc/rc.common
 
+# check if we are on real system
+[ -n "${IPKG_INSTROOT}" ] && exit 0
+
 START=15
 . /lib/functions/network.sh
 . /lib/functions.sh


### PR DESCRIPTION
When creating final images the build-scripts running the package init-scripts. As of including files like on a real system (line 4, 5), with absolute path, this will fail. 

> Activating init scripts
build_dir/target-mips_24kc_musl/root-ar71xx/etc/init.d/freifunk-policyrouting: line 4: /lib/functions/network.sh: No such file or directory
build_dir/target-mips_24kc_musl/root-ar71xx/etc/init.d/freifunk-policyrouting: line 5: /lib/functions.sh: No such file or directory

Running this init-script outside of a real-system don't seem to make sense at all, so just exit gracefully.