### PR TITLE
luci-mod-admin-full: Respect default wifi section names

### DIFF
--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -1476,11 +1476,24 @@ function wifidev.get_wifinets(self)
 	return nets
 end
 
-function wifidev.add_wifinet(self, options)
+function wifidev.get_num_wifinets(self)
+	local num_wifinets = 0
+
+	_uci:foreach("wireless", "wifi-iface",
+		function(s)
+			if s.device == self.sid then
+				num_wifinets = num_wifinets + 1
+			end
+		end)
+
+	return num_wifinets
+end
+
+function wifidev.add_wifinet(self, name, options)
 	options = options or { }
 	options.device = self.sid
 
-	local wnet = _uci:section("wireless", "wifi-iface", nil, options)
+	local wnet = _uci:section("wireless", "wifi-iface", name, options)
 	if wnet then
 		return wifinet(wnet, options)
 	end

--- a/modules/luci-mod-admin-full/luasrc/controller/admin/network.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/network.lua
@@ -190,7 +190,9 @@ function wifi_add()
 	dev = dev and ntm:get_wifidev(dev)
 
 	if dev then
-		local net = dev:add_wifinet({
+		local num_wifinets = dev:get_num_wifinets()
+		local wifinet_name = num_wifinets == 0 and "default_" .. dev.sid or nil
+		local net = dev:add_wifinet(wifinet_name, {
 			mode       = "ap",
 			ssid       = "OpenWrt",
 			encryption = "none"

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi_add.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi_add.lua
@@ -141,7 +141,7 @@ function newnet.parse(self, section)
 	else
 		wconf.network = net:name()
 
-		local wnet = wdev:add_wifinet(wconf)
+		local wnet = wdev:add_wifinet("default_" .. m.hidden.device, wconf)
 		if wnet then
 			if zone then
 				fw:del_network(net:name())


### PR DESCRIPTION
The default wifi-iface sections (the ones created by mac80211.sh) are
named "default_radioX". Respect this naming scheme when either replacing
the current wifi configuration, or when adding a network to a device
without any networks.

Signed-off-by: Kristian Evensen <kristian.evensen@gmail.com>