### PR TITLE
luci-app-adblock: sync with adblock 3.5.4

### DIFF
--- a/applications/luci-app-adblock/luasrc/controller/adblock.lua
+++ b/applications/luci-app-adblock/luasrc/controller/adblock.lua
@@ -3,9 +3,14 @@
 
 module("luci.controller.adblock", package.seeall)
 
+local sys   = require("luci.sys")
 local util  = require("luci.util")
+local http  = require("luci.http")
 local templ = require("luci.template")
 local i18n  = require("luci.i18n")
+local json  = require("luci.jsonc")
+local uci   = require("luci.model.uci").cursor()
+local fs    = require("nixio.fs")
 
 function index()
 	if not nixio.fs.access("/etc/config/adblock") then
@@ -13,24 +18,58 @@ function index()
 	end
 	entry({"admin", "services", "adblock"}, firstchild(), _("Adblock"), 30).dependent = false
 	entry({"admin", "services", "adblock", "tab_from_cbi"}, cbi("adblock/overview_tab", {hideresetbtn=true, hidesavebtn=true}), _("Overview"), 10).leaf = true
-	entry({"admin", "services", "adblock", "logfile"}, call("logread"), _("View Logfile"), 20).leaf = true
+	entry({"admin", "services", "adblock", "log"}, template("adblock/logread"), _("View Logfile"), 20).leaf = true
 	entry({"admin", "services", "adblock", "advanced"}, firstchild(), _("Advanced"), 100)
 	entry({"admin", "services", "adblock", "advanced", "blacklist"}, form("adblock/blacklist_tab"), _("Edit Blacklist"), 110).leaf = true
 	entry({"admin", "services", "adblock", "advanced", "whitelist"}, form("adblock/whitelist_tab"), _("Edit Whitelist"), 120).leaf = true
 	entry({"admin", "services", "adblock", "advanced", "configuration"}, form("adblock/configuration_tab"), _("Edit Configuration"), 130).leaf = true
 	entry({"admin", "services", "adblock", "advanced", "query"}, template("adblock/query"), _("Query domains"), 140).leaf = true
 	entry({"admin", "services", "adblock", "advanced", "result"}, call("queryData"), nil, 150).leaf = true
+	entry({"admin", "services", "adblock", "logread"}, call("logread"), nil).leaf = true
+	entry({"admin", "services", "adblock", "status"}, call("status_update"), nil).leaf = true
+	entry({"admin", "services", "adblock", "action"}, call("adb_action"), nil).leaf = true
+end
+
+function adb_action(value)
+	if value == "Suspend" then
+		luci.sys.call("/etc/init.d/adblock suspend >/dev/null 2>&1")
+	elseif value == "Resume" then
+		luci.sys.call("/etc/init.d/adblock resume >/dev/null 2>&1")
+	elseif value == "Refresh" then
+		luci.sys.call("/etc/init.d/adblock reload >/dev/null 2>&1")
+	end
+	luci.http.prepare_content("text/plain")	
+	luci.http.write("0")
+end
+
+function status_update()
+	local rt_file
+	local content
+
+	rt_file = uci:get("adblock", "global", "adb_rtfile") or "/tmp/adb_runtime.json"
+
+	if fs.access(rt_file) then
+		content = json.parse(fs.readfile(rt_file))
+		if content then
+			http.prepare_content("application/json")
+			http.write_json(content)
+		end
+	end
 end
 
 function logread()
-	local logfile
+	local content
 
 	if nixio.fs.access("/var/log/messages") then
-		logfile = util.trim(util.exec("grep -F 'adblock-' /var/log/messages"))
+		content = util.trim(util.exec("grep -F 'adblock-' /var/log/messages"))
 	else
-		logfile = util.trim(util.exec("logread -e 'adblock-'"))
+		content = util.trim(util.exec("logread -e 'adblock-'"))
 	end
-	templ.render("adblock/logread", {title = i18n.translate("Adblock Logfile"), content = logfile})
+	
+	if content == "" then
+		content = "No adblock related logs yet!"
+	end
+	http.write(content)
 end
 
 function queryData(domain)

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/blacklist_tab.lua
@@ -1,19 +1,19 @@
 -- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
