### PR TITLE
luci-app-ddns: improve performance

### DIFF
--- a/applications/luci-app-ddns/Makefile
+++ b/applications/luci-app-ddns/Makefile
@@ -16,7 +16,7 @@ PKG_VERSION:=2.4.9
 
 # Release == build
 # increase on changes of translation files
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/applications/luci-app-ddns/luasrc/controller/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/controller/ddns.lua
@@ -21,7 +21,6 @@ luci_helper = "/usr/lib/ddns/dynamic_dns_lucihelper.sh"
 
 local srv_name    = "ddns-scripts"
 local srv_ver_min = "2.7.7"			-- minimum version of service required
-local srv_ver_cmd = luci_helper .. [[ -V | awk {'print $2'}]]
 local app_name    = "luci-app-ddns"
 local app_title   = "Dynamic DNS"
 local app_version = "2.4.9-1"
@@ -29,7 +28,6 @@ local app_version = "2.4.9-1"
 function index()
 	local nxfs	= require "nixio.fs"		-- global definitions not available
 	local sys	= require "luci.sys"		-- in function index()
-	local ddns	= require "luci.tools.ddns"	-- ddns multiused functions
 	local muci	= require "luci.model.uci"
 
 	-- no config create an empty one
@@ -81,26 +79,41 @@ end
 
 -- Standardized application/service functions
 function app_title_main()
