### PR TITLE
luci-app-firewall/luci-base/luci-mod-admin-full: some fixes and improvements

### DIFF
--- a/applications/luci-app-firewall/luasrc/view/firewall/cbi_addrule.htm
+++ b/applications/luci-app-firewall/luasrc/view/firewall/cbi_addrule.htm
@@ -2,6 +2,7 @@
 	local fw = require "luci.model.firewall".init()
 	local wz = fw:get_zone("wan")
 	local lz = fw:get_zone("lan")
+	local zones = fw:get_zones()
 %>
 
 <div class="cbi-section-create cbi-tblsection-create">
@@ -38,7 +39,7 @@
 			</tr>
 		</table>
 	<% end %>
-	<% if wz and lz then %>
+	<% if #zones > 1 then %>
 		<table class="cbi-section-table" style="margin-left:5px">
 			<tr class="cbi-section-table-titles">
 				<th class="cbi-section-table-cell left" colspan="6"><br /><%:New forward rule%>:</th>

--- a/applications/luci-app-firewall/luasrc/view/firewall/cbi_addrule.htm
+++ b/applications/luci-app-firewall/luasrc/view/firewall/cbi_addrule.htm
@@ -57,14 +57,14 @@
 				<td class="cbi-section-table-cell" style="width:110px">
 					<select class="cbi-input-text" id="_newfwd.src" name="_newfwd.src">
 						<% local k, v; for k, v in ipairs(fw:get_zones()) do -%>
-							<option<%=ifattr(v:name() == "lan", "selected", "selected")%> value="<%=v:name()%>"><%=v:name()%></option>
+							<option<%=ifattr(v:name() == "wan", "selected", "selected")%> value="<%=v:name()%>"><%=v:name()%></option>
 						<%- end %>
 					</select>
 				</td>
 				<td class="cbi-section-table-cell" style="width:110px">
 					<select class="cbi-input-text" id="_newfwd.dest" name="_newfwd.dest">
 						<% local k, v; for k, v in ipairs(fw:get_zones()) do -%>
-							<option<%=ifattr(v:name() == "wan", "selected", "selected")%> value="<%=v:name()%>"><%=v:name()%></option>
+							<option<%=ifattr(v:name() == "lan", "selected", "selected")%> value="<%=v:name()%>"><%=v:name()%></option>
 						<%- end %>
 					</select>
 				</td>

--- a/applications/luci-app-firewall/luasrc/view/firewall/cbi_addsnat.htm
+++ b/applications/luci-app-firewall/luasrc/view/firewall/cbi_addsnat.htm
@@ -1,8 +1,7 @@
 <%
 	local fw = require "luci.model.firewall".init()
 	local nw = require "luci.model.network".init()
-	local wz = fw:get_zone("wan")
-	local lz = fw:get_zone("lan")
+	local zones = fw:get_zones()
 
 	local keys, vals, a, k, v = {}, {}
 	for k, v in ipairs(nw:get_interfaces()) do
@@ -14,7 +13,7 @@
 %>
 
 <div class="cbi-section-create cbi-tblsection-create">
-	<% if wz and lz then %>
+	<% if #zones > 1 then %>
 		<br />
 		<table class="cbi-section-table" style="width:700px; margin-left:5px">
 			<tr class="cbi-section-table-titles">

--- a/modules/luci-base/luasrc/view/cbi/browser.htm
+++ b/modules/luci-base/luasrc/view/cbi/browser.htm
@@ -2,6 +2,7 @@
 <%+cbi/valueheader%>
 	<input class="cbi-input-text" type="text"<%= attr("value", v) .. attr("name", cbid) .. attr("id", cbid) %> />
 	<script type="text/javascript">
+cbi_init()
 cbi_browser_init('<%=cbid%>', '<%=resource%>', '<%=url('admin/filebrowser')%>'<%=self.default_path and ", '"..self.default_path.."'"%>);
 	</script>
 <%+cbi/valuefooter%>

--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
@@ -54,6 +54,9 @@
 				</div>
 			</form>
 		</div>
+		<% if reset_avail then %>
+		<div class="alert-message warning"><%:Custom files (certificates, scripts) may remain on the system. To prevent this, perform a factory-reset first.%></div>
+		<% end %>
 	</fieldset>
 
 	<br />


### PR DESCRIPTION
luci-app-firewall: only show SNAT template if there are more then one zone
luci-app-firewall: on forward rule change pre-selection to wan
luci-app-firewall: only show portforward template if there are more then one zone
luci-mod-admin-full: add hint on backup restore that there will not be a factory reset before
luci-base: fix browser.htm template icon view if "cbi_init()" is not called no icon will be found