-local fs       = require("nixio.fs")
-local util     = require("luci.util")
-local uci      = require("luci.model.uci").cursor()
-local adbinput = uci:get("adblock", "blacklist", "adb_src") or "/etc/adblock/adblock.blacklist"
+local fs    = require("nixio.fs")
+local util  = require("luci.util")
+local uci   = require("luci.model.uci").cursor()
+local input = uci:get("adblock", "blacklist", "adb_src") or "/etc/adblock/adblock.blacklist"
 
-if not fs.access(adbinput) then
+if not fs.access(input) then
 	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
 	m.reset = false
 	m.submit = false
 	return m
 end
 
-if fs.stat(adbinput).size >= 102400 then
+if fs.stat(input).size >= 102400 then
 	m = SimpleForm("error", nil,
 		translate("The file size is too large for online editing in LuCI (&ge; 100 KB). ")
 		.. translate("Please edit this file directly in a terminal session."))
@@ -28,7 +28,7 @@ m.submit = translate("Save")
 m.reset = false
 
 s = m:section(SimpleSection, nil,
-	translatef("This form allows you to modify the content of the adblock blacklist (%s).<br />", adbinput)
+	translatef("This form allows you to modify the content of the adblock blacklist (%s). ", input)
 	.. translate("Please add only one domain per line. Comments introduced with '#' are allowed - ip addresses, wildcards and regex are not."))
 
 f = s:option(TextValue, "data")
@@ -37,11 +37,15 @@ f.rows = 20
 f.rmempty = true
 
 function f.cfgvalue()
-	return fs.readfile(adbinput) or ""
+	return fs.readfile(input) or ""
 end
 
 function f.write(self, section, data)
-	return fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+	return fs.writefile(input, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+end
+
+function f.remove(self, section, value)
+	return fs.writefile(input, "")
 end
 
 function s.handle(self, state, data)

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/configuration_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/configuration_tab.lua
@@ -1,18 +1,18 @@
 -- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
-local fs       = require("nixio.fs")
-local util     = require("luci.util")
-local adbinput = "/etc/config/adblock"
+local fs    = require("nixio.fs")
+local util  = require("luci.util")
+local input = "/etc/config/adblock"
 
-if not fs.access(adbinput) then
+if not fs.access(input) then
 	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
 	m.reset = false
 	m.submit = false
 	return m
 end
 
-if fs.stat(adbinput).size >= 102400 then
+if fs.stat(input).size >= 102400 then
 	m = SimpleForm("error", nil,
 		translate("The file size is too large for online editing in LuCI (&ge; 100 KB). ")
 		.. translate("Please edit this file directly in a terminal session."))
@@ -34,11 +34,15 @@ f.rows = 20
 f.rmempty = true
 
 function f.cfgvalue()
-	return fs.readfile(adbinput) or ""
+	return fs.readfile(input) or ""
 end
 
 function f.write(self, section, data)
-	return fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+	return fs.writefile(input, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+end
+
+function f.remove(self, section, value)
+	return fs.writefile(input, "")
 end
 
 function s.handle(self, state, data)

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
@@ -1,69 +1,32 @@
 -- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
-local fs       = require("nixio.fs")
-local uci      = require("luci.model.uci").cursor()
-local sys      = require("luci.sys")
-local util     = require("luci.util")
-local dump     = util.ubus("network.interface", "dump", {})
-local json     = require("luci.jsonc")
-local adbinput = uci:get("adblock", "global", "adb_rtfile") or "/tmp/adb_runtime.json"
+local fs   = require("nixio.fs")
+local uci  = require("luci.model.uci").cursor()
+local sys  = require("luci.sys")
+local util = require("luci.util")
+local dump = util.ubus("network.interface", "dump", {})
 
 m = Map("adblock", translate("Adblock"),
 	translate("Configuration of the adblock package to block ad/abuse domains by using DNS. ")
 	.. translatef("For further information "
 	.. "<a href=\"%s\" target=\"_blank\">"
 	.. "check the online documentation</a>", "https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md"))
-m.apply_on_parse = true
 
 function m.on_apply(self)
 	luci.sys.call("/etc/init.d/adblock reload >/dev/null 2>&1")
-	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "adblock"))
 end
 
 -- Main adblock options
 
 s = m:section(NamedSection, "global", "adblock")
 
