### PR TITLE
luci-app-travelmate: fix function calls

### DIFF
--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
@@ -8,9 +8,9 @@ local util     = require("luci.util")
 local nw       = require("luci.model.network").init()
 local fw       = require("luci.model.firewall").init()
 local dump     = util.ubus("network.interface", "dump", {})
-local trmiface = uci.get("travelmate", "global", "trm_iface") or "trm_wwan"
-local trminput = uci.get("travelmate", "global", "trm_rtfile") or "/tmp/trm_runtime.json"
-local uplink   = uci.get("network", trmiface) or ""
+local trmiface = uci:get("travelmate", "global", "trm_iface") or "trm_wwan"
+local trminput = uci:get("travelmate", "global", "trm_rtfile") or "/tmp/trm_runtime.json"
+local uplink   = uci:get("network", trmiface) or ""
 local parse    = json.parse(fs.readfile(trminput) or "")
 
 m = Map("travelmate", translate("Travelmate"),

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
@@ -4,7 +4,7 @@
 local fs       = require("nixio.fs")
 local uci      = require("luci.model.uci").cursor()
 local http     = require("luci.http")
-local trmiface = uci.get("travelmate", "global", "trm_iface") or "trm_wwan"
+local trmiface = uci:get("travelmate", "global", "trm_iface") or "trm_wwan"
 local encr_psk = {"psk", "psk2", "psk-mixed"}
 local encr_wpa = {"wpa", "wpa2", "wpa-mixed"}
 


### PR DESCRIPTION
* fix function calls that have an implicit extra parameter self,
  pre-requisite for PR #1681

Signed-off-by: Dirk Brenken <dev@brenken.org>