### PR TITLE
Removed retired nameserver 213.73.91.35 from the Freifunk profiles

### DIFF
--- a/contrib/package/community-profiles/files/etc/config/profile_berlin
+++ b/contrib/package/community-profiles/files/etc/config/profile_berlin
@@ -33,7 +33,7 @@ config 'defaults' 'ssidscheme'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
-	option 'dns' '85.214.20.141 213.73.91.35 194.150.168.168 2001:4ce8::53 2001:910:800::12'
+	option 'dns' '85.214.20.141 194.150.168.168 2001:4ce8::53 2001:910:800::12'
 
 config 'dhcp' 'dhcp'
 	option leasetime '5m'

--- a/contrib/package/community-profiles/files/etc/config/profile_cottbus
+++ b/contrib/package/community-profiles/files/etc/config/profile_cottbus
@@ -31,7 +31,7 @@ config 'defaults' 'ssidscheme'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
-	option 'dns' '85.214.20.141 213.73.91.35 194.150.168.168 2001:4ce8::53 2001:910:800::12'
+	option 'dns' '85.214.20.141 194.150.168.168 2001:4ce8::53 2001:910:800::12'
 
 config 'dhcp' 'dhcp'
 	option 'leasetime' '5m'

--- a/contrib/package/community-profiles/files/etc/config/profile_potsdam
+++ b/contrib/package/community-profiles/files/etc/config/profile_potsdam
@@ -11,7 +11,7 @@ config 'community' 'profile'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.0.0'
-	option 'dns' '85.214.20.141 213.73.91.35 194.150.168.168'
+	option 'dns' '85.214.20.141 194.150.168.168'
 	option 'delegate' '0'
 
 config 'defaults' 'wifi_device'

--- a/contrib/package/community-profiles/files/etc/config/profile_tulumlibre
+++ b/contrib/package/community-profiles/files/etc/config/profile_tulumlibre
@@ -7,4 +7,4 @@ config 'community' 'profile'
 	option 'splash_prefix' '28'
 
 config 'defaults' 'interface'
-	option 'dns' '213.73.91.35 216.87.84.211'
+	option 'dns' '216.87.84.211'


### PR DESCRIPTION
See issue openwrt/luci#1757

Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>