### PR TITLE
luci-app-travelmate: made "ignore bssid" flag conditional

### DIFF
--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
@@ -26,16 +26,20 @@ m.hidden = {
 	wpa_version = http.formvalue("wpa_version")
 }
 
-if m.hidden.ssid ~= "" then
+if m.hidden.ssid == "" then
+	wssid = m:field(Value, "ssid", translate("SSID (hidden)"))
+else
 	wssid = m:field(Value, "ssid", translate("SSID"))
 	wssid.datatype = "rangelength(1,32)"
 	wssid.default = m.hidden.ssid or ""
-else
-	wssid = m:field(Value, "ssid", translate("SSID (hidden)"))
 end
 
 nobssid = m:field(Flag, "no_bssid", translate("Ignore BSSID"))
-nobssid.default = nobssid.enabled
+if m.hidden.ssid == "" then
+	nobssid.default = nobssid.disabled
+else
+	nobssid.default = nobssid.enabled
+end
 
 bssid = m:field(Value, "bssid", translate("BSSID"))
 bssid:depends("no_bssid", 0)


### PR DESCRIPTION
* made the "ignore bssid" flag conditional to ease connection to hidden networks:
    * default for hidden networks "disabled"
    * default for all others "enabled"

Signed-off-by: Dirk Brenken <dev@brenken.org>