### PR TITLE
luci-app-samba4: add new application

### DIFF
--- a/applications/luci-app-samba4/Makefile
+++ b/applications/luci-app-samba4/Makefile
@@ -1,0 +1,10 @@
+# This is free software, licensed under the Apache License, Version 2.0 .
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Network Shares - Samba 4 SMB/CIFS module
+LUCI_DEPENDS:=+samba4-server
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-samba4/luasrc/controller/samba4.lua
+++ b/applications/luci-app-samba4/luasrc/controller/samba4.lua
@@ -1,0 +1,14 @@
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.controller.samba4", package.seeall)
+
+function index()
+	if not nixio.fs.access("/etc/config/samba4") then
+		return
+	end
+
+	local page
+
+	page = entry({"admin", "services", "samba4"}, cbi("samba4"), _("Network Shares"))
+	page.dependent = true
+end

--- a/applications/luci-app-samba4/luasrc/model/cbi/samba4.lua
+++ b/applications/luci-app-samba4/luasrc/model/cbi/samba4.lua
@@ -1,0 +1,90 @@
+-- Licensed to the public under the Apache License 2.0.
+
+m = Map("samba4", translate("Network Shares"))
+
+s = m:section(TypedSection, "samba", "Samba")
+s.anonymous = true
+
+s:tab("general",  translate("General Settings"))
+s:tab("template", translate("Edit Template"))
+
+s:taboption("general", Value, "name", translate("Hostname"))
+s:taboption("general", Value, "description", translate("Description"))
+s:taboption("general", Value, "workgroup", translate("Workgroup"))
+h = s:taboption("general", Flag, "homes", translate("Share home-directories"),
+        translate("Allow system users to reach their home directories via " ..
+                "network shares"))
+h.rmempty = false
+s:taboption("general", Flag, "disable_netbios", translate("Disable Netbios"))
+s:taboption("general", Flag, "disable_ad_dc", translate("Disable Active Directory Domain Controller"))
+s:taboption("general", Flag, "disable_winbind", translate("Disable Winbind"))
+
+tmpl = s:taboption("template", Value, "_tmpl",
+	translate("Edit the template that is used for generating the samba configuration."), 
+	translate("This is the content of the file '/etc/samba/smb.conf.template' from which your samba configuration will be generated. " ..
+		"Values enclosed by pipe symbols ('|') should not be changed. They get their values from the 'General Settings' tab."))
+
+tmpl.template = "cbi/tvalue"
+tmpl.rows = 20
+
+function tmpl.cfgvalue(self, section)
+	return nixio.fs.readfile("/etc/samba/smb.conf.template")
+end
+
+function tmpl.write(self, section, value)
+	value = value:gsub("\r\n?", "\n")
+	nixio.fs.writefile("/etc/samba/smb.conf.template", value)
+end
+
+
+s = m:section(TypedSection, "sambashare", translate("Shared Directories")
+  , translate("Please add directories to share. Each directory refers to a folder on a mounted device."))
+s.anonymous = true
+s.addremove = true
+s.template = "cbi/tblsection"
+
+s:option(Value, "name", translate("Name"))
+pth = s:option(Value, "path", translate("Path"))
+if nixio.fs.access("/etc/config/fstab") then
+	pth.titleref = luci.dispatcher.build_url("admin", "system", "fstab")
+end
+
+s:option(Value, "users", translate("Allowed users")).rmempty = true
+
+ro = s:option(Flag, "read_only", translate("Read-only"))
+ro.rmempty = false
+ro.enabled = "yes"
+ro.disabled = "no"
+
+br = s:option(Flag, "browseable", translate("Browseable"))
+br.rmempty = false
+br.default = "yes"
+br.enabled = "yes"
+br.disabled = "no"
+
+go = s:option(Flag, "guest_ok", translate("Allow guests"))
+go.rmempty = false
+go.enabled = "yes"
+go.disabled = "no"
+
+gon = s:option(Flag, "guest_only", translate("Guests only"))
+gon.rmempty = false
+gon.enabled = "yes"
+gon.disabled = "no"
+
+io = s:option(Flag, "inherit_owner", translate("Inherit owner"))
+io.rmempty = false
+io.enabled = "yes"
+io.disabled = "no"
+
+cm = s:option(Value, "create_mask", translate("Create mask"))
+cm.rmempty = true
+cm.size = 4
+
+dm = s:option(Value, "dir_mask", translate("Directory mask"))
+dm.rmempty = true
+dm.size = 4
+
+s:option(Value, "vfs_objects", translate("Vfs objects")).rmempty = true
+
+return m

--- a/applications/luci-app-samba4/po/ca/samba4.po
+++ b/applications/luci-app-samba4/po/ca/samba4.po
@@ -1,0 +1,121 @@
+#  samba.pot
+#  generated from ./applications/luci-samba/luasrc/i18n/samba.en.lua
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-06-10 03:40+0200\n"
+"PO-Revision-Date: 2014-07-01 05:47+0200\n"
+"Last-Translator: Alex <alexhenrie24@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.0.6\n"
+
+msgid "Allow guests"
+msgstr "Permet convidats"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Permet que els usuaris del sistema pugin arribar als seus directoris d'inici "
+"via comparticions de xarxa"
+
+msgid "Allowed users"
+msgstr "Usuaris permesos"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Crea màscara"
+
+msgid "Description"
+msgstr "Descripció"
+
+msgid "Directory mask"
+msgstr "Màscara de directori"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Edita plantilla"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Edita la plantilla que s'usa per generar la configuració de samba."
+
+msgid "General Settings"
+msgstr "Ajusts generals"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Nom de màquina"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Nom"
+
+msgid "Network Shares"
+msgstr "Comparticions de xarxa"
+
+msgid "Path"
+msgstr "Ruta"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Només lectura"
+
+msgid "Share home-directories"
+msgstr "Comparteix directoris d'inici"
+
+msgid "Shared Directories"
+msgstr "Directoris compartits"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Això és el contingut del fitxer '/etc/samba/smb.conf.template' del qual la "
+"vostra configuració de samba es generarà. Valors encerclats per símbols de "
+"barra ('|') no es deuen canviar. Reben els seus valors de la pestanya "
+"'Ajusts generals'."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Grup de treball"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Màscara per directoris nous"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Màscara per fitxers nous"
+
+#~ msgid "Shared Directory"
+#~ msgstr "Directori compartit"
+
+#~ msgid "Physical Path"
+#~ msgstr "Ruta física"
+
+#~ msgid "optional"
+#~ msgstr "opcional"

