### PR TITLE
i18n: fix syntax errors in Ukrainian po

### DIFF
--- a/applications/luci-app-firewall/po/uk/firewall.po
+++ b/applications/luci-app-firewall/po/uk/firewall.po
@@ -11,9 +11,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
 "10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-msgid ""
-msgstr "Content-Type: text/plain; charset=UTF-8"
-
 msgid "%s in %s"
 msgstr "%s у %s"
 

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -11,9 +11,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
 "10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-msgid ""
-msgstr ""Content-Type: text/plain; charset=UTF-8"
-
 msgid "%.1f dB"
 msgstr "%.1f дБ"
 
@@ -203,7 +200,7 @@ msgstr "Поріг повторювання ARP"
 
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
-"<abbr title=\"Asynchronous Transfer Mode — асинхронний режим передавання"\">ATM</abbr>"
+"<abbr title=\"Asynchronous Transfer Mode — асинхронний режим передавання\">ATM</abbr>"
 
 msgid "ATM Bridges"
 msgstr "ATM-мости"


### PR DESCRIPTION
"Content-Type: text/plain; charset=UTF-8" was wrote twice in each
of base.po and firewall.po, and one was an incorrect place which
was the cause of the errors.

And, The escape in abbr HTML tag was incorrect, so I fixed it.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>