### PR TITLE
luci-base: update and improve Russian translation

### DIFF
--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -3,12 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: LuCI: base\n"
 "POT-Creation-Date: 2010-05-09 01:01+0300\n"
-"PO-Revision-Date: 2018-07-17 01:48+0300\n"
+"PO-Revision-Date: 2018-07-17 11:24+0300\n"
 "Language-Team: http://cyber-place.ru\n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Vladimir aka sunny <picfun@ya.ru>\n"
+"Last-Translator: Anton Kikin <a.kikin@tano-systems.com>\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Language: ru\n"
@@ -16,10 +16,10 @@ msgstr ""
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
 msgid "%.1f dB"
-msgstr "%.1f dB"
+msgstr "%.1f дБ"
 
 msgid "%s is untagged in multiple VLANs!"
-msgstr "%s is untagged in multiple VLANs!"
+msgstr "%s не тегирован в множестве VLAN!"
 
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d минутное окно, %d секундный интервал)"
@@ -52,7 +52,7 @@ msgid "-- match by uuid --"
 msgstr "-- проверка по uuid --"
 
 msgid "-- please select --"
-msgstr ""
+msgstr "-- сделайте выбор --"
 
 msgid "1 Minute Load:"
 msgstr "Загрузка за 1 минуту:"
@@ -110,34 +110,34 @@ msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Расширенный идентификатор обслуживания\">ESSID</abbr>"
 
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"
-msgstr "<abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-Адрес"
+msgstr "<abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-адрес"
 
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Gateway"
-msgstr "<abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-Шлюз"
+msgstr "<abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-шлюз"
 
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Netmask"
-msgstr "<abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-Маска сети"
+msgstr "<abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-маска сети"
 
 msgid ""
 "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Address or Network "
 "(CIDR)"
 msgstr ""
-"<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-Адрес или Сеть (CIDR)"
+"<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-адрес или сеть (CIDR)"
 
 msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Gateway"
-msgstr "<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-Шлюз"
+msgstr "<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-шлюз"
 
 msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
-msgstr "<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-Суффикс (hex)"
+msgstr "<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-суффикс (hex)"
 
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Настройка <abbr title=\"Светодиод\">LED</abbr> индикации"
 
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Name"
-msgstr "<abbr title=\"Светодиод\">LED</abbr> Имя"
+msgstr "Имя <abbr title=\"Светодиод\">LED</abbr>"
 
 msgid "<abbr title=\"Media Access Control\">MAC</abbr>-Address"
-msgstr "<abbr title=\"Управление доступом к носителю\">MAC</abbr>-Адрес"
+msgstr "<abbr title=\"Управление доступом к носителю\">MAC</abbr>-адрес"
 
 msgid "<abbr title=\"The DHCP Unique Identifier\">DUID</abbr>"
 msgstr "<abbr title=\"Уникальный идентификатор DHCP\">DUID</abbr>"
@@ -189,16 +189,16 @@ msgid "ARP retry threshold"
 msgstr "Порог повтора ARP"
 
 msgid "ATM (Asynchronous Transfer Mode)"
-msgstr "ATM (Режим Асинхронной Передачи)"
+msgstr "ATM (режим асинхронной передачи)"
 
 msgid "ATM Bridges"
-msgstr "ATM Мосты"
+msgstr "ATM мосты"
 
 msgid "ATM Virtual Channel Identifier (VCI)"
-msgstr "ATM Идентификатор Виртуального Канала (VCI)"
+msgstr "ATM идентификатор виртуального канала (VCI)"
 
 msgid "ATM Virtual Path Identifier (VPI)"
-msgstr "ATM Идентификатор Виртуального Пути (VPI)"
+msgstr "ATM идентификатор виртуального пути (VPI)"
 
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
@@ -213,7 +213,7 @@ msgid "ATM device number"
 msgstr "ATM номер устройства"
 
 msgid "ATU-C System Vendor ID"
-msgstr "ATU-C System Vendor ID"
+msgstr "ATU-C идентификатор производителя"
 
 msgid "Access Concentrator"
 msgstr "Концентратор доступа"
@@ -225,10 +225,10 @@ msgid "Actions"
 msgstr "Действия"
 
 msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
-msgstr "Active <abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-Маршруты"
+msgstr "Active <abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-маршруты"
 
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
-msgstr "Active <abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-Маршруты"
+msgstr "Active <abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-маршруты"
 
 msgid "Active Connections"
 msgstr "Активные соединения"
@@ -271,7 +271,7 @@ msgid "Advanced Settings"
 msgstr "Дополнительные настройки"
 
 msgid "Aggregate Transmit Power(ACTATP)"
