### PR TITLE
luci-mod-admin-full: fix apply backup archive on invalid backup.tar.gz

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
@@ -341,9 +341,17 @@ function action_restore()
 
 	local upload = http.formvalue("archive")
 	if upload and #upload > 0 then
-		luci.template.render("admin_system/applyreboot")
-		os.execute("tar -C / -xzf %q >/dev/null 2>&1" % archive_tmp)
-		luci.sys.reboot()
+		if os.execute("gunzip -t %q >/dev/null 2>&1" % archive_tmp) == 0 then
+			luci.template.render("admin_system/applyreboot")
+			os.execute("tar -C / -xzf %q >/dev/null 2>&1" % archive_tmp)
+			luci.sys.reboot()
+		else
+			luci.template.render("admin_system/flashops", {
+				reset_avail   = supports_reset(),
+				upgrade_avail = supports_sysupgrade(),
+				backup_invalid = true
+			})
+		end
 		return
 	end
 

--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
@@ -46,13 +46,18 @@
 			<form class="inline" method="post" action="<%=url('admin/system/flashops/restore')%>" enctype="multipart/form-data">
 				<div class="cbi-value cbi-value-last">
 					<label class="cbi-value-title" for="archive"><%:Restore backup%>:</label>
-					<div class="cbi-value-field">
+					<div class="cbi-value-field<% if backup_invalid then %> cbi-value-error<% end %>">
 						<input type="hidden" name="token" value="<%=token%>" />
 						<input type="file" name="archive" id="archive" />
 						<input type="submit" class="cbi-button cbi-input-apply" name="restore" value="<%:Upload archive...%>" />
 					</div>
 				</div>
 			</form>
+			<% if backup_invalid then %>
+			<div class="cbi-section-error">
+				<%:Unable to apply damaged backup archive.%>
+			</div>
+			<% end %>
 		</div>
 		<% if reset_avail then %>
 		<div class="alert-message warning"><%:Custom files (certificates, scripts) may remain on the system. To prevent this, perform a factory-reset first.%></div>

--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
@@ -10,7 +10,7 @@
 
 <ul class="cbi-tabmenu">
 	<li class="cbi-tab"><a href="#"><%:Actions%></a></li>
-	<li class="cbi-tab-disabled"><a href="<%=REQUEST_URI%>/backupfiles"><%:Configuration%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url('admin/system/flashops/backupfiles')%>"><%:Configuration%></a></li>
 </ul>
 
 <fieldset class="cbi-section">


### PR DESCRIPTION
This PR includes two fixes.

- luci-mod-admin-full: check backup.tar.gz on apply

If an uploaded backup.tar.gz is not valid we will not get a respond from
LuCI. The system will perform a reboot without applying the "tar.gz"
even though the backup import failed.

To fix this check if the backup archive is valid with the command
"gunzip -t <archive>" and if the validation fails render the flashops page
with a hint. On the other hand apply the backup archive and perform a
reboot as before.

- luci-mod-admin-full: fix flashops url generation for config tab

If a firmware image is not valid then url generation for the config tab
is wrong. To fix this use the luci.dispatcher.build_url function.