### PR TITLE
luci-mod-admin-full: fix non working page

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
@@ -49,12 +49,12 @@ local function txpower_list(iw)
 	local _, val
 	for _, val in ipairs(list) do
 		local dbm = val.dbm + off
-		local mw  = math.floor(10 ^ (dbm / 10))
-		if mw ~= prev then
-			prev = mw
+		local mw = math.floor(10 ^ ( dbm/10 ))
+		if val.dbm ~= prev then
+			prev = val.dbm
 			new[#new+1] = {
 				display_dbm = dbm,
-				display_mw  = mw,
+				display_mw  = not tostring(mw):match("%.") and mw or nil,
 				driver_dbm  = val.dbm,
 				driver_mw   = val.mw
 			}
@@ -213,8 +213,8 @@ if hwtype == "mac80211" then
 
 		tp:value("", translate("auto"))
 		for _, p in ipairs(tx_power_list) do
-			tp:value(p.driver_dbm, "%i dBm (%i mW)"
-				%{ p.display_dbm, p.display_mw })
+			tp:value(p.driver_dbm, "%i dBm (%s mW)"
+				%{ p.display_dbm, p.display_mw or "Can't convert to"})
 		end
 	end
 

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab/mount.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab/mount.lua
@@ -59,7 +59,7 @@ o = mount:taboption("general", Value, "uuid", translate("UUID"),
 o:value("", translate("-- match by uuid --"))
 
 for i, d in ipairs(devices) do
-	if d.uuid and d.size then
+	if d.uuid and d.size and not tostring(d.size):match("%.") then
 		o:value(d.uuid, "%s (%s, %d MB)" %{ d.uuid, d.dev, d.size })
 	elseif d.uuid then
 		o:value(d.uuid, "%s (%s)" %{ d.uuid, d.dev })
@@ -75,7 +75,7 @@ o:value("", translate("-- match by label --"))
 o:depends("uuid", "")
 
 for i, d in ipairs(devices) do
-	if d.label and d.size then
+	if d.label and d.size and not tostring(d.size):match("%.") then
 		o:value(d.label, "%s (%s, %d MB)" %{ d.label, d.dev, d.size })
 	elseif d.label then
 		o:value(d.label, "%s (%s)" %{ d.label, d.dev })
@@ -91,7 +91,7 @@ o:value("", translate("-- match by device --"))
 o:depends({ uuid = "", label = "" })
 
 for i, d in ipairs(devices) do
-	if d.size then
+	if d.size and not tostring(d.size):match("%.") then
 		o:value(d.dev, "%s (%d MB)" %{ d.dev, d.size })
 	else
 		o:value(d.dev)

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab/swap.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/fstab/swap.lua
@@ -41,7 +41,11 @@ o = mount:taboption("general", Value, "device", translate("Device"),
 	translate("The device file of the memory or partition (<abbr title=\"for example\">e.g.</abbr> <code>/dev/sda1</code>)"))
 
 for i, d in ipairs(devices) do
-	o:value(d, size[d] and "%s (%s MB)" % {d, size[d]})
+	if d and size[d] and not tostring(size[d]):match("%.") then
+		o:value(d, "%s (%s MB)" %{ d, size[d] })
+	elseif d then
+		o:value(d, "%s" % {d})
+	end
 end
 
 o = mount:taboption("advanced", Value, "uuid", translate("UUID"),

--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/packages.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/packages.htm
@@ -20,7 +20,14 @@ local space_total = fstat and fstat.blocks or 0
 local space_free  = fstat and fstat.bfree  or 0
 local space_used  = space_total - space_free
 
-local used_perc = math.floor(0.5 + ((space_total > 0) and ((100 / space_total) * space_used) or 100))
+local used_space_perc = math.floor(0.5 + ((space_total > 0) and ((100 / space_total) * space_used) or 100))
+
+local free_space_perc = tostring(100 - used_space_perc)
+
+if free_space_perc:match("%.") then
+	free_space_perc = free_space_perc:gsub("%..*","")
+end
+
 local free_byte = space_free * fstat.frsize
 
 local filter = { }
@@ -86,9 +93,9 @@ end
 				<% end %>
 
 				<div class="cbi-value cbi-value-last">
-					<%:Free space%>: <strong><%=(100-used_perc)%>%</strong> (<strong><%=wa.byte_format(free_byte)%></strong>)
+					<%:Free space%>: <strong><%=free_space_perc%>%</strong> (<strong><%=wa.byte_format(free_byte)%></strong>)
 					<div style="margin:3px 0; width:300px; height:10px; border:1px solid #000000; background-color:#80C080">
-						<div style="background-color:#F08080; border-right:1px solid #000000; height:100%; width:<%=used_perc%>%">&#160;</div>
+						<div style="background-color:#F08080; border-right:1px solid #000000; height:100%; width:<%=used_space_perc%>%">&#160;</div>
 					</div>
 				</div>
 			</fieldset>


### PR DESCRIPTION
This fix the error page in mount,wifi page and fix wrong % in package status page.
The code doesn't handle float value correctly. As some device return float disk size and some mW value are float, the page crash as except only integer value. This can be solved by displaying this float value in string type (%s) (and gain an unnecessary long number) or just remove all the char after the point. I also notice that math.floor require number with "," and not "." to actually return an integer.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>