### PR TITLE
luci-mod-admin-full: backport add missing "isolate" option for mac80211

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -535,6 +535,10 @@ if hwtype == "mac80211" then
 	wmm:depends({mode="ap-wds"})
 	wmm.default = wmm.enabled
 
+	isolate = s:taboption("advanced", Flag, "isolate", translate("Isolate Clients"), translate("Prevents client-to-client communication"))
+	isolate:depends({mode="ap"})
+	isolate:depends({mode="ap-wds"})
+
 	ifname = s:taboption("advanced", Value, "ifname", translate("Interface name"), translate("Override default interface name"))
 	ifname.optional = true
 end


### PR DESCRIPTION
@dibdot Following our discussion in #1659, I'd like to propose backporting this nearly year-old change from `master`. It helps improve consistency across HW for the GUI, and exposes a widely used security feature for easier use. 

Based on my own non-Luci usage and the [comments](https://github.com/openwrt/luci/pull/1140#issuecomment-298299068) from PR #1140, the capability has been available in mac80211 for a few years now.

Tested on: LEDE-17.01.4 / ar71xx