### PR TITLE
luci-base: network.lua: bridge information request functions fixes

### DIFF
--- a/modules/luci-compat/luasrc/model/network.lua
+++ b/modules/luci-compat/luasrc/model/network.lua
@@ -1447,6 +1447,7 @@ function interface.ports(self)
 		for _, iface in ipairs(members) do
 			ifaces[#ifaces+1] = interface(iface)
 		end
+		return ifaces
 	end
 end
 

--- a/modules/luci-compat/luasrc/model/network.lua
+++ b/modules/luci-compat/luasrc/model/network.lua
@@ -371,6 +371,7 @@ function init(cursor)
 					b.ifnames[1].bridge = b
 				end
 				_bridge[r[1]] = b
+				_interfaces[r[1]].bridge = b
 			elseif b then
 				b.ifnames[#b.ifnames+1] = _interfaces[r[2]]
 				b.ifnames[#b.ifnames].bridge = b
@@ -1452,16 +1453,16 @@ function interface.ports(self)
 end
 
 function interface.bridge_id(self)
-	if self.br then
-		return self.br.id
+	if self.dev and self.dev.bridge then
+		return self.dev.bridge.id
 	else
 		return nil
 	end
 end
 
 function interface.bridge_stp(self)
-	if self.br then
-		return self.br.stp
+	if self.dev and self.dev.bridge then
+		return self.dev.bridge.stp
 	else
 		return false
 	end
@@ -1480,7 +1481,8 @@ function interface.is_bridge(self)
 end
 
 function interface.is_bridgeport(self)
-	return self.dev and self.dev.bridge and true or false
+	return self.dev and self.dev.bridge and
+	       (self.dev.bridge.name != self:name()) and true or false
 end
 
 function interface.tx_bytes(self)


### PR DESCRIPTION
Fixes these bugs:

1. Functions interface.bridge_id() and interface.bridge_stp() uses self.br field
   that is not exists at all
2. Function interface.is_bridgeport() return true only for bridge interface, not for
   bridge port interfaces.
3. Function interface.ports() is not return anything
