### PR TITLE
luci-app-firewall: expose flow offloading options

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/zones.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/zones.lua
@@ -3,6 +3,7 @@
 
 local ds = require "luci.dispatcher"
 local fw = require "luci.model.firewall"
+local fs = require "nixio.fs"
 
 local m, s, o, p, i, v
 
@@ -32,6 +33,28 @@ for i, v in ipairs(p) do
 	v:value("ACCEPT", translate("accept"))
 end
 
+-- Netfilter flow offload support
+
+local offload = fs.access("/sys/module/xt_FLOWOFFLOAD/refcnt")
+
+if offload then
+	s:option(DummyValue, "offload_advice",
+		translate("Routing/NAT Offloading"),
+		translate("Experimental feature. Not fully compatible with QoS/SQM."))
+
+	o = s:option(Flag, "flow_offloading",
+		translate("Software flow offloading"),
+		translate("Software based offloading for routing/NAT"))
+	o.optional = true
+
+	o = s:option(Flag, "flow_offloading_hw",
+		translate("Hardware flow offloading"),
+		translate("Requires hardware NAT support. Implemented at least for mt7621"))
+	o.optional = true
+	o:depends( "flow_offloading", 1)
+end
+
+-- Firewall zones
 
 s = m:section(TypedSection, "zone", translate("Zones"))
 s.template = "cbi/tblsection"


### PR DESCRIPTION
@nbd168 @jow- 
comments, please.

Is it sensible to expose the offloading options in LuCI?
 
I noticed on forum discussion that some people have even tried to make over-complex special LuCI apps for controlling the offloading, but now that the feature is in the normal firewall uci config in /etc/config/firewall, I see no need for a special LuCI app just for that.

Please give feedback if there should be more explanations or the proposed ones should be changed.

I did not try to craft kernel version (or offloading support) detection logic, but simply exposed the two options while mentioning that kernel 4.14 is required.

![image](https://user-images.githubusercontent.com/7926856/40574776-48a072a0-60e1-11e8-8423-5d255387884f.png)