-msgstr "Aggregate Transmit Power(ACTATP)"
+msgstr "Aggregate Transmit Power (ACTATP)"
 
 msgid "Alert"
 msgstr "Тревога"
@@ -286,7 +286,7 @@ msgstr ""
 "Выделять IP адреса последовательно, начинать с меньшего доступного адреса."
 
 msgid "Allocate IP sequentially"
-msgstr "IP последовательно"
+msgstr "Выделять IP-адреса последовательно"
 
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
@@ -327,7 +327,7 @@ msgid "Allowed IPs"
 msgstr "Разрешенные IP-адреса"
 
 msgid "Always announce default router"
-msgstr "Объявлять всегда, как дефолтный маршрутизатор"
+msgstr "Объявлять всегда, как маршрутизатор по умолчанию"
 
 msgid "Annex"
 msgstr "Annex"
@@ -407,13 +407,13 @@ msgid "Any zone"
 msgstr "Любая зона"
 
 msgid "Apply request failed with status <code>%h</code>"
-msgstr ""
+msgstr "Ошибка <code>%h</code> запроса на применение"
 
 msgid "Apply unchecked"
-msgstr ""
+msgstr "Применить без проверки"
 
 msgid "Architecture"
-msgstr ""
+msgstr "Архитектура"
 
 msgid ""
 "Assign a part of given length of every public IPv6-prefix to this interface"
@@ -434,7 +434,7 @@ msgid "Associated Stations"
 msgstr "Подключенные клиенты"
 
 msgid "Associations"
-msgstr ""
+msgstr "Ассоциации"
 
 msgid "Auth Group"
 msgstr "Группа аутентификации"
@@ -506,13 +506,13 @@ msgid "Back"
 msgstr "Назад"
 
 msgid "Back to Overview"
-msgstr "Назад в меню"
+msgstr "Назад к обзору"
 
 msgid "Back to configuration"
-msgstr "Назад к настройке"
+msgstr "Назад к настройкам"
 
 msgid "Back to overview"
-msgstr "Назад в меню"
+msgstr "Назад к обзору"
 
 msgid "Back to scan results"
 msgstr "Назад к результатам поиска"
@@ -594,7 +594,7 @@ msgid "CPU usage (%)"
 msgstr "Загрузка ЦП (%)"
 
 msgid "Call failed"
-msgstr ""
+msgstr "Ошибка вызова"
 
 msgid "Cancel"
 msgstr "Отменить"
@@ -612,7 +612,7 @@ msgid "Changes applied."
 msgstr "Изменения приняты."
 
 msgid "Changes have been reverted."
-msgstr ""
+msgstr "Изменения были возвращены назад."
 
 msgid "Changes the administrator password for accessing the device"
 msgstr "Изменить пароль администратора для доступа к устройству."
@@ -624,12 +624,14 @@ msgid ""
 "Channel %d is not available in the %s regulatory domain and has been auto-"
 "adjusted to %d."
 msgstr ""
+"Канал %d не доступен в регуляторном домене %s и был автоматически изменен "
+"на %d."
 
 msgid "Check"
 msgstr "Проверить"
 
 msgid "Check filesystems before mount"
-msgstr "Проверка"
+msgstr "Проверка файловых систем перед монтированием"
 
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
@@ -662,7 +664,7 @@ msgid "Cipher"
 msgstr "Алгоритм шифрования"
 
 msgid "Cisco UDP encapsulation"
-msgstr "формирование пакетов данных Cisco UDP "
+msgstr "Формирование пакетов данных Cisco UDP "
 
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
@@ -711,16 +713,16 @@ msgid "Configuration"
 msgstr "Настройка config файла"
 
 msgid "Configuration failed"
-msgstr ""
+msgstr "Ошибка конфигурации"
 
 msgid "Configuration files will be kept."
 msgstr "Config файлы будут сохранены."
 
 msgid "Configuration has been applied."
-msgstr ""
+msgstr "Конфигурация применена"
 
 msgid "Configuration has been rolled back!"
-msgstr ""
+msgstr "Конфигурация возвращена назад!"
 
 msgid "Confirmation"
 msgstr "Подтверждение пароля"
@@ -735,7 +737,7 @@ msgid "Connection Limit"
 msgstr "Ограничение соединений"
 
 msgid "Connection attempt failed"
-msgstr ""
+msgstr "Ошибка попытки соединения"
 
 msgid "Connections"
 msgstr "Соединения"
@@ -745,6 +747,9 @@ msgid ""
 "changes. You might need to reconnect if you modified network related "
 "settings such as the IP address or wireless security credentials."
 msgstr ""
