### PR TITLE
luci-app-lxc: small fixes & cosmetics

### DIFF
--- a/applications/luci-app-lxc/luasrc/model/cbi/lxc.lua
+++ b/applications/luci-app-lxc/luasrc/model/cbi/lxc.lua
@@ -16,7 +16,7 @@ Author: Petar Koretic <petar.koretic@sartura.hr>
 
 m = Map("lxc", translate("LXC Containers"),
 	translate("<b>Please note:</b> For LXC Containers you need a custom OpenWrt image.<br />")
-	.. translate("The image should include at least support for 'kernel cgroups', 'kernel namespaces' and 'miscellaneous LXC related options'."))
+	.. translate("The image should include at least support for 'kernel cgroups', 'kernel namespaces' and 'miscellaneous LXC related options' plus 'kmod-veth' for optional network support."))
 m:section(SimpleSection).template = "lxc"
 
 s = m:section(TypedSection, "lxc", translate("Options"))

--- a/applications/luci-app-lxc/luasrc/view/lxc.htm
+++ b/applications/luci-app-lxc/luasrc/view/lxc.htm
@@ -19,8 +19,8 @@ local nx     = require "nixio"
 local target = nx.uname().machine
 -%>
 
-<fieldset class="cbi-section">
-	<legend><%:Available Containers%></legend>
+<div class="cbi-section">
+	<h3><%:Available Containers%></h3>
 	<div class="cbi-section-node">
 		<div class="table cbi-section-table" id="t_lxc_list">
 			<div class="tr cbi-section-table-titles">
@@ -30,15 +30,15 @@ local target = nx.uname().machine
 			</div>
 		</div>
 	</div>
-</fieldset>
+</div>
 
-<fieldset class="cbi-section">
+<div class="cbi-section">
 	<span id="lxc-list-output"></span>
-</fieldset>
+</div>
 
 <hr />
-<fieldset class="cbi-section">
-	<legend><%:Create New Container%></legend>
+<div class="cbi-section">
+	<h3><%:Create New Container%></h3>
 	<div class="cbi-section-node">
 		<div class="table cbi-section-table" id="t_lxc_create">
 			<div class="tr cbi-section-table-titles">
@@ -56,11 +56,11 @@ local target = nx.uname().machine
 			</div>
 		</div>
 	</div>
-</fieldset>
+</div>
 
-<fieldset class="cbi-section">
+<div class="cbi-section">
 	<span id="lxc-add-output"></span>
-</fieldset>
+</div>
 
 <hr />
 


### PR DESCRIPTION
* backingstore support via ubus does not work, remove it for now
* fix target mapping for linuximages.org
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>