### PR TITLE
wireguard: add dependency to luci-proto-wireguard

### DIFF
--- a/applications/luci-app-wireguard/Makefile
+++ b/applications/luci-app-wireguard/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=WireGuard Status
-LUCI_DEPENDS:=+wireguard-tools +kmod-wireguard
+LUCI_DEPENDS:=+wireguard-tools +kmod-wireguard +luci-proto-wireguard
 LUCI_PKGARCH:=all
 
 PKG_MAINTAINER:=Dan Luedtke <mail@danrl.com>


### PR DESCRIPTION
Installing luci-app-wireguard should also install luci-proto-wireguard, to have it as an protocol for interface setup.

Signed-off-by: Sven Roederer <devel-sven@geroedel.de>