+"Не удалось восстановить доступ к устройству после применения конфигурации. "
+"Возможно вам придется подключиться заново, если вы изменили сетевые "
+"настройки, такие как IP-адрес или параметры доступа к беспроводной сети."
 
 msgid "Country"
 msgstr "Страна"
@@ -783,7 +788,7 @@ msgid ""
 "Custom feed definitions, e.g. private feeds. This file can be preserved in a "
 "sysupgrade."
 msgstr ""
-"Custom-ные feed-ы - это пользовательские feed-ы. Этот файл может быть "
+"Custom-ные feed-ы — это пользовательские feed-ы. Этот файл может быть "
 "сохранен при перепрошивке sysupgrade-совместимым образом."
 
 msgid "Custom feeds"
@@ -793,13 +798,15 @@ msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
 msgstr ""
+"Пользовательские файлы (сертификаты, скрипты) могут остаться в системе. "
+"Чтобы этого не произошло, выполните сначала сброс к заводским настройкам."
 
 msgid ""
 "Customizes the behaviour of the device <abbr title=\"Light Emitting Diode"
 "\">LED</abbr>s if possible."
 msgstr ""
 "Настройка поведения светодиодной индикации <abbr title=\"Светодиод\">LED</"
-"abbr>s устройства, если это возможно."
+"abbr> устройства, если это возможно."
 
 msgid "DHCP Server"
 msgstr "DHCP-сервер"
@@ -811,16 +818,16 @@ msgid "DHCP client"
 msgstr "DHCP-клиент"
 
 msgid "DHCP-Options"
-msgstr "DHCP-Настройки"
+msgstr "DHCP настройки"
 
 msgid "DHCPv6 client"
 msgstr "DHCPv6 клиент"
 
 msgid "DHCPv6-Mode"
-msgstr "DHCPv6-Режим"
+msgstr "DHCPv6 режим"
 
 msgid "DHCPv6-Service"
-msgstr "DHCPv6-Сервис"
+msgstr "DHCPv6 сервис"
 
 msgid "DNS"
 msgstr "DNS"
@@ -868,7 +875,7 @@ msgid "Default gateway"
 msgstr "Шлюз по умолчанию"
 
 msgid "Default is stateless + stateful"
-msgstr "Значение по умолчанию - 'stateless + stateful'."
+msgstr "Значение по умолчанию — 'stateless + stateful'."
 
 msgid "Default state"
 msgstr "Начальное состояние"
@@ -913,7 +920,7 @@ msgid "Device unreachable!"
 msgstr "Устройство недоступно"
 
 msgid "Device unreachable! Still waiting for device..."
-msgstr ""
+msgstr "Устройство недоступно! Ожидание устройства..."
 
 msgid "Diagnostics"
 msgstr "Диагностика"
@@ -941,7 +948,7 @@ msgid "Disable Encryption"
 msgstr "Отключить шифрование"
 
 msgid "Disable this network"
-msgstr ""
+msgstr "Отключить данную сеть"
 
 msgid "Disabled"
 msgstr "Отключено"
@@ -953,10 +960,10 @@ msgid "Discard upstream RFC1918 responses"
 msgstr "Отбрасывать ответы внешней сети RFC1918."
 
 msgid "Disconnection attempt failed"
-msgstr ""
+msgstr "Ошибка попытки отключения"
 
 msgid "Dismiss"
-msgstr ""
+msgstr "Отклонить"
 
 msgid "Displaying only packages containing"
 msgstr "Показываются только пакеты, содержащие"
@@ -1012,7 +1019,7 @@ msgstr ""
 "без <abbr title=\"Служба доменных имён\">DNS</abbr>-имени."
 
 msgid "Down"
-msgstr ""
+msgstr "Вниз"
 
 msgid "Download and install package"
 msgstr "Загрузить и установить пакет"
@@ -1030,7 +1037,7 @@ msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
 msgstr ""
-"Dropbear - это <abbr title=\"Secure Shell\">SSH</abbr>-сервер со встроенным "
+"Dropbear — это <abbr title=\"Secure Shell\">SSH</abbr>-сервер со встроенным "
 "<abbr title=\"Secure Copy\">SCP</abbr>."
 
 msgid "Dual-Stack Lite (RFC6333)"
@@ -1081,7 +1088,8 @@ msgstr "Включить"
 msgid ""
 "Enable <abbr title=\"Internet Group Management Protocol\">IGMP</abbr> "
 "snooping"
-msgstr ""
+msgstr "Включить <abbr title=\"Internet Group Management Protocol\">IGMP</abbr> "
+"snooping"
 
 msgid "Enable <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgstr "Включить <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
