### PR TITLE
luci-app-statistics: backport completed support for apcups plugin

### DIFF
--- a/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
+++ b/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
@@ -23,6 +23,7 @@ function index()
 		s_general	= _("General plugins"),
 		s_network	= _("Network plugins"),
 
+		apcups		= _("APC UPS"),
 		conntrack	= _("Conntrack"),
 		contextswitch	= _("Context Switches"),
 		cpu			= _("Processor"),
@@ -59,8 +60,8 @@ function index()
 	-- our collectd menu
 	local collectd_menu = {
 		output  = { "csv", "network", "rrdtool", "unixsock" },
-		general = { "contextswitch", "cpu", "cpufreq", "df", "disk", "email",
-			"entropy", "exec", "irq", "load", "memory",
+		general = { "apcups", "contextswitch", "cpu", "cpufreq", "df",
+			"disk", "email", "entropy", "exec", "irq", "load", "memory",
 			"nut", "processes", "sensors", "thermal", "uptime" },
 		network = { "conntrack", "dns", "interface", "iptables",
 			"netlink", "olsrd", "openvpn", "ping",

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua
@@ -1,0 +1,28 @@
+-- Copyright 2015 Jo-Philipp Wich <jow@openwrt.org>
+-- Licensed to the public under the Apache License 2.0.
+
+m = Map("luci_statistics",
+	translate("APCUPS Plugin Configuration"),
+	translate(
+		"The APCUPS plugin collects statistics about the APC UPS."
+	))
+
+-- collectd_apcups config section
+s = m:section( NamedSection, "collectd_apcups", "luci_statistics" )
+
+-- collectd_apcups.enable
+enable = s:option( Flag, "enable", translate("Enable this plugin") )
+enable.default = 0
+
+-- collectd_apcups.host (Host)
+host = s:option( Value, "Host", translate("Monitor host"), translate ("Add multiple hosts separated by space."))
+host.default = "localhost"
+host:depends( "enable", 1 )
+
+-- collectd_apcups.port (Port)
+port = s:option( Value, "Port", translate("Port for apcupsd communication") )
+port.isinteger = true
+port.default   = 3551
+port:depends( "enable", 1 )
+
+return m

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
@@ -1,0 +1,101 @@
+-- Copyright 2015 Jo-Philipp Wich <jow@openwrt.org>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.statistics.rrdtool.definitions.apcups",package.seeall)
+
+function rrdargs( graph, plugin, plugin_instance, dtype )
+
+	local voltages = {
+		title = "%H: Voltages on APC UPS ",
+		vlabel = "V",
+		number_format = "%5.1lfV",
+		data = {
+			instances = {
+				voltage = { "battery", "input", "output" }
+			},
+
+			options = {
+				voltage_output  = { color = "00e000", title = "Output voltage", noarea=true, overlay=true },
+				voltage_battery = { color = "0000ff", title = "Battery voltage", noarea=true, overlay=true },
+				voltage_input   = { color = "ffb000", title = "Input voltage", noarea=true, overlay=true }
+			}
+		}
+	}
+
+	local percentload = {
+		title = "%H: Load on APC UPS ",
+		vlabel = "Percent",
+		y_min = "0",
+		y_max = "100",
+		number_format = "%5.1lf%%",
+		data = {
+			sources = {
+				percent_load = { "value" }
+			},
+			instances = {
+				percent = "load"
+			},
+			options = {
+				percent_load = { color = "00ff00", title = "Load level"  }
+			}
+		}
+	}
+
+	local charge_percent = {
+		title = "%H: Battery charge on APC UPS ",
+		vlabel = "Percent",
+		y_min = "0",
+		y_max = "100",
+		number_format = "%5.1lf%%",
+		data = {
+			types = { "charge" },
+			options = {
+				charge = { color = "00ff0b", title = "Charge level"  }
+			}
+		}
+	}
+
+	local temperature = {
+		title = "%H: Battery temperature on APC UPS ",
+		vlabel = "\176C",
+		number_format = "%5.1lf\176C",
+		data = {
+			types = { "temperature" },
+			options = {
+				temperature = { color = "ffb000", title = "Battery temperature" } }
+		}
+	}
+
+	local timeleft = {
+		title = "%H: Time left on APC UPS ",
+		vlabel = "Minutes",
+		number_format = "%.1lfm",
+		data = {
+			sources = {
+				timeleft = { "value" }
+			},
+			options = {
+				timeleft = { color = "0000ff", title = "Time left" }
+			}
+		}
+	}
+
+	local frequency = {
+		title = "%H: Incoming line frequency on APC UPS ",
+		vlabel = "Hz",
+		number_format = "%5.0lfhz",
+		data = {
+			sources = {
+				frequency_input = { "value" }
+			},
+			instances = {
+				frequency = "frequency"
+			},
+			options = {
+				frequency_frequency = { color = "000fff", title = "Line frequency" }
+			}
+		}
+	}
+
+	return { voltages, percentload, charge_percent, temperature, timeleft, frequency }
+end

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
@@ -5,18 +5,34 @@ module("luci.statistics.rrdtool.definitions.apcups",package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
 
-	local voltages = {
-		title = "%H: Voltages on APC UPS ",
-		vlabel = "V",
+	local voltagesdc = {
+		title = "%H: Voltages on APC UPS - Battery",
+		vlabel = "Volts DC",
+    alt_autoscale = true,
 		number_format = "%5.1lfV",
 		data = {
 			instances = {
-				voltage = { "battery", "input", "output" }
+				voltage = { "battery" }
+			},
+
+			options = { 
+				voltage = { title = "Battery voltage", noarea=true }
+			}
+		}
+	}
+	
+	local voltages = {
+		title = "%H: Voltages on APC UPS - AC",
+		vlabel = "Volts AC",
+		alt_autoscale = true,
+		number_format = "%5.1lfV",
+		data = {
+			instances = {
+				voltage = {  "input", "output" }
 			},
 
 			options = {
 				voltage_output  = { color = "00e000", title = "Output voltage", noarea=true, overlay=true },
-				voltage_battery = { color = "0000ff", title = "Battery voltage", noarea=true, overlay=true },
 				voltage_input   = { color = "ffb000", title = "Input voltage", noarea=true, overlay=true }
 			}
 		}
@@ -97,5 +113,5 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		}
 	}
 
-	return { voltages, percentload, charge_percent, temperature, timeleft, frequency }
+	return { voltages, voltagesdc, percentload, charge_percent, temperature, timeleft, frequency }
 end

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
@@ -3,25 +3,80 @@
 
 module("luci.statistics.rrdtool.definitions.apcups",package.seeall)
 
-function rrdargs( graph, plugin, plugin_instance, dtype )
+function rrdargs( graph, plugin, plugin_instance )
+
+	local lu = require("luci.util")
+	local rv = { }
+
+	-- Types and instances supported by APC UPS
+	-- e.g. ups_types -> { 'timeleft', 'charge', 'percent', 'voltage' }
+	-- e.g. ups_inst['voltage'] -> { 'input', 'battery' }
+
+	local ups_types = graph.tree:data_types( plugin, plugin_instance )
+
+	local ups_inst = {}
+	for _, t in ipairs(ups_types) do
+		ups_inst[t] = graph.tree:data_instances( plugin, plugin_instance, t )
+	end
+
+
+    -- Check if hash table or array is empty or nil-filled
+
+	local function empty( t )
+		for _, v in pairs(t) do
+			if type(v) then return false end
+		end
+		return true
+	end
+
+
+	-- Append graph definition but only types/instances which are
+	-- supported and available to the plugin and UPS.
+
+	local function add_supported( t, defs )
+		local def_inst = defs['data']['instances']
+
+		if type(def_inst) == "table" then
+			for k, v in pairs( def_inst ) do
+				if lu.contains( ups_types, k) then
+					for j = #v, 1, -1 do
+						if not lu.contains( ups_inst[k], v[j] ) then
+							table.remove( v, j )
+						end
+					end
+					if #v == 0 then
+						def_inst[k] = nil  -- can't assign v: immutable
+					end
+				else
+					def_inst[k] = nil  -- can't assign v: immutable
+				end
+			end
+			if empty(def_inst) then return end
+		end
+		table.insert( t, defs )
+	end
+
+
+    -- Graph definitions for APC UPS measurements MUST use only 'instances':
+    -- e.g. instances = { voltage = {  "input", "output" } }
 
 	local voltagesdc = {
 		title = "%H: Voltages on APC UPS - Battery",
 		vlabel = "Volts DC",
-    alt_autoscale = true,
+		alt_autoscale = true,
 		number_format = "%5.1lfV",
 		data = {
 			instances = {
 				voltage = { "battery" }
 			},
-
-			options = { 
+			options = {
 				voltage = { title = "Battery voltage", noarea=true }
 			}
 		}
 	}
-	
-	local voltages = {
+	add_supported( rv, voltagesdc )
+
+	local voltagesac = {
 		title = "%H: Voltages on APC UPS - AC",
 		vlabel = "Volts AC",
 		alt_autoscale = true,
@@ -30,13 +85,13 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 			instances = {
 				voltage = {  "input", "output" }
 			},
-
 			options = {
 				voltage_output  = { color = "00e000", title = "Output voltage", noarea=true, overlay=true },
 				voltage_input   = { color = "ffb000", title = "Input voltage", noarea=true, overlay=true }
 			}
 		}
 	}
+	add_supported( rv, voltagesac )
 
 	local percentload = {
 		title = "%H: Load on APC UPS ",
@@ -45,17 +100,15 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		y_max = "100",
 		number_format = "%5.1lf%%",
 		data = {
-			sources = {
-				percent_load = { "value" }
-			},
 			instances = {
-				percent = "load"
+				percent = { "load" }
 			},
 			options = {
 				percent_load = { color = "00ff00", title = "Load level"  }
 			}
 		}
 	}
+	add_supported( rv, percentload )
 
 	local charge_percent = {
 		title = "%H: Battery charge on APC UPS ",
@@ -64,54 +117,59 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		y_max = "100",
 		number_format = "%5.1lf%%",
 		data = {
-			types = { "charge" },
+			instances = {
+				charge = { "" }
+			},
 			options = {
 				charge = { color = "00ff0b", title = "Charge level"  }
 			}
 		}
 	}
+	add_supported( rv, charge_percent )
 
 	local temperature = {
 		title = "%H: Battery temperature on APC UPS ",
 		vlabel = "\176C",
 		number_format = "%5.1lf\176C",
 		data = {
-			types = { "temperature" },
+			instances = {
+				temperature = { "" }
+			},
 			options = {
 				temperature = { color = "ffb000", title = "Battery temperature" } }
 		}
 	}
+	add_supported( rv, temperature )
 
 	local timeleft = {
 		title = "%H: Time left on APC UPS ",
 		vlabel = "Minutes",
 		number_format = "%.1lfm",
 		data = {
-			sources = {
-				timeleft = { "value" }
+			instances = {
+				timeleft = { "" }
 			},
 			options = {
 				timeleft = { color = "0000ff", title = "Time left" }
 			}
 		}
 	}
+	add_supported( rv, timeleft )
 
 	local frequency = {
 		title = "%H: Incoming line frequency on APC UPS ",
 		vlabel = "Hz",
 		number_format = "%5.0lfhz",
 		data = {
-			sources = {
-				frequency_input = { "value" }
-			},
 			instances = {
-				frequency = "frequency"
+				frequency = { "input" }
 			},
 			options = {
-				frequency_frequency = { color = "000fff", title = "Line frequency" }
+				frequency_input = { color = "000fff", title = "Line frequency" }
 			}
 		}
 	}
+	add_supported( rv, frequency )
 
-	return { voltages, voltagesdc, percentload, charge_percent, temperature, timeleft, frequency }
+	return rv
 end

--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -49,6 +49,11 @@ config statistics 'collectd_unixsock'
 
 # input plugins
 
+config statistics 'collectd_apcups'
+	option enable '0'
+	option Host 'localhost'
+	option Port '3551'
+
 config statistics 'collectd_conntrack'
 	option enable '0'
 

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -255,6 +255,12 @@ end
 
 
 plugins = {
+	apcups = {
+		{ "Host", "Port" },
+		{ },
+		{ }
+	},
+
 	collectd = {
 		{ "BaseDir", "Include", "PIDFile", "PluginDir", "TypesDB", "Interval", "ReadThreads", "Hostname" },
 		{ },


### PR DESCRIPTION
### Description:
OpenWRT/LEDE support for APC UPSes has been partial, including only the collectd
apcups plugin. The related lua code has been developed on `lede-17.01` and added
to `master` over several months, and this change backports those improvements.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
Tested-on: LEDE-17.01.4 / ar71xx / UPS: Back-UPS ES_650

### Notes:
@hnyman I've taken the liberty of following up on this [conversation](https://github.com/openwrt/luci/pull/1653#issuecomment-373888724) from #1653 and proposing the backport PR. The commits are all straight cherry-picks, and the resulting affected code is identical between `master` and `lede-17.01` branches.

For reference, pinging @bobmseagithub and @stephengeorgewest as interested parties, and noting this change addresses #1412 on LEDE stable.

Kind regards,
Tony