### PR TITLE
luci-app-olsr: handle empty result for non-status tables

### DIFF
--- a/applications/luci-app-olsr/luasrc/controller/olsr.lua
+++ b/applications/luci-app-olsr/luasrc/controller/olsr.lua
@@ -379,9 +379,9 @@ function fetch_jsoninfo(otable)
 
 	if jsonreq4 ~= "" then
 		has_v4 = 1
-		jsondata4 = json.decode(jsonreq4)
+		jsondata4 = json.decode(jsonreq4) or {}
 		if otable == 'status' then
-			data4 = jsondata4 or {}
+			data4 = jsondata4
 		else
 			data4 = jsondata4[otable] or {}
 		end
@@ -393,9 +393,9 @@ function fetch_jsoninfo(otable)
 	end
 	if jsonreq6 ~= "" then
 		has_v6 = 1
-		jsondata6 = json.decode(jsonreq6)
+		jsondata6 = json.decode(jsonreq6) or {}
 		if otable == 'status' then
-			data6 = jsondata6 or {}
+			data6 = jsondata6
 		else
 			data6 = jsondata6[otable] or {}
 		end


### PR DESCRIPTION
The response of the jsoninfo request may be non-empty (e.g. a linebreak
or just whitespace), but still yield "nil" after "json.decode".
This situation was handled before for the "status" request, but it lead
to a dictionary access against a "nil" value for all other tables.