### PR TITLE
luci-app-simple-adblock: remove extra controller file

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.
 LUCI_DEPENDS:=+luci-mod-admin-full +simple-adblock
 LUCI_PKGARCH:=all
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 include ../../luci.mk
 

--- a/applications/luci-app-simple-adblock/luasrc/controller/simpleadblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/controller/simpleadblock.lua
@@ -1,7 +1,0 @@
-module("luci.controller.simpleadblock", package.seeall)
-function index()
-	if not nixio.fs.access("/etc/config/simple-adblock") then
-		return
-	end
-	entry({"admin", "services", "simpleadblock"}, cbi("simpleadblock"), _("Simple AdBlock"))
-end

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -94,9 +94,6 @@ msgstr ""
 msgid "Some output"
 msgstr ""
 
-msgid "Start Simple Adblock service"
-msgstr ""
-
 msgid "Stop the download if it is stalled for set number of seconds"
 msgstr ""
 


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.net>

Uhm, dunno what to say, my bad, extra controller file wasn't deleted when I sent the previous PR. Still learning.

And still, please back-port to 18.06.

Again, sorry to be creating extra burden so close to release.