### PR TITLE
luci-app-mwan3: fix aliased interfaces (@wan6)

### DIFF
--- a/applications/luci-app-mwan3/luasrc/controller/mwan3.lua
+++ b/applications/luci-app-mwan3/luasrc/controller/mwan3.lua
@@ -138,10 +138,12 @@ function diagnosticsData(interface, task)
 	local number = getInterfaceNumber(interface)
 
 	local uci = require "luci.model.uci".cursor(nil, "/var/state")
-	local device = uci:get("network", interface, "ifname")
+	local nw = require "luci.model.network".init()
+	local network = nw:get_network(interface)
+	local device = network and network:ifname()
 
 	luci.http.prepare_content("text/plain")
-	if device ~= "" then
+	if device then
 		if task == "ping_gateway" then
 			local gateway = get_gateway(interface)
 			if gateway ~= nil then


### PR DESCRIPTION
Attempting to do a diagnostic ping in mwan3 fails for interfaces that are aliased, such as @wan6 is to @wan.

Code is courtesy of @jow- (thank you) and tested & slightly fixed by myself. Issue #1918

@feckert