### PR TITLE
luci-app-travelmate: remove qrencode short options

### DIFF
--- a/applications/luci-app-travelmate/luasrc/view/travelmate/ap_qr.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/ap_qr.htm
@@ -45,7 +45,7 @@ This is free software, licensed under the Apache License, Version 2.0
         local e_key = string.gsub(key,"[\"\\';:, ]",[[\\\%1]])
         local qrcode = ""
         if nixio.fs.access("/usr/bin/qrencode") then
-          qrcode = luci.sys.exec("/usr/bin/qrencode -I -t SVG -8 -o - 'WIFI:S:\"'" .. e_ssid .. "'\";T:'" .. enc .. "';P:\"'" .. e_key .. "'\";H:'" .. hidden .. "';'")
+          qrcode = luci.sys.exec("/usr/bin/qrencode --inline --8bit --type=SVG --output=- 'WIFI:S:\"'" .. e_ssid .. "'\";T:'" .. enc .. "';P:\"'" .. e_key .. "'\";H:'" .. hidden .. "';'")
         end
 -%>
     <fieldset class="cbi-section">


### PR DESCRIPTION
* forthcoming qrencode version will remove the short option "-I"
  for inline, to get prepared switch to normal qrencode
  command line parameters.

Signed-off-by: Dirk Brenken <dev@brenken.org>