### PR TITLE
luci-proto-ppp: expose pppoe host_uniq tag setting

### DIFF
--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua
@@ -114,6 +114,14 @@ keepalive_interval.placeholder = "5"
 keepalive_interval.datatype    = "min(1)"
 
 
+host_uniq = section:taboption("advanced", Value, "host_uniq",
+	translate("Host-Uniq tag content"),
+	translate("Raw hex-encoded bytes. Leave empty unless your ISP require this"))
+
+host_uniq.placeholder = translate("auto")
+host_uniq.datatype    = "hex"
+
+
 demand = section:taboption("advanced", Value, "demand",
 	translate("Inactivity timeout"),
 	translate("Close inactive connection after the given amount of seconds, use 0 to persist connection"))


### PR DESCRIPTION
The host_uniq tag setting is supported by uci since CC15. It is actually the only setting that is not available within LuCi to support full internet service setup for some ISP to be completed by webui only.

The PPPoE RFC provide no upper bound to tag length, so its field datatype is unlimited length hex-encoded bytes string.

Signed-off-by: Luca Piccirillo <luca.piccirillo@gmail.com>