--- a/applications/luci-app-samba4/po/cs/samba4.po
+++ b/applications/luci-app-samba4/po/cs/samba4.po
@@ -1,0 +1,109 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2014-05-31 13:56+0200\n"
+"Last-Translator: koli <lukas.koluch@gmail.com>\n"
+"Language-Team: none\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Pootle 2.0.6\n"
+
+msgid "Allow guests"
+msgstr "Povolení hosté"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Povoluje systémovým uživatelům přístup do jejich domácích adresářů skrze "
+"sdílení přes síť."
+
+msgid "Allowed users"
+msgstr "Povolení uživatelé"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Vytvořit masku"
+
+msgid "Description"
+msgstr "Popis"
+
+msgid "Directory mask"
+msgstr "Maska adresáře"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Editovat šablonu"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+"Editovat šablonu, která je použita pro generování konfiguračního souboru pro "
+"sambu."
+
+msgid "General Settings"
+msgstr "Obecné nastavení"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Název počítače."
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Jméno"
+
+msgid "Network Shares"
+msgstr "Síťová sdílení"
+
+msgid "Path"
+msgstr "Cesta"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Pouze pro čtení"
+
+msgid "Share home-directories"
+msgstr "Sdílet domácí adresáře"
+
+msgid "Shared Directories"
+msgstr "Sdílené adresáře"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Toto je obsah souboru \"/etc/samba/smb.conf.template\", ze kterého je "
+"konfigurace samby generována. Hodnoty uzavřené rourou (\"|\"), by se neměly "
+"měnit. Tyto hodnoty jsou brány ze záložky \"Obecná nastavení\"."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Skupina"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Maska pro nové adresáře"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Maska pro nové soubory"

--- a/applications/luci-app-samba4/po/de/samba4.po
+++ b/applications/luci-app-samba4/po/de/samba4.po
@@ -1,0 +1,113 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-05-26 17:57+0200\n"
+"PO-Revision-Date: 2011-10-18 13:13+0200\n"
+"Last-Translator: Manuel <freifunk@somakoma.de>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr "Gastzugang"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Systembenutzer dürfen ihre Heimatverzeichnis über Netzwerkfreigaben "
+"erreichen."
+
+msgid "Allowed users"
+msgstr "Legitimierte Benutzer"
+
+msgid "Browseable"
+msgstr "Suchbar"
+
+msgid "Create mask"
+msgstr "Berechtigungsmaske für neue Dateien"
+
+msgid "Description"
+msgstr "Beschreibung"
+
+msgid "Directory mask"
+msgstr "Verzeichnismaske"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr "Deaktiviere Active Directory Domain Controller"
+
+msgid "Disable Netbios"
+msgstr "Deaktiviere Netbios"
+
+msgid "Disable Winbind"
+msgstr "Deaktiviere Winbind"
+
+msgid "Edit Template"
+msgstr "Template bearbeiten"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+"Hier kann das Template bearbeitet werden, das zur Erstellung der Samba-"
+"Konfigurationsdateien verwendet wird."
+
+msgid "General Settings"
+msgstr "Allgemeine Einstellungen"
+
+msgid "Guests only"
+msgstr "Nur Gaeste"
+
+msgid "Hostname"
+msgstr "Hostname"
+
+msgid "Inherit owner"
+msgstr "Besitzer Erben"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Network Shares"
+msgstr "Netzwerkfreigaben"
+
+msgid "Path"
+msgstr "Pfad"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Nur Lesen"
+
+msgid "Share home-directories"
+msgstr "Heimatverzeichnisse freigeben"
+
+msgid "Shared Directories"
+msgstr "Freigegebene Verzeichnisse"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Dieses Fenster zeigt den Inhalt der Datei '/etc/samba/smb.conf.template', "
+"die als Template zum Erstellen der Samba-Konfiguration verwendet wird. Werte "
+"die von Pipe Symbolen (|) eingeschlossen sind sollten nicht verändert "
+"werden, da diese beim Erstellen der Konfiguration mit den Werten aus dem Tab "
+"'Allgemeine Einstellungen' ersetzt werden."
+
+msgid "Vfs objects"
+msgstr "Virtuelle Filesystem Module"
+
+msgid "Workgroup"
+msgstr "Arbeitsgruppe"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Maske für neue Verzeichnisse"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Maske für neue Dateien"

--- a/applications/luci-app-samba4/po/el/samba4.po
+++ b/applications/luci-app-samba4/po/el/samba4.po
@@ -1,0 +1,98 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-05-28 02:08+0200\n"
+"PO-Revision-Date: 2012-03-18 15:31+0200\n"
+"Last-Translator: Vasilis <acinonyx@openwrt.gr>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr ""
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+
+msgid "Allowed users"
+msgstr ""
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Directory mask"
+msgstr ""
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr ""
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "General Settings"
+msgstr ""
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Όνομα"
+
+msgid "Network Shares"
+msgstr ""
+
+msgid "Path"
+msgstr ""
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr ""
+
+msgid "Share home-directories"
+msgstr ""
+
+msgid "Shared Directories"
+msgstr ""
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr ""

