### PR TITLE
Add sort by signal feature to the wifi scanlist function

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_join.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_join.htm
@@ -80,7 +80,9 @@
 				end
 			end
 		end
-
+		
+		table.sort(l, function(a, b) return a.signal > b.signal end)
+		
 		return l
 	end
 -%>


### PR DESCRIPTION
It's common that people always want to join a better wireless network, so this sort by signal feature might be reasonable.