### PR TITLE
luci-base: fix dispacher fail

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -364,7 +364,7 @@ function dispatch(request)
 					url[#url+1] = "?"
 					url[#url+1] = query
 				end
-				return table.concat(url, "")
+				return url[0] and table.concat(url, "") or ""
 			elseif key == "token" then
 				return ctx.authtoken
 			else


### PR DESCRIPTION
table.concat fail if url is empty. I found this specific condition while trying to add support for uwsgi, the only case this occur is in the initial login stage.
@jow- 
```
A runtime error occured: /usr/lib/lua/luci/dispatcher.lua:366: invalid value (nil) at index 1 in table for 'concat'
stack traceback:
        [C]: in function 'assert'
        /usr/lib/lua/luci/dispatcher.lua:509: in function 'dispatch'
        /usr/lib/lua/luci/dispatcher.lua:127: in function </usr/lib/lua/luci/dispatcher.lua:126>

```


Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>