-local parse = json.parse(fs.readfile(adbinput) or "")
-if parse then
-	status  = parse.data.adblock_status
-	version = parse.data.adblock_version
-	domains = parse.data.overall_domains
-	fetch   = parse.data.fetch_utility
-	backend = parse.data.dns_backend
-	rundate = parse.data.last_rundate
-end
-
 o1 = s:option(Flag, "adb_enabled", translate("Enable Adblock"))
 o1.default = o1.disabled
 o1.rmempty = false
 
-btn = s:option(Button, "", translate("Suspend / Resume Adblock"))
-if parse and status == "enabled" then
-	btn.inputtitle = translate("Suspend")
-	btn.inputstyle = "reset"
-	btn.disabled = false
-	function btn.write()
-		luci.sys.call("/etc/init.d/adblock suspend >/dev/null 2>&1")
-		luci.http.redirect(luci.dispatcher.build_url("admin", "services", "adblock"))
-	end
-elseif parse and status == "paused" then
-	btn.inputtitle = translate("Resume")
-	btn.inputstyle = "apply"
-	btn.disabled = false
-	function btn.write()
-		luci.sys.call("/etc/init.d/adblock resume >/dev/null 2>&1")
-		luci.http.redirect(luci.dispatcher.build_url("admin", "services", "adblock"))
-	end
-else
-	btn.inputtitle = translate("-------")
-	btn.inputstyle = "button"
-	btn.disabled = true
-end
-
 o2 = s:option(ListValue, "adb_dns", translate("DNS Backend (DNS Directory)"),
-	translate("List of supported DNS backends with their default list export directory.<br />")
+	translate("List of supported DNS backends with their default list export directory. ")
 	.. translate("To overwrite the default path use the 'DNS Directory' option in the extra section below."))
 o2:value("dnsmasq", "dnsmasq (/tmp)")
 o2:value("unbound", "unbound (/var/lib/unbound)")
@@ -85,7 +48,7 @@ o3.default = "uclient-fetch"
 o3.rmempty = false
 
 o4 = s:option(ListValue, "adb_trigger", translate("Startup Trigger"),
-	translate("List of available network interfaces. Usually the startup will be triggered by the 'wan' interface.<br />")
+	translate("List of available network interfaces. Usually the startup will be triggered by the 'wan' interface. ")
 	.. translate("Choose 'none' to disable automatic startups, 'timed' to use a classic timeout (default 30 sec.) or select another trigger interface."))
 o4:value("none")
 o4:value("timed")
@@ -101,66 +64,8 @@ o4.rmempty = false
 
 -- Runtime information
 
-ds = m:section(NamedSection, "global", "adblock", translate("Runtime Information"))
-
-dv1 = ds:option(DummyValue, "", translate("Adblock Status"))
-dv1.template = "adblock/runtime"
-if parse == nil then
-	dv1.value = translate("n/a")
-else
-	if status == "error" then
-		dv1.value = translate("error")
-	elseif status == "disabled" then
-		dv1.value = translate("disabled")
-	elseif status == "paused" then
-		dv1.value = translate("paused")
-	elseif status == "running" then
-		dv1.value = translate("running")
-	else
-		dv1.value = translate("enabled")
-	end
-end
-
-dv2 = ds:option(DummyValue, "", translate("Adblock Version"))
-dv2.template = "adblock/runtime"
-if parse == nil then
-	dv2.value = translate("n/a")
-else
-	dv2.value = version
-end
-
-dv3 = ds:option(DummyValue, "", translate("Download Utility (SSL Library)"),
-	translate("For SSL protected blocklist sources you need a suitable SSL library, e.g. 'libustream-ssl' or 'built-in'."))
-dv3.template = "adblock/runtime"
-if parse == nil then
-	dv3.value = translate("n/a")
-else
-	dv3.value = fetch
-end
-
-dv4 = ds:option(DummyValue, "", translate("DNS Backend (DNS Directory)"))
-dv4.template = "adblock/runtime"
-if parse == nil then
-	dv4.value = translate("n/a")
-else
-	dv4.value = backend
-end
-
-dv5 = ds:option(DummyValue, "", translate("Overall Domains"))
-dv5.template = "adblock/runtime"
-if parse == nil then
-	dv5.value = translate("n/a")
-else
-	dv5.value = domains
-end
-
-dv6 = ds:option(DummyValue, "", translate("Last Run"))
-dv6.template = "adblock/runtime"
-if parse == nil then
-	dv6.value = translate("n/a")
-else
-	dv6.value = rundate
-end
+ds = s:option(DummyValue, "_dummy")
+ds.template = "adblock/runtime"
 
 -- Blocklist table
 
