### PR TITLE
luci-app-openvpn getPid() returns always nil

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
@@ -26,7 +26,7 @@ uci:foreach( "openvpn_recipes", "openvpn_recipe",
 )
 
 function s.getPID(section) -- Universal function which returns valid pid # or nil
-	local pid = sys.exec("%s | grep -w '[o]penvpn(%s)'" % { psstring, section })
+	local pid = sys.exec("%s | grep -w '[o]penvpn(%s)' | awk '{print $1}'" % { psstring, section })
 	if pid and #pid > 0 then
 		return tonumber(pid:match("^%d+"))
 	else

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
@@ -26,9 +26,9 @@ uci:foreach( "openvpn_recipes", "openvpn_recipe",
 )
 
 function s.getPID(section) -- Universal function which returns valid pid # or nil
-	local pid = sys.exec("%s | grep -w '[o]penvpn(%s)' | awk '{print $1}'" % { psstring, section })
+	local pid = sys.exec("%s | grep -w '[o]penvpn(%s)'" % { psstring, section })
 	if pid and #pid > 0 then
-		return tonumber(pid:match("^%d+"))
+		return tonumber(pid:match("%d+"))
 	else
 		return nil
 	end


### PR DESCRIPTION
getPid function can't return pid of openvpn process, instead of pid returns nil.