### PR TITLE
ff_olsr_watchdog: delete stale tunnels

### DIFF
--- a/contrib/package/freifunk-common/files/usr/sbin/ff_olsr_watchdog
+++ b/contrib/package/freifunk-common/files/usr/sbin/ff_olsr_watchdog
@@ -23,6 +23,15 @@ if fs.access("/var/run/olsrd.pid") or fs.access("/var/run/olsrd4.pid") then
 
 		if not wdgtime or ( systime - wdgtime ) > ( intv * 2 ) then
 			os.execute("logger -t 'OLSR watchdog' 'Process died - restarting!'")
+			local tnls = io.popen("ip tunnel show | cut -d : -f 1")
+			while true do
+				tnl = tnls:read("*line")
+				if tnl == nil then break end
+				if string.find(tnl, "tnl_") == 1 then
+					os.execute(string.format("logger -t 'OLSR watchdog' 'Deleting stale tunnel %s'", tnl))
+					os.execute(string.format("ip link del %s", tnl))
+				end
+			end
 			os.execute("/etc/init.d/olsrd restart")
 		end
 	end


### PR DESCRIPTION
When OLSRd crashes, the old tunnels still exist.  This can lead to unexpected behaviour.
The tunnels to be removed start with "tnl_"

See freifunk-berlin/firmware#522