### PR TITLE
luci-app-travelmate: final frontend changes for 18.x

### DIFF
--- a/applications/luci-app-travelmate/Makefile
+++ b/applications/luci-app-travelmate/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for Travelmate
-LUCI_DEPENDS:=+travelmate +luci-lib-jsonc +qrencode
+LUCI_DEPENDS:=+travelmate +luci-lib-jsonc
 LUCI_PKGARCH:=all
 
 include ../../luci.mk

--- a/applications/luci-app-travelmate/luasrc/controller/travelmate.lua
+++ b/applications/luci-app-travelmate/luasrc/controller/travelmate.lua
@@ -14,14 +14,14 @@ function index()
 	entry({"admin", "services", "travelmate"}, firstchild(), _("Travelmate"), 40).dependent = false
 	entry({"admin", "services", "travelmate", "tab_from_cbi"}, cbi("travelmate/overview_tab", {hideresetbtn=true, hidesavebtn=true}), _("Overview"), 10).leaf = true
 	entry({"admin", "services", "travelmate", "stations"}, template("travelmate/stations"), _("Wireless Stations"), 20).leaf = true
-	entry({"admin", "services", "travelmate", "apqr"}, template("travelmate/ap_qr"), _("AP QR-Codes"), 30).leaf = true
-	entry({"admin", "services", "travelmate", "logfile"}, call("logread"), _("View Logfile"), 40).leaf = true
+	entry({"admin", "services", "travelmate", "logfile"}, call("logread"), _("View Logfile"), 30).leaf = true
 	entry({"admin", "services", "travelmate", "advanced"}, firstchild(), _("Advanced"), 100)
 	entry({"admin", "services", "travelmate", "advanced", "configuration"}, cbi("travelmate/configuration_tab"), _("Edit Travelmate Configuration"), 110).leaf = true
 	entry({"admin", "services", "travelmate", "advanced", "cfg_wireless"}, cbi("travelmate/cfg_wireless_tab"), _("Edit Wireless Configuration"), 120).leaf = true
 	entry({"admin", "services", "travelmate", "advanced", "cfg_network"}, cbi("travelmate/cfg_network_tab"), _("Edit Network Configuration"), 130).leaf = true
 	entry({"admin", "services", "travelmate", "advanced", "cfg_firewall"}, cbi("travelmate/cfg_firewall_tab"), _("Edit Firewall Configuration"), 140).leaf = true
 
+	entry({"admin", "services", "travelmate", "apqr"}, template("travelmate/ap_qr")).leaf = true
 	entry({"admin", "services", "travelmate", "wifiscan"}, template("travelmate/wifi_scan")).leaf = true
 	entry({"admin", "services", "travelmate", "wifiadd"}, cbi("travelmate/wifi_add", {hideresetbtn=true, hidesavebtn=true})).leaf = true
 	entry({"admin", "services", "travelmate", "wifiedit"}, cbi("travelmate/wifi_edit", {hideresetbtn=true, hidesavebtn=true})).leaf = true

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
@@ -96,20 +96,26 @@ end
 o4.default = trmiface
 o4.rmempty = false
 
-o5 = s:option(Value, "trm_triggerdelay", translate("Trigger Delay"),
-	translate("Additional trigger delay in seconds before travelmate processing begins."))
-o5.datatype = "range(1,60)"
-o5.default = 2
-o5.rmempty = false
+if fs.access("/usr/bin/qrencode") then
+	btn1 = s:option(Button, "btn1", translate("View AP QR-Codes"),
+		translate("Connect your Android or iOS devices to your router's WiFi using the shown QR code."))
+	btn1.inputtitle = translate("QR-Codes")
+	btn1.inputstyle = "apply"
+	btn1.disabled = false
 
-btn = s:option(Button, "", translate("Manual Rescan"),
+	function btn1.write()
+		luci.http.redirect(luci.dispatcher.build_url("admin", "services", "travelmate", "apqr"))
+	end
+end
+
+btn2 = s:option(Button, "btn2", translate("Manual Rescan"),
 	translate("Force a manual uplink rescan / reconnect in 'trigger' mode."))
-btn:depends("trm_automatic", "")
-btn.inputtitle = translate("Rescan")
-btn.inputstyle = "find"
-btn.disabled = false
+btn2:depends("trm_automatic", "")
+btn2.inputtitle = translate("Rescan")
+btn2.inputstyle = "find"
+btn2.disabled = false
 
-function btn.write()
+function btn2.write()
 	luci.sys.call("env -i /etc/init.d/travelmate start >/dev/null 2>&1")
 	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "travelmate"))
 end