--- a/applications/luci-app-samba4/po/en/samba4.po
+++ b/applications/luci-app-samba4/po/en/samba4.po
@@ -1,0 +1,108 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2010-03-22 15:23+0100\n"
+"PO-Revision-Date: 2011-10-25 21:26+0200\n"
+"Last-Translator: awm1 <awm1klimes8vladimir@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr "Allow guests"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr "Allow system users to reach their home directories via network shares"
+
+msgid "Allowed users"
+msgstr "Allowed users"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Create mask"
+
+msgid "Description"
+msgstr "Description"
+
+msgid "Directory mask"
+msgstr "Directory mask"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Edit template"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Edit the template that is used for generating the Samba configuration."
+
+msgid "General Settings"
+msgstr "General settings"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Hostname"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Network Shares"
+msgstr "Network Shares"
+
+msgid "Path"
+msgstr "Path"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Read-only"
+
+msgid "Share home-directories"
+msgstr "Share home-directories"
+
+msgid "Shared Directories"
+msgstr "Shared Directories"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your Samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"settings' tab."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Workgroup"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Mask for new directories"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Mask for new files"

--- a/applications/luci-app-samba4/po/es/samba4.po
+++ b/applications/luci-app-samba4/po/es/samba4.po
@@ -1,0 +1,118 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-06-10 03:41+0200\n"
+"PO-Revision-Date: 2012-08-22 17:45+0200\n"
+"Last-Translator: José Vicente <josevteg@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.0.6\n"
+
+msgid "Allow guests"
+msgstr "Permitir invitados"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Permitir a los usuarios acceder a sus directorios de inicio vía "
+"comparticiones de red"
+
+msgid "Allowed users"
+msgstr "Usuarios permitidos"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Crear máscara"
+
+msgid "Description"
+msgstr "Descripción"
+
+msgid "Directory mask"
+msgstr "Máscara de directorio"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Editar plantilla"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Editar la plantilla usada para generar la configuración de samba."
+
+msgid "General Settings"
+msgstr "Configuración general"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Nombre de máquina"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Nombre"
+
+msgid "Network Shares"
+msgstr "Comparticiones de red"
+
+msgid "Path"
+msgstr "Dirección"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Solo lectura"
+
+msgid "Share home-directories"
+msgstr "Compartir directorios personales"
+
+msgid "Shared Directories"
+msgstr "Directorios compartidos"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Contenido del fichero '/etc/samba/smb.conf.template' desde el que se "
+"generará la configuración de samba. Los valores entre tuberías ('|') no "
+"deben cambiarse. Su valor se toma desde la pestaña 'Configuración General'."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Grupo de trabajo"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Máscara para directorios nuevos"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Máscara para archivos nuevos"
+
+#~ msgid "Shared Directory"
+#~ msgstr "Directorio compatido"
+
+#~ msgid "Physical Path"
+#~ msgstr "Ruta Física"
+
+#~ msgid "optional"
+#~ msgstr "opcional"

--- a/applications/luci-app-samba4/po/fr/samba4.po
+++ b/applications/luci-app-samba4/po/fr/samba4.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-05-19 19:36+0200\n"
+"PO-Revision-Date: 2011-11-23 22:36+0200\n"
+"Last-Translator: fredb <fblistes+luci@free.fr>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr "Invités autorisés"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Autoriser les utilisateurs système à atteindre leurs dossiers personnels via "
+"les partages réseau"
+
+msgid "Allowed users"
+msgstr "Utilisateurs autorisés"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Maque de création"
+
+msgid "Description"
+msgstr "Description"
+
+msgid "Directory mask"
+msgstr "Masque des dossiers"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Éditer le modèle"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Éditer le modèle utilisé pour générer la configuration Samba."
+
+msgid "General Settings"
+msgstr "Paramètres généraux"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Nom d'hôte"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Nom"
+
+msgid "Network Shares"
+msgstr "Partages réseau"
+
+msgid "Path"
+msgstr "Chemin"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Lecture seule"
+
+msgid "Share home-directories"
+msgstr "Partager les dossiers personnels"
+
+msgid "Shared Directories"
+msgstr "Dossiers partagés"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Voici le contenu du fichier '/etc/samba/smb.conf.template' d'où sera généré "
+"votre configuration Samba. Les valeurs entre les symboles barre-verticale "
+" (« | ») ne doivent pas être modifiées, elles proviennent de l'onglet "
+"« Paramètres généraux »."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Groupe de travail"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Masque pour les nouveaux dossiers"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Masque pour les nouveaux fichiers"

--- a/applications/luci-app-samba4/po/he/samba4.po
+++ b/applications/luci-app-samba4/po/he/samba4.po
@@ -1,0 +1,93 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Allow guests"
+msgstr ""
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+
+msgid "Allowed users"
+msgstr ""
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Directory mask"
+msgstr ""
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr ""
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "General Settings"
+msgstr ""
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Network Shares"
+msgstr ""
+
+msgid "Path"
+msgstr ""
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr ""
+
+msgid "Share home-directories"
+msgstr ""
+
+msgid "Shared Directories"
+msgstr ""
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr ""

