### PR TITLE
[openwrt-18.06] luci-app-unbound: point documentation to 18.06 branch

### DIFF
--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
@@ -27,7 +27,7 @@ s1:tab("basic", translate("Basic"),
   .. "UCI documentation can be found on "
   .. "<a href=\"%s\" target=\"_blank\">github (link)</a>.",
   "https://www.unbound.net/",
-  "https://github.com/openwrt/packages/blob/master/net/unbound/files/README.md"))
+  "https://github.com/openwrt/packages/blob/openwrt-18.06/net/unbound/files/README.md"))
 
 
 if valman ~= "1" then


### PR DESCRIPTION
Change "master" to "openwrt-18.06" in help link.