@@ -180,28 +186,34 @@ e2 = e:option(Value, "trm_radio", translate("Radio selection"),
 e2.datatype = "and(uciname,rangelength(6,6))"
 e2.rmempty = true
 
-e3 = e:option(Value, "trm_maxretry", translate("Connection Limit"),
-	translate("Retry limit to connect to an uplink."))
-e3.default = 3
-e3.datatype = "range(1,10)"
+e3 = e:option(Value, "trm_triggerdelay", translate("Trigger Delay"),
+	translate("Additional trigger delay in seconds before travelmate processing begins."))
+e3.datatype = "range(1,60)"
+e3.default = 2
 e3.rmempty = false
 
-e4 = e:option(Value, "trm_minquality", translate("Signal Quality Threshold"),
-	translate("Minimum signal quality threshold as percent for conditional uplink (dis-) connections."))
-e4.default = 35
-e4.datatype = "range(20,80)"
+e4 = e:option(Value, "trm_maxretry", translate("Connection Limit"),
+	translate("Retry limit to connect to an uplink."))
+e4.default = 3
+e4.datatype = "range(1,10)"
 e4.rmempty = false
 
-e5 = e:option(Value, "trm_maxwait", translate("Interface Timeout"),
-	translate("How long should travelmate wait for a successful wlan uplink connection."))
-e5.default = 30
-e5.datatype = "range(20,40)"
+e5 = e:option(Value, "trm_minquality", translate("Signal Quality Threshold"),
+	translate("Minimum signal quality threshold as percent for conditional uplink (dis-) connections."))
+e5.default = 35
+e5.datatype = "range(20,80)"
 e5.rmempty = false
 
-e6 = e:option(Value, "trm_timeout", translate("Overall Timeout"),
-	translate("Timeout in seconds between retries in 'automatic' mode."))
-e6.default = 60
-e6.datatype = "range(30,300)"
+e6 = e:option(Value, "trm_maxwait", translate("Interface Timeout"),
+	translate("How long should travelmate wait for a successful wlan uplink connection."))
+e6.default = 30
+e6.datatype = "range(20,40)"
 e6.rmempty = false
+
+e7 = e:option(Value, "trm_timeout", translate("Overall Timeout"),
+	translate("Timeout in seconds between retries in 'automatic' mode."))
+e7.default = 60
+e7.datatype = "range(30,300)"
+e7.rmempty = false
 
 return m

--- a/applications/luci-app-travelmate/luasrc/view/travelmate/ap_qr.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/ap_qr.htm
@@ -44,9 +44,7 @@ This is free software, licensed under the Apache License, Version 2.0
         local e_ssid = string.gsub(ssid,"[\"\\';:, ]",[[\\\%1]])
         local e_key = string.gsub(key,"[\"\\';:, ]",[[\\\%1]])
         local qrcode = ""
-        if nixio.fs.access("/usr/bin/qrencode") then
-          qrcode = luci.sys.exec("/usr/bin/qrencode --inline --8bit --type=SVG --output=- 'WIFI:S:\"'" .. e_ssid .. "'\";T:'" .. enc .. "';P:\"'" .. e_key .. "'\";H:'" .. hidden .. "';'")
-        end
+        qrcode = luci.sys.exec("/usr/bin/qrencode --inline --8bit --type=SVG --output=- 'WIFI:S:\"'" .. e_ssid .. "'\";T:'" .. enc .. "';P:\"'" .. e_key .. "'\";H:'" .. hidden .. "';'")
 -%>
     <fieldset class="cbi-section">
         <legend>AP on <%=device%> with SSID "<%=ssid%>"</legend>
@@ -57,6 +55,11 @@ This is free software, licensed under the Apache License, Version 2.0
     end
   end)
 %>
+</div>
+<div class="cbi-page-actions right">
+    <form class="inline" action="<%=luci.dispatcher.build_url('admin/services/travelmate/tab_from_cbi')%>" method="post">
+        <input class="cbi-button cbi-button-reset" type="submit" value="<%:Back to overview%>"/>
+    </form>
 </div>
 
 <%+footer%>


### PR DESCRIPTION
* made qrencode support optional (remove hardcoded dependency)
  * add a conditional QR Code button on overview page,
    remove separate "QR Codes" tab
* move trigger timeout setting to extra section

Signed-off-by: Dirk Brenken <dev@brenken.org>