### PR TITLE
luci-app-adblock: fix frontend typo

### DIFF
--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
@@ -251,7 +251,7 @@ e9.rmempty = true
 
 e10 = e:option(Flag, "adb_notify", translate("Email Notification"),
 	translate("Send notification emails in case of a processing error or if domain count is &le; 0.<br />")
-	.. translate("Please note: this needs additional 'mstmp' package installation and setup."))
+	.. translate("Please note: this needs additional 'msmtp' package installation and setup."))
 e10.default = e10.disabled
 e10.rmempty = true
 

--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -236,7 +236,7 @@ msgstr ""
 "Per favore modifica questo file direttamente in una sessione al terminale."
 
 msgid ""
-"Please note: this needs additional 'mstmp' package installation and setup."
+"Please note: this needs additional 'msmtp' package installation and setup."
 msgstr ""
 
 msgid "Please update your adblock config file to use this package.<br />"

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -256,9 +256,9 @@ msgid "Please edit this file directly in a terminal session."
 msgstr "ターミナル セッションで直接このファイルを編集してください。"
 
 msgid ""
-"Please note: this needs additional 'mstmp' package installation and setup."
+"Please note: this needs additional 'msmtp' package installation and setup."
 msgstr ""
-"注意: これには、追加で 'mstmp' のインストールとセットアップが必要です。"
+"注意: これには、追加で 'msmtp' のインストールとセットアップが必要です。"
 
 msgid "Please update your adblock config file to use this package.<br />"
 msgstr ""

--- a/applications/luci-app-adblock/po/pt-br/adblock.po
+++ b/applications/luci-app-adblock/po/pt-br/adblock.po
@@ -229,7 +229,7 @@ msgid "Please edit this file directly in a terminal session."
 msgstr "Por favor edite esse arquivo direto em uma sessão de terminal."
 
 msgid ""
-"Please note: this needs additional 'mstmp' package installation and setup."
+"Please note: this needs additional 'msmtp' package installation and setup."
 msgstr ""
 
 msgid "Please update your adblock config file to use this package.<br />"

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -260,8 +260,8 @@ msgid "Please edit this file directly in a terminal session."
 msgstr "Отредактируйте данный файл, строго в терминале."
 
 msgid ""
-"Please note: this needs additional 'mstmp' package installation and setup."
-msgstr "Внимание: это потребует дополнительной установки пакета 'mstmp'."
+"Please note: this needs additional 'msmtp' package installation and setup."
+msgstr "Внимание: это потребует дополнительной установки пакета 'msmtp'."
 
 msgid "Please update your adblock config file to use this package.<br />"
 msgstr "Обновите config файл Adblock, чтобы использовать этот пакет.<br />"

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -218,7 +218,7 @@ msgid "Please edit this file directly in a terminal session."
 msgstr "Vänligen redigera den här filen direkt i en terminal-session."
 
 msgid ""
-"Please note: this needs additional 'mstmp' package installation and setup."
+"Please note: this needs additional 'msmtp' package installation and setup."
 msgstr ""
 
 msgid "Please update your adblock config file to use this package.<br />"

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -210,7 +210,7 @@ msgid "Please edit this file directly in a terminal session."
 msgstr ""
 
 msgid ""
-"Please note: this needs additional 'mstmp' package installation and setup."
+"Please note: this needs additional 'msmtp' package installation and setup."
 msgstr ""
 
 msgid "Please update your adblock config file to use this package.<br />"

--- a/applications/luci-app-adblock/po/zh-cn/adblock.po
+++ b/applications/luci-app-adblock/po/zh-cn/adblock.po
@@ -228,7 +228,7 @@ msgid "Please edit this file directly in a terminal session."
 msgstr "请在终端会话中直接编辑此文件。"
 
 msgid ""
-"Please note: this needs additional 'mstmp' package installation and setup."
+"Please note: this needs additional 'msmtp' package installation and setup."
 msgstr ""
 
 msgid "Please update your adblock config file to use this package.<br />"

--- a/applications/luci-app-adblock/po/zh-tw/adblock.po
+++ b/applications/luci-app-adblock/po/zh-tw/adblock.po
@@ -228,7 +228,7 @@ msgid "Please edit this file directly in a terminal session."
 msgstr "請在終端會話中直接編輯此檔案。"
 
 msgid ""
-"Please note: this needs additional 'mstmp' package installation and setup."
+"Please note: this needs additional 'msmtp' package installation and setup."
 msgstr ""
 
 msgid "Please update your adblock config file to use this package.<br />"


### PR DESCRIPTION
fix trivial 'msmtp' typo & changed .po files as well

Signed-off-by: Dirk Brenken <dev@brenken.org>