### PR TITLE
luci-base: update Polish translation

### DIFF
--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: LuCI\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2010-04-20 09:40+0200\n"
-"PO-Revision-Date: 2018-07-14 21:35+0200\n"
+"PO-Revision-Date: 2018-07-21 18:35+0200\n"
 "Last-Translator: Rixerx <krystian.kozak20@gmail.com>\n"
 "Language-Team: Polish\n"
 "Language: pl\n"
@@ -279,16 +279,16 @@ msgid "Alert"
 msgstr "Alarm"
 
 msgid "Alias Interface"
-msgstr ""
+msgstr "Alias Interfejsu"
 
 msgid "Alias interface"
 msgstr "Alias interfejsu"
 
 msgid "Alias of \"%s\""
-msgstr ""
+msgstr "Alias \"%s\""
 
 msgid "All Servers"
-msgstr ""
+msgstr "Wszystkie serwery"
 
 msgid ""
 "Allocate IP addresses sequentially, starting from the lowest available "
@@ -303,7 +303,7 @@ msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Pozwól na logowanie <abbr title=\"Secure Shell\">SSH</abbr>"
 
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
-msgstr ""
+msgstr "Pozwól aby tryb AP rozłączał stacje STA w oparciu o niski stan ACK"
 
 msgid "Allow all except listed"
 msgstr "Pozwól wszystkim oprócz wymienionych"
@@ -342,6 +342,8 @@ msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
+"Zawsze używaj kanału 40 MHz, nawet jeśli kanał dodatkowy nachodzi na inny. "
+"Używanie tej opcji nie jest zgodne z IEEE 802.11n-2009!"
 
 msgid "Annex"
 msgstr ""
@@ -541,7 +543,7 @@ msgid "Band"
 msgstr ""
 
 msgid "Beacon Interval"
-msgstr ""
+msgstr "Interwał Beaconu"
 
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -577,7 +579,6 @@ msgstr "Interfejs mostu"
 msgid "Bridge unit number"
 msgstr "Numer Mostu (urządzenia)"
 
-# Podejrzewam że chodzi o interfejs? mam rację?
 msgid "Bring up on boot"
 msgstr "Podnieś przy stracie"
 
@@ -860,7 +861,7 @@ msgid "DSL line mode"
 msgstr ""
 
 msgid "DTIM Interval"
-msgstr ""
+msgstr "Interwał DTIM"
 
 msgid "DUID"
 msgstr "DUID"
@@ -901,12 +902,11 @@ msgid "Delete this network"
 msgstr "Usuń tą sieć"
 
 msgid "Delivery Traffic Indication Message Interval"
-msgstr ""
+msgstr "Interwał komunikatu o wskazaniu dostawy ruchu"
 
 msgid "Description"
 msgstr "Opis"
 
-# Ktoś tłumaczył bez zobaczenia tego w gui. Dotyczy zmiany motywu ten opis.
 msgid "Design"
 msgstr "Motyw"
 
@@ -963,7 +963,7 @@ msgid "Disabled (default)"
 msgstr "Wyłączone (domyślnie)"
 
 msgid "Disassociate On Low Acknowledgement"
-msgstr ""
+msgstr "Rozłączaj przy niskim stanie ramek ACK"
 
 msgid "Discard upstream RFC1918 responses"
 msgstr "Odrzuć wychodzące odpowiedzi RFC1918"
@@ -990,15 +990,14 @@ msgstr ""
 msgid "Diversity"
 msgstr "Wielorakość"
 
-# Nie wiem czy nie zamotałem ja rozumiem;)
 msgid ""
 "Dnsmasq is a combined <abbr title=\"Dynamic Host Configuration Protocol"
 "\">DHCP</abbr>-Server and <abbr title=\"Domain Name System\">DNS</abbr>-"
 "Forwarder for <abbr title=\"Network Address Translation\">NAT</abbr> "
 "firewalls"
 msgstr ""
-"Dnsmasq jest to serwer <abbr title=\"Dynamic Host Configuration Protocol"
-"\">DHCP</abbr> połączony z serwerem <abbr title=\"Domain Name System\">DNS</"
+"Dnsmasq jest kombajnem serwera <abbr title=\"Dynamic Host Configuration Protocol"
+"\">DHCP</abbr> połączonym z serwerem <abbr title=\"Domain Name System\">DNS</"
 "abbr>. Jest to serwer przekazujący (Fowarder) dla firewalli <abbr title="
 "\"Network Address Translation\">NAT</abbr>"
 
@@ -1055,7 +1054,6 @@ msgstr ""
 msgid "Dual-Stack Lite (RFC6333)"
 msgstr ""
 