--- a/applications/luci-app-samba4/po/hu/samba4.po
+++ b/applications/luci-app-samba4/po/hu/samba4.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2012-04-06 10:56+0200\n"
+"Last-Translator: juhosg <juhosg@openwrt.org>\n"
+"Language-Team: none\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr "Vendég hozzáférés"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"A rendszerfelhasználók hálózati megosztáson keresztül hozzáférhetnek a home "
+"könyvtárukhoz."
+
+msgid "Allowed users"
+msgstr "Engedélyezett felhasználók"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Létrehozási maszk"
+
+msgid "Description"
+msgstr "Leírás"
+
+msgid "Directory mask"
+msgstr "Könyvtár maszk"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Sablon szerkesztése"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+"Itt szerkesztheti a sablont, ami a végleges samba konfiguráció "
+"elkészítéséhez kerül felhasználásra."
+
+msgid "General Settings"
+msgstr "Általános beállítások"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Gépnév"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Név"
+
+msgid "Network Shares"
+msgstr "Hálózati megosztások"
+
+msgid "Path"
+msgstr "Elérési út"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Csak olvasható"
+
+msgid "Share home-directories"
+msgstr "Home könyvtárak megosztása"
+
+msgid "Shared Directories"
+msgstr "Megosztott könyvtárak"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Itt látható a /etc/samba/smb.conf.template file tartalma, ami a samba "
+"konfiguráció előállításához kerül felhasználásra. A pipe szimbólumok ('|') "
+"közé zárt értékek módosítása nem szükséges, az értéküket az általános "
+"beállítások fülről kapják."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Munkacsoport"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Új könyvtárak maszkja"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Új fájlok maszkja"

--- a/applications/luci-app-samba4/po/it/samba4.po
+++ b/applications/luci-app-samba4/po/it/samba4.po
@@ -1,0 +1,113 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-05-19 19:36+0200\n"
+"PO-Revision-Date: 2017-09-06 01:28+0200\n"
+"Last-Translator: bubu83 <bubu83@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr "Permetti ospiti"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Autorizza gli utenti del sistema a raggiungere la loro cartella home "
+"attraverso le condivisioni di rete"
+
+msgid "Allowed users"
+msgstr "Utenti ammessi"
+
+msgid "Browseable"
+msgstr "Sfogliabile"
+
+msgid "Create mask"
+msgstr "Crea maschera"
+
+msgid "Description"
+msgstr "Descrizione"
+
+msgid "Directory mask"
+msgstr "Maschera della cartella"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Modifica Template"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+"Modifica il template utilizzato per generare la configurazione di samba."
+
+msgid "General Settings"
+msgstr "Opzioni Generali"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Hostname"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Nome"
+
+msgid "Network Shares"
+msgstr "Condivisioni di rete"
+
+msgid "Path"
+msgstr "Percorso"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+"Per favore aggiungi le directory da condividere. Ogni directory si riferisce "
+"a una cartella su un dispositivo montato."
+
+msgid "Read-only"
+msgstr "Solo lettura"
+
+msgid "Share home-directories"
+msgstr "Condividi cartelle home"
+
+msgid "Shared Directories"
+msgstr "Cartelle Condivise"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Questo è il contenuto del file '/etc/samba/smb.conf.template' dal quale sarà "
+"generata la tua configurazione di samba. I valori racchiusi tra il simbolo "
+"('|') non dovrebbero essere toccati. Essi vengono generati dalla schermata "
+"'Opzioni Generali'."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Gruppo di lavoro"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Maschera per le nuove cartelle"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Maschera per i nuovi files"

--- a/applications/luci-app-samba4/po/ja/samba4.po
+++ b/applications/luci-app-samba4/po/ja/samba4.po
@@ -1,0 +1,109 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-05-19 19:36+0200\n"
+"PO-Revision-Date: 2017-08-16 00:41+0900\n"
+"Last-Translator: INAGAKI Hiroshi <musashino.open@gmail.com>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.0.3\n"
+"Language-Team: \n"
+
+msgid "Allow guests"
+msgstr "ゲストアクセスを許可"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr "sambaを介してユーザーのホームディレクトリへのアクセスを許可します"
+
+msgid "Allowed users"
+msgstr "許可されたユーザー"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "マスクの作成"
+
+msgid "Description"
+msgstr "説明"
+
+msgid "Directory mask"
+msgstr "ディレクトリのマスク"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "テンプレートの編集"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "samba設定を生成するテンプレートを編集します。"
+
+msgid "General Settings"
+msgstr "一般設定"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "ホスト名"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "名前"
+
+msgid "Network Shares"
+msgstr "ネットワーク共有"
+
+msgid "Path"
+msgstr "パス"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+"共有するディレクトリを追加してください。マウントされたデバイス等のディレクト"
+"リを設定し、公開することができます。"
+
+msgid "Read-only"
+msgstr "読み込みのみ"
+
+msgid "Share home-directories"
+msgstr "ホームディレクトリの共有"
+
+msgid "Shared Directories"
+msgstr "共有ディレクトリ"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"これは、samba設定を生成するための'/etc/samba/smb.conf.template' ファイルの内"
+"容です。パイプ('|')で閉じられた値は変更しないでください。これらの値は'一般設"
+"定'タブ内の値によって置き換えられます。"
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "ワークグループ"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "新規ディレクトリのマスク"
+
+#~ msgid "Mask for new files"
+#~ msgstr "新規ファイルのマスク"

--- a/applications/luci-app-samba4/po/ms/samba4.po
+++ b/applications/luci-app-samba4/po/ms/samba4.po
@@ -1,0 +1,92 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Allow guests"
+msgstr ""
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+
+msgid "Allowed users"
+msgstr ""
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Directory mask"
+msgstr ""
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr ""
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "General Settings"
+msgstr ""
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Network Shares"
+msgstr ""
+
+msgid "Path"
+msgstr ""
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr ""
+
+msgid "Share home-directories"
+msgstr ""
+
+msgid "Shared Directories"
+msgstr ""
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr ""