@@ -1132,7 +1140,7 @@ msgid "Enable this mount"
 msgstr "Включить эту точку монтирования"
 
 msgid "Enable this network"
-msgstr ""
+msgstr "Включить данную сеть"
 
 msgid "Enable this swap"
 msgstr "Включить этот раздел подкачки"
@@ -1144,7 +1152,7 @@ msgid "Enabled"
 msgstr "Включено"
 
 msgid "Enables IGMP snooping on this bridge"
-msgstr ""
+msgstr "Включает IGMP snooping на данном мосту"
 
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
@@ -1169,10 +1177,10 @@ msgid "Endpoint Port"
 msgstr "Конечная точка Порта"
 
 msgid "Enter custom value"
-msgstr ""
+msgstr "Введите пользовательское значение"
 
 msgid "Enter custom values"
-msgstr ""
+msgstr "Введите пользовательские значения"
 
 msgid "Erasing..."
 msgstr "Стирание..."
@@ -1235,7 +1243,7 @@ msgid "FT protocol"
 msgstr "FT протокол"
 
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
-msgstr ""
+msgstr "Не удалось подтвердить применение в течении %d сек., ожидание отката..."
 
 msgid "File"
 msgstr "Файл"
@@ -1256,7 +1264,7 @@ msgid "Filter useless"
 msgstr "Фильтровать бесполезные"
 
 msgid "Finalizing failed"
-msgstr ""
+msgstr "Ошибка финализации"
 
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
@@ -1379,7 +1387,7 @@ msgid "Gateway"
 msgstr "Шлюз"
 
 msgid "Gateway address is invalid"
-msgstr ""
+msgstr "Неверный адрес шлюза"
 
 msgid "Gateway ports"
 msgstr "Порты шлюза"
@@ -1439,7 +1447,7 @@ msgid "Hang Up"
 msgstr "Перезапустить"
 
 msgid "Header Error Code Errors (HEC)"
-msgstr "Ошибки кода ошибки заголовка (HEC)"
+msgstr "Ошибки контроля ошибок заголовка (HEC)"
 
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
@@ -1471,7 +1479,7 @@ msgid "Host-<abbr title=\"Internet Protocol Address\">IP</abbr> or Network"
 msgstr "<abbr title=\"Адрес Интернет протокола\">IP</abbr>-адрес или сеть"
 
 msgid "Host-Uniq tag content"
-msgstr ""
+msgstr "Содержимое Host-Uniq тега"
 
 msgid "Hostname"
 msgstr "Имя хоста"
@@ -1489,16 +1497,16 @@ msgid "IKE DH Group"
 msgstr "IKE DH Group"
 
 msgid "IP Addresses"
-msgstr "IP-Адреса"
+msgstr "IP-адреса"
 
 msgid "IP address"
 msgstr "IP-адрес"
 
 msgid "IP address in invalid"
-msgstr ""
+msgstr "Неверный IP-адрес"
 
 msgid "IP address is missing"
-msgstr ""
+msgstr "IP-адрес не указан"
 
 msgid "IPv4"
 msgstr "IPv4"
@@ -1507,7 +1515,7 @@ msgid "IPv4 Firewall"
 msgstr "Межсетевой экран IPv4"
 
 msgid "IPv4 Upstream"
-msgstr ""
+msgstr "Основной IPv4"
 
 msgid "IPv4 address"
 msgstr "IPv4-адрес"
@@ -1558,7 +1566,7 @@ msgid "IPv6 ULA-Prefix"
 msgstr "IPv6 ULA-Prefix"
 
 msgid "IPv6 Upstream"
-msgstr ""
+msgstr "Основной IPv6"
 
 msgid "IPv6 address"
 msgstr "IPv6-адрес"
@@ -1606,23 +1614,23 @@ msgid "Identity"
 msgstr "Идентификация EAP"
 
 msgid "If checked, 1DES is enabled"
-msgstr "Если выбрано, что 1DES включено"
+msgstr "Если выбрано, то 1DES включено"
 
 msgid "If checked, encryption is disabled"
-msgstr "Если проверено, что шифрование выключено"
+msgstr "Если выбрано, то шифрование выключено"
 
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
-"Если выбрано монтировать устройство используя его UUID, вместо "
-"фиксированного файла устройства."
+"Если выбрано, монтировать устройство используя его UUID, а не "
+"фиксированный файл устройства."
 
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
 msgstr ""
-"Если выбрано монтировать устройство используя название его раздела, вместо "
-"фиксированного файла устройства."
+"Если выбрано, монтировать устройство используя название его раздела, а не "
+"фиксированный файл устройства."
 
 msgid "If unchecked, no default route is configured"
 msgstr "Если не выбрано, то маршрут по умолчанию не настраивается."
