### PR TITLE
luci-app-upnp: change leasefile location hint

### DIFF
--- a/applications/luci-app-upnp/luasrc/model/cbi/upnp/upnp.lua
+++ b/applications/luci-app-upnp/luasrc/model/cbi/upnp/upnp.lua
@@ -74,7 +74,7 @@ pu = s:taboption("advanced", Value, "presentation_url", translate("Presentation 
 pu.placeholder = "http://192.168.1.1/"
 
 lf = s:taboption("advanced", Value, "upnp_lease_file", translate("UPnP lease file"))
-lf.placeholder = "/var/log/upnp.leases"
+lf.placeholder = "/var/run/miniupnpd.leases"
 
 
 s2 = m:section(TypedSection, "perm_rule", translate("MiniUPnP ACLs"),


### PR DESCRIPTION
Change default leasefile hint from /var/log/upnp.leases to
/var/run/miniupnpd.leases

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>