### PR TITLE
luci-proto-ppp: add translation to ipv6 handling

### DIFF
--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua
@@ -18,13 +18,13 @@ password = section:taboption("general", Value, "password", translate("PAP/CHAP p
 password.password = true
 
 if luci.model.network:has_ipv6() then
-
-        ipv6 = section:taboption("advanced", ListValue, "ipv6")
-        ipv6:value("auto", translate("Automatic"))
-        ipv6:value("0", translate("Disabled"))
-        ipv6:value("1", translate("Manual"))
-        ipv6.default = "auto"
-
+	ipv6 = section:taboption("advanced", ListValue, "ipv6",
+		translate("Obtain IPv6-Address"),
+		translate("Enable IPv6 negotiation on the PPP link"))
+	ipv6:value("auto", translate("Automatic"))
+	ipv6:value("0", translate("Disabled"))
+	ipv6:value("1", translate("Manual"))
+	ipv6.default = "auto"
 end
 
 defaultroute = section:taboption("advanced", Flag, "defaultroute",

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua
@@ -30,13 +30,13 @@ password.password = true
 
 
 if luci.model.network:has_ipv6() then
-
-        ipv6 = section:taboption("advanced", ListValue, "ipv6")
-        ipv6:value("auto", translate("Automatic"))
-        ipv6:value("0", translate("Disabled"))
-        ipv6:value("1", translate("Manual"))
-        ipv6.default = "auto"
-
+	ipv6 = section:taboption("advanced", ListValue, "ipv6",
+		translate("Obtain IPv6-Address"),
+		translate("Enable IPv6 negotiation on the PPP link"))
+	ipv6:value("auto", translate("Automatic"))
+	ipv6:value("0", translate("Disabled"))
+	ipv6:value("1", translate("Manual"))
+	ipv6.default = "auto"
 end
 
 

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua
@@ -36,13 +36,13 @@ password.password = true
 
 
 if luci.model.network:has_ipv6() then
-
-        ipv6 = section:taboption("advanced", ListValue, "ipv6")
-        ipv6:value("auto", translate("Automatic"))
-        ipv6:value("0", translate("Disabled"))
-        ipv6:value("1", translate("Manual"))
-        ipv6.default = "auto"
-
+	ipv6 = section:taboption("advanced", ListValue, "ipv6",
+		translate("Obtain IPv6-Address"),
+		translate("Enable IPv6 negotiation on the PPP link"))
+	ipv6:value("auto", translate("Automatic"))
+	ipv6:value("0", translate("Disabled"))
+	ipv6:value("1", translate("Manual"))
+	ipv6.default = "auto"
 end
 
 

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua
@@ -30,13 +30,13 @@ service.placeholder = translate("auto")
 
 
 if luci.model.network:has_ipv6() then
-
-        ipv6 = section:taboption("advanced", ListValue, "ipv6")
-        ipv6:value("auto", translate("Automatic"))
-        ipv6:value("0", translate("Disabled"))
-        ipv6:value("1", translate("Manual"))
-        ipv6.default = "auto"
-
+	ipv6 = section:taboption("advanced", ListValue, "ipv6",
+		translate("Obtain IPv6-Address"),
+		translate("Enable IPv6 negotiation on the PPP link"))
+	ipv6:value("auto", translate("Automatic"))
+	ipv6:value("0", translate("Disabled"))
+	ipv6:value("1", translate("Manual"))
+	ipv6.default = "auto"
 end
 
 


### PR DESCRIPTION
If there is no translation set, then on the material theme the dropdown
selection is displaced. To fix this add an translation to this dropdown.

The commit also changes source code whitespace shifting.