-	return	[[<a href="javascript:alert(']]
-			.. I18N.translate("Version Information")
-			.. [[\n\n]] .. app_name
-			.. [[\n\t]] .. I18N.translate("Version") .. [[:\t]] .. app_version
-			.. [[\n\n]] .. srv_name .. [[ ]] .. I18N.translate("required") .. [[:]]
-			.. [[\n\t]] .. I18N.translate("Version") .. [[:\t]]
-				.. srv_ver_min .. [[ ]] .. I18N.translate("or higher")
-			.. [[\n\n]] .. srv_name .. [[ ]] .. I18N.translate("installed") .. [[:]]
-			.. [[\n\t]] .. I18N.translate("Version") .. [[:\t]]
-				.. (service_version() or I18N.translate("NOT installed"))
-			.. [[\n\n]]
-	 	.. [[')">]]
-		.. I18N.translate(app_title)
-		.. [[</a>]]
+	tmp = {}
+	tmp[#tmp+1] = 	[[<a href="javascript:alert(']]
+	tmp[#tmp+1] = 		 I18N.translate("Version Information")
+	tmp[#tmp+1] = 		 [[\n\n]] .. app_name
+	tmp[#tmp+1] = 		 [[\n\t]] .. I18N.translate("Version") .. [[:\t]] .. app_version
+	tmp[#tmp+1] = 		 [[\n\n]] .. srv_name .. [[ ]] .. I18N.translate("required") .. [[:]]
+	tmp[#tmp+1] = 		 [[\n\t]] .. I18N.translate("Version") .. [[:\t]]
+	tmp[#tmp+1] = 			 srv_ver_min .. [[ ]] .. I18N.translate("or higher")
+	tmp[#tmp+1] = 		 [[\n\n]] .. srv_name .. [[ ]] .. I18N.translate("installed") .. [[:]]
+	tmp[#tmp+1] = 		 [[\n\t]] .. I18N.translate("Version") .. [[:\t]]
+	tmp[#tmp+1] = 			 (service_version() or I18N.translate("NOT installed"))
+	tmp[#tmp+1] = 		 [[\n\n]]
+	tmp[#tmp+1] = 	 [[')">]]
+	tmp[#tmp+1] = 	 I18N.translate(app_title)
+	tmp[#tmp+1] = 	 [[</a>]]
+		
+	return table.concat(tmp)
 end
 function service_version()
-	local ver = nil
 
+	local nxfs	= require "nixio.fs"
+
+	local ver = nil
+	local ver_helper
+	
+	if nxfs.access("/bin/opkg") then
+		ver_helper = "/bin/opkg info " .. srv_name .. " | grep 'Version'"
+	else
+		ver_helper = luci_helper .. " -V"
+	end
+	
+	local srv_ver_cmd = ver_helper .. " | awk {'print $2'} "
+	
 	ver = UTIL.exec(srv_ver_cmd)
-	if #ver > 0 then return ver end
+	if ver and #ver > 0 then return ver end
 
 	IPKG.list_installed(srv_name, function(n, v, d)
 			if v and (#v > 0) then ver = v end
@@ -108,6 +121,7 @@ function service_version()
 	)
 	return	ver
 end
+
 function service_ok()
 	return	IPKG.compare_versions((service_version() or "0"), ">=", srv_ver_min)
 end

--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua
@@ -48,7 +48,7 @@ if not SYS.init.enabled("ddns") then
 end
 
 -- No IPv6 support
-if not DDNS.has_ipv6 then
+if not DDNS.env_info("has_ipv6") then
 	local v6 = s:option(DummyValue, "_no_ipv6")
 	v6.titleref = 'http://www.openwrt.org" target="_blank'
 	v6.rawhtml  = true
@@ -60,7 +60,7 @@ if not DDNS.has_ipv6 then
 end
 
 -- No HTTPS support
-if not DDNS.has_ssl then
+if not DDNS.env_info("has_ssl") then
 	local sl = s:option(DummyValue, "_no_https")
 	sl.titleref = DISP.build_url("admin", "system", "packages")
 	sl.rawhtml  = true
@@ -74,7 +74,7 @@ if not DDNS.has_ssl then
 end
 
 -- No bind_network
-if not DDNS.has_bindnet then
+if not DDNS.env_info("has_bindnet") then
 	local bn = s:option(DummyValue, "_no_bind_network")
 	bn.titleref = DISP.build_url("admin", "system", "packages")
 	bn.rawhtml  = true
@@ -90,7 +90,7 @@ if not DDNS.has_bindnet then
 end
 
 -- currently only cURL possibly without proxy support
-if not DDNS.has_proxy then
+if not DDNS.env_info("has_proxy") then
 	local px = s:option(DummyValue, "_no_proxy")
 	px.titleref = DISP.build_url("admin", "system", "packages")
 	px.rawhtml  = true
@@ -104,7 +104,7 @@ if not DDNS.has_proxy then
 end
 
 -- "Force IP Version not supported"
-if not DDNS.has_forceip then
+if not DDNS.env_info("has_forceip") then
 	local fi = s:option(DummyValue, "_no_force_ip")
 	fi.titleref = DISP.build_url("admin", "system", "packages")
 	fi.rawhtml  = true
@@ -112,11 +112,11 @@ if not DDNS.has_forceip then
 		translate("Force IP Version not supported") .. bold_off
 	local value = translate("BusyBox's nslookup and Wget do not support to specify " ..
 				"the IP version to use for communication with DDNS Provider!")
-	if not (DDNS.has_wgetssl or DDNS.has_curl or DDNS.has_fetch) then
+	if not (DDNS.env_info("has_wgetssl") or DDNS.env_info("has_curl") or DDNS.env_info("has_fetch")) then
 		value = value .. "<br />- " ..
 			translate("You should install 'wget' or 'curl' or 'uclient-fetch' package.")
 	end
-	if not DDNS.has_bindhost then
+	if not DDNS.env_info("has_bindhost") then
 		value = value .. "<br />- " ..
 			translate("You should install 'bind-host' or 'knot-host' or 'drill' package for DNS requests.")
 	end
@@ -124,7 +124,7 @@ if not DDNS.has_forceip then
 end
 
 -- "DNS requests via TCP not supported"
-if not DDNS.has_bindhost then
+if not DDNS.env_info("has_bindhost") then
 	local dt = s:option(DummyValue, "_no_dnstcp")
 	dt.titleref = DISP.build_url("admin", "system", "packages")
 	dt.rawhtml  = true
@@ -137,7 +137,7 @@ if not DDNS.has_bindhost then
 end
 
 -- nslookup compiled with musl produce problems when using
-if not DDNS.has_dnsserver then
+if not DDNS.env_info("has_dnsserver") then
 	local ds = s:option(DummyValue, "_no_dnsserver")
 	ds.titleref = DISP.build_url("admin", "system", "packages")
 	ds.rawhtml  = true
@@ -151,7 +151,7 @@ if not DDNS.has_dnsserver then
 end
 
 -- certificates installed
-if DDNS.has_ssl and not DDNS.has_cacerts then
+if DDNS.env_info("has_ssl") and not DDNS.env_info("has_cacerts") then
 	local ca = s:option(DummyValue, "_no_certs")
 	ca.titleref = DISP.build_url("admin", "system", "packages")
 	ca.rawhtml  = true

--- a/applications/luci-app-ddns/luasrc/model/cbi/ddns/overview.lua
+++ b/applications/luci-app-ddns/luasrc/model/cbi/ddns/overview.lua
@@ -1,21 +1,20 @@
 -- Copyright 2014-2018 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 -- Licensed to the public under the Apache License 2.0.
 
-local NXFS = require "nixio.fs"
 local DISP = require "luci.dispatcher"
 local HTTP = require "luci.http"
 local SYS  = require "luci.sys"
 local CTRL = require "luci.controller.ddns"	-- this application's controller
 local DDNS = require "luci.tools.ddns"		-- ddns multiused functions
 
-local show_hints = not (DDNS.has_ipv6		-- IPv6 support
-		    and DDNS.has_ssl		-- HTTPS support
-		    and DDNS.has_proxy		-- Proxy support
-		    and DDNS.has_bindhost	-- DNS TCP support
-		    and DDNS.has_forceip	-- Force IP version
-		    and DDNS.has_dnsserver	-- DNS server support
-		    and DDNS.has_bindnet	-- Bind to network/interface
-		    and DDNS.has_cacerts	-- certificates installed at /etc/ssl/certs
+local show_hints = not (DDNS.env_info("has_ipv6")		-- IPv6 support
+				   and  DDNS.env_info("has_ssl")		-- HTTPS support
+				   and  DDNS.env_info("has_proxy")		-- Proxy support
+				   and  DDNS.env_info("has_bindhost")	-- DNS TCP support
+				   and  DDNS.env_info("has_forceip")	-- Force IP version
+				   and  DDNS.env_info("has_dnsserver")	-- DNS server support
+				   and  DDNS.env_info("has_bindnet")	-- Bind to network/interface
+				   and  DDNS.env_info("has_cacerts")	-- certificates installed at /etc/ssl/certs
 		)
 local not_enabled = not SYS.init.enabled("ddns")
 local need_update = not CTRL.service_ok()


### PR DESCRIPTION
Every request directed to the ddns app call ddns tools module.
Ddns tools module have lots of global variable that call slow os.execute function. This adds 10 second to every ddns request even if the function that is requested doesn't need that global variable. This commit introduce env_info function that execute os.execute command by executing what is actually requested and not process all the variables. Also remove 2 unecessary module that are not used. More researh find that major slowdown was caused by the calling of ddns script for the version check. Now we check if opkg is present and use it to check ddns-scripts version.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>