### PR TITLE
community-profiles: potsdam - changed SSID

### DIFF
--- a/contrib/package/community-profiles/files/etc/config/profile_potsdam
+++ b/contrib/package/community-profiles/files/etc/config/profile_potsdam
@@ -1,7 +1,7 @@
 config 'community' 'profile'
 	option 'name' 'Freifunk Potsdam'
 	option 'homepage' 'http://potsdam.freifunk.net'
-	option 'ssid' 'Freifunk-Potsdam-XXX-YYY'
+	option 'ssid' 'freifunk-potsdam.de'
 	option 'mesh_network' '10.22.0.0/16'
 	option 'splash_network' '192.168.22.0/24'
 	option 'splash_prefix' '24'


### PR DESCRIPTION
I know there was a recently PR #1634 on this profile, but there was an ongoing discussion about "fixed" SSID's. Finaly we came to a conclusion, so here is a new PR withe only a ssid change.

Commit message:
```
community-profiles: potsdam - changed SSID

After some discussion in our meetings and on the maling list we decided to
change the SSID to a fixed one.

Signed-off-by: Hannes Fuchs <hannes.fuchs@gmx.org>
```