### PR TITLE
luci-app-ddns: fix recognizing nslookup tools

### DIFF
--- a/applications/luci-app-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/tools/ddns.lua
@@ -113,7 +113,7 @@ function env_info(type)
 			return has_hostip()
 		elseif type == "has_nslookup" then
 			return has_nslookup()
-		elseif tyep == "has_dnsserver" then
+		elseif type == "has_dnsserver" then
 			if has_bindhost() then return true end
 			if has_hostip() then return true end
 			if has_nslookup() then return true end


### PR DESCRIPTION
Fix typo in luci-app-ddns that causes recognition of alternative nslookup utilities to fail.

Closes issue #1914 @Ansuel 