### PR TITLE
luci-app-adblock: fix the msgid to keep the translations

### DIFF
--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -275,7 +275,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Size of the download queue to handle downloads & list processing in parallel "
+"Size of the download queue to handle downloads &amp; list processing in parallel "
 "(default '4').<br />"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -301,7 +301,7 @@ msgstr ""
 "処理エラーまたはドメイン カウントが0以下の場合、メールを送信します。<br />"
 
 msgid ""
-"Size of the download queue to handle downloads & list processing in parallel "
+"Size of the download queue to handle downloads &amp; list processing in parallel "
 "(default '4').<br />"
 msgstr ""
 "ダウンロードの制御とリストの処理を同時並行的に行うダウンロード キューのサイズ"

--- a/applications/luci-app-adblock/po/pt-br/adblock.po
+++ b/applications/luci-app-adblock/po/pt-br/adblock.po
@@ -267,7 +267,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Size of the download queue to handle downloads & list processing in parallel "
+"Size of the download queue to handle downloads &amp; list processing in parallel "
 "(default '4').<br />"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -303,7 +303,7 @@ msgstr ""
 "&le; 0.<br />"
 
 msgid ""
-"Size of the download queue to handle downloads & list processing in parallel "
+"Size of the download queue to handle downloads &amp; list processing in parallel "
 "(default '4').<br />"
 msgstr ""
 "Значение очереди загрузки для выполнения параллельных загрузок (по умолчанию "

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -256,7 +256,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Size of the download queue to handle downloads & list processing in parallel "
+"Size of the download queue to handle downloads &amp; list processing in parallel "
 "(default '4').<br />"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -248,7 +248,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Size of the download queue to handle downloads & list processing in parallel "
+"Size of the download queue to handle downloads &amp; list processing in parallel "
 "(default '4').<br />"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/zh-cn/adblock.po
+++ b/applications/luci-app-adblock/po/zh-cn/adblock.po
@@ -266,7 +266,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Size of the download queue to handle downloads & list processing in parallel "
+"Size of the download queue to handle downloads &amp; list processing in parallel "
 "(default '4').<br />"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/zh-tw/adblock.po
+++ b/applications/luci-app-adblock/po/zh-tw/adblock.po
@@ -266,7 +266,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"Size of the download queue to handle downloads & list processing in parallel "
+"Size of the download queue to handle downloads &amp; list processing in parallel "
 "(default '4').<br />"
 msgstr ""
 


### PR DESCRIPTION
XHTML markup of "&" in the description about "download queue" was fixed
in 71230d2. Since UI text of it no longer matches msgid, I fixed it.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>