### PR TITLE
luci-base/util.lua: enhance checklib function 

### DIFF
--- a/modules/luci-base/luasrc/util.lua
+++ b/modules/luci-base/luasrc/util.lua
@@ -652,7 +652,8 @@ end
 function checklib(fullpathexe, wantedlib)
 	local fs = require "nixio.fs"
 	local haveldd = fs.access('/usr/bin/ldd')
-	if not haveldd then
+	local haveexe = fs.access(fullpathexe)
+	if not haveldd or not haveexe then
 		return false
 	end
 	local libs = exec("/usr/bin/ldd " .. fullpathexe)


### PR DESCRIPTION
* enhance the checklib function in util.lua to check the 'fullpathexe'
  as well, e.g. this fixes runtime errors on the dhcp/dns template in
  environments without dnsmasq

Signed-off-by: Dirk Brenken <dev@brenken.org>