### PR TITLE
luci-mod-admin-full: fix connection lookup_queue

### DIFF
--- a/modules/luci-base/luasrc/sys.lua
+++ b/modules/luci-base/luasrc/sys.lua
@@ -340,6 +340,32 @@ function net.conntrack(callback)
 					if entry[key] == nil then
 						entry[key] = val
 					end
+					if entry["ptype"] == nil then
+						val = tonumber(val)
+						if key == "sport" then
+							if (val == 443) then
+								entry["ptype"] = "Https / SSL"
+							elseif val == 80 then
+								entry["ptype"] = "Http"
+							elseif val == 53 then
+								entry["ptype"] = "Dns"
+							elseif val == 22 then
+								entry["ptype"] = "SSH"
+							elseif val == 1900 then
+								entry["ptype"] = "UPnP"
+							elseif val == 123 then
+								entry["ptype"] = "NTP"
+							elseif val == 137 then
+								entry["ptype"] = "NetBIOS"
+							elseif val == 139 or val == 445 then
+								entry["ptype"] = "Samba"	
+							elseif val == 993 then
+								entry["ptype"] = "IMAP-SSL"
+							end
+						elseif (val >= 6902) and (val <= 6968) then
+								entry["ptype"] = "Torrent"
+						end
+					end
 				elseif val then
 					entry[key] = val
 				end

--- a/modules/luci-mod-admin-full/luasrc/view/admin_status/connections.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_status/connections.htm
@@ -131,15 +131,21 @@
 				}
 
 				label_scale.innerHTML = String.format('<%:(%d minute window, %d second interval)%>', data_wanted / 60, 3);
+				
+				var recheck_lookup_queue = {};
 
 				/* render datasets, start update interval */
 				XHR.poll(3, '<%=build_url("admin/status/realtime/connections_status")%>', null,
 					function(x, json)
 					{
-						var rows = [];
+
+						if (!json.connections)
+							return;
+
 						var conn = json.connections;
 
 						var lookup_queue = [ ];
+						var rows = [];
 
 						conn.sort(function(a, b) {
 							return b.bytes - a.bytes;
@@ -153,10 +159,10 @@
 							    (c.src == '::1'       && c.dst == '::1'))
 								continue;
 
-							if (!dns_cache[c.src])
+							if (!dns_cache[c.src] && lookup_queue.indexOf(c.src) == -1)
 								lookup_queue.push(c.src);
 
-							if (!dns_cache[c.dst])
+							if (!dns_cache[c.dst] && lookup_queue.indexOf(c.dst) == -1)
 								lookup_queue.push(c.dst);
 
 							var src = dns_cache[c.src] || (c.layer3 == 'ipv6' ? '[' + c.src + ']' : c.src);
@@ -165,22 +171,49 @@
 							rows.push([
 								c.layer3.toUpperCase(),
 								c.layer4.toUpperCase(),
-								src + ':' + c.sport,
-								dst + ':' + c.dport,
+								c.ptype,
+								[ src, c.sport ? ':' + c.sport : '' ],
+								[ dst, c.dport ? ':' + c.dport : '' ],
 								'%1024.2mB (%d <%:Pkts.%>)'.format(c.bytes, c.packets)
 							]);
 						}
 
 						cbi_update_table(conn_table, rows, '<em><%:No information available%></em>');
 
-						if (lookup_queue.length > 0)
-							XHR.get('<%=build_url("admin/status/nameinfo")%>/' + lookup_queue.slice(0, 100).join('/'), null,
-								function(x, json)
-								{
-									for (var addr in json)
-										dns_cache[addr] = json[addr];
+						if (lookup_queue.length > 0) {
+						  var reduced_lookup_queue = lookup_queue;
+						
+						  if (lookup_queue.length > 100)
+						  	reduced_lookup_queue = lookup_queue.slice(0, 100);							
+
+						  XHR.get('<%=build_url("admin/status/nameinfo")%>/' + reduced_lookup_queue.join('/'), null,
+						  	function(x, json)
+						  	{
+							  if (!json)
+								return;
+							
+							  for (var index in reduced_lookup_queue) {
+								var address = reduced_lookup_queue[index];
+								
+								if (!address)
+								  continue;
+								
+						  	    if (json[address]) {
+						  	      dns_cache[address] = json[address];
+						  	      lookup_queue.splice(reduced_lookup_queue.indexOf(address),1);
+								  continue;
 								}
-							);
+
+						  	    if(recheck_lookup_queue[address] > 2) {
+						  	      dns_cache[address] = (address.match(/:/)) ? '[' + address + ']' : address;
+						  	      lookup_queue.splice(index,1);
+						  	    } else {
+						  	      recheck_lookup_queue[address] != null ? recheck_lookup_queue[address]++ : recheck_lookup_queue[address] = 0;
+								}
+						  	  }
+						  	}
+						  );
+						}
 
 
 						var data = json.statistics;
@@ -359,6 +392,7 @@
 			<div class="tr table-titles">
 				<div class="th col-2 hide-xs"><%:Network%></div>
 				<div class="th col-2"><%:Protocol%></div>
+				<div class="th col-2"><%:Type%></div>
 				<div class="th col-7"><%:Source%></div>
 				<div class="th col-7"><%:Destination%></div>
 				<div class="th col-4"><%:Transfer%></div>


### PR DESCRIPTION
I notice that in the connection tab the lookup array keep checking all the entities everytime and adds to the dns_cache list only the resolved ones. This looks wrong as it's very unluckily that an addr thats not resolved in this instance gets resolved in the next one. This change how the dns_cache list works. We put in it every tried addr even if not resolved. Also this fix some error if for some reason the page doesn't receive the right data.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>