@@ -1640,7 +1648,7 @@ msgstr ""
 "Если физической памяти не достаточно, то неиспользуемые данные могут быть "
 "временно перемещены в раздел подкачки, что в свою очередь приведет к "
 "увеличению объёму свободной <abbr title=\"Random Access Memory\">RAM</abbr>."
-" Однако, перемещение в файл - это достаточно долгий процесс, так как "
+" Однако, перемещение в файл — это достаточно долгий процесс, так как "
 "устройство, на котором располагается раздел подкачки, работает гораздо "
 "медленнее, чем <abbr title=\"Random Access Memory\">RAM</abbr>."
 
@@ -1677,7 +1685,7 @@ msgid "Info"
 msgstr "Информация"
 
 msgid "Initialization failure"
-msgstr ""
+msgstr "Ошибка инициализации"
 
 msgid "Initscript"
 msgstr "Скрипт инициализации"
@@ -1755,7 +1763,7 @@ msgstr ""
 "не помещается в чип флэш-памяти, проверьте ваш файл прошивки!"
 
 msgid "JavaScript required!"
-msgstr "Требуется Java скрипт!"
+msgstr "Требуется JavaScript!"
 
 msgid "Join Network"
 msgstr "Подключение к сети"
@@ -1925,10 +1933,10 @@ msgid "Loading"
 msgstr "Загрузка"
 
 msgid "Local IP address is invalid"
-msgstr ""
+msgstr "Неверный локальный IP-адрес"
 
 msgid "Local IP address to assign"
-msgstr "Присвоение локального IP адреса"
+msgstr "Присвоение локального IP-адреса"
 
 msgid "Local IPv4 address"
 msgstr "Локальный IPv4-адрес"
@@ -1953,7 +1961,7 @@ msgid ""
 "and are resolved from DHCP or hosts files only"
 msgstr ""
 "Согласно требованиям, имена соответствующие этому домену, никогда не "
-"передаются. И разрешаются только из файла DHCP(/etc/config/dhcp) или "
+"передаются. И разрешаются только из файла DHCP (/etc/config/dhcp) или "
 "файла хостов (/etc/hosts)."
 
 msgid "Local domain suffix appended to DHCP names and hosts file entries"
@@ -2014,7 +2022,7 @@ msgid "MAP / LW4over6"
 msgstr "MAP / LW4over6"
 
 msgid "MAP rule is invalid"
-msgstr ""
+msgstr "Неверное MAP правило"
 
 msgid "MB/s"
 msgstr "МБ/с"
@@ -2032,8 +2040,8 @@ msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
 msgstr ""
-"Прежде чем перенести корень на внешний носитель, используйте команды "
-"приведенные ниже:"
+"Прежде чем перенести корневую файловую систему на внешний носитель, исполь"
+"зуйте команды приведенные ниже:"
 
 msgid "Manual"
 msgstr "Вручную"
@@ -2100,7 +2108,7 @@ msgid "Modem device"
 msgstr "Модем"
 
 msgid "Modem information query failed"
-msgstr ""
+msgstr "Ошибка запроса информации о модеме"
 
 msgid "Modem init timeout"
 msgstr "Время ожидания инициализации модема"
@@ -2118,10 +2126,10 @@ msgid "Mount Points"
 msgstr "Монтирование разделов"
 
 msgid "Mount Points - Mount Entry"
-msgstr "Точки монтирования - Настройка разделов"
+msgstr "Точки монтирования — Настройка разделов"
 
 msgid "Mount Points - Swap Entry"
-msgstr "Точки монтирования - Настройка Swap"
+msgstr "Точки монтирования — Настройка Swap"
 
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
@@ -2200,7 +2208,7 @@ msgid "Network boot image"
 msgstr "Образ системы для сетевой загрузки"
 
 msgid "Network device is not present"
-msgstr ""
+msgstr "Нет сетевого устройства"
 
 msgid "Network without interfaces."
 msgstr "Сеть без интерфейсов."
@@ -2212,7 +2220,7 @@ msgid "No DHCP Server configured for this interface"
 msgstr "DHCP-сервер не настроен для этого интерфейса"
 
 msgid "No NAT-T"
-msgstr "не NAT-T"
+msgstr "Без NAT-T"
 
 msgid "No chains in this table"
 msgstr "Нет цепочек в этой таблице"
@@ -2224,7 +2232,7 @@ msgid "No information available"
 msgstr "Нет доступной информации"
 
 msgid "No matching prefix delegation"