--- a/applications/luci-app-samba4/po/no/samba4.po
+++ b/applications/luci-app-samba4/po/no/samba4.po
@@ -1,0 +1,98 @@
+msgid ""
+msgstr ""
+"Last-Translator: Lars Hardy <lars.hardy@gmail.com>\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Allow guests"
+msgstr "Tillat gjester"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr "Tillat systembrukere å nå sine hjemmekataloger via nettverks mapper."
+
+msgid "Allowed users"
+msgstr "Tillatte brukere"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Opprett Maske"
+
+msgid "Description"
+msgstr "Beskrivelse"
+
+msgid "Directory mask"
+msgstr "Katalog maske"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Rediger Mal"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Rediger malen som brukes til å generere samba konfigurasjonen."
+
+msgid "General Settings"
+msgstr "Generelle Innstillinger"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Vertsnavn"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Navn"
+
+msgid "Network Shares"
+msgstr "Nettverks Mapper"
+
+msgid "Path"
+msgstr "Fysisk bane"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Skrivebeskyttet"
+
+msgid "Share home-directories"
+msgstr "Del Hjemmekataloger"
+
+msgid "Shared Directories"
+msgstr "Delte Kataloger"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Dette er innholdet av filen '/etc/samba/smb.conf.template' som din samba "
+"konfigurasjon vil bli generert fra. Verdier omsluttet av ('|') bør ikke "
+"endres. De får sine verdier fra 'Generelle Innstillinger' fanen."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Arbeidsgruppe"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Maske for nye kataloger"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Maske for nye filer"

--- a/applications/luci-app-samba4/po/pl/samba4.po
+++ b/applications/luci-app-samba4/po/pl/samba4.po
@@ -1,0 +1,109 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2011-08-26 09:51+0200\n"
+"Last-Translator: Staszek <fistaszek@tlen.pl>\n"
+"Language-Team: none\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr "Zezwalaj Gościom"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Użytkownicy systemu mogą dostać się do swoich katalogów domowych za "
+"pośrednictwem udziałów sieciowych."
+
+msgid "Allowed users"
+msgstr "Użytkownicy z prawem dostępu"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Utwórz maskę"
+
+msgid "Description"
+msgstr "Opis"
+
+msgid "Directory mask"
+msgstr "Maska katalogu"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Edytuj szablon"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Edytuj szablon, który jest używany do generowania konfiguracji samby."
+
+msgid "General Settings"
+msgstr "Ustawienia ogólne"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Nazwa hosta"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Nazwa"
+
+msgid "Network Shares"
+msgstr "Udziały sieciowe"
+
+msgid "Path"
+msgstr "Ścieżka"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Tylko do odczytu"
+
+msgid "Share home-directories"
+msgstr "Udostępniaj katalogi domowe"
+
+msgid "Shared Directories"
+msgstr "Udostępniane katalogi"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"To jest zawartość pliku '/etc/samba/smb.conf.template\", na podstawie "
+"którego zostanie wygenerowana konfiguracja samby. Wartości otoczone symbolem "
+"kreski pionowej ('|') nie powinny być zmieniane. Wartości ich zostaną "
+"pobrane z zakładki \"Ustawienia ogólne\"."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Grupa robocza"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Maska dla nowych katalogów"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Maska dla nowych plików"

--- a/applications/luci-app-samba4/po/pt-br/samba4.po
+++ b/applications/luci-app-samba4/po/pt-br/samba4.po
@@ -1,0 +1,119 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-06-10 03:41+0200\n"
+"PO-Revision-Date: 2013-04-06 22:54+0200\n"
+"Last-Translator: Luiz Angelo <luizluca@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Pootle 2.0.6\n"
+
+msgid "Allow guests"
+msgstr "Permitir convidados"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Usuários do sistema poderão acessar seu diretório home através dos "
+"compartilhamentos de rede"
+
+msgid "Allowed users"
+msgstr "Usuários permitidos"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Máscara de criação"
+
+msgid "Description"
+msgstr "Descrição"
+
+msgid "Directory mask"
+msgstr "Máscara do diretório"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Editar modelo"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Edita o modelo que é usado para gerar a configuração do samba."
+
+msgid "General Settings"
+msgstr "Configurações Gerais"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Nome do equipamento"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Nome"
+
+msgid "Network Shares"
+msgstr "Compartilhamentos de Rede"
+
+msgid "Path"
+msgstr "Caminho"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Somente leitura"
+
+msgid "Share home-directories"
+msgstr "Compartilhar diretórios home"
+
+msgid "Shared Directories"
+msgstr "Diretórios Compartilhados"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Este é o conteúdo do arquivo '/etc/samba/smb.conf.template' a partir do qual "
+"sua configuração do samba será gerada. Valores entre simbolos de pipe ('|') "
+"não devem ser alterados. Estes valores serão obtidos a partir da aba "
+"'Configurações Gerais'."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Grupo de trabalho"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Máscara para novos diretórios"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Máscara para novos arquivos"
+
+#~ msgid "Shared Directory"
+#~ msgstr "Diretório Compartilhado"
+
+#~ msgid "Physical Path"
+#~ msgstr "Caminho Físico"
+
+#~ msgid "optional"
+#~ msgstr "opcional"

