### PR TITLE
Disable port fields when protocol is not one of TCP, UDP or TCP+UDP

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/forward-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/forward-details.lua
@@ -88,6 +88,10 @@ o.rmempty = true
 o.datatype = "neg(portrange)"
 o.placeholder = translate("any")
 
+o:depends("proto", "tcp")
+o:depends("proto", "udp")
+o:depends("proto", "tcp udp")
+
 
 o = s:option(Value, "src_dip",
 	translate("External IP address"),
@@ -107,6 +111,10 @@ o = s:option(Value, "src_dport", translate("External port"),
 	translate("Match incoming traffic directed at the given " ..
 		"destination port or port range on this host"))
 o.datatype = "neg(portrange)"
+
+o:depends("proto", "tcp")
+o:depends("proto", "udp")
+o:depends("proto", "tcp udp")
 
 
 
@@ -132,6 +140,10 @@ o = s:option(Value, "dest_port",
 		the internal host"))
 o.placeholder = translate("any")
 o.datatype = "portrange"
+
+o:depends("proto", "tcp")
+o:depends("proto", "udp")
+o:depends("proto", "tcp udp")
 
 
 o = s:option(Flag, "reflection", translate("Enable NAT Loopback"))

--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/rule-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/rule-details.lua
@@ -280,7 +280,10 @@ else
 	o = s:option(Value, "src_port", translate("Source port"))
 	o.datatype = "list(neg(portrange))"
 	o.placeholder = translate("any")
-
+  
+	o:depends("proto", "tcp")
+	o:depends("proto", "udp")
+	o:depends("proto", "tcp udp")
 
 	o = s:option(Value, "dest", translate("Destination zone"))
 	o.nocreate = true
@@ -302,6 +305,9 @@ else
 	o.datatype = "list(neg(portrange))"
 	o.placeholder = translate("any")
 
+	o:depends("proto", "tcp")
+	o:depends("proto", "udp")
+	o:depends("proto", "tcp udp")
 
 	o = s:option(ListValue, "target", translate("Action"))
 	o.default = "ACCEPT"

--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/rule-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/rule-details.lua
@@ -115,6 +115,10 @@ elseif rule_type == "redirect" then
 	o.datatype = "neg(portrange)"
 	o.placeholder = translate("any")
 
+	o:depends("proto", "tcp")
+	o:depends("proto", "udp")
+	o:depends("proto", "tcp udp")
+
 
 	o = s:option(Value, "dest", translate("Destination zone"))
 	o.nocreate = true
@@ -139,6 +143,10 @@ elseif rule_type == "redirect" then
 	o.placeholder = translate("any")
 	o.datatype = "neg(portrange)"
 
+	o:depends("proto", "tcp")
+	o:depends("proto", "udp")
+	o:depends("proto", "tcp udp")
+
 
 	o = s:option(Value, "src_dip",
 		translate("SNAT IP address"),
@@ -162,6 +170,10 @@ elseif rule_type == "redirect" then
 	o.datatype = "portrange"
 	o.rmempty = true
 	o.placeholder = translate('Do not rewrite')
+
+	o:depends("proto", "tcp")
+	o:depends("proto", "udp")
+	o:depends("proto", "tcp udp")
 
 
 	s:option(Value, "extra",
@@ -280,7 +292,7 @@ else
 	o = s:option(Value, "src_port", translate("Source port"))
 	o.datatype = "list(neg(portrange))"
 	o.placeholder = translate("any")
-  
+
 	o:depends("proto", "tcp")
 	o:depends("proto", "udp")
 	o:depends("proto", "tcp udp")


### PR DESCRIPTION
It's currently possible to generate nonsensical firewall rules by inputting combinations which include i) protocols other than UDP/TCP and ii) source and destination ports.
There is some discussion of the issue on the forum [here](https://forum.lede-project.org/t/if-you-set-the-protocol-to-any-the-resulting-iptables-rule-ignores-the-portspec/15191/15). 

This patch makes fields like `src_port` and `dest_port` depend on protocol being tcp, udp or "tcp udp" in the input, forwarding and source NAT forms.

Signed-off-by: Tom Hodder <tom@limepepper.co.uk>