### PR TITLE
luci-app-advanced-reboot: change style of buttons to important

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Stan Grishin (stangri@melmac.net)
+# Copyright 2017-2018 Stan Grishin (stangri@melmac.net)
 # This is free software, licensed under the GNU General Public License v3.
 
 include $(TOPDIR)/rules.mk
@@ -13,7 +13,7 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 
 LUCI_DEPENDS:=+luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=32
+PKG_RELEASE:=33
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
@@ -1,4 +1,4 @@
--- Copyright 2017 Stan Grishin <stangri@melmac.net>
+-- Copyright 2017-2018 Stan Grishin <stangri@melmac.net>
 -- Licensed to the public under the Apache License 2.0.
 
 module("luci.controller.advanced_reboot", package.seeall)

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm
@@ -1,7 +1,7 @@
 <%#
  Copyright 2008 Steven Barth <steven@midlink.org>
  Copyright 2008-2015 Jo-Philipp Wich <jow@openwrt.org>
- Copyright 2017 Stan Grishin <stangri@melmac.net>
+ Copyright 2017-2018 Stan Grishin <stangri@melmac.net>
  Licensed to the public under the Apache License 2.0.
 -%>
 
@@ -42,12 +42,12 @@
         <%- if boot_envvar1_partition_one == current_partition then -%>
         <form method="post" action="<%=url('admin/system/advanced_reboot/reboot')%>">
           <input type="hidden" name="token" value="<%=token%>" />
-          <input id="reboot-button" type="submit" class="cbi-button cbi-button-apply" value="<%:Reboot to current partition%>" />
+          <input id="reboot-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Reboot to current partition%>" />
         </form>
       <%- else -%>
       <form method="post" action="<%=url('admin/system/advanced_reboot/alternative_reboot')%>">
         <input type="hidden" name="token" value="<%=token%>" />
-        <input id="altreboot-button" type="submit" class="cbi-button cbi-button-apply" value="<%:Reboot to alternative partition...%>" />
+        <input id="altreboot-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Reboot to alternative partition...%>" />
       </form>
         <%- end -%>
       </div>
@@ -66,12 +66,12 @@
         <%- if boot_envvar1_partition_two == current_partition then -%>
           <form method="post" action="<%=url('admin/system/advanced_reboot/reboot')%>">
           	<input type="hidden" name="token" value="<%=token%>" />
-            <input id="reboot-button" type="submit" class="cbi-button cbi-button-apply" value="<%:Reboot to current partition%>" />
+            <input id="reboot-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Reboot to current partition%>" />
           </form>
         <%- else -%>
         <form method="post" action="<%=url('admin/system/advanced_reboot/alternative_reboot')%>">
           <input type="hidden" name="token" value="<%=token%>" />
-          <input id="altreboot-button" type="submit" class="cbi-button cbi-button-apply" value="<%:Reboot to alternative partition...%>" />
+          <input id="altreboot-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Reboot to alternative partition...%>" />
         </form>
         <%- end -%>
       </div>
@@ -82,7 +82,7 @@
   <%- if rom_board_name then -%>
     <p class="alert-message warning"><%=pcdata(translatef("Warning: Device (%s) is unknown or isn't a dual-partition device!", rom_board_name))%></p>
   <%- else -%>
-    <p class="alert-message warning"><%:Warning: Unable to obtain device information!%></p>
+    <p class="alert-message warning"><%=pcdata(translatef("Warning: Unable to obtain device information!"))%></p>
   <%- end -%>
 <%- end -%>
 
@@ -91,7 +91,7 @@
 <%- if nixio.fs.access("/sbin/poweroff") then -%>
 <form method="post" action="<%=url('admin/system/advanced_reboot/power_off')%>">
 	<input type="hidden" name="token" value="<%=token%>" />
-  <input id="poweroff-button" type="submit" class="cbi-button cbi-button-apply" value="<%:Perform power off...%>" />
+  <input id="poweroff-button" type="submit" class="cbi-button cbi-button-apply important" value="<%:Perform power off...%>" />
 </form>
 <%- else -%>
   <p class="alert-message warning"><%:Warning: This system does not support powering off!%></p>

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/alternative_reboot.htm
@@ -1,7 +1,7 @@
 <%#
  Copyright 2008 Steven Barth <steven@midlink.org>
  Copyright 2008-2009 Jo-Philipp Wich <jow@openwrt.org>
- Copyright 2017 Stan Grishin <stangri@melmac.net>
+ Copyright 2017-2018 Stan Grishin <stangri@melmac.net>
  Licensed to the public under the Apache License 2.0.
 -%>
 
@@ -21,8 +21,8 @@
 	<form class="inline" action="<%=REQUEST_URI%>" method="post">
 		<input type="hidden" name="token" value="<%=token%>" />
 		<input type="hidden" name="step" value="2" />
-		<input class="cbi-button cbi-button-reset" name="cancel" type="submit" value="<%:Cancel%>" />
-		<input class="cbi-button cbi-button-apply" type="submit" value="<%:Proceed%>" />
+		<input class="cbi-button cbi-button-reset important" name="cancel" type="submit" value="<%:Cancel%>" />
+		<input class="cbi-button cbi-button-apply important" type="submit" value="<%:Proceed%>" />
 	</form>
 </div>
 

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/power_off.htm
@@ -1,7 +1,7 @@
 <%#
  Copyright 2008 Steven Barth <steven@midlink.org>
  Copyright 2008-2009 Jo-Philipp Wich <jow@openwrt.org>
- Copyright 2017 Stan Grishin <stangri@melmac.net>
+ Copyright 2017-2018 Stan Grishin <stangri@melmac.net>
  Licensed to the public under the Apache License 2.0.
 -%>
 
@@ -17,8 +17,8 @@
 	<form class="inline" action="<%=REQUEST_URI%>" method="post">
 		<input type="hidden" name="token" value="<%=token%>" />
 		<input type="hidden" name="step" value="2" />
-		<input class="cbi-button cbi-button-reset" name="cancel" type="submit" value="<%:Cancel%>" />
-		<input class="cbi-button cbi-button-apply" type="submit" value="<%:Proceed%>" />
+		<input class="cbi-button cbi-button-reset important" name="cancel" type="submit" value="<%:Cancel%>" />
+		<input class="cbi-button cbi-button-apply important" type="submit" value="<%:Proceed%>" />
 	</form>
 </div>
 


### PR DESCRIPTION
Added ```important``` styling to buttons to be consistent with the new styling/reboot page.

Backport to 18.06 please.

Signed-off-by: Stan Grishin <stangri@melmac.net>