### PR TITLE
luci-app-fwknop:  backport a check to not overwrite user configured keys

### DIFF
--- a/applications/luci-app-fwknopd/Makefile
+++ b/applications/luci-app-fwknopd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Fwknopd config - web config for the firewall knock daemon
 LUCI_DEPENDS:=+fwknopd +qrencode
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPLv2
 PKG_MAINTAINER:=Jonathan Bennett <JBennett@incomsystems.biz>
 include ../../luci.mk

--- a/applications/luci-app-fwknopd/root/etc/uci-defaults/40_luci-fwknopd
+++ b/applications/luci-app-fwknopd/root/etc/uci-defaults/40_luci-fwknopd
@@ -3,6 +3,7 @@
 #-- Licensed to the public under the GNU General Public License v2.
 . /lib/functions/network.sh
 
+[ "$(uci -q get fwknopd.@access[0].KEY)" != "CHANGEME" ] && exit 0
 uci batch <<EOF
 	add ucitrack fwknopd
 	set ucitrack.@fwknopd[-1].init=fwknopd


### PR DESCRIPTION
Maintainer: @jp-bennett 

Since its initial inclusion in `lede-17.01`, package `luci-app-fwknopd` suffers from a bug which wipes existing credentials (key/hmac) on upgrade, and may result in loss of remote access for users.  This change backports the simple fix from `master`. Thanks for reviewing!

Tested on: LEDE 17.01.4 / ar71xx