--- a/applications/luci-app-samba4/po/pt/samba4.po
+++ b/applications/luci-app-samba4/po/pt/samba4.po
@@ -1,0 +1,119 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-05-26 19:03+0200\n"
+"PO-Revision-Date: 2013-05-01 01:13+0200\n"
+"Last-Translator: pedromrgoncalves <pedromrgoncalves@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.0.6\n"
+
+msgid "Allow guests"
+msgstr "Permitir Convidados"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Utilizadores do sistema poderão aceder ao seu directório home através das "
+"partilhas de rede."
+
+msgid "Allowed users"
+msgstr "Utilizadores Permitidos"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Criar Máscara"
+
+msgid "Description"
+msgstr "Descrição"
+
+msgid "Directory mask"
+msgstr "Máscara do Directório"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Editar Template"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Editar a template que é utilizada para gerar a configuração samba"
+
+msgid "General Settings"
+msgstr "Definições Gerais"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Nome do host"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Nome"
+
+msgid "Network Shares"
+msgstr "Partilhas da Rede"
+
+msgid "Path"
+msgstr "Caminho"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Apenas Leitura"
+
+msgid "Share home-directories"
+msgstr "Partilha de directórios home"
+
+msgid "Shared Directories"
+msgstr "Directórios Partilhados"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Isto é o conteúdo do ficheiro 'etc/samba/smb.conf.template' a partir do qual "
+"será gerado o ficheiro de configuração do samba. Os valores entre o símbolo "
+"| não devem ser alterados. Eles recebem os valores do separador 'Definições "
+"Gerais'."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Grupo de trabalho"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Máscara para novos directórios"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Máscara para novos ficheiros"
+
+#~ msgid "Shared Directory"
+#~ msgstr "Diretório Compartilhado"
+
+#~ msgid "Physical Path"
+#~ msgstr "Caminho Físico"
+
+#~ msgid "optional"
+#~ msgstr "opcional"

--- a/applications/luci-app-samba4/po/ro/samba4.po
+++ b/applications/luci-app-samba4/po/ro/samba4.po
@@ -1,0 +1,108 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2011-10-07 17:16+0200\n"
+"Last-Translator: Daniel <daniel.petre@pitesti.rcs-rds.ro>\n"
+"Language-Team: none\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2);;\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr "Permite oaspeti"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Permite utilizatorii de sistem sa acceseze directoarele lor peste "
+"partajarile de retea"
+
+msgid "Allowed users"
+msgstr "Utilizatori acceptati"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Creaza masca"
+
+msgid "Description"
+msgstr "Descriere"
+
+msgid "Directory mask"
+msgstr "Masca director"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Editeaza sablon"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Editeaza sablonul care e folosit pentru generarea configuratiei samba."
+
+msgid "General Settings"
+msgstr "Setari generale"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Numele de host"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Nume"
+
+msgid "Network Shares"
+msgstr "Partajari pe retea"
+
+msgid "Path"
+msgstr "Cale"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Doar citire"
+
+msgid "Share home-directories"
+msgstr "Partajeaza directoarele proprii"
+
+msgid "Shared Directories"
+msgstr "Directoare partajate"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Acesta este continutul fisierului '/etc/samba/smb.conf.template' din care se "
+"genereaza configuratia samba. Valorile dintre liniuta verticala ('|') n-ar "
+"trebui schimbate, ele iau valorile direct din tab-ul de \"Setari generale\"."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Workgroup"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Masca pentru directoarele noi"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Masca pentru fisierele noi"

--- a/applications/luci-app-samba4/po/ru/samba4.po
+++ b/applications/luci-app-samba4/po/ru/samba4.po
@@ -1,0 +1,114 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: LuCI: samba\n"
+"POT-Creation-Date: 2009-05-19 19:36+0200\n"
+"PO-Revision-Date: 2018-01-14 11:43+0300\n"
+"Language-Team: http://cyber-place.ru\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"Last-Translator: Vladimir aka sunny <picfun@ya.ru>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Language: ru\n"
+"Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
+"интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
+
+msgid "Allow guests"
+msgstr "Разрешить гостевой вход"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Разрешить пользователям получать доступ к их домашним папкам, через "
+"локальную сеть."
+
+msgid "Allowed users"
+msgstr "Разрешенные пользователи"
+
+msgid "Browseable"
+msgstr "Виден в списке доступных ресурсов"
+
+msgid "Create mask"
+msgstr "Создать маску"
+
+msgid "Description"
+msgstr "Описание"
+
+msgid "Directory mask"
+msgstr "Маска папок"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Настройка config файла"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "Настройка config<br />файла samba."
+
+msgid "General Settings"
+msgstr "Основные настройки"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Имя хоста"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Имя"
+
+msgid "Network Shares"
+msgstr "Сетевые ресурсы"
+
+msgid "Path"
+msgstr "Путь"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+"Добавьте папки для совместного доступа. Каждая папка - соответствует разделу "
+"на подключенном устройстве."
+
+msgid "Read-only"
+msgstr "Только для чтения"
+
+msgid "Share home-directories"
+msgstr "Совместно использовать домашние папки"
+
+msgid "Shared Directories"
+msgstr "Совместно используемые папки"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Это содержимое файла '/etc/samba/smb.conf.template', из которого "
+"генерируется config файл - samba.<br />Значения, заключенные в символы "
+"('|'), не должны быть изменены.<br />Они будут автоматически заменены на "
+"значения со страницы 'Основные настройки'."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Рабочая группа"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Маска для новых папок"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Маска для новых файлов"

--- a/applications/luci-app-samba4/po/sk/samba4.po
+++ b/applications/luci-app-samba4/po/sk/samba4.po
@@ -1,0 +1,93 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+msgid "Allow guests"
+msgstr ""
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+
+msgid "Allowed users"
+msgstr ""
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Directory mask"
+msgstr ""
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr ""
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "General Settings"
+msgstr ""
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Network Shares"
+msgstr ""
+
+msgid "Path"
+msgstr ""
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr ""
+
+msgid "Share home-directories"
+msgstr ""
+
+msgid "Shared Directories"
+msgstr ""
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr ""