@@ -197,46 +102,54 @@ e1 = e:option(Flag, "adb_debug", translate("Verbose Debug Logging"),
 e1.default = e1.disabled
 e1.rmempty = false
 
-e2 = e:option(Flag, "adb_forcedns", translate("Force Local DNS"),
-	translate("Redirect all DNS queries from 'lan' zone to the local resolver."))
+e2 = e:option(Flag, "adb_nice", translate("Low Priority Service"),
+	translate("Set the nice level to 'low priority' and the adblock background processing will take less resources from the system. ")
+	..translate("This change requires a manual service stop/re-start to take effect."))
 e2.default = e2.disabled
+e2.disabled = "0"
+e2.enabled = "10"
 e2.rmempty = false
 
-e3 = e:option(Flag, "adb_forcesrt", translate("Force Overall Sort"),
-	translate("Enable memory intense overall sort / duplicate removal on low memory devices (&lt; 64 MB free RAM)"))
+e3 = e:option(Flag, "adb_forcedns", translate("Force Local DNS"),
+	translate("Redirect all DNS queries from 'lan' zone to the local resolver, apply to udp and tcp protocol on ports 53, 853 and 5353."))
 e3.default = e3.disabled
 e3.rmempty = false
 
-e4 = e:option(Flag, "adb_backup", translate("Enable Blocklist Backup"),
-	translate("Create compressed blocklist backups, they will be used in case of download errors or during startup in backup mode."))
+e4 = e:option(Flag, "adb_forcesrt", translate("Force Overall Sort"),
+	translate("Enable memory intense overall sort / duplicate removal on low memory devices (&lt; 64 MB free RAM)"))
 e4.default = e4.disabled
 e4.rmempty = false
 
-e5 = e:option(Value, "adb_backupdir", translate("Backup Directory"),
+e5 = e:option(Flag, "adb_backup", translate("Enable Blocklist Backup"),
+	translate("Create compressed blocklist backups, they will be used in case of download errors or during startup in backup mode."))
+e5.default = e5.disabled
+e5.rmempty = false
+
+e6 = e:option(Value, "adb_backupdir", translate("Backup Directory"),
 	translate("Target directory for adblock backups. Please use only non-volatile disks, e.g. an external usb stick."))
-e5:depends("adb_backup", 1)
-e5.datatype = "directory"
-e5.default = "/mnt"
+e6:depends("adb_backup", 1)
+e6.datatype = "directory"
+e6.default = "/mnt"
 e5.rmempty = true
 
-e6 = e:option(Flag, "adb_backup_mode", translate("Backup Mode"),
+e7 = e:option(Flag, "adb_backup_mode", translate("Backup Mode"),
 	translate("Do not automatically update blocklists during startup, use blocklist backups instead."))
-e6:depends("adb_backup", 1)
-e6.default = e6.disabled
-e6.rmempty = true
+e7:depends("adb_backup", 1)
+e7.default = e7.disabled
+e7.rmempty = true
 
-e7 = e:option(Value, "adb_maxqueue", translate("Max. Download Queue"),
-	translate("Size of the download queue to handle downloads &amp; list processing in parallel (default '4').<br />")
+e8 = e:option(Value, "adb_maxqueue", translate("Max. Download Queue"),
+	translate("Size of the download queue to handle downloads &amp; list processing in parallel (default '4'). ")
 	.. translate("For further performance improvements you can raise this value, e.g. '8' or '16' should be safe."))
-e7.default = 4
-e7.datatype = "range(1,32)"
-e7.rmempty = false
+e8.default = 4
+e8.datatype = "range(1,32)"
+e8.rmempty = false
 
-e8 = e:option(Flag, "adb_jail", translate("'Jail' Blocklist Creation"),
-	translate("Builds an additional 'Jail' list (/tmp/adb_list.jail) to block access to all domains except those listed in the whitelist file.<br />")
+e9 = e:option(Flag, "adb_jail", translate("'Jail' Blocklist Creation"),
+	translate("Builds an additional 'Jail' list (/tmp/adb_list.jail) to block access to all domains except those listed in the whitelist file. ")
 	.. translate("You can use this restrictive blocklist manually e.g. for guest wifi or kidsafe configurations."))
-e8.default = e8.disabled
-e8.rmempty = true
+e9.default = e9.disabled
+e9.rmempty = true
 
 e9 = e:option(Flag, "adb_dnsflush", translate("Flush DNS Cache"),
 	translate("Flush DNS Cache after adblock processing."))
@@ -244,13 +157,13 @@ e9.default = e9.disabled
 e9.rmempty = true
 
 e10 = e:option(Flag, "adb_notify", translate("Email Notification"),
-	translate("Send notification emails in case of a processing error or if domain count is &le; 0.<br />")
+	translate("Send notification emails in case of a processing error or if domain count is &le; 0. ")
 	.. translate("Please note: this needs additional 'msmtp' package installation and setup."))
 e10.default = e10.disabled
 e10.rmempty = true
 
 e11 = e:option(Value, "adb_notifycnt", translate("Email Notification Count"),
-	translate("Raise the minimum email notification count, to get emails if the overall count is less or equal to the given limit (default 0),<br />")
+	translate("Raise the minimum email notification count, to get emails if the overall count is less or equal to the given limit (default 0), ")
 	.. translate("e.g. to receive an email notification with every adblock update set this value to 150000."))
 e11.default = 0
 e11.datatype = "min(0)"

--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/whitelist_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/whitelist_tab.lua
@@ -1,19 +1,19 @@
 -- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
-local fs       = require("nixio.fs")
-local util     = require("luci.util")
-local uci      = require("luci.model.uci").cursor()
-local adbinput = uci:get("adblock", "global", "adb_whitelist") or "/etc/adblock/adblock.whitelist"
+local fs    = require("nixio.fs")
+local util  = require("luci.util")
+local uci   = require("luci.model.uci").cursor()
+local input = uci:get("adblock", "global", "adb_whitelist") or "/etc/adblock/adblock.whitelist"
 
-if not fs.access(adbinput) then
+if not fs.access(input) then
 	m = SimpleForm("error", nil, translate("Input file not found, please check your configuration."))
 	m.reset = false
 	m.submit = false
 	return m
 end
 
-if fs.stat(adbinput).size >= 102400 then
+if fs.stat(input).size >= 102400 then
 	m = SimpleForm("error", nil,
 		translate("The file size is too large for online editing in LuCI (&ge; 100 KB). ")
 		.. translate("Please edit this file directly in a terminal session."))
@@ -28,7 +28,7 @@ m.submit = translate("Save")
 m.reset = false
 
 s = m:section(SimpleSection, nil,
-	translatef("This form allows you to modify the content of the adblock whitelist (%s).<br />", adbinput)
+	translatef("This form allows you to modify the content of the adblock whitelist (%s). ", input)
 	.. translate("Please add only one domain per line. Comments introduced with '#' are allowed - ip addresses, wildcards and regex are not."))
 
 f = s:option(TextValue, "data")
@@ -37,11 +37,15 @@ f.rows = 20
 f.rmempty = true
 
 function f.cfgvalue()
-	return fs.readfile(adbinput) or ""
+	return fs.readfile(input) or ""
 end
 
 function f.write(self, section, data)
-	return fs.writefile(adbinput, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+	return fs.writefile(input, "\n" .. util.trim(data:gsub("\r\n", "\n")) .. "\n")
+end
+
+function f.remove(self, section, value)
+	return fs.writefile(input, "")
 end
 
 function s.handle(self, state, data)

--- a/applications/luci-app-adblock/luasrc/view/adblock/blocklist.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/blocklist.htm
@@ -4,35 +4,20 @@ This is free software, licensed under the Apache License, Version 2.0
 -%>
 
 <%-
-local rowcnt = 1
-function rowstyle()
-	rowcnt = rowcnt + 1
-	return (rowcnt % 2) + 1
-end
-
-function width(o)
-	if o.width then
-		if type(o.width) == 'number' then
-			return ' style="width:%dpx"' % o.width
-		end
-		return ' style="width:%s"' % o.width
-	end
-	return ''
-end
+local anonclass  = (not self.anonymous or self.sectiontitle) and "named" or "anonymous"
 -%>
 
 <style type="text/css">
 .table.cbi-section-table .th,
 .table.cbi-section-table .td,
 .cbi-section-table-cell,
-.cbi-section-table-row
+.cbi-section-table-row,
+.tr[data-title]::before
 {
 	text-align:left;
 	vertical-align:top;
-	margin-right:auto;
 	margin-left:0px;
 	padding-left:2px;
-	line-height:20px;
 }
 .table.cbi-section-table .th
 {
@@ -42,6 +27,12 @@ end
 {
 	width:7em;
 }
+.cbi-section-table-row > .cbi-value-field [data-dynlist] > input,
+.table.cbi-section-table input
+{
+	width:7em;
+}
+
 .cbi-input-text
 {
 	text-align:left;
@@ -49,36 +40,29 @@ end
 	outline:none;
 	box-shadow:none;
 	background:transparent;
-	height:20px;
-	width:10em;
+	width:7em;
 }
 </style>
 
-<%-
-	local anonclass = (not self.anonymous or self.sectiontitle) and "named" or "anonymous"
-	local titlename = ifattr(not self.anonymous or self.sectiontitle, "data-title", translate("Name"))
--%>
-
-<fieldset class="cbi-section" id="cbi-<%=self.config%>-<%=self.sectiontype%>">
+<div class="cbi-section" id="cbi-<%=self.config%>-<%=self.sectiontype%>">
 	<% if self.title then -%>
 		<legend><%=self.title%></legend>
 	<%- end %>
 	<div class="cbi-section-descr"><%=self.description%></div>
 	<div class="cbi-section-node">
 		<div class="table cbi-section-table">
-			<div class="tr cbi-section-table-titles <%=anonclass%>"<%=titlename%>>
+			<div class="tr cbi-section-table-titles <%=anonclass%>">
 			<%- for i, k in pairs(self.children) do -%>
-				<div class="th cbi-section-table-cell"<%=width(k)%>>
+				<div class="th cbi-section-table-cell">
 					<%-=k.title-%>
 				</div>
 			<%- end -%>
 			</div>
-			<%- local isempty = true
+			<%- local section, scope, isempty = true
 				for i, k in ipairs(self:cfgsections()) do
-					local section = k
-					local sectionname = striptags((type(self.sectiontitle) == "function") and self:sectiontitle(section) or k)
+					section = k
+					local sectionname  = striptags((type(self.sectiontitle) == "function") and self:sectiontitle(section) or k)
 					local sectiontitle = ifattr(sectionname and (not self.anonymous or self.sectiontitle), "data-title", sectionname)
-
 					isempty = false
 					scope = { valueheader = "cbi/cell_valueheader", valuefooter = "cbi/cell_valuefooter" }
 			-%>
@@ -95,4 +79,4 @@ end
 			<%- end -%>
 		</div>
 	</div>
-</fieldset>
+</div>

--- a/applications/luci-app-adblock/luasrc/view/adblock/logread.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/logread.htm
@@ -5,16 +5,31 @@ This is free software, licensed under the Apache License, Version 2.0
 
 <%+header%>
 
-<div class="cbi-map">
-	<fieldset class="cbi-section">
-		<div class="cbi-section-descr"><%:This form shows the syslog output, pre-filtered for adblock related messages only.%></div>
-		<textarea id="logread_id" style="width: 100%; height: 450px; border: 1px solid #cccccc; padding: 5px; font-size: 12px; font-family: monospace; resize: none;" readonly="readonly" wrap="off" rows="<%=content:cmatch("\n")+2%>"><%=content:pcdata()%></textarea>
-	</fieldset>
-</div>
-
 <script type="text/javascript">
-	var textarea = document.getElementById('logread_id');
-	textarea.scrollTop = textarea.scrollHeight;
+//<![CDATA[
+	function log_update()
+	{
+		XHR.poll(5, '<%=luci.dispatcher.build_url("admin", "services", "adblock", "logread")%>', null,
+		function(x)
+		{
+			if (!x)
+			{
+				return;
+			}
+			var view       = document.getElementById("view_id");
+			view.value     = x.responseText;
+			view.scrollTop = view.scrollHeight;
+		});
+	}
+	window.onload = log_update();
+//]]>
 </script>
+
+<div class="cbi-map">
+	<div class="cbi-section">
+		<div class="cbi-section-descr"><%:The syslog output, pre-filtered for adblock related messages only.%></div>
+		<textarea id="view_id" style="width:100%;height:450px;border:1px solid #cccccc;padding:5px;font-size:12px;font-family:monospace;resize:none;" readonly="readonly" wrap="off" value=""></textarea>
+	</div>
+</div>
 
 <%+footer%>

--- a/applications/luci-app-adblock/luasrc/view/adblock/query.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/query.htm
@@ -45,7 +45,7 @@ This is free software, licensed under the Apache License, Version 2.0
 
 <form method="post" action="<%=REQUEST_URI%>">
 	<div class="cbi-map">
-		<fieldset class="cbi-section">
+		<div class="cbi-section">
 			<div class="cbi-section-descr"><%:This form allows you to query active block lists for certain domains, e.g. for whitelisting.%></div>
 			<div style="width:33%; float:left;">
 				<input style="margin: 5px 0" type="text" value="google.com" name="input" />
@@ -53,12 +53,12 @@ This is free software, licensed under the Apache License, Version 2.0
 			</div>
 			<br style="clear:both" />
 			<br />
-		</fieldset>
+		</div>
 	</div>
-	<fieldset class="cbi-section" style="display:none">
-		<legend id="query_input"><%:Collecting data...%></legend>
+	<div class="cbi-section" style="display:none">
+		<h3 id="query_input"><%:Collecting data...%></h3>
 		<span id="query_output"></span>
-	</fieldset>
+	</div>
 </form>
 
 <%+footer%>

--- a/applications/luci-app-adblock/luasrc/view/adblock/runtime.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/runtime.htm
@@ -1,10 +1,192 @@
 <%#
 Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
 This is free software, licensed under the Apache License, Version 2.0
+local sys     = require("luci.sys")
+
 -%>
+<style type="text/css">
+.runtime
+{
+	color:#0069d6;
+	font-weight:bold;
+	display:inline-block;
+	width:100%;
+	padding-top: 0.5rem;
+}
+</style>
 
-<%+cbi/valueheader%>
+<script type="text/javascript">
+//<![CDATA[
+	function status_update(json)
+	{
+			var view  = document.getElementById("value_1");
+			var btn1  = document.getElementById("btn1");
+			var btn2  = document.getElementById("btn2");
+			var input = json.data.adblock_status;
 
-<input name="runtime" id="runtime" type="text" class="cbi-input-text" style="outline:none;border:none;box-shadow:none;background:transparent;color:#0069d6;font-weight:bold;line-height:30px;height:30px;width:20em;" value="<%=self:cfgvalue(section)%>" disabled="disabled" />
+			view.innerHTML = input || "-";
+			if (input === "enabled")
+			{
+				btn1.value = "Suspend";
+				btn2.value = "Refresh";
+				btn1.disabled = false;
+				running(btn1_running, 0);
+				btn2.disabled = false;
+				running(btn2_running, 0);
+			}
+			else if (input === "paused")
+			{
+				btn1.value = "Resume";
+				btn2.value = "Refresh";
+				btn1.disabled = false;
+				running(btn1_running, 0);
+				btn2.disabled = false;
+				running(btn2_running, 0);
+			}
+			else
+			{
+				btn1.value = "Suspend";
+				btn2.value = "Refresh";
+				btn1.disabled = true;
+				btn2.disabled = true;
+			}
+			view = document.getElementById("value_2");
+			input = json.data.adblock_version;
+			view.innerHTML = input || "-";
+			view = document.getElementById("value_3");
+			input = json.data.fetch_utility;
+			view.innerHTML = input || "-";
+			view = document.getElementById("value_4");
+			input = json.data.dns_backend;
+			view.innerHTML = input || "-";
+			view = document.getElementById("value_5");
+			input = json.data.overall_domains;
+			view.innerHTML = input || "-";
+			view = document.getElementById("value_6");
+			input = json.data.last_rundate;
+			view.innerHTML = input || "-";
+	}
 
-<%+cbi/valuefooter%>
+	function btn_action(action)
+	{
+		var btn1 = document.getElementById("btn1");
+		var btn1_running = document.getElementById("btn1_running");
+		var btn2 = document.getElementById("btn2");
+		var btn2_running = document.getElementById("btn2_running");
+
+		btn1.disabled = true;
+		btn2.disabled = true;
+
+		if (action.value === "Refresh")
+		{
+			running(btn2_running, 1);
+		}
+		else
+		{
+			running(btn1_running, 1);
+		}
+
+		new XHR.get('<%=luci.dispatcher.build_url("admin", "services", "adblock")%>/action/' + action.value, null,
+		function(x)
+		{
+			if (!x)
+			{
+				return;
+			}
+		});
+	}
+
+	function running(element, state)
+	{
+		if (state === 1)
+		{
+			var running_html = '<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" width="16" height="16" style="vertical-align:middle" />';
+			element.innerHTML = running_html;
+		}
+		else
+		{
+			element.innerHTML = '';
+		}
+	}
+
+	XHR.get('<%=luci.dispatcher.build_url("admin", "services", "adblock", "status")%>', null,
+	function(x, json_info)
+	{
+		if (!x || !json_info)
+		{
+			var btn1 = document.getElementById("btn1");
+			var btn2 = document.getElementById("btn2");
+			btn1.value = "Suspend";
+			btn2.value = "Refresh";
+			btn1.disabled = true;
+			btn2.disabled = false;
+			return;
+		}
+		status_update(json_info)
+	});
+
+	XHR.poll(5, '<%=luci.dispatcher.build_url("admin", "services", "adblock", "status")%>', null,
+	function(x, json_info)
+	{
+		if (!x || !json_info)
+		{
+			return;
+		}
+		status_update(json_info)
+	});
+//]]>
+</script>
+
+<h3>Runtime Information</h3>
+<div class="cbi-value" id="status_1">
+	<label class="cbi-value-title" for="status_1">Adblock Status</label>
+	<div class="cbi-value-field">
+		<span class="runtime" id="value_1">-</span>
+	</div>
+</div>
+<div class="cbi-value" id="status_2">
+	<label class="cbi-value-title" for="status_2">Adblock Version</label>
+	<div class="cbi-value-field">
+		<span class="runtime" id="value_2">-</span>
+	</div>
+</div>
+<div class="cbi-value" id="status_3">
+	<label class="cbi-value-title" for="status_3">Download Utility (SSL Library)</label>
+	<div class="cbi-value-field">
+		<span class="runtime" id="value_3">-</span>
+	</div>
+</div>
+<div class="cbi-value" id="status_4">
+	<label class="cbi-value-title" for="status_4">DNS Backend (DNS Directory)</label>
+	<div class="cbi-value-field">
+		<span class="runtime" id="value_4">-</span>
+	</div>
+</div>
+<div class="cbi-value" id="status_5">
+	<label class="cbi-value-title" for="status_5">Overall Domains</label>
+	<div class="cbi-value-field">
+		<span class="runtime" id="value_5">-</span>
+	</div>
+</div>
+<div class="cbi-value" id="status_6">
+	<label class="cbi-value-title" for="status_6">Last Run</label>
+	<div class="cbi-value-field">
+		<span class="runtime" id="value_6">-</span>
+	</div>
+</div>
+<hr />
+<div class="cbi-value" id="button_1">
+	<label class="cbi-value-title" for="button_1">Suspend / Resume Adblock</label>
+	<div class="cbi-value-field">
+		<input class="cbi-button cbi-button-reset" id="btn1" type="button" value="" onclick="btn_action(this)" />
+		<span id="btn1_running" style="display:inline-block; width:16px; height:16px; margin:0 5px"></span>
+	</div>
+</div>
+<p />
+<div class="cbi-value" id="button_2">
+	<label class="cbi-value-title" for="button_2">Refresh Blocklist Sources</label>
+	<div class="cbi-value-field">
+		<input class="cbi-button cbi-button-apply" id="btn2" type="button" value="" onclick="btn_action(this)" />
+		<span id="btn2_running" style="display:inline-block; width:16px; height:16px; margin:0 5px"></span>
+	</div>
+</div>


### PR DESCRIPTION
backend:
* add low priority mode (nice level 10), disabled by default
* enhance 'Force DNS' to redirect ports 53, 853 and 5353

frontend:
* switch to dynamic XHR polling for runtime information and logfile
viewing
* add new 'Refresh' button to reload blocklists
* various cleanups & small fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>