### PR TITLE
luci-proto-ncm: remove mode 'auto' as default

### DIFF
--- a/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
+++ b/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
@@ -32,7 +32,7 @@ end
 
 
 mode = section:taboption("general", Value, "mode", translate("Service Type"))
-mode.default = "auto"
+mode:value("", translate("Modem default"))
 mode:value("preferlte", translate("Prefer LTE"))
 mode:value("preferumts", translate("Prefer UMTS"))
 mode:value("lte", "LTE")


### PR DESCRIPTION
The default seting should be none.
Most modems have persistent mode setting that is stored in internal flash.
If option mode is unset the default modem setting is used.
If we choose some mode, then on every connection we write to modem flash.
In the current state we can't disable that from LuCI.

Signed-off-by: Dmitry Tunin <hanipouspilot@gmail.com>