-msgstr ""
+msgstr "Отсутствует соответствующая делегация префикса"
 
 msgid "No negative cache"
 msgstr "Отключить кэш отрицательных ответов"
@@ -2278,7 +2286,7 @@ msgid "Not connected"
 msgstr "Не подключено"
 
 msgid "Note: Configuration files will be erased."
-msgstr "Примечание: config файлы будут удалены."
+msgstr "Внимание: config файлы будут удалены."
 
 msgid "Note: interface name length"
 msgstr "Внимание: длина имени интерфейса"
@@ -2291,6 +2299,8 @@ msgstr "DNS-запрос"
 
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
+"Количество кэшированных DNS записей (максимум — 10000, 0 — "
+"отключить кэширование)"
 
 msgid "OK"
 msgstr "OK"
@@ -2305,7 +2315,7 @@ msgid "Obfuscated Password"
 msgstr "Obfuscated Password"
 
 msgid "Obtain IPv6-Address"
-msgstr ""
+msgstr "Получение IPv6-адреса"
 
 msgid "Off-State Delay"
 msgstr "Задержка выключенного состояния"
@@ -2372,7 +2382,7 @@ msgid ""
 "for the interface."
 msgstr ""
 "Необязательно. Допустимые значения: 'eui64', 'random', фиксированное "
-"значение например '::1' или '::1:2'. Когда IPv6 префикс такой как - ('a:"
+"значение например '::1' или '::1:2'. Когда IPv6 префикс такой как — ('a:"
 "b:c:d::'), используйте суффикс на вроде ('::1') для этого IPv6 адреса ('a:b:"
 "c:d::1') для этого интерфейса."
 
@@ -2388,7 +2398,7 @@ msgstr ""
 "Необязательно. Создавать маршруты для разрешенных IP адресов для этого узла."
 
 msgid "Optional. Description of peer."
-msgstr ""
+msgstr "Необязательно. Описание узла."
 
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
@@ -2476,7 +2486,7 @@ msgid "PIN"
 msgstr "PIN"
 
 msgid "PIN code rejected"
-msgstr ""
+msgstr "PIN код отвергнут"
 
 msgid "PMK R1 Push"
 msgstr "PMK R1 Push"
@@ -2566,7 +2576,7 @@ msgid "Peer IP address to assign"
 msgstr "Запрос IP адреса назначения"
 
 msgid "Peer address is missing"
-msgstr ""
+msgstr "Отсутствует адрес пира"
 
 msgid "Peers"
 msgstr "Пиры"
@@ -2593,7 +2603,7 @@ msgid "Ping"
 msgstr "Пинг-запрос"
 
 msgid "Pkts."
-msgstr "Пакетов."
+msgstr "Пакетов"
 
 msgid "Please enter your username and password."
 msgstr "Введите логин и пароль."
@@ -2726,6 +2736,8 @@ msgstr "Сервер Radius-Authentication"
 
 msgid "Raw hex-encoded bytes. Leave empty unless your ISP require this"
 msgstr ""
+"Строка в шестнадцатеричном коде. Оставьте пустой, если ваш провайдер "
+"не требует этого"
 
 msgid ""
 "Read <code>/etc/ethers</code> to configure the <abbr title=\"Dynamic Host "
@@ -2738,6 +2750,9 @@ msgid ""
 "Really delete this interface? The deletion cannot be undone! You might lose "
 "access to this device if you are connected via this interface"
 msgstr ""
+"Действительно удалить этот интерфейс? Удаление не может быть отменено! "
+"Вы можете потерять доступ к этому устройству, если вы подключены через "
+"данный интерфейс."
 
 msgid ""
 "Really delete this wireless network? The deletion cannot be undone! You "
@@ -2869,7 +2884,7 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 "Требуется поддержка внешней сетью DNSSEC; убедитесь, что ответы "
-"неподписанного домена - действительно поступают от неподписанных доменов."
+"неподписанного домена — действительно поступают от неподписанных доменов."
 
 msgid "Reset"
 msgstr "Сбросить"
@@ -2893,7 +2908,7 @@ msgid "Restart Firewall"
 msgstr "Перезапустить межсетевой экран"
 
 msgid "Restart radio interface"
-msgstr ""
+msgstr "Перезапустить радио-интерфейс"
 
 msgid "Restore"
 msgstr "Восстановление"
@@ -2908,13 +2923,13 @@ msgid "Revert"
 msgstr "Вернуть"
 
 msgid "Revert changes"
-msgstr ""
+msgstr "Вернуть изменения"
 
 msgid "Revert request failed with status <code>%h</code>"
-msgstr ""
+msgstr "Ошибка <code>%h</code> отмены конфигурации"
 
 msgid "Reverting configuration…"