--- a/applications/luci-app-samba4/po/sv/samba4.po
+++ b/applications/luci-app-samba4/po/sv/samba4.po
@@ -1,0 +1,101 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Allow guests"
+msgstr "Tillåt gäster"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr "Tillåt systemanvändare att nå deras hem-mappar via nätverksdelningar"
+
+msgid "Allowed users"
+msgstr "Tillåtna användare"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Skapa mask"
+
+msgid "Description"
+msgstr "Beskrivning"
+
+msgid "Directory mask"
+msgstr "Mask för mapp"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Redigera mall"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+"Redigera mallen som används för att generera konfigurationen för samba."
+
+msgid "General Settings"
+msgstr "Generella inställningar"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Värdnamn"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Namn"
+
+msgid "Network Shares"
+msgstr "Nätverksdelningar"
+
+msgid "Path"
+msgstr "Genväg"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Endast läsbar"
+
+msgid "Share home-directories"
+msgstr "Dela hem-mappar"
+
+msgid "Shared Directories"
+msgstr "Delade mappar"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Arbetsgrupp"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Mask för nya mappar"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Mask för nya filer"

--- a/applications/luci-app-samba4/po/templates/samba4.pot
+++ b/applications/luci-app-samba4/po/templates/samba4.pot
@@ -1,0 +1,86 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "Allow guests"
+msgstr ""
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+
+msgid "Allowed users"
+msgstr ""
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Directory mask"
+msgstr ""
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr ""
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "General Settings"
+msgstr ""
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Network Shares"
+msgstr ""
+
+msgid "Path"
+msgstr ""
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr ""
+
+msgid "Share home-directories"
+msgstr ""
+
+msgid "Shared Directories"
+msgstr ""
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr ""

--- a/applications/luci-app-samba4/po/tr/samba4.po
+++ b/applications/luci-app-samba4/po/tr/samba4.po
@@ -1,0 +1,93 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "Allow guests"
+msgstr ""
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+
+msgid "Allowed users"
+msgstr ""
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Directory mask"
+msgstr ""
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr ""
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "General Settings"
+msgstr ""
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Network Shares"
+msgstr ""
+
+msgid "Path"
+msgstr ""
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr ""
+
+msgid "Share home-directories"
+msgstr ""
+
+msgid "Shared Directories"
+msgstr ""
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr ""

--- a/applications/luci-app-samba4/po/uk/samba4.po
+++ b/applications/luci-app-samba4/po/uk/samba4.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2012-03-18 20:35+0200\n"
+"Last-Translator: YuriPet <yuripet@gmail.com>\n"
+"Language-Team: none\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
+"10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Pootle 2.0.4\n"
+
+msgid "Allow guests"
+msgstr "Дозволити гостьовий вхід"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Дозволити користувачам системи досягати своїх домашніх каталогів через "
+"загальні мережеві ресурси"
+
+msgid "Allowed users"
+msgstr "Дозволені користувачі"
+
+msgid "Browseable"
+msgstr ""
+
+msgid "Create mask"
+msgstr "Створити маску"
+
+msgid "Description"
+msgstr "Опис"
+
+msgid "Directory mask"
+msgstr "Маска каталогу"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "Редагувати шаблон"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+"Редагувати шаблон, який використовується для створення конфігурації samba."
+
+msgid "General Settings"
+msgstr "Загальні настройки"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "Назва (ім'я) вузла"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "Ім'я"
+
+msgid "Network Shares"
+msgstr "Загальні мережеві ресурси"
+
+msgid "Path"
+msgstr "Шлях"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+msgid "Read-only"
+msgstr "Тільки читання"
+
+msgid "Share home-directories"
+msgstr "Спільно використовувати домашні каталоги"
+
+msgid "Shared Directories"
+msgstr "Загальні каталоги"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"Це вміст файлу '/etc/samba/smb.conf.template', з якого буде генеруватися "
+"ваша конфігурація samba. Значення, укладені в символи \"вертикальна риска"
+"\" (\"|\") не повинні змінюватися. Вони отримують свої значення з вкладки "
+"\"Загальні налаштування\"."
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Робоча група"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Маска для нових каталогів"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Маска для нових файлів"

--- a/applications/luci-app-samba4/po/vi/samba4.po
+++ b/applications/luci-app-samba4/po/vi/samba4.po
@@ -1,0 +1,122 @@
+#  samba.pot
+#  generated from ./applications/luci-samba/luasrc/i18n/samba.en.lua
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-08-16 06:59+0200\n"
+"PO-Revision-Date: 2009-08-13 03:54+0200\n"
+"Last-Translator: Hong Phuc Dang <dhppat@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Pootle 1.1.0\n"
+
+#, fuzzy
+msgid "Allow guests"
+msgstr "Cho phép khách"
+
+#, fuzzy
+msgid "Allow system users to reach their home directories via network shares"
+msgstr ""
+"Những người sử dụng hệ thống có thể tiếp cận những thư mục tại nhà thông qua "
+"mạng lưới chia sẻ trực tuyến."
+
+#, fuzzy
+msgid "Allowed users"
+msgstr "Người sử dụng được cho phép"
+
+msgid "Browseable"
+msgstr ""
+
+#, fuzzy
+msgid "Create mask"
+msgstr "Tạo Mask"
+
+msgid "Description"
+msgstr "Mô tả"
+
+#, fuzzy
+msgid "Directory mask"
+msgstr "Thư mục Mask"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr ""
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "General Settings"
+msgstr ""
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "tên máy chủ"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Network Shares"
+msgstr "Mạng chia sẻ"
+
+msgid "Path"
+msgstr ""
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr ""
+
+#, fuzzy
+msgid "Read-only"
+msgstr "Chỉ đọc "
+
+msgid "Share home-directories"
+msgstr "Chia sẻ danh bạ chính"
+
+msgid "Shared Directories"
+msgstr "Thư mục chia sẻ"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "Nhóm làm việc "
+
+#~ msgid "Mask for new directories"
+#~ msgstr "Mask cho thư mục mới"
+
+#~ msgid "Mask for new files"
+#~ msgstr "Mask cho tập tin mới"
+
+#~ msgid "Shared Directory"
+#~ msgstr "Đã chia sẻ thư mục"
+
+#~ msgid "Physical Path"
+#~ msgstr "Đường dẫn vật lý"
+
+#~ msgid "optional"
+#~ msgstr "Tùy thích"

