### PR TITLE
fix compilation failure when luasrcdiet is being copied to non existing directory

### DIFF
--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -41,6 +41,7 @@ endef
 
 define Host/Install
 	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_DIR) $(1)/lib/lua/5.1
 	$(INSTALL_BIN) src/po2lmo $(1)/bin/po2lmo
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/luasrcdiet $(1)/bin/luasrcdiet
 	$(CP) $(HOST_BUILD_DIR)/luasrcdiet $(1)/lib/lua/5.1/


### PR DESCRIPTION
fix compilation failure when luasrcdiet is being copied to non existing directory