-msgstr ""
+msgstr "Отмена конфигурации..."
 
 msgid "Root"
 msgstr "Корень"
@@ -3030,10 +3045,10 @@ msgid "Set up Time Synchronization"
 msgstr "Настройка синхронизации времени"
 
 msgid "Setting PLMN failed"
-msgstr ""
+msgstr "Ошибка установки PLMN"
 
 msgid "Setting operation mode failed"
-msgstr ""
+msgstr "Ошибка установки режима работы"
 
 msgid "Setup DHCP Server"
 msgstr "Настроить сервер DHCP"
@@ -3066,7 +3081,7 @@ msgid "Size (.ipk)"
 msgstr "Размер (.ipk)"
 
 msgid "Size of DNS query cache"
-msgstr ""
+msgstr "Размер кэша DNS запроса"
 
 msgid "Skip"
 msgstr "Пропустить"
@@ -3153,7 +3168,7 @@ msgid "Start priority"
 msgstr "Приоритет"
 
 msgid "Starting configuration apply…"
-msgstr ""
+msgstr "Применение конфигурации..."
 
 msgid "Startup"
 msgstr "Загрузка"
@@ -3218,7 +3233,7 @@ msgstr "Коммутатор %q (%s)"
 msgid ""
 "Switch %q has an unknown topology - the VLAN settings might not be accurate."
 msgstr ""
-"Коммутатор %q имеет неизвестную топологию-настройки VLAN не могут быть "
+"Коммутатор %q имеет неизвестную топологию — настройки VLAN не могут быть "
 "точными."
 
 msgid "Switch Port Mask"
@@ -3320,7 +3335,7 @@ msgstr ""
 "<code>_</code>"
 
 msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
+msgstr "Архив резервной копии не являетсяg правильным gzip файлом."
 
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "Не удалось загрузить config файл из-за следующей ошибки:"
@@ -3334,6 +3349,12 @@ msgid ""
 "or revert all pending changes to keep the currently working configuration "
 "state."
 msgstr ""
+"Устройство недоступно в течение %d секунд после применения изменений. "
+"Это привело к откату конфигурации из соображений безопасности. Если вы "
+"считаете, что конфигурация верна, выполните настройку без проверки. "
+"Кроме того, вы можете отклонить это предупреждение и отредактировать "
+"изменения перед попыткой применить конфигурацию снова или отктить все "
+"изменения чтобы сохранить рабочее состояние конфигурации."
 
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
@@ -3401,7 +3422,7 @@ msgstr ""
 "сети\">VLAN</abbr>ы часто используются для разделения нескольких сетевых "
 "сегментов. Обычно по умолчанию используется один порт для подключения к "
 "внешней сети, например к Интернету и другие порты предназначенные для "
-"внутренней - локальной сети."
+"внутренней — локальной сети."
 
 msgid "The selected protocol needs a device assigned"
 msgstr "Для выбранного протокола необходимо задать устройство"
@@ -3436,7 +3457,7 @@ msgid "There are no active leases."
 msgstr "Нет активных арендованных адресов."
 
 msgid "There are no changes to apply."
-msgstr ""
+msgstr "Нет изменений для применения."
 
 msgid "There are no pending changes to revert!"
 msgstr "Нет изменений, которые можно отменить!"
@@ -3518,8 +3539,8 @@ msgstr ""
 
 msgid "This is the system crontab in which scheduled tasks can be defined."
 msgstr ""
-"На странице содержимое /etc/crontabs/root - файла (задания crontab), здесь "
-"вы можете запланировать ваши задания. "
+"Содержимое файла /etc/crontabs/root (задания crontab). Здесь "
+"вы можете запланировать ваши задания."
 
 msgid ""
 "This is usually the address of the nearest PoP operated by the tunnel broker"
@@ -3623,25 +3644,25 @@ msgid "UUID"
 msgstr "UUID"
 
 msgid "Unable to determine device name"
-msgstr ""
+msgstr "Невозможно определить имя устройства"
 
 msgid "Unable to determine external IP address"
-msgstr ""
+msgstr "Невозможно определить внешний IP-адрес"
 
 msgid "Unable to determine upstream interface"
-msgstr ""
+msgstr "Невозможно определить основной интерфейс"
 
 msgid "Unable to dispatch"
 msgstr "Невозможно обработать запрос для"
 
 msgid "Unable to obtain client ID"
-msgstr ""
+msgstr "Невозможно получить идентификатор клиента"
 
 msgid "Unable to resolve AFTR host name"
-msgstr ""
+msgstr "Не удалось разрешить AFTR имя хоста"
 
 msgid "Unable to resolve peer host name"
