### PR TITLE
luci-app-pagekitec: new package

### DIFF
--- a/applications/luci-app-pagekitec/Makefile
+++ b/applications/luci-app-pagekitec/Makefile
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2018 Karl Palsson <karlp@tweak.net.au>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI Support for PageKite
+LUCI_DEPENDS:=+pagekitec
+
+PKG_MAINTAINER:=Karl Palsson <karlp@tweak.net.au>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-pagekitec/luasrc/controller/pagekitec.lua
+++ b/applications/luci-app-pagekitec/luasrc/controller/pagekitec.lua
@@ -1,0 +1,8 @@
+-- Copyright 2018 Karl Palsson <karlp@tweak.net.au>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.controller.pagekitec", package.seeall)
+
+function index()
+    entry({"admin", "services", "pagekitec"}, cbi("pagekitec"), _("PageKite"))
+end

--- a/applications/luci-app-pagekitec/luasrc/model/cbi/pagekitec.lua
+++ b/applications/luci-app-pagekitec/luasrc/model/cbi/pagekitec.lua
@@ -1,0 +1,26 @@
+m = Map("pagekitec", translate("PageKite"),
+    translate([[
+<p/>Note: you need a working PageKite account, or at least, your own running front end for this form to work.
+Visit <a href="https://pagekite.net/home/">your account</a> to set up a name for your
+router and get a secret key for the connection.
+<p/><em>Note: this web configurator only supports
+some very very basic uses of pagekite.</em>
+]]))
+
+s = m:section(TypedSection, "pagekitec", translate("PageKite"))
+s.anonymous = true
+
+p = s:option(Value, "kitename", translate("Kite Name"))
+p = s:option(Value, "kitesecret", translate("Kite Secret"))
+p.password = true
+p = s:option(Flag, "static", translate("Static Setup"),
+	translate([[Static setup, disable FE failover and DDNS updates, set this if you are running your
+	own frontend without a pagekite.me account]]))
+
+p = s:option(Flag, "simple_http", translate("Basic HTTP"),
+    translate([[Enable a tunnel to the local HTTP server (in most cases, this admin
+site)]]))
+p = s:option(Flag, "simple_ssh", translate("Basic SSH"),
+    translate([[Enable a tunnel to the local SSH server]]))
+
+return m

--- a/applications/luci-app-pagekitec/po/templates/pagekitec.pot
+++ b/applications/luci-app-pagekitec/po/templates/pagekitec.pot
@@ -1,0 +1,40 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid ""
+"<p/>Note: you need a working PageKite account, or at least, your own running "
+"front end for this form to work. Visit <a href=\"https://pagekite.net/home/"
+"\">your account</a> to set up a name for your router and get a secret key "
+"for the connection. <p/><em>Note: this web configurator only supports some "
+"very very basic uses of pagekite.</em>"
+msgstr ""
+
+msgid "Basic HTTP"
+msgstr ""
+
+msgid "Basic SSH"
+msgstr ""
+
+msgid ""
+"Enable a tunnel to the local HTTP server (in most cases, this admin site)"
+msgstr ""
+
+msgid "Enable a tunnel to the local SSH server"
+msgstr ""
+
+msgid "Kite Name"
+msgstr ""
+
+msgid "Kite Secret"
+msgstr ""
+
+msgid "PageKite"
+msgstr ""
+
+msgid "Static Setup"
+msgstr ""
+
+msgid ""
+"Static setup, disable FE failover and DDNS updates, set this if you are "
+"running your own frontend without a pagekite.me account"
+msgstr ""

--- a/applications/luci-app-pagekitec/root/etc/uci-defaults/40_luci-pagekitec
+++ b/applications/luci-app-pagekitec/root/etc/uci-defaults/40_luci-pagekitec
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+uci -q batch <<-EOF >/dev/null
+	delete ucitrack.@pagekitec[-1]
+	add ucitrack pagekitec
+	set ucitrack.@pagekitec[-1].init=pagekitec
+	commit ucitrack
+EOF
+
+rm -f /tmp/luci-indexcache
+exit 0


### PR DESCRIPTION
Adds a simple interface to the basic functionality of pagekite services.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

Note: I'm not sure I've setup the i18n correctly.  I used i18n-scan to generate po/template/pagekite.pot, is there anything else that should happen?