### PR TITLE
luci-mod-admin-full: allow setting dns cachesize

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -212,6 +212,12 @@ cq.optional = true
 cq.datatype = "uinteger"
 cq.placeholder = 150
 
+cs = s:taboption("advanced", Value, "cachesize",
+        translate("Size of dnsmasq query cache"),
+        translate("Maximum number of dnsmasq cached entries"))
+cs.optional = true
+cs.datatype = "uinteger"
+cs.placeholder = 150
 
 s:taboption("tftp", Flag, "enable_tftp",
 	translate("Enable TFTP server")).optional = true


### PR DESCRIPTION
In the case of more powerful routers the default
cachesizevalue == 150 is too small and can easily
be extended to 1,000's and 10,000's of entries.
It makes sense to make it easy configurable.

Tested on Netgear R7800
Signed-off-by: Marc Benoit <marcb62185@gmail.com>