### PR TITLE
freifunk-policyrouting: do not add to ucitrack multiple times

### DIFF
--- a/contrib/package/freifunk-policyrouting/Makefile
+++ b/contrib/package/freifunk-policyrouting/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-policyrouting
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-policyrouting/files/etc/uci-defaults/freifunk-policyrouting
+++ b/contrib/package/freifunk-policyrouting/files/etc/uci-defaults/freifunk-policyrouting
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+if [ "$(uci -q get ucitrack.@freifunk-policyrouting[-1].exec)" = "'/etc/init.d/freifunk-policyrouting restart'" ]
+        exit 0
+fi
+
 uci batch <<-EOF
         add ucitrack freifunk-policyrouting
         add_list ucitrack.@freifunk-policyrouting[-1].exec="/etc/init.d/freifunk-policyrouting restart"


### PR DESCRIPTION
Do not update ucitrack when the last list already has the correct option set. This prevents from adding the same items on every upgrade.

Signed-off-by: Sven Roederer <freifunk@it-solutions.geroedel.de>