### PR TITLE
luci-proto-ncm: remove unrelated options

### DIFF
--- a/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
+++ b/protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua
@@ -12,9 +12,8 @@ You may obtain a copy of the License at
 
 local map, section, net = ...
 
-local device, apn, service, pincode, username, password, dialnumber
-local ipv6, maxwait, defaultroute, metric, peerdns, dns,
-      keepalive_failure, keepalive_interval, demand
+local device, apn, service, pincode, username, password
+local ipv6, delay, defaultroute, metric, peerdns, dns
 
 
 device = section:taboption("general", Value, "device", translate("Modem device"))
@@ -60,8 +59,6 @@ username = section:taboption("general", Value, "username", translate("PAP/CHAP u
 password = section:taboption("general", Value, "password", translate("PAP/CHAP password"))
 password.password = true
 
-dialnumber = section:taboption("general", Value, "dialnumber", translate("Dial number"))
-dialnumber.placeholder = "*99***1#"
 
 if luci.model.network:has_ipv6() then
 
@@ -74,12 +71,12 @@ if luci.model.network:has_ipv6() then
 end
 
 
-maxwait = section:taboption("advanced", Value, "maxwait",
+delay = section:taboption("advanced", Value, "delay",
 	translate("Modem init timeout"),
 	translate("Maximum amount of seconds to wait for the modem to become ready"))
 
-maxwait.placeholder = "20"
-maxwait.datatype    = "min(1)"
+delay.placeholder = "10"
+delay.datatype    = "min(1)"
 
 
 defaultroute = section:taboption("advanced", Flag, "defaultroute",
@@ -110,55 +107,3 @@ dns:depends("peerdns", "")
 dns.datatype = "ipaddr"
 dns.cast     = "string"
 
-
-keepalive_failure = section:taboption("advanced", Value, "_keepalive_failure",
-	translate("LCP echo failure threshold"),
-	translate("Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures"))
-
-function keepalive_failure.cfgvalue(self, section)
-	local v = m:get(section, "keepalive")
-	if v and #v > 0 then
-		return tonumber(v:match("^(%d+)[ ,]+%d+") or v)
-	end
-end
-
-function keepalive_failure.write() end
-function keepalive_failure.remove() end
-
-keepalive_failure.placeholder = "0"
-keepalive_failure.datatype    = "uinteger"
-
-
-keepalive_interval = section:taboption("advanced", Value, "_keepalive_interval",
-	translate("LCP echo interval"),
-	translate("Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold"))
-
-function keepalive_interval.cfgvalue(self, section)
-	local v = m:get(section, "keepalive")
-	if v and #v > 0 then
-		return tonumber(v:match("^%d+[ ,]+(%d+)"))
-	end
-end
-
-function keepalive_interval.write(self, section, value)
-	local f = tonumber(keepalive_failure:formvalue(section)) or 0
-	local i = tonumber(value) or 5
-	if i < 1 then i = 1 end
-	if f > 0 then
-		m:set(section, "keepalive", "%d %d" %{ f, i })
-	else
-		m:del(section, "keepalive")
-	end
-end
-
-keepalive_interval.remove      = keepalive_interval.write
-keepalive_interval.placeholder = "5"
-keepalive_interval.datatype    = "min(1)"
-
-
-demand = section:taboption("advanced", Value, "demand",
-	translate("Inactivity timeout"),
-	translate("Close inactive connection after the given amount of seconds, use 0 to persist connection"))
-
-demand.placeholder = "0"
-demand.datatype    = "uinteger"


### PR DESCRIPTION
This removes all options 100% unrelated to NCM protocol.
Some options like 'dns' are not currently used by connection scripts,
but may be used in the future.

Signed-off-by: Dmitry Tunin <hanipouspilot@gmail.com>