-msgstr ""
+msgstr "Не удалось разрешить имя хоста пира"
 
 msgid "Unavailable Seconds (UAS)"
 msgstr "Секунды неготовности (UAS)"
@@ -3653,7 +3674,7 @@ msgid "Unknown Error, password not changed!"
 msgstr "Неизвестная ошибка, пароль не был изменен!"
 
 msgid "Unknown error (%s)"
-msgstr ""
+msgstr "Неизвестная ошибка (%s)"
 
 msgid "Unmanaged"
 msgstr "Неуправляемый"
@@ -3665,16 +3686,16 @@ msgid "Unsaved Changes"
 msgstr "Непринятые изменения"
 
 msgid "Unsupported MAP type"
-msgstr ""
+msgstr "Неподдерживаемый тип MAP"
 
 msgid "Unsupported modem"
-msgstr ""
+msgstr "Неподдерживаемый модем"
 
 msgid "Unsupported protocol type."
 msgstr "Неподдерживаемый тип протокола."
 
 msgid "Up"
-msgstr ""
+msgstr "Вверх"
 
 msgid "Update lists"
 msgstr "Обновить списки"
@@ -3686,7 +3707,7 @@ msgid ""
 msgstr ""
 "Загрузите sysupgrade-совместимый образ, чтобы заменить текущую прошивку "
 "устройства. Поставьте галочку 'Сохранить настройки', чтобы сохранить текущие "
-"config файлы - ваши настройки устройства (требуется совместимый образ "
+"config файлы — ваши настройки устройства (требуется совместимый образ "
 "прошивки)."
 
 msgid "Upload archive..."
@@ -3748,7 +3769,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 "Нажмите кнопку <em>'Добавить'</em>, чтобы добавить новую запись аренды. "
-"<em>'MAC-Адрес'</em> идентифицирует хост, <em>'IPv4-Адрес'</em> указывает "
+"<em>'MAC-адрес'</em> идентифицирует хост, <em>'IPv4-адрес'</em> указывает "
 "фиксированный адрес, а <em>'Имя хоста'</em> присваивается в качестве "
 "символьного имени для запрашивающего хоста. Необязательно <em>'Время "
 "аренды адреса'</em> может быть использовано для того, чтобы установить "
@@ -3820,7 +3841,7 @@ msgid "Version"
 msgstr "Версия"
 
 msgid "Virtual dynamic interface"
-msgstr ""
+msgstr "Виртуальный динамический винтерфейс"
 
 msgid "WDS"
 msgstr "WDS"
@@ -3854,7 +3875,7 @@ msgid "Waiting for command to complete..."
 msgstr "Ожидание завершения выполнения команды..."
 
 msgid "Waiting for configuration to get applied… %ds"
-msgstr ""
+msgstr "Ожидание применения конфигурации... %d сек."
 
 msgid "Waiting for device..."
 msgstr "Ожидание подключения устройства..."
@@ -3864,7 +3885,7 @@ msgstr "Внимание"
 
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
-"Внимание: Есть не сохраненные изменения, которые будут потеряны при "
+"Предупреждение: Есть не сохраненные изменения, которые будут потеряны при "
 "перезагрузке!"
 
 msgid ""
@@ -3952,7 +3973,7 @@ msgid "bridged"
 msgstr "соед. мостом"
 
 msgid "create"
-msgstr ""
+msgstr "создать"
 
 msgid "create:"
 msgstr "создать:"
@@ -3961,10 +3982,10 @@ msgid "creates a bridge over specified interface(s)"
 msgstr "Создаёт мост для выбранных сетевых интерфейсов."
 
 msgid "dB"
-msgstr "dB"
+msgstr "дБ"
 
 msgid "dBm"
-msgstr "dBm"
+msgstr "дБм"
 
 msgid "disable"
 msgstr "отключить"
@@ -4004,13 +4025,13 @@ msgid "input"
 msgstr "ввод"
 
 msgid "kB"
-msgstr "kB"
+msgstr "кБ"
 
 msgid "kB/s"
-msgstr "kB/s"
+msgstr "кБ/с"
 
 msgid "kbit/s"
-msgstr "kbit/s"
+msgstr "кбит/с"
 
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "Локальный <abbr title=\"Служба доменных имён\">DNS</abbr>-файл."
@@ -4040,7 +4061,7 @@ msgid "open"
 msgstr "открыть"
 
 msgid "output"
-msgstr ""
+msgstr "вывод"
 
 msgid "overlay"
 msgstr "overlay"


### PR DESCRIPTION
Add missing translations and update existing not quite correct translations.
Replaced hyphens on em dashes where it is required by the Russian rules.

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>