### PR TITLE
luci-nginx: add nginx metapackages

### DIFF
--- a/collections/luci-nginx/Makefile
+++ b/collections/luci-nginx/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TYPE:=col
-LUCI_BASENAME:=luci
+LUCI_BASENAME:=nginx
 
-LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (default)
+LUCI_TITLE:=LuCI interface with Nginx as Webserver
 LUCI_DESCRIPTION:=Standard OpenWrt set including full admin with ppp support and the default Bootstrap theme
 LUCI_DEPENDS:= \
-	+uhttpd +uhttpd-mod-ubus +luci-mod-admin-full +luci-theme-bootstrap \
+	+nginx +luci-mod-admin-full +luci-theme-bootstrap \
 	+luci-app-firewall +luci-proto-ppp +libiwinfo-lua +IPV6:luci-proto-ipv6 \
 	+rpcd-mod-rrdns
 

--- a/collections/luci-ssl-nginx/Makefile
+++ b/collections/luci-ssl-nginx/Makefile
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2008-2016 The LuCI Team
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TYPE:=col
+LUCI_BASENAME:=ssl
+
+LUCI_TITLE:=LuCI with HTTPS support (mbedTLS as SSL backend)
+LUCI_DEPENDS:=+luci-nginx +libustream-mbedtls +px5g
+
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/collections/luci-ssl-openssl-nginx/Makefile
+++ b/collections/luci-ssl-openssl-nginx/Makefile
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2016 The LuCI Team
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TYPE:=col
+LUCI_BASENAME:=ssl-openssl
+
+LUCI_TITLE:=LuCI with HTTPS support (OpenSSL as SSL backend)
+LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
+ OpenSSL cmd tools (openssl-util) are used by uhttpd for SSL key generation \
+ instead of the default px5g. (If px5g is installed, uhttpd will prefer that.)
+
+LUCI_DEPENDS:=+luci-nginx +libustream-openssl +openssl-util
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
Permit to remove uhttpd dep if nginx package is selected

@jow-  any idea why i have this? By testing it the dep works correctly
(by unselecting nginx, uhttpd gets selected and viceversa)

```
Collecting package info: done
tmp/.config-package.in:40035:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:40035:   symbol PACKAGE_luci is selected by PACKAGE_luci-ssl
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:40072:   symbol PACKAGE_luci-ssl depends on PACKAGE_uhttpd
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:85327:   symbol PACKAGE_uhttpd is selected by PACKAGE_luci
```

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>