### PR TITLE
luci-app-ddns: remove block-loading function

### DIFF
--- a/applications/luci-app-ddns/luasrc/controller/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/controller/ddns.lua
@@ -29,7 +29,6 @@ local app_version = "2.4.9-1"
 function index()
 	local nxfs	= require "nixio.fs"		-- global definitions not available
 	local sys	= require "luci.sys"		-- in function index()
-	local ddns	= require "luci.tools.ddns"	-- ddns multiused functions
 	local muci	= require "luci.model.uci"
 
 	-- no config create an empty one


### PR DESCRIPTION
Load the massive ddns tools function adds 10s delay to luci interface, this cause every XHR requst that refresh every 5 second to fail. The "ddns" variable is not even used in index function, so it's just a waste of resource and cause lots of problem. By removing itall the delay problem are solved.

@jow-  another fix... remeber all my issue? well this was causing all the xhr error 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>