### PR TITLE
luci-app-simple-adblock: change style of button to important

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
 LUCI_DEPENDS:=+luci-mod-admin-full +simple-adblock
 LUCI_PKGARCH:=all
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 include ../../luci.mk
 

--- a/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
@@ -24,7 +24,7 @@ else
 	if enabledFlag ~= "1" or status:match("Stopped") then
 		en.title      = translate("Service is disabled/stopped")
 		en.inputtitle = translate("Enable/Start")
-		en.inputstyle = "apply"
+		en.inputstyle = "apply important"
 		if nixio.fs.access("/var/simple-adblock.cache") then
 			ds = h:option(DummyValue, "_dummy", translate("Service Status"))
 			ds.template = "simple-adblock/status"
@@ -33,7 +33,7 @@ else
 	else
 		en.title      = translate("Service is enabled/started")
 		en.inputtitle = translate("Stop/Disable")
-		en.inputstyle = "reset"
+		en.inputstyle = "reset important"
 		ds = h:option(DummyValue, "_dummy", translate("Service Status"))
 		ds.template = "simple-adblock/status"
 		ds.value = status
@@ -41,7 +41,7 @@ else
 			reload = h:option(Button, "__reload")
 			reload.title      = translate("Service started with error")
 			reload.inputtitle = translate("Reload")
-			reload.inputstyle = "apply"
+			reload.inputstyle = "apply important"
 			function reload.write()
 				luci.sys.exec("/etc/init.d/simple-adblock reload")
 				luci.http.redirect(luci.dispatcher.build_url("admin/services/" .. packageName))


### PR DESCRIPTION
Added ```important``` styling to buttons to be consistent with the new styling.

Backport to 18.06 please.

Signed-off-by: Stan Grishin <stangri@melmac.net>