### PR TITLE
luci-base: show wifi chip identification on overview

### DIFF
--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -1428,7 +1428,7 @@ function wifidev.hwmodes(self)
 end
 
 function wifidev.get_i18n(self)
-	local t = "Generic"
+	local t = self.iwinfo.hardware_name or "Generic"
 	if self.iwinfo.type == "wl" then
 		t = "Broadcom"
 	end


### PR DESCRIPTION
@jow-   Need you opinion on this. I am not sure how expensive the extra call to iwinfo is here.

Show the correct wifi chip identification in case iwinfo recognises the chip.

So far the wifidev.get_i18n function has practically always returned just "Generic", but use iwinfo.hardware_name to fetch the name.

In case the default "Generic MAC80211" is returned from iwinfo, use just "Generic" to avoid double 80211 in the final string.

----

Until now, the network/wireless page has shown the correct ID, but the frontpage overview has shown just "Generic mac80211...".

References:
* iwinfo returns "Generic MAC80211" by default, leading into a need of polishing the output a bit. https://git.openwrt.org/?p=project/iwinfo.git;a=blob;f=iwinfo_nl80211.c;h=de5d2b4baabb3772d2a0ea70915a33ec667dabb1;hb=HEAD#l2773
  (note that the same polishing should likely be done for network/wireless, where the double output 80211 can be seen, as the both iwinfo and LuCI get_i18n add 80211 to the final string in case the chip is not recognised)
   https://github.com/openwrt/luci/blob/ac2210376dd294f7a69589de79ea5f4845787db5/modules/luci-base/luasrc/model/network.lua#L1430
* call to iwinfo.hardware_name in network/wireless: https://github.com/openwrt/luci/blob/2685855d778f8ca55a5c88a24779dfa1dca78c48/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_overview.htm#L35


Overview page:
![image](https://user-images.githubusercontent.com/7926856/38777509-c29da636-40b1-11e8-9235-97f80be7e293.png)

If the chip is unknown, the output is as earlier "Generic mac80211..."
![image](https://user-images.githubusercontent.com/7926856/38777514-e107d33a-40b1-11e8-84c0-47d54b534b18.png)


Double 80211, which is not corrected by this change.
![image](https://user-images.githubusercontent.com/7926856/38777554-d8aa63aa-40b2-11e8-8d80-ffa7b512a920.png)

