### PR TITLE
luci-mod-admin-full: limit dns cachesize to 10000

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -214,9 +214,9 @@ cq.placeholder = 150
 
 cs = s:taboption("advanced", Value, "cachesize",
 	translate("Size of DNS query cache"),
-	translate("Maximum number of cached DNS entries"))
+	translate("Number of cached DNS entries (max is 10000, 0 is no caching)"))
 cs.optional = true
-cs.datatype = "uinteger"
+cs.datatype = "range(0,10000)"
 cs.placeholder = 150
 
 s:taboption("tftp", Flag, "enable_tftp",


### PR DESCRIPTION
The value of cachesize is hardcoded to 10000 in
dnsmasq-2.79/src/option.c to 10000 max

    case 'c':  /* --cache-size */
      {
        int size;

        if (!atoi_check(arg, &size))
          ret_err(gen_err);
        else
          {
            /* zero is OK, and means no caching. */

            if (size < 0)
              size = 0;
            else if (size > 10000)
              size = 10000;

            daemon->cachesize = size;
          }
        break;
      }

Tested on Netgear R7800
Signed-off-by: Marc Benoit <marcb62185@gmail.com>