--- a/applications/luci-app-samba4/po/zh-cn/samba4.po
+++ b/applications/luci-app-samba4/po/zh-cn/samba4.po
@@ -1,0 +1,112 @@
+#
+# Yangfl <mmyangfl@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-06-10 03:40+0200\n"
+"PO-Revision-Date: 2017-10-29 15:36+0800\n"
+"Last-Translator: Yangfl <mmyangfl@gmail.com>\n"
+"Language-Team:  <debian-l10n-chinese@lists.debian.org>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Gtranslator 2.91.7\n"
+
+msgid "Allow guests"
+msgstr "允许匿名用户"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr "允许系统用户通过网络共享访问他们的家目录"
+
+msgid "Allowed users"
+msgstr "允许用户"
+
+msgid "Browseable"
+msgstr "可浏览"
+
+msgid "Create mask"
+msgstr "创建权限掩码"
+
+msgid "Description"
+msgstr "描述"
+
+msgid "Directory mask"
+msgstr "目录权限掩码"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "编辑模板"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "编辑用来生成 samba 设置的模板"
+
+msgid "General Settings"
+msgstr "基本设置"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "主机名"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "共享名"
+
+msgid "Network Shares"
+msgstr "网络共享"
+
+msgid "Path"
+msgstr "目录"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr "请添加要共享的目录。每个目录指到已挂载设备上的文件夹。"
+
+msgid "Read-only"
+msgstr "只读"
+
+msgid "Share home-directories"
+msgstr "共享家目录"
+
+msgid "Shared Directories"
+msgstr "共享目录"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"这是将从其上生成 samba 配置的文件“/etc/samba/smb.conf.template”的内容。由管道"
+"符（“|”）包围的值不应更改。它们将从“常规设置”标签中获取其值。"
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "工作组"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "新目录权限掩码"
+
+#~ msgid "Mask for new files"
+#~ msgstr "新文件权限掩码"
+
+#~ msgid "Physical Path"
+#~ msgstr "物理路径"

--- a/applications/luci-app-samba4/po/zh-tw/samba4.po
+++ b/applications/luci-app-samba4/po/zh-tw/samba4.po
@@ -1,0 +1,112 @@
+#
+# Yangfl <mmyangfl@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-06-10 03:40+0200\n"
+"PO-Revision-Date: 2017-10-29 15:36+0800\n"
+"Last-Translator: Yangfl <mmyangfl@gmail.com>\n"
+"Language-Team:  <debian-l10n-chinese@lists.debian.org>\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Gtranslator 2.91.7\n"
+
+msgid "Allow guests"
+msgstr "允許匿名使用者"
+
+msgid "Allow system users to reach their home directories via network shares"
+msgstr "允許系統使用者通過網路共享訪問他們的家目錄"
+
+msgid "Allowed users"
+msgstr "允許使用者"
+
+msgid "Browseable"
+msgstr "可瀏覽"
+
+msgid "Create mask"
+msgstr "建立權限掩碼"
+
+msgid "Description"
+msgstr "描述"
+
+msgid "Directory mask"
+msgstr "目錄權限掩碼"
+
+msgid "Disable Active Directory Domain Controller"
+msgstr ""
+
+msgid "Disable Netbios"
+msgstr ""
+
+msgid "Disable Winbind"
+msgstr ""
+
+msgid "Edit Template"
+msgstr "編輯模板"
+
+msgid "Edit the template that is used for generating the samba configuration."
+msgstr "編輯用來生成 samba 設定的模板"
+
+msgid "General Settings"
+msgstr "基本設定"
+
+msgid "Guests only"
+msgstr ""
+
+msgid "Hostname"
+msgstr "主機名"
+
+msgid "Inherit owner"
+msgstr ""
+
+msgid "Name"
+msgstr "共享名"
+
+msgid "Network Shares"
+msgstr "網路共享"
+
+msgid "Path"
+msgstr "目錄"
+
+msgid ""
+"Please add directories to share. Each directory refers to a folder on a "
+"mounted device."
+msgstr "請新增要共享的目錄。每個目錄指到已掛載裝置上的資料夾。"
+
+msgid "Read-only"
+msgstr "只讀"
+
+msgid "Share home-directories"
+msgstr "共享家目錄"
+
+msgid "Shared Directories"
+msgstr "共享目錄"
+
+msgid ""
+"This is the content of the file '/etc/samba/smb.conf.template' from which "
+"your samba configuration will be generated. Values enclosed by pipe symbols "
+"('|') should not be changed. They get their values from the 'General "
+"Settings' tab."
+msgstr ""
+"這是將從其上生成 samba 配置的檔案“/etc/samba/smb.conf.template”的內容。由管道"
+"符（“|”）包圍的值不應更改。它們將從“常規設定”標籤中獲取其值。"
+
+msgid "Vfs objects"
+msgstr ""
+
+msgid "Workgroup"
+msgstr "工作組"
+
+#~ msgid "Mask for new directories"
+#~ msgstr "新目錄權限掩碼"
+
+#~ msgid "Mask for new files"
+#~ msgstr "新檔案權限掩碼"
+
+#~ msgid "Physical Path"
+#~ msgstr "物理路徑"


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mips (master)
Run tested: arm/mvebu (master)

Description:
Its the updated luci-ui for this PR openwrt/packages#5563.
Basically just a copy from the latest `luci-app-samba`, with some added extra options for samba 4 and changed deps/names.