-# "n"  brakowało...
 msgid "Dynamic <abbr title=\"Dynamic Host Configuration Protocol\">DHCP</abbr>"
 msgstr ""
 "<abbr title=\"Dynamic Host Configuration Protocol\">DHCP</abbr> dynamiczne"
@@ -1334,7 +1332,7 @@ msgid "Force"
 msgstr "Wymuś"
 
 msgid "Force 40MHz mode"
-msgstr ""
+msgstr "Wymuś tryb 40MHz"
 
 msgid "Force CCMP (AES)"
 msgstr "Wymuś CCMP (AES)"
@@ -1733,7 +1731,6 @@ msgstr ""
 msgid "Interface Configuration"
 msgstr "Konfiguracja Interfejsu"
 
-# Tam jest lista interfejsów....
 msgid "Interface Overview"
 msgstr "Przegląd Interfejsów"
 
@@ -1752,7 +1749,6 @@ msgstr "Interfejsy"
 msgid "Internal"
 msgstr ""
 
-# Nadużycie tagu abbr uważam za uzasadnione.
 msgid "Internal Server Error"
 msgstr "Wewnętrzny błąd serwera"
 
@@ -2013,7 +2009,7 @@ msgid "Lowest leased address as offset from the network address."
 msgstr "Najniższy wydzierżawiony adres jako offset dla adresu sieci."
 
 msgid "MAC"
-msgstr ""
+msgstr "MAC"
 
 msgid "MAC-Address"
 msgstr "Adres MAC"
@@ -2260,7 +2256,7 @@ msgid "No rules in this chain"
 msgstr "Brak zasad w tym łańcuchu"
 
 msgid "No scan results available yet..."
-msgstr ""
+msgstr "Brak wyników skanowania..."
 
 msgid "No zone assigned"
 msgstr "Brak przypisanej strefy"
@@ -2699,6 +2695,7 @@ msgid ""
 "Query all available upstream <abbr title=\"Domain Name System\">DNS</abbr> "
 "servers"
 msgstr ""
+"Zapytaj o wszystkie dostępne serwery <abbr title=\"Domain Name System\">DNS</abbr> "
 
 msgid "R0 Key Lifetime"
 msgstr ""
@@ -2995,11 +2992,10 @@ msgid "Scan"
 msgstr "Skanuj"
 
 msgid "Scan request failed"
-msgstr ""
+msgstr "Próba skanowania nie powiodła się"
 
-# Raczej nie stosuje się kilku dużych liter w tym samym
 msgid "Scheduled Tasks"
-msgstr "Zaplanowane zadania"
+msgstr "Zaplanowane Zadania"
 
 msgid "Section added"
 msgstr "Dodano sekcję"
@@ -3059,7 +3055,7 @@ msgid "Short GI"
 msgstr ""
 
 msgid "Short Preamble"
-msgstr ""
+msgstr "Krótki Wstęp"
 
 msgid "Show current backup file list"
 msgstr "Pokaż aktualną listę plików do backupu"
@@ -3169,7 +3165,7 @@ msgid "Starting configuration apply…"
 msgstr ""
 
 msgid "Starting wireless scan..."
-msgstr ""
+msgstr "Rozpoczynanie skanowania..."
 
 msgid "Startup"
 msgstr "Autostart"
@@ -3936,7 +3932,7 @@ msgid ""
 msgstr ""
 "Tutaj można włączyć lub wyłączyć zainstalowane skrypty. Zmiany zostaną "
 "zastosowane po ponownym uruchomieniu urządzenia.<br /><strong>Ostrzeżenie: "
-"Jeśli wyłączysz podstawowe skrypty typu \"networks\", urządzenie może stać "
+"Jeśli wyłączysz podstawowe skrypty typu \"network\", urządzenie może stać "
 "się nieosiągalne!</strong>"
 
 msgid ""
@@ -4034,7 +4030,7 @@ msgid "minutes"
 msgstr "minuty"
 
 msgid "mixed WPA/WPA2"
-msgstr ""
+msgstr "mieszany WPA/WPA2"
 
 msgid "no"
 msgstr "nie"


### PR DESCRIPTION
Updated Polish translations.

@jow- @musashino205 
I have a question to you. In commit https://github.com/openwrt/luci/commit/86660f92d12b963a05118a8f9471513a18773be4 and https://github.com/openwrt/luci/commit/524ce90c4e22dcb64ac8e6c2e012eb54cd5f098e, you have added "Alias interface" and "Alias Interface". Should there be almost identical expressions here?

Signed-off-by: Krystian Kozak <krystian.kozak20@gmail.com>