### PR TITLE
luci-mod-admin-full: add igmp snooping option

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
@@ -272,6 +272,11 @@ if not net:is_virtual() then
 		translate("Enables the Spanning Tree Protocol on this bridge"))
 	stp:depends("type", "bridge")
 	stp.rmempty = true
+
+	igmp = s:taboption("physical", Flag, "igmp_snooping", translate("Enable <abbr title=\"Internet Group Management Protocol\">IGMP</abbr> snooping"),
+		translate("Enables IGMP snooping on this bridge"))
+	igmp:depends("type", "bridge")
+	igmp.rmempty = true
 end
 
 


### PR DESCRIPTION
Adds the option to configure IGMP snooping on a bridge. An useful addition for people with IPTV, since IGMP snooping is disabled by default in OpenWrt/Lede.