### PR TITLE
luci-mod-admin-full: Add processor and architecture from /proc/cpuinfo to admin_status page

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -16,6 +16,9 @@
 
 	local sysinfo = luci.util.ubus("system", "info") or { }
 	local boardinfo = luci.util.ubus("system", "board") or { }
+	local cpuinfo = luci.sys.exec("cat /proc/cpuinfo") or {}
+	local processor = cpuinfo:match("system type\t+: ([^\n]+)") or cpuinfo:match("model name\t+: ([^\n]+)") or { }
+	local march = cpuinfo:match("cpu model\t+: ([^\n]+)") or cpuinfo:match("Hardware\t+: ([^\n]+)") or { }
 	local unameinfo = nixio.uname() or { }
 
 	local meminfo = sysinfo.memory or {
@@ -682,6 +685,8 @@
 	<table width="100%" cellspacing="10">
 		<tr><td width="33%"><%:Hostname%></td><td><%=luci.sys.hostname() or "?"%></td></tr>
 		<tr><td width="33%"><%:Model%></td><td><%=pcdata(boardinfo.model or boardinfo.system or "?")%></td></tr>
+		<tr><td width="33%"><%:Processor%></td><td><%=pcdata(processor or "?")%></td></tr>
+		<tr><td width="33%"><%:Architecture%></td><td><%=pcdata(march or "?")%></td></tr>
 		<tr><td width="33%"><%:Firmware Version%></td><td>
 			<%=pcdata(ver.distname)%> <%=pcdata(ver.distversion)%> /
 			<%=pcdata(ver.luciname)%> (<%=pcdata(ver.luciversion)%>)


### PR DESCRIPTION
This adds processor and architecture information from /proc/cpuinfo to admin_status page. 
Slightly modified after https://github.com/gwlim/mips74k-ar71xx-lede-patch/blob/lede-17.01/patch/063-add-luci-mips-processor-march.patch and tested on tp-link wdr3600 and linksys wrt1900acv2.
Signed-off-by: Daniel Petre <contact@superwrt.download>
