### PR TITLE
luci-mod-admin-full: fix empty SSH-Keys textarea issue

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/admin.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/admin.lua
@@ -104,16 +104,17 @@ end
 keys = s2:option(TextValue, "_data", "")
 keys.wrap    = "off"
 keys.rows    = 3
-keys.rmempty = false
 
 function keys.cfgvalue()
 	return fs.readfile("/etc/dropbear/authorized_keys") or ""
 end
 
 function keys.write(self, section, value)
-	if value then
-		fs.writefile("/etc/dropbear/authorized_keys", value:gsub("\r\n", "\n"))
-	end
+	return fs.writefile("/etc/dropbear/authorized_keys", value:gsub("\r\n", "\n"))
+end
+
+function keys.remove(self, section, value)
+	return fs.writefile("/etc/dropbear/authorized_keys", "")
 end
 
 end


### PR DESCRIPTION
If you delete all ssh keys in the textarea then LuCI will rais an error.
So if you added one ssh-key to the textarea and then you want to delete them
again that is not possbile in LuCI.
To fix this remove "rmempty" attribute and add a remove function which will
called if the textarea is empty.

This should fix https://github.com/openwrt/luci/issues/668