### PR TITLE
luci-mod-admin-full: Allow setting cache size and flag to query all available upstream servers to admin_network dhcp page

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -122,6 +122,9 @@ s:taboption("advanced", Flag, "strictorder",
 	translate("<abbr title=\"Domain Name System\">DNS</abbr> servers will be queried in the " ..
 		"order of the resolvfile")).optional = true
 
+s:taboption("advanced", Flag, "allservers",
+        translate("All Servers"),
+        translate("Query all available upstream <abbr title=\"Domain Name System\">DNS</abbr> servers")).optional = true
 
 bn = s:taboption("advanced", DynamicList, "bogusnxdomain", translate("Bogus NX Domain Override"),
 	translate("List of hosts that supply bogus NX domain results"))
@@ -212,6 +215,13 @@ cq.optional = true
 cq.datatype = "uinteger"
 cq.placeholder = 150
 
+cs = s:taboption("advanced", Value, "cachesize",
+        translate("<abbr title=\"Domain Name System\">DNS</abbr> Cache size"),
+        translate("Set size of DNS Cache"))
+
+cs.optional = true
+cs.datatype = "uinteger"
+cs.placeholder = 150
 
 s:taboption("tftp", Flag, "enable_tftp",
 	translate("Enable TFTP server")).optional = true

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -247,8 +247,16 @@ if hwtype == "mac80211" then
 		end
 	end
 
+	noscan=s:taboption("advanced", Flag, "noscan", translate("Force 40MHz mode"),"Always use 40MHz channels even if the secondary channel overlaps. Using this option does not comply with IEEE 802.11n-2009!")
+        noscan.optional = true
+
 	s:taboption("advanced", Value, "frag", translate("Fragmentation Threshold"))
 	s:taboption("advanced", Value, "rts", translate("RTS/CTS Threshold"))
+
+	beacon_int = s:taboption("advanced", Value, "beacon_int", translate("Beacon Interval"),"(15 - 65535)")
+        beacon_int.optional = true
+        beacon_int.placeholder = 100
+
 end
 
 
@@ -488,6 +496,16 @@ if hwtype == "mac80211" then
 
 	ifname = s:taboption("advanced", Value, "ifname", translate("Interface name"), translate("Override default interface name"))
 	ifname.optional = true
+
+	short_preamble = s:taboption("general", Flag, "short_preamble", translate("Short Preamble"))
+        short_preamble.default = short_preamble.enabled
+
+        dtim_period = s:taboption("general", Value, "dtim_period", translate("DTIM Interval"),"Delivery Traffic Indication Message Interval")
+        dtim_period.optional = true
+        dtim_period.placeholder = 2
+
+        disassoc_low_ack = s:taboption("general", Flag, "disassoc_low_ack", translate("Disassociate On Low Acknowledgement"),"Allow AP mode to disconnect STAs based on low ACK condition")
+        disassoc_low_ack.default = disassoc_low_ack.enabled
 end
 
 

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/index.htm
@@ -16,6 +16,9 @@
 
 	local sysinfo = luci.util.ubus("system", "info") or { }
 	local boardinfo = luci.util.ubus("system", "board") or { }
+	local cpuinfo = luci.sys.exec("cat /proc/cpuinfo") or {}
+	local processor = cpuinfo:match("system type\t+: ([^\n]+)") or cpuinfo:match("model name\t+: ([^\n]+)") or { }
+	local march = cpuinfo:match("cpu model\t+: ([^\n]+)") or cpuinfo:match("Hardware\t+: ([^\n]+)") or { }
 	local unameinfo = nixio.uname() or { }
 
 	local meminfo = sysinfo.memory or {
@@ -682,6 +685,8 @@
 	<table width="100%" cellspacing="10">
 		<tr><td width="33%"><%:Hostname%></td><td><%=luci.sys.hostname() or "?"%></td></tr>
 		<tr><td width="33%"><%:Model%></td><td><%=pcdata(boardinfo.model or boardinfo.system or "?")%></td></tr>
+		<tr><td width="33%"><%:Processor%></td><td><%=pcdata(processor or "?")%></td></tr>
+		<tr><td width="33%"><%:Architecture%></td><td><%=pcdata(march or "?")%></td></tr>
 		<tr><td width="33%"><%:Firmware Version%></td><td>
 			<%=pcdata(ver.distname)%> <%=pcdata(ver.distversion)%> /
 			<%=pcdata(ver.luciname)%> (<%=pcdata(ver.luciversion)%>)


### PR DESCRIPTION
This allows setting cache size (defaults to 150) and flag to query all available upstream servers to admin_network dhcp page.
Original patch found at https://github.com/gwlim/mips24k-ar71xx-lede-patch/blob/lede-17.01/patch/063-add-DNS-cachesize-option.patch
Signed-off-by: Daniel Petre contact@superwrt.download