### PR TITLE
luci-proto-3g: fix error on proto selection

### DIFF
--- a/protocols/luci-proto-3g/luasrc/model/network/proto_3g.lua
+++ b/protocols/luci-proto-3g/luasrc/model/network/proto_3g.lua
@@ -1,0 +1,49 @@
+-- Copyright 2018 Florian Eckert <fe@dev.tdt.de>
+-- Licensed to the public under the Apache License 2.0.
+
+local netmod = luci.model.network
+local interface = luci.model.network.interface
+
+local proto = netmod:register_protocol("3g")
+
+function proto.get_i18n(self)
+	return luci.i18n.translate("UMTS/GPRS/EV-DO")
+end
+
+function proto.ifname(self)
+	return "3g-" .. self.sid
+end
+
+function proto.get_interface(self)
+	return interface(self:ifname(), self)
+end
+
+function proto.is_installed(self)
+	return nixio.fs.access("/lib/netifd/proto/3g.sh")
+end
+
+function proto.opkg_package(self)
+	return "comgt"
+end
+
+function proto.is_floating(self)
+	return true
+end
+
+function proto.is_virtual(self)
+	return true
+end
+
+function proto.get_interfaces(self)
+	return nil
+end
+
+function proto.contains_interface(self, ifname)
+	if self:is_floating() then
+		return (netmod:ifnameof(ifc) == self:ifname())
+	else
+		return netmod.protocol.contains_interface(self, ifc)
+	end
+end
+
+netmod:register_pattern_virtual("^3g%-%w")

--- a/protocols/luci-proto-ppp/luasrc/model/network/proto_ppp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/network/proto_ppp.lua
@@ -4,7 +4,7 @@
 local netmod = luci.model.network
 
 local _, p
-for _, p in ipairs({"ppp", "pptp", "pppoe", "pppoa", "3g", "l2tp", "pppossh"}) do
+for _, p in ipairs({"ppp", "pptp", "pppoe", "pppoa", "l2tp", "pppossh"}) do
 
 	local proto = netmod:register_protocol(p)
 
@@ -13,8 +13,6 @@ for _, p in ipairs({"ppp", "pptp", "pppoe", "pppoa", "3g", "l2tp", "pppossh"}) d
 			return luci.i18n.translate("PPP")
 		elseif p == "pptp" then
 			return luci.i18n.translate("PPtP")
-		elseif p == "3g" then
-			return luci.i18n.translate("UMTS/GPRS/EV-DO")
 		elseif p == "pppoe" then
 			return luci.i18n.translate("PPPoE")
 		elseif p == "pppoa" then
@@ -33,8 +31,6 @@ for _, p in ipairs({"ppp", "pptp", "pppoe", "pppoa", "3g", "l2tp", "pppossh"}) d
 	function proto.opkg_package(self)
 		if p == "ppp" then
 			return p
-		elseif p == "3g" then
-			return "comgt"
 		elseif p == "pptp" then
 			return "ppp-mod-pptp"
 		elseif p == "pppoe" then
@@ -55,8 +51,6 @@ for _, p in ipairs({"ppp", "pptp", "pppoe", "pppoa", "3g", "l2tp", "pppossh"}) d
 			return (nixio.fs.glob("/usr/lib/pppd/*/rp-pppoe.so")() ~= nil)
 		elseif p == "pptp" then
 			return (nixio.fs.glob("/usr/lib/pppd/*/pptp.so")() ~= nil)
-		elseif p == "3g" then
-			return nixio.fs.access("/lib/netifd/proto/3g.sh")
 		elseif p == "l2tp" then
 			return nixio.fs.access("/lib/netifd/proto/l2tp.sh")
 		elseif p == "pppossh" then


### PR DESCRIPTION
If you select the proto 3g you will see the following error

>    Missing protocol extension for proto "3g"
>    cannot open /usr/lib/lua/luci/model/cbi/admin_network/proto_3g.lua: No such file or directory

To fix this move the 3g proto from luci-proto-ppp to luci-proto-3g and add the missing file proto_3g.lua under /model/network/.

I am open this PR again because the other discussion #1682 was not related to this topic anymore. As suggested by @yousong.