### PR TITLE
luci-lib-nixio: restored tls provider menu in makefile and fixed cyassl support

### DIFF
--- a/libs/luci-lib-nixio/Makefile
+++ b/libs/luci-lib-nixio/Makefile
@@ -10,6 +10,44 @@ LUCI_TITLE:=NIXIO POSIX library
 LUCI_DEPENDS:=+PACKAGE_luci-lib-nixio_openssl:libopenssl +PACKAGE_luci-lib-nixio_cyassl:libcyassl +liblua
 
 PKG_LICENSE:=Apache-2.0
+define Package/luci-lib-nixio/config
+	choice
+		prompt "TLS Provider"
+		default PACKAGE_luci-lib-nixio_notls
+
+		config PACKAGE_luci-lib-nixio_notls
+			bool "Disabled"
+
+		config PACKAGE_luci-lib-nixio_axtls
+			bool "Builtin (axTLS)"
+
+		config PACKAGE_luci-lib-nixio_cyassl
+			bool "CyaSSL"
+			select PACKAGE_libcyassl
+
+		config PACKAGE_luci-lib-nixio_openssl
+			bool "OpenSSL"
+			select PACKAGE_libopenssl
+	endchoice
+endef
+
+NIXIO_TLS:=
+
+ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_axtls),)
+  NIXIO_TLS:=axtls
+endif
+
+ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_openssl),)
+  NIXIO_TLS:=openssl
+endif
+
+ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_cyassl),)
+  NIXIO_TLS:=cyassl
+  #LUCI_CFLAGS+=-I$(STAGING_DIR)/usr/include/cyassl
+  $(warning POPIPOPIAA)
+endif
+
+MAKE_EXTRA_VARS := NIXIO_TLS="$(NIXIO_TLS)"
 
 define Package/luci-lib-nixio/config
 	choice
@@ -50,5 +88,6 @@ endif
 MAKE_VARS += NIXIO_TLS="$(NIXIO_TLS)"
 
 include ../../luci.mk
+
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/libs/luci-lib-nixio/src/Makefile
+++ b/libs/luci-lib-nixio/src/Makefile
@@ -35,6 +35,7 @@ ifeq ($(NIXIO_TLS),cyassl)
 	TLS_DEPENDS = cyassl-compat.o
 	TLS_CFLAGS = -include cyassl-compat.h
 	NIXIO_OBJ += cyassl-compat.o
+	NIXIO_CFLAGS+=-I$(STAGING_DIR)/usr/include/cyassl
 endif
 
 ifeq ($(NIXIO_TLS),)

--- a/libs/luci-lib-nixio/src/cyassl-compat.c
+++ b/libs/luci-lib-nixio/src/cyassl-compat.c
@@ -1,5 +1,6 @@
 #include "cyassl-compat.h"
 
+#ifndef WOLFSSL_MD5_H_
 int MD5_Init(MD5_CTX *md5) {
 	InitMd5(md5);
 	return 1;
@@ -14,7 +15,9 @@ int MD5_Final(void *input, MD5_CTX *md5) {
 	Md5Final(md5, input);
 	return 1;
 }
+#endif
 
+#ifndef WOLFSSL_SHA_H_
 int SHA1_Init(SHA_CTX *sha) {
 	InitSha(sha);
 	return 1;
@@ -29,3 +32,4 @@ int SHA1_Final(void *input, SHA_CTX *sha) {
 	ShaFinal(sha, input);
 	return 1;
 }
+#endif

--- a/libs/luci-lib-nixio/src/cyassl-compat.h
+++ b/libs/luci-lib-nixio/src/cyassl-compat.h
@@ -4,17 +4,23 @@
 
 typedef unsigned int word32;
 
-
+#ifndef WOLFSSL_MD5_H_
 #define MD5_DIGEST_LENGTH 16
 typedef struct MD5_CTX {
     int dummy[24];
 } MD5_CTX;
 
+int MD5_Init(MD5_CTX *md5);
+int MD5_Update(MD5_CTX *md5, void *input, unsigned long sz);
+int MD5_Final(void *input, MD5_CTX *md5);
+
 void InitMd5(MD5_CTX*);
 void Md5Update(MD5_CTX*, void*, word32);
 void Md5Final(MD5_CTX*, void*);
+#endif
 
 
+#ifndef WOLFSSL_SHA_H_
 #define SHA_DIGEST_LENGTH 20
 typedef struct SHA_CTX {
     int dummy[24];
@@ -24,9 +30,7 @@ void InitSha(SHA_CTX*);
 void ShaUpdate(SHA_CTX*, void*, word32);
 void ShaFinal(SHA_CTX*, void*);
 
-int MD5_Init(MD5_CTX *md5);
-int MD5_Update(MD5_CTX *md5, void *input, unsigned long sz);
-int MD5_Final(void *input, MD5_CTX *md5);
 int SHA1_Init(SHA_CTX *md5);
 int SHA1_Update(SHA_CTX *sha, void *input, unsigned long sz);
 int SHA1_Final(void *input, SHA_CTX *sha);
+#endif

--- a/luci.mk
+++ b/luci.mk
@@ -147,7 +147,7 @@ endef
 
 ifneq ($(wildcard ${CURDIR}/src/Makefile),)
  MAKE_PATH := src/
- MAKE_VARS += FPIC="$(FPIC)" LUCI_VERSION="$(PKG_VERSION)" LUCI_GITBRANCH="$(PKG_GITBRANCH)"
+ MAKE_VARS += FPIC="$(FPIC)" LUCI_VERSION="$(PKG_VERSION)" LUCI_GITBRANCH="$(PKG_GITBRANCH)" $(MAKE_EXTRA_VARS)
 
  define Build/Compile
 	$(call Build/Compile/Default,clean compile)


### PR DESCRIPTION
This PR has 2 fixes:
The first is just a makefile change that restores nixio ability to make https requests using openssl or cyassl.
The second fixes nixio's cyassl support with new wolfssl version.

The change is tested OK with 3 settings: notls, openssl and cyassl.
