### PR TITLE
luci-mod-admin-full: fix switch_status for material theme

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/switch_status.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/switch_status.htm
@@ -3,6 +3,12 @@
 	XHR.poll(5, '<%=url('admin/network/switch_status')%>/' + switches.join(','), null,
 		function(x, st)
 		{
+			var el = document.getElementsByClassName('cbi-section-table-descr');
+			for(var i = 0; i < el.length; i++){
+				if (el[i].style.display == 'none')
+					el[i].style.display = ''
+			}
+
 			for (var i = 0; i < switches.length; i++)
 			{
 				var ports = st[switches[i]];


### PR DESCRIPTION
The material-theme hides all empty cbi-section-table-descr tr's by default.
So unhide it when the port-status information is inserted.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>