### PR TITLE
luci-app-adblock: partly revert last commit

### DIFF
--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
@@ -171,7 +171,7 @@ bl.template = "adblock/blocklist"
 name = bl:option(Flag, "enabled", translate("Enabled"))
 name.rmempty = false
 
-ssl = bl:option(DummyValue, "adb_src", translate("SSL&#160;req."))
+ssl = bl:option(DummyValue, "adb_src", translate("SSL req."))
 function ssl.cfgvalue(self, section)
 	local source = self.map:get(section, "adb_src")
 	if source and source:match("https://") then
@@ -183,7 +183,7 @@ end
 
 des = bl:option(DummyValue, "adb_src_desc", translate("Description"))
 
-cat = bl:option(DynamicList, "adb_src_cat", translate("Archive&#160;Categories"))
+cat = bl:option(DynamicList, "adb_src_cat", translate("Archive Categories"))
 cat.datatype = "uciname"
 cat.optional = true
 

--- a/applications/luci-app-adblock/luasrc/view/adblock/blocklist.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/blocklist.htm
@@ -35,6 +35,10 @@ end
 	line-height:20px;
 	height:20px;
 }
+.table.cbi-section-table .th
+{
+	white-space:nowrap;
+}
 .table.cbi-section-table input
 {
 	width:7em;


### PR DESCRIPTION
* use now CSS for non breaking spaces in div table header

Signed-off-by: Dirk Brenken <dev@brenken.org>