### PR TITLE
luci-app-firewall: Fix typo in forwards redirect

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/forwards.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/forwards.lua
@@ -54,7 +54,7 @@ function s.parse(self, ...)
 	if created then
 		m.uci:save("firewall")
 		luci.http.redirect(ds.build_url(
-			"admin/network/firewall/redirect", created
+			"admin/network/firewall/forwards", created
 		))
 	end
 end


### PR DESCRIPTION
When creating a forwarding rule with protocol set to other, a user is
forwarded to the configuration page. The URL for the configuration page
contained a typo - the user was forwarded to
admin/network/firewall/redirect/cfg... and not
admin/network/firewall/forwards/cfg..., leading to a 404.

Signed-off-by: Kristian Evensen <kristian.evensen@gmail.com>