### PR TITLE
luci-base: fix ipkg.info and ipkg.status

### DIFF
--- a/modules/luci-base/luasrc/model/ipkg.lua
+++ b/modules/luci-base/luasrc/model/ipkg.lua
@@ -95,11 +95,11 @@ end
 
 
 function info(pkg)
-	return _lookup("info", pkg)
+	return _lookup("info", pkg)[pkg]
 end
 
 function status(pkg)
-	return _lookup("status", pkg)
+	return _lookup("status", pkg)[pkg]
 end
 
 function install(...)


### PR DESCRIPTION
Currently this 2 function doesn't return a table but just the name of the package. From the documentation, this is wrong so let's return the right table filled with the value from opkg.

@jow- can you help me with this? i can't understand why use the c variable... think this function is pretty broke and not used by any package... Is it good this way? I tested with luci package that contain all possible value and works good (by creating a for loop and return a string of the content scanned). 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>