### PR TITLE
luci-nginx: add nginx support file

### DIFF
--- a/collections/luci-nginx/Makefile
+++ b/collections/luci-nginx/Makefile
@@ -12,7 +12,7 @@ LUCI_BASENAME:=nginx
 LUCI_TITLE:=LuCI interface with Nginx as Webserver
 LUCI_DESCRIPTION:=Standard OpenWrt set including full admin with ppp support and the default Bootstrap theme
 LUCI_DEPENDS:= \
-	+nginx +luci-mod-admin-full +luci-theme-bootstrap \
+	+nginx +nginx-mod-luci +luci-mod-admin-full +luci-theme-bootstrap \
 	+luci-app-firewall +luci-proto-ppp +libiwinfo-lua +IPV6:luci-proto-ipv6 \
 	+rpcd-mod-rrdns
 

--- a/collections/luci-ssl-nginx/Makefile
+++ b/collections/luci-ssl-nginx/Makefile
@@ -10,7 +10,7 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
 LUCI_TITLE:=LuCI with HTTPS support (mbedTLS as SSL backend)
-LUCI_DEPENDS:=+luci-nginx +libustream-mbedtls +px5g
+LUCI_DEPENDS:=+luci-nginx +nginx-mod-luci-ssl +libustream-mbedtls +px5g
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci-ssl-openssl-nginx/Makefile
+++ b/collections/luci-ssl-openssl-nginx/Makefile
@@ -14,7 +14,7 @@ LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
  OpenSSL cmd tools (openssl-util) are used by uhttpd for SSL key generation \
  instead of the default px5g. (If px5g is installed, uhttpd will prefer that.)
 
-LUCI_DEPENDS:=+luci-nginx +libustream-openssl +openssl-util
+LUCI_DEPENDS:=+luci-nginx +nginx-mod-luci-ssl +libustream-openssl +openssl-util
 
 include ../../luci.mk
 


### PR DESCRIPTION
This adds nginx-mod-luci as a dependency of this package.
@hnyman 
Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>