### PR TITLE
luci-base: drop unused icons

### DIFF
--- a/applications/luci-app-mjpg-streamer/luasrc/controller/mjpg-streamer.lua
+++ b/applications/luci-app-mjpg-streamer/luasrc/controller/mjpg-streamer.lua
@@ -5,7 +5,6 @@ module("luci.controller.mjpg-streamer", package.seeall)
 
 function index()
 	require("luci.i18n")
-	luci.i18n.loadc("mjpg-streamer")
 	if not nixio.fs.access("/etc/config/mjpg-streamer") then
 		return
 	end

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -1606,6 +1606,9 @@ function matchesElem(node, selector)
 
 function findParent(node, selector)
 {
+	if (node.closest)
+		return node.closest(selector);
+
 	while (node)
 		if (matchesElem(node, selector))
 			return node;

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -15,6 +15,57 @@ var cbi_d = [];
 var cbi_t = [];
 var cbi_strings = { path: {}, label: {} };
 
+function sfh(s) {
+	if (s === null || s.length === 0)
+		return null;
+
+	var hash = (s.length >>> 0),
+	    len = (s.length >>> 2),
+	    off = 0, tmp;
+
+	while (len--) {
+		hash += ((s.charCodeAt(off + 1) << 8) + s.charCodeAt(off)) >>> 0;
+		tmp   = ((((s.charCodeAt(off + 3) << 8) + s.charCodeAt(off + 2)) << 11) ^ hash) >>> 0;
+		hash  = ((hash << 16) ^ tmp) >>> 0;
+		hash += hash >>> 11;
+		off  += 4;
+	}
+
+	switch ((s.length & 3) >>> 0) {
+	case 3:
+		hash += ((s.charCodeAt(off + 1) << 8) + s.charCodeAt(off)) >>> 0;
+		hash  = (hash ^ (hash << 16)) >>> 0;
+		hash  = (hash ^ (s.charCodeAt(off + 2) << 18)) >>> 0;
+		hash += hash >> 11;
+		break;
+
+	case 2:
+		hash += ((s.charCodeAt(off + 1) << 8) + s.charCodeAt(off)) >>> 0;
+		hash  = (hash ^ (hash << 11)) >>> 0;
+		hash += hash >>> 17;
+		break;
+
+	case 1:
+		hash += s.charCodeAt(off);
+		hash  = (hash ^ (hash << 10)) >>> 0;
+		hash += hash >>> 1;
+		break;
+	}
+
+	hash  = (hash ^ (hash << 3)) >>> 0;
+	hash += hash >>> 5;
+	hash  = (hash ^ (hash << 4)) >>> 0;
+	hash += hash >>> 17;
+	hash  = (hash ^ (hash << 25)) >>> 0;
+	hash += hash >>> 6;
+
+	return (0x100000000 + hash).toString(16).substr(1);
+}
+
+function _(s) {
+	return (window.TR && TR[sfh(s)]) || s;
+}
+
 function Int(x) {
 	return (/^-?\d+$/.test(x) ? +x : NaN);
 }

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -732,7 +732,7 @@ function cbi_combobox(id, values, def, man, focus) {
 		if (obj.value == "") {
 			var optdef = document.createElement("option");
 			optdef.value = "";
-			optdef.appendChild(document.createTextNode(typeof(def) === 'string' ? def : cbi_strings.label.choose));
+			optdef.appendChild(document.createTextNode(typeof(def) === 'string' ? def : _('-- Please choose --')));
 			sel.appendChild(optdef);
 		}
 		else {
@@ -757,7 +757,7 @@ function cbi_combobox(id, values, def, man, focus) {
 
 	var optman = document.createElement("option");
 	optman.value = "";
-	optman.appendChild(document.createTextNode(typeof(man) === 'string' ? man : cbi_strings.label.custom));
+	optman.appendChild(document.createTextNode(typeof(man) === 'string' ? man : _('-- custom --')));
 	sel.appendChild(optman);
 
 	obj.style.display = "none";
@@ -887,7 +887,7 @@ function cbi_dynlist_init(parent, datatype, optional, choices)
 				cbi_validate_field(t.id, ((i+1) == values.length) || optional, datatype);
 
 			if (choices) {
-				cbi_combobox_init(t.id, choices, '', cbi_strings.label.custom);
+				cbi_combobox_init(t.id, choices, '', _('-- custom --'));
 				b.index = i;
 
 				cbi_bind(b, 'keydown',  cbi_dynlist_keydown);

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -729,7 +729,7 @@ function cbi_init() {
 	for (var i = 0, node; (node = nodes[i]) !== undefined; i++) {
 		var events = node.getAttribute('data-update').split(' ');
 		for (var j = 0, event; (event = events[j]) !== undefined; j++)
-			cbi_bind(node, event, cbi_d_update);
+			node.addEventListener(event, cbi_d_update);
 	}
 
 	nodes = document.querySelectorAll('[data-choices]');
@@ -794,24 +794,6 @@ function cbi_init() {
 	cbi_d_update();
 }
 
-function cbi_bind(obj, type, callback, mode) {
-	if (!obj.addEventListener) {
-		obj.attachEvent('on' + type,
-			function(){
-				var e = window.event;
-
-				if (!e.target && e.srcElement)
-					e.target = e.srcElement;
-
-				return !!callback(e);
-			}
-		);
-	} else {
-		obj.addEventListener(type, callback, !!mode);
-	}
-	return obj;
-}
-
 function cbi_combobox(id, values, def, man, focus) {
 	var selid = "cbi.combobox." + id;
 	if (document.getElementById(selid)) {
@@ -870,7 +852,7 @@ function cbi_combobox(id, values, def, man, focus) {
 	if (dt)
 		cbi_validate_field(sel, op == 'true', dt);
 
-	cbi_bind(sel, "change", function() {
+	sel.addEventListener("change", function() {
 		if (sel.selectedIndex == sel.options.length - 1) {
 			obj.style.display = "inline";
 			sel.blur();
@@ -897,7 +879,7 @@ function cbi_combobox(id, values, def, man, focus) {
 
 function cbi_combobox_init(id, values, def, man) {
 	var obj = (typeof(id) === 'string') ? document.getElementById(id) : id;
-	cbi_bind(obj, "blur", function() {
+	obj.addEventListener("blur", function() {
 		cbi_combobox(obj.id, values, def, man, true);
 	});
 	cbi_combobox(obj.id, values, def, man, false);
@@ -927,7 +909,7 @@ function cbi_browser_init(id, resource, defpath)
 	btn.src = (resource || cbi_strings.path.resource) + '/cbi/folder.gif';
 	field.parentNode.insertBefore(btn, field.nextSibling);
 
-	cbi_bind(btn, 'click', cbi_browser_btnclick);
+	btn.addEventListener('click', cbi_browser_btnclick);
 }
 
 function cbi_dynlist_init(parent, datatype, optional, choices)
@@ -995,15 +977,15 @@ function cbi_dynlist_init(parent, datatype, optional, choices)
 				cbi_combobox_init(t.id, choices, '', _('-- custom --'));
 				b.index = i;
 
-				cbi_bind(b, 'keydown',  cbi_dynlist_keydown);
-				cbi_bind(b, 'keypress', cbi_dynlist_keypress);
+				b.addEventListener('keydown',  cbi_dynlist_keydown);
+				b.addEventListener('keypress', cbi_dynlist_keypress);
 
 				if (i == focus || -i == focus)
 					b.focus();
 			}
 			else {
-				cbi_bind(t, 'keydown',  cbi_dynlist_keydown);
-				cbi_bind(t, 'keypress', cbi_dynlist_keypress);
+				t.addEventListener('keydown',  cbi_dynlist_keydown);
+				t.addEventListener('keypress', cbi_dynlist_keypress);
 
 				if (i == focus) {
 					t.focus();
@@ -1018,7 +1000,7 @@ function cbi_dynlist_init(parent, datatype, optional, choices)
 				}
 			}
 
-			cbi_bind(b, 'click', cbi_dynlist_btnclick);
+			b.addEventListener('click', cbi_dynlist_btnclick);
 		}
 	}
 
@@ -1274,12 +1256,12 @@ function cbi_validate_field(cbid, optional, type)
 
 		field.form.cbi_validators.push(validatorFn);
 
-		cbi_bind(field, "blur",  validatorFn);
-		cbi_bind(field, "keyup", validatorFn);
+		field.addEventListener("blur",  validatorFn);
+		field.addEventListener("keyup", validatorFn);
 
 		if (matchesElem(field, 'select')) {
-			cbi_bind(field, "change", validatorFn);
-			cbi_bind(field, "click",  validatorFn);
+			field.addEventListener("change", validatorFn);
+			field.addEventListener("click",  validatorFn);
 		}
 
 		field.setAttribute("cbi_validate", validatorFn);

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -2191,6 +2191,58 @@ function cbi_update_table(table, data, placeholder) {
 	});
 }
 
+var tooltipDiv = null, tooltipTimeout = null;
+
+function showTooltip(ev) {
+	if (!matchesElem(ev.target, '[data-tooltip]'))
+		return;
+
+	if (tooltipTimeout !== null) {
+		window.clearTimeout(tooltipTimeout);
+		tooltipTimeout = null;
+	}
+
+	var rect = ev.target.getBoundingClientRect(),
+	    x = rect.left              + window.pageXOffset,
+	    y = rect.top + rect.height + window.pageYOffset;
+
+	tooltipDiv.className = 'cbi-tooltip';
+	tooltipDiv.innerHTML = '▲ ';
+	tooltipDiv.firstChild.data += ev.target.getAttribute('data-tooltip');
+
+	if (ev.target.hasAttribute('data-tooltip-style'))
+		tooltipDiv.classList.add(ev.target.getAttribute('data-tooltip-style'));
+
+	if ((y + tooltipDiv.offsetHeight) > (window.innerHeight + window.pageYOffset)) {
+		y -= (tooltipDiv.offsetHeight + ev.target.offsetHeight);
+		tooltipDiv.firstChild.data = '▼ ' + tooltipDiv.firstChild.data.substr(2);
+	}
+
+	tooltipDiv.style.top = y + 'px';
+	tooltipDiv.style.left = x + 'px';
+	tooltipDiv.style.opacity = 1;
+}
+
+function hideTooltip(ev) {
+	if (ev.target === tooltipDiv || ev.relatedTarget === tooltipDiv)
+		return;
+
+	if (tooltipTimeout !== null) {
+		window.clearTimeout(tooltipTimeout);
+		tooltipTimeout = null;
+	}
+
+	tooltipDiv.style.opacity = 0;
+	tooltipTimeout = window.setTimeout(function() { tooltipDiv.removeAttribute('style'); }, 250);
+}
+
 document.addEventListener('DOMContentLoaded', function() {
+	tooltipDiv = document.body.appendChild(E('div', { 'class': 'cbi-tooltip' }));
+
+	document.addEventListener('mouseover', showTooltip, true);
+	document.addEventListener('mouseout', hideTooltip, true);
+	document.addEventListener('focus', showTooltip, true);
+	document.addEventListener('blur', hideTooltip, true);
+
 	document.querySelectorAll('.table').forEach(cbi_update_table);
 });

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -106,7 +106,8 @@ function IPv6(x) {
 	var prefix = (prefix_suffix[0] || '0').split(/:/);
 	var suffix = prefix_suffix.length > 1 ? (prefix_suffix[1] || '0').split(/:/) : [];
 
-	if (suffix.length ? (prefix.length + suffix.length > 7) : (prefix.length > 8))
+	if (suffix.length ? (prefix.length + suffix.length > 7)
+	                  : ((prefix_suffix.length < 2 && prefix.length < 8) || prefix.length > 8))
 		return null;
 
 	var i, word;

--- a/modules/luci-base/luasrc/controller/admin/index.lua
+++ b/modules/luci-base/luasrc/controller/admin/index.lua
@@ -82,6 +82,9 @@ function index()
 		page.leaf = true
 	end
 
+	page = entry({"admin", "translations"}, call("action_translations"), nil)
+	page.leaf = true
+
 	-- Logout is last
 	entry({"admin", "logout"}, call("action_logout"), _("Logout"), 999)
 end
@@ -100,6 +103,27 @@ function action_logout()
 	end
 
 	luci.http.redirect(dsp.build_url())
+end
+
+function action_translations(lang)
+	local i18n = require "luci.i18n"
+	local http = require "luci.http"
+	local fs = require "nixio".fs
+
+	if lang and #lang > 0 then
+		lang = i18n.setlanguage(lang)
+		if lang then
+			local s = fs.stat("%s/base.%s.lmo" %{ i18n.i18ndir, lang })
+			if s then
+				http.header("Cache-Control", "public, max-age=31536000")
+				http.header("ETag", "%x-%x-%x" %{ s["ino"], s["size"], s["mtime"] })
+			end
+		end
+	end
+
+	http.prepare_content("application/javascript; charset=utf-8")
+	http.write("window.TR=")
+	http.write_json(i18n.dump())
 end
 
 

--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -296,10 +296,6 @@ function dispatch(request)
 	ctx.requestpath = ctx.requestpath or freq
 	ctx.path = preq
 
-	if track.i18n then
-		i18n.loadc(track.i18n)
-	end
-
 	-- Init template engine
 	if (c and c.index) or not track.notemplate then
 		local tpl = require("luci.template")
@@ -602,9 +598,6 @@ function createtree()
 	ctx.treecache = setmetatable({}, {__mode="v"})
 	ctx.tree = tree
 	ctx.modifiers = modi
-
-	-- Load default translation
-	require "luci.i18n".loadc("base")
 
 	local scope = setmetatable({}, {__index = luci.dispatcher})
 

--- a/modules/luci-base/luasrc/i18n.lua
+++ b/modules/luci-base/luasrc/i18n.lua
@@ -23,15 +23,31 @@ function loadc(file, force)
 end
 
 function setlanguage(lang)
-	context.lang   = lang:gsub("_", "-")
-	context.parent = (context.lang:match("^([a-z][a-z])_"))
-	if not tparser.load_catalog(context.lang, i18ndir) then
-		if context.parent then
-			tparser.load_catalog(context.parent, i18ndir)
+	local code, subcode = lang:match("^([A-Za-z][A-Za-z])[%-_]([A-Za-z][A-Za-z])$")
+	if not (code and subcode) then
+		subcode = lang:match("^([A-Za-z][A-Za-z])$")
+		if not subcode then
+			return nil
+		end
+	end
+
+	context.parent = code and code:lower()
+	context.lang   = context.parent and context.parent.."-"..subcode:lower() or subcode:lower()
+
+	if tparser.load_catalog(context.lang, i18ndir) and
+	   tparser.change_catalog(context.lang)
+	then
+		return context.lang
+
+	elseif context.parent then
+		if tparser.load_catalog(context.parent, i18ndir) and
+		   tparser.change_catalog(context.parent)
+		then
 			return context.parent
 		end
 	end
-	return context.lang
+
+	return nil
 end
 
 function translate(key)

--- a/modules/luci-base/luasrc/i18n.lua
+++ b/modules/luci-base/luasrc/i18n.lua
@@ -69,3 +69,9 @@ end
 function stringf(key, ...)
 	return tostring(translate(key)):format(...)
 end
+
+function dump()
+	local rv = {}
+	tparser.get_translations(function(k, v) rv[k] = v end)
+	return rv
+end

--- a/modules/luci-base/luasrc/i18n.lua
+++ b/modules/luci-base/luasrc/i18n.lua
@@ -1,26 +1,16 @@
 -- Copyright 2008 Steven Barth <steven@midlink.org>
 -- Licensed to the public under the Apache License 2.0.
 
-module("luci.i18n", package.seeall)
-require("luci.util")
+local tparser  = require "luci.template.parser"
+local util     = require "luci.util"
+local tostring = tostring
 
-local tparser = require "luci.template.parser"
+module "luci.i18n"
 
-table   = {}
-i18ndir = luci.util.libpath() .. "/i18n/"
-loaded  = {}
-context = luci.util.threadlocal()
+i18ndir = util.libpath() .. "/i18n/"
+context = util.threadlocal()
 default = "en"
 
-function clear()
-end
-
-function load(file, lang, force)
-end
-
--- Alternatively load the translation of the fallback language.
-function loadc(file, force)
-end
 
 function setlanguage(lang)
 	local code, subcode = lang:match("^([A-Za-z][A-Za-z])[%-_]([A-Za-z][A-Za-z])$")
@@ -55,18 +45,6 @@ function translate(key)
 end
 
 function translatef(key, ...)
-	return tostring(translate(key)):format(...)
-end
-
--- and ensure that the returned value is a Lua string value.
--- This is the same as calling <code>tostring(translate(...))</code>
-function string(key)
-	return tostring(translate(key))
-end
-
--- Ensure that the returned value is a Lua string value.
--- This is the same as calling <code>tostring(translatef(...))</code>
-function stringf(key, ...)
 	return tostring(translate(key)):format(...)
 end
 

--- a/modules/luci-base/luasrc/i18n.luadoc
+++ b/modules/luci-base/luasrc/i18n.luadoc
@@ -4,35 +4,6 @@ LuCI translation library.
 module "luci.i18n"
 
 ---[[
-Clear the translation table.
-
-@class function
-@name clear
-]]
-
----[[
-Load a translation and copy its data into the translation table.
-
-@class function
-@name load
-@param file	Language file
-@param lang	Two-letter language code
-@param force	Force reload even if already loaded (optional)
-@return		Success status
-]]
-
----[[
-Load a translation file using the default translation language.
-
-Alternatively load the translation of the fallback language.
-
-@class function
-@name loadc
-@param file	Language file
-@param force	Force reload even if already loaded (optional)
-]]
-
----[[
 Set the context default translation language.
 
 @class function
@@ -55,32 +26,6 @@ Return the translated value for a specific translation key and use it as sprintf
 
 @class function
 @name translatef
-@param key		Default translation text
-@param ...		Format parameters
-@return			Translated and formatted string
-]]
-
----[[
-Return the translated value for a specific translation key
-and ensure that the returned value is a Lua string value.
-
-This is the same as calling <code>tostring(translate(...))</code>
-
-@class function
-@name string
-@param key		Default translation text
-@return			Translated string
-]]
-
----[[
-Return the translated value for a specific translation key and use it as sprintf pattern.
-
-Ensure that the returned value is a Lua string value.
-
-This is the same as calling <code>tostring(translatef(...))</code>
-
-@class function
-@name stringf
 @param key		Default translation text
 @param ...		Format parameters
 @return			Translated and formatted string

--- a/modules/luci-base/luasrc/i18n.luadoc
+++ b/modules/luci-base/luasrc/i18n.luadoc
@@ -6,7 +6,6 @@ module "luci.i18n"
 ---[[
 Clear the translation table.
 
-
 @class function
 @name clear
 ]]
@@ -26,6 +25,7 @@ Load a translation and copy its data into the translation table.
 Load a translation file using the default translation language.
 
 Alternatively load the translation of the fallback language.
+
 @class function
 @name loadc
 @param file	Language file
@@ -62,9 +62,10 @@ Return the translated value for a specific translation key and use it as sprintf
 
 ---[[
 Return the translated value for a specific translation key
-
 and ensure that the returned value is a Lua string value.
+
 This is the same as calling <code>tostring(translate(...))</code>
+
 @class function
 @name string
 @param key		Default translation text
@@ -75,7 +76,9 @@ This is the same as calling <code>tostring(translate(...))</code>
 Return the translated value for a specific translation key and use it as sprintf pattern.
 
 Ensure that the returned value is a Lua string value.
+
 This is the same as calling <code>tostring(translatef(...))</code>
+
 @class function
 @name stringf
 @param key		Default translation text
@@ -83,3 +86,12 @@ This is the same as calling <code>tostring(translatef(...))</code>
 @return			Translated and formatted string
 ]]
 
+---[[
+Return all currently loaded translation strings as a key-value table. The key is the
+hexadecimal representation of the translation key while the value is the translated
+text content.
+
+@class function
+@name dump
+@return			Key-value translation string table.
+]]

--- a/modules/luci-base/luasrc/i18n.luadoc
+++ b/modules/luci-base/luasrc/i18n.luadoc
@@ -37,7 +37,8 @@ Set the context default translation language.
 
 @class function
 @name setlanguage
-@param lang	Two-letter language code
+@param lang	An IETF/BCP 47 language tag or ISO3166 country code, e.g. "en-US" or "de"
+@return		The effective loaded language, e.g. "en" for "en-US" - or nil on failure
 ]]
 
 ---[[

--- a/modules/luci-base/src/template_lmo.c
+++ b/modules/luci-base/src/template_lmo.c
@@ -216,7 +216,7 @@ int lmo_load_catalog(const char *lang, const char *dir)
 	if (!_lmo_active_catalog)
 		_lmo_active_catalog = cat;
 
-	return 0;
+	return cat->archives ? 0 : -1;
 
 err:
 	if (dh) closedir(dh);
@@ -299,6 +299,20 @@ int lmo_translate(const char *key, int keylen, char **out, int *outlen)
 	}
 
 	return -1;
+}
+
+void lmo_iterate(lmo_iterate_cb_t cb, void *priv)
+{
+	unsigned int i;
+	lmo_entry_t *e;
+	lmo_archive_t *ar;
+
+	if (!_lmo_active_catalog)
+		return;
+
+	for (ar = _lmo_active_catalog->archives; ar; ar = ar->next)
+		for (i = 0, e = &ar->index[0]; i < ar->length; e = &ar->index[++i])
+			cb(ntohl(e->key_id), ar->mmap + ntohl(e->offset), ntohl(e->length), priv);
 }
 
 void lmo_close_catalog(const char *lang)

--- a/modules/luci-base/src/template_lmo.h
+++ b/modules/luci-base/src/template_lmo.h
@@ -73,6 +73,7 @@ struct lmo_catalog {
 
 typedef struct lmo_catalog lmo_catalog_t;
 
+typedef void (*lmo_iterate_cb_t)(uint32_t, const char *, int, void *);
 
 uint32_t sfh_hash(const char *data, int len);
 uint32_t lmo_canon_hash(const char *data, int len);
@@ -87,6 +88,7 @@ extern lmo_catalog_t *_lmo_active_catalog;
 int lmo_load_catalog(const char *lang, const char *dir);
 int lmo_change_catalog(const char *lang);
 int lmo_translate(const char *key, int keylen, char **out, int *outlen);
+void lmo_iterate(lmo_iterate_cb_t cb, void *priv);
 void lmo_close_catalog(const char *lang);
 
 #endif

--- a/modules/luci-base/src/template_lualib.c
+++ b/modules/luci-base/src/template_lualib.c
@@ -129,6 +129,24 @@ static int template_L_change_catalog(lua_State *L) {
 	return 1;
 }
 
+static void template_L_get_translations_cb(uint32_t key, const char *val, int len, void *priv) {
+	lua_State *L = priv;
+	char hex[9];
+
+	luaL_checktype(L, 1, LUA_TFUNCTION);
+	snprintf(hex, sizeof(hex), "%08x", key);
+
+	lua_pushvalue(L, 1);
+	lua_pushstring(L, hex);
+	lua_pushlstring(L, val, len);
+	lua_call(L, 2, 0);
+}
+
+static int template_L_get_translations(lua_State *L) {
+	lmo_iterate(template_L_get_translations_cb, L);
+	return 0;
+}
+
 static int template_L_translate(lua_State *L) {
 	size_t len;
 	char *tr;
@@ -168,6 +186,7 @@ static const luaL_reg R[] = {
 	{ "load_catalog",		template_L_load_catalog },
 	{ "close_catalog",		template_L_close_catalog },
 	{ "change_catalog",		template_L_change_catalog },
+	{ "get_translations",		template_L_get_translations },
 	{ "translate",			template_L_translate },
 	{ "hash",				template_L_hash },
 	{ NULL,					NULL }

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2051,3 +2051,13 @@ html body.apply-overlay-active {
 [data-page="admin-network-dhcp"] [data-name="ip"] {
 	width: 15%;
 }
+
+@keyframes flash {
+	0% { opacity: 1; }
+	50% { opacity: .5; }
+	100% { opacity: 1; }
+}
+
+.flash {
+	animation: flash .35s;
+}

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1168,7 +1168,8 @@ footer {
 .btn.info,
 .alert-message.info,
 .btn.info:hover,
-.alert-message.info:hover {
+.alert-message.info:hover,
+.cbi-tooltip.error, .cbi-tooltip.success, .cbi-tooltip.info {
 	color: #fff;
 }
 
@@ -1180,25 +1181,26 @@ footer {
 .btn.danger,
 .alert-message.danger,
 .btn.error,
-.alert-message.error {
+.alert-message.error,
+.cbi-tooltip.error {
 	background: linear-gradient(to bottom, #ee5f5b, #c43c35) repeat-x;
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
-.btn.success, .alert-message.success {
+.btn.success, .alert-message.success, .cbi-tooltip.success {
 	background: linear-gradient(to bottom, #62c462, #57a957) repeat-x;
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
-.btn.info, .alert-message.info {
+.btn.info, .alert-message.info, .cbi-tooltip.info {
 	background: linear-gradient(to bottom, #5bc0de, #339bb9) repeat-x;
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
-.alert-message.notice {
+.alert-message.notice, .cbi-tooltip.notice {
 	background: linear-gradient(to bottom, #efefef, #fefefe) repeat-x;
 	text-shadow: 0 -1px 0 rgba(255, 255, 255, 0.25);
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
@@ -1491,8 +1493,13 @@ select + .cbi-button {
 	position: absolute;
 	z-index: 1000;
 	left: -1000px;
+	box-shadow: 0 0 2px #ccc;
+	border-radius: 3px;
+	background: #fff;
+	white-space: pre;
+	padding: 2px 5px;
 	opacity: 0;
-	transition: opacity .25s ease-out;
+	transition: opacity .25s ease-in;
 }
 
 .cbi-tooltip-container:hover .cbi-tooltip:not(:empty) {

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -492,10 +492,45 @@ select,
 	box-sizing: border-box;
 }
 
-.cbi-dropdown {
+.cbi-dropdown,
+.cbi-dynlist {
 	min-width: 210px;
 	max-width: 400px;
 	width: auto;
+}
+
+.cbi-dynlist {
+	height: auto;
+	min-height: 30px;
+	display: inline-flex;
+	flex-direction: column;
+}
+
+.cbi-dynlist > .item {
+	margin-bottom: 4px;
+	box-shadow: 0 0 2px #ccc;
+	background: #fff;
+	padding: 2px 2em 2px 4px;
+	border: 1px solid #ccc;
+	border-radius: 3px;
+	position: relative;
+	pointer-events: none;
+}
+
+.cbi-dynlist > .item::after {
+	content: "×";
+	position: absolute;
+	display: inline-flex;
+	align-items: center;
+	top: -1px;
+	right: -1px;
+	bottom: -1px;
+	padding: 0 6px;
+	border: 1px solid #ccc;
+	border-radius: 0 3px 3px 0;
+	font-weight: bold;
+	color: #c44;
+	pointer-events: auto;
 }
 
 select {
@@ -548,7 +583,8 @@ textarea {
 .td > input[type=text],
 .td > input[type=password],
 .td > select,
-.td > .cbi-dropdown {
+.td > .cbi-dropdown,
+.cbi-dynlist > .add-item > .cbi-dropdown {
 	width: 100%;
 }
 
@@ -568,11 +604,12 @@ textarea {
 	color: #bfbfbf;
 }
 
-.btn, .cbi-button, input, textarea {
+.item::after, .btn, .cbi-button, input, textarea {
 	transition: border linear 0.2s, box-shadow linear 0.2s;
 	box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
+.item:hover::after,
 .btn:hover, .cbi-button:hover,
 input:focus, textarea:focus {
 	outline: 0;
@@ -1206,6 +1243,7 @@ footer {
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
+.item::after,
 .btn,
 .cbi-button {
 	cursor: pointer;
@@ -1318,6 +1356,7 @@ footer {
 	color: #404040;
 }
 
+.cbi-dynlist > .item:focus,
 .cbi-dropdown:focus {
 	outline: 2px solid #4b6e9b;
 }
@@ -1354,6 +1393,7 @@ footer {
 	font-weight: bold;
 	text-shadow: 1px 1px 0px #fff;
 	display: none;
+	justify-content: center;
 }
 
 .cbi-dropdown > ul > li {
@@ -1452,6 +1492,14 @@ footer {
 .cbi-dropdown[open] > ul.dropdown > li:last-child {
 	margin-bottom: 0;
 	border-bottom: none;
+}
+
+.cbi-dropdown[open] > ul.dropdown > li[unselectable] {
+	opacity: 0.7;
+}
+
+.cbi-dropdown[open] > ul.dropdown > li > input.create-item-input:first-child:last-child {
+	width: 100%;
 }
 
 .cbi-dropdown[disabled] {

--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -167,6 +167,7 @@
 		<% if css then %>
 			<style title="text/css"><%= css %></style>
 		<% end -%>
+		<script src="<%=url('admin/translations', luci.i18n.context.lang)%><%# ?v=PKG_VERSION %>"></script>
 		<script src="<%=resource%>/cbi.js"></script>
 		<script src="<%=resource%>/xhr.js"></script>
 	</head>

--- a/themes/luci-theme-freifunk-generic/htdocs/luci-static/freifunk-generic/cascade.css
+++ b/themes/luci-theme-freifunk-generic/htdocs/luci-static/freifunk-generic/cascade.css
@@ -156,12 +156,17 @@ a img {
 	color: #000;
 }
 
-.alert-message.notice {
+.alert-message, .cbi-tooltip.error {
+	background: #fee;
+	color: #a22;
+}
+
+.alert-message.notice, .cbi-tooltip.notice {
 	background: linear-gradient(#ccc 0%, #eee 100%);
 	color: #4a6b7c;
 }
 
-.alert-message.warning {
+.alert-message.warning, .cbi-tooltip.warning {
 	background: linear-gradient(#dda 0%, #dd8 100%);
 	color: #c00;
 }
@@ -1354,6 +1359,10 @@ td.cbi-value-error {
 	position: absolute;
 	z-index: 1000;
 	left: -1000px;
+	border-radius: 3px;
+	background: #fff;
+	padding: 2px 5px;
+	white-space: pre;
 	opacity: 0;
 	transition: opacity .25s ease-out;
 	pointer-events: none;

--- a/themes/luci-theme-freifunk-generic/luasrc/view/themes/freifunk-generic/header.htm
+++ b/themes/luci-theme-freifunk-generic/luasrc/view/themes/freifunk-generic/header.htm
@@ -81,6 +81,7 @@
 </style>
 <% end -%>
 <meta name="viewport" content="initial-scale=1.0" />
+<script type="text/javascript" src="<%=url('admin/translations', luci.i18n.context.lang)%><%# ?v=PKG_VERSION %>"></script>
 <script type="text/javascript" src="<%=resource%>/cbi.js"></script>
 <script type="text/javascript" src="<%=resource%>/xhr.js"></script>
 

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -291,7 +291,7 @@ header {
 }
 
 header > .fill > .container {
-    padding-top: 0.25rem; 
+    padding-top: 0.25rem;
     padding-right: 1rem;
     padding-bottom: 0.25rem;
     display: flex;
@@ -1481,6 +1481,10 @@ small {
     position: absolute;
     z-index: 1000;
     left: -1000px;
+    border-radius: 3px;
+    background: #fff;
+    padding: 2px 5px;
+    white-space: pre;
     opacity: 0;
     transition: opacity .25s ease-out;
     pointer-events: none;

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -153,7 +153,9 @@ input,
 }
 
 select:not([multiple="multiple"]):focus,
-input:focus {
+input:focus,
+.cbi-dropdown:focus,
+.cbi-dynlist > .item:focus {
     border-color: #0099CC;
 }
 
@@ -642,7 +644,7 @@ td > table > tbody > tr > td,
 
 /* button style */
 
-.btn, .cbi-button {
+.btn, .cbi-button, .item::after {
     -webkit-appearance: none;
     text-transform: uppercase;
     color: rgba(0, 0, 0, 0.87);
@@ -675,6 +677,7 @@ td > table > tbody > tr > td,
 .cbi-button:hover,
 .cbi-button:focus,
 .cbi-button:active,
+.item:hover::after,
 .cbi-page-actions .cbi-button-apply + .cbi-button-save:hover,
 .cbi-page-actions .cbi-button-apply + .cbi-button-save:focus,
 .cbi-page-actions .cbi-button-apply + .cbi-button-save:active {
@@ -958,16 +961,13 @@ td > table > tbody > tr > td,
 }
 
 
+.cbi-dynlist,
 .cbi-dropdown {
     display: inline-flex;
     cursor: pointer;
     position: relative;
     padding: 0;
     height: auto;
-}
-
-.cbi-dropdown:focus {
-    outline: 2px solid #4b6e9b;
 }
 
 .cbi-dropdown > ul {
@@ -1109,6 +1109,14 @@ td > table > tbody > tr > td,
     border-bottom: none;
 }
 
+.cbi-dropdown[open] > ul.dropdown > li[unselectable] {
+    opacity: 0.7;
+}
+
+.cbi-dropdown[open] > ul.dropdown > li > input.create-item-input:first-child:last-child {
+    width: 100%;
+}
+
 .cbi-dropdown[disabled] {
     pointer-events: none;
     opacity: .6;
@@ -1120,6 +1128,37 @@ td > table > tbody > tr > td,
 
 .cbi-dropdown[open] .zonebadge {
     width: auto;
+}
+
+.cbi-dynlist {
+    height: auto;
+    min-height: 30px;
+    display: inline-flex;
+    flex-direction: column;
+}
+
+.cbi-dynlist > .item {
+    margin: 0 2em 4px 0;
+    padding: 2px 4px;
+    border-bottom: 2px solid rgba(0, 0, 0, .26);
+    position: relative;
+    pointer-events: none;
+    cursor: default;
+}
+
+.cbi-dynlist > .item::after {
+    content: "×";
+    position: absolute;
+    display: inline-flex;
+    align-items: center;
+    top: 0;
+    right: -2em;
+    bottom: 0;
+    padding: 0 6px;
+    border: 1px solid #c44;
+    font-weight: bold;
+    color: #c44;
+    pointer-events: auto;
 }
 
 

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1215,6 +1215,11 @@ td > table > tbody > tr > td,
     width: 15rem;
 }
 
+.cbi-value-field .cbi-input-invalid {
+    border-bottom-color: #f00;
+    color: #f00;
+}
+
 .th[data-type="button"], .td[data-type="button"],
 .th[data-type="fvalue"], .td[data-type="fvalue"] {
     flex: 1 1 2em;

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -207,6 +207,7 @@
 	<% if css then %>
 		<style title="text/css"><%= css %></style>
 	<% end -%>
+	<script src="<%=url('admin/translations', luci.i18n.context.lang)%><%# ?v=PKG_VERSION %>"></script>
 	<script src="<%=resource%>/cbi.js"></script>
 	<script src="<%=resource%>/xhr.js"></script>
 </head>

--- a/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
+++ b/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
@@ -231,18 +231,22 @@ hr {
 	padding: .5em;
 	border-radius: 3px;
 	border: 1px solid #a22;
-	color: #a22;
-	background: #fee;
 	margin: 0 0 .5em 0;
 }
 
-.alert-message.notice {
+.alert-message, .cbi-tooltip.error {
+	border-color: #a22;
+	background: #fee;
+	color: #a22;
+}
+
+.alert-message.notice, .cbi-tooltip.notice {
 	border-color: #15a;
 	background: #e6f6ff;
 	color: #15a;
 }
 
-.alert-message.warning {
+.alert-message.warning, .cbi-tooltip.warning {
 	border-color: #ed5;
 	background: #fe9;
 	color: #650;
@@ -1173,6 +1177,10 @@ select + .cbi-button {
 	position: absolute;
 	z-index: 1000;
 	left: -1000px;
+	border-radius: 3px;
+	background: #fff;
+	padding: 2px 5px;
+	white-space: pre;
 	opacity: 0;
 	transition: opacity .25s ease-out;
 	pointer-events: none;

--- a/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
+++ b/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
@@ -516,7 +516,8 @@ input.cbi-input-password + img {
 
 .td select,
 .td .cbi-dropdown,
-.td input[type=text] {
+.td input[type=text],
+.cbi-dynlist > .add-item > .cbi-dropdown {
 	width: 100%;
 }
 
@@ -531,7 +532,7 @@ img.cbi-image-button {
 	vertical-align: middle;
 }
 
-.btn, .cbi-button {
+.btn, .cbi-button, .item::after {
 	padding: 0 .5em;
 	border-radius: 3px;
 	border: 1px solid #aaa;
@@ -545,9 +546,11 @@ img.cbi-image-button {
 	font-weight: bold;
 	line-height: 13pt;
 	height: 16pt;
+	box-sizing: border-box;
+	cursor: pointer;
 }
 
-.btn:hover, .cbi-button:hover {
+.btn:hover, .cbi-button:hover, .item:hover::after {
 	box-shadow: 0 0 3px #37c;
 }
 
@@ -1009,7 +1012,8 @@ ul.cbi-tabmenu li.cbi-tab {
 	background: #fff;
 }
 
-.cbi-dropdown:focus {
+.cbi-dropdown:focus,
+.cbi-dynlist > .item:focus {
 	outline: 2px solid #4b6e9b;
 }
 
@@ -1150,9 +1154,58 @@ ul.cbi-tabmenu li.cbi-tab {
 	border-bottom: none;
 }
 
+.cbi-dropdown[open] > ul.dropdown > li[unselectable] {
+	opacity: 0.7;
+}
+
+.cbi-dropdown[open] > ul.dropdown > li > input.create-item-input:first-child:last-child {
+	width: 100%;
+}
+
 .cbi-dropdown[disabled] {
 	pointer-events: none;
 	opacity: .6;
+}
+
+.cbi-dynlist {
+	height: auto;
+	min-height: 30px;
+	min-width: 210px;
+	max-width: 100%;
+	width: auto;
+	display: inline-flex;
+	flex-direction: column;
+}
+
+.cbi-dynlist > .item {
+	margin-bottom: 4px;
+	background: #eee;
+	padding: 2px 2em 2px 4px;
+	border: 1px outset #000;
+	border-radius: 3px;
+	position: relative;
+	pointer-events: none;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.cbi-dynlist > .item::after {
+	content: "×";
+	position: absolute;
+	display: inline-flex;
+	align-items: center;
+	top: -1px;
+	right: -1px;
+	bottom: -1px;
+	padding: 0 6px;
+	border: 1px outset #000;
+	background: #fff;
+	border-radius: 0 3px 3px 0;
+	font-weight: bold;
+	color: #c44;
+	pointer-events: auto;
+	height: auto;
 }
 
 input[type="text"] + .cbi-button,
@@ -1695,13 +1748,14 @@ select + .cbi-button {
 		height: 1.4em;
 	}
 
-	[data-dynlist] > input,
 	input.cbi-input-password {
 		width: calc(100% - 20px);
 	}
 
+	.cbi-dynlist,
 	.cbi-dropdown {
 		min-width: 100%;
+		display: flex;
 	}
 
 	.btn, .cbi-button {

--- a/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
+++ b/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
@@ -160,6 +160,7 @@
 <%= css %>
 </style>
 <% end -%>
+<script type="text/javascript" src="<%=url('admin/translations', luci.i18n.context.lang)%><%# ?v=PKG_VERSION %>"></script>
 <script type="text/javascript" src="<%=resource%>/cbi.js"></script>
 <script type="text/javascript" src="<%=resource%>/xhr.js"></script>
 <script type="text/javascript">//<![CDATA[


### PR DESCRIPTION
Remove icons which aren't used by the Bootstrap or OpenWrt themes anymore,
which saves about 4.1KB in the luci-base package.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>