### PR TITLE
luci-app-ocserv: match default value of compression

### DIFF
--- a/applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua
+++ b/applications/luci-app-ocserv/luasrc/model/cbi/ocserv/main.lua
@@ -86,7 +86,7 @@ pip.default = "1"
 
 local compr = s:taboption("general", Flag, "compression", translate("Enable compression"),
 	translate("Enable compression"))
-compr.default = "1"
+compr.default = "0"
 
 local udp = s:taboption("general", Flag, "udp", translate("Enable UDP"),
 	translate("Enable UDP channel support; this must be enabled unless you know what you are doing"))


### PR DESCRIPTION
Modify the default setting of compression to match the default
value of the package ocserv.

Signed-off-by: Raymond Tau <raymondtau@gmail.com>