### PR TITLE
luci-base/network.lua: fix get_interface function

### DIFF
--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -629,7 +629,7 @@ function get_interface(self, i)
 	if _interfaces[i] or _wifi_iface(i) then
 		return interface(i)
 	else
-		local netid = _wifi_netid_by_netname(i)
+		local netid = _wifi_netid_by_sid(i)
 		return netid and interface(netid)
 	end
 end


### PR DESCRIPTION
* fix wrong private function call to handle
  section id as parameter (fix for #1687)

Signed-off-by: Dirk Brenken <dev@brenken.org>