### PR TITLE
luci-mod-admin-full: improve applyreboot page

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/applyreboot.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/applyreboot.htm
@@ -6,35 +6,46 @@
 
 <html>
 	<head>
-		<title><%=luci.sys.hostname()%> - <% if title then %><%=title%><% else %><%:Rebooting...%><% end %></title>
+		<title><%=luci.sys.hostname()%> - <%= title or translate("Rebooting...") %></title>
 		<link rel="stylesheet" type="text/css" media="screen" href="<%=media%>/cascade.css" />
 		<script type="text/javascript" src="<%=resource%>/xhr.js"></script>
 		<script type="text/javascript">//<![CDATA[
 			var interval = window.setInterval(function() {
 				var img = new Image();
-
+				var target = ('https:' == document.location.protocol ? 'https://' : 'http://') + <%=addr and "'%s'" % addr or "window.location.host"%>;
+		
 				img.onload = function() {
 					window.clearInterval(interval);
-					location.href = ('https:' == document.location.protocol ? 'https://' : 'http://') + '<%=addr or luci.http.getenv("SERVER_NAME")%>/';
 				};
-
-				img.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + '<%=addr or luci.http.getenv("SERVER_NAME")%><%=resource%>/icons/loading.gif?' + Math.random();
+				
+				img.src = target + '<%=resource%>/icons/loading.gif?' + Math.random();
+				
 			}, 5000);
 		//]]></script>
 	</head>
 	<body>
-		<div id="maincontainer">
-			<div id="maincontent">
-				<h2 name="content"><%:System%> - <% if title then %><%=title%><% else %><%:Rebooting...%><% end %></h2>
-				<fieldset class="cbi-section">
-					<p>
-						<% if msg then %><%=msg%><% else %><%:Changes applied.%><% end %>
-					</p>
-					<p>
-						<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle" />
-						<%:Waiting for changes to be applied...%>
-					</p>
-				</fieldset>
+		<header>
+			<div class="fill">
+				<div class="container">
+					<p class="brand"><%=luci.sys.hostname() or "?"%></p>
+				</div>
+			</div>
+		</header>
+		&#160;
+		<div class="main">
+			<div id="maincontainer">
+				<div id="maincontent" class="container">
+					<h2 name="content" style="margin: 2rem;"><%:System%> - <%= title or translate("Rebooting...") %></h2>
+					<fieldset class="cbi-section" style="margin: 2rem; line-height: 300%;">
+						<p>
+							<%= msg or translate("Changes applied.") %>
+						</p>
+						<p>
+							<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle" />
+							<%:Waiting for changes to be applied...%>
+						</p>
+					</fieldset>
+				</div>
 			</div>
 		</div>
 	</body>

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -23,11 +23,11 @@
  */
 @font-face {
     font-family: 'icomoon';
-    src: url('../fonts/font.eot');
-    src: url('../fonts/font.eot') format('embedded-opentype'),
-    url('../fonts/font.ttf') format('truetype'),
-    url('../fonts/font.woff') format('woff'),
-    url('../fonts/font.svg') format('svg');
+    src: url('fonts/font.eot');
+    src: url('fonts/font.eot') format('embedded-opentype'),
+    url('fonts/font.ttf') format('truetype'),
+    url('fonts/font.woff') format('woff'),
+    url('fonts/font.svg') format('svg');
     font-weight: normal;
     font-style: normal;
 }
@@ -285,12 +285,12 @@ header {
     color: white;
 }
 
-header > .container {
+header > .fill > .container {
     margin-top: 0.5rem;
     padding: 0.5rem 1rem 0 1rem;
 }
 
-header > .container > .brand {
+header > .fill > .container > .brand {
     font-size: 1.4rem;
     color: white;
     text-decoration: none;

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -203,7 +203,7 @@
 	<link rel="icon" href="<%=media%>/logo.png" sizes="144x144">
 	<link rel="apple-touch-icon-precomposed" href="<%=media%>/logo.png" sizes="144x144">
 
-	<link rel="stylesheet" href="<%=media%>/css/style.css">
+	<link rel="stylesheet" href="<%=media%>/cascade.css">
 	<link rel="shortcut icon" href="<%=media%>/favicon.ico">
 	<% if node and node.css then %>
 		<link rel="stylesheet" href="<%=resource%>/<%=node.css%>">
@@ -216,15 +216,17 @@
 </head>
 <body class="lang_<%=luci.i18n.context.lang%> <%- if node then %><%= striptags( node.title ) %><%- end %> <% if luci.dispatcher.context.authsession then %>logged-in<% end %>">
 <header>
-	<div class="container">
-		<span class="showSide"></span>
-		<a class="brand" href="#"><%=boardinfo.hostname or "?"%></a>
-		<div class="pull-right">
-			<% render_changes() %>
-			<span id="xhr_poll_status" style="display:none" onclick="XHR.running() ? XHR.halt() : XHR.run()">
-				<span class="label success" id="xhr_poll_status_on"><span class="mobile-hide"><%:Auto Refresh%></span> <%:on%></span>
-				<span class="label" id="xhr_poll_status_off" style="display:none"><span class="mobile-hide"><%:Auto Refresh%></span> <%:off%></span>
-			</span>
+	<div class="fill">
+		<div class="container">
+			<span class="showSide"></span>
+			<a class="brand" href="#"><%=boardinfo.hostname or "?"%></a>
+			<div class="pull-right">
+				<% render_changes() %>
+				<span id="xhr_poll_status" style="display:none" onclick="XHR.running() ? XHR.halt() : XHR.run()">
+					<span class="label success" id="xhr_poll_status_on"><span class="mobile-hide"><%:Auto Refresh%></span> <%:on%></span>
+					<span class="label" id="xhr_poll_status_off" style="display:none"><span class="mobile-hide"><%:Auto Refresh%></span> <%:off%></span>
+				</span>
+			</div>
 		</div>
 	</div>
 </header>


### PR DESCRIPTION
Currently applyreboot page lost the style and result in an empty page with some text. With this the page renders correctly. Also we fix problems when server address is broken by taking the ipaddr from the browser directly and we make the flash message more readable.

@jow-  think the only problem is the css part... didn't find a better way to hide it in a general way... 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>