### PR TITLE
luci-app-travelmate: bring back cbi element to wifi_add.lua

### DIFF
--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
@@ -34,14 +34,18 @@ end
 wssid.datatype = "rangelength(1,32)"
 wssid.default = m.hidden.ssid or ""
 
+nobssid = m:field(Flag, "no_bssid", translate("Ignore BSSID"))
+if m.hidden.ssid == "" then
+	nobssid.default = nobssid.disabled
+else
+	nobssid.default = nobssid.enabled
+end
+
 bssid = m:field(Value, "bssid", translate("BSSID"),
 	translatef("The BSSID information '%s' is optional and only required for hidden networks", m.hidden.bssid or ""))
+bssid:depends("no_bssid", 0)
 bssid.datatype = "macaddr"
-if m.hidden.ssid == "" then
-	bssid.default = m.hidden.bssid or ""
-else
-	bssid.default = ""
-end
+bssid.default = m.hidden.bssid or ""
 
 if (tonumber(m.hidden.wep) or 0) == 1 then
 	encr = m:field(ListValue, "encryption", translate("Encryption"))


### PR DESCRIPTION
* b00b676 fixed the cbi initialization for SimpleForm, therefore bring
  back "Ignore BSSID" flag with dependent input field

Signed-off-by: Dirk Brenken <dev@brenken.org>