### PR TITLE
luci-app-adblock: "final" fixes

### DIFF
--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
@@ -3,7 +3,6 @@
 
 local fs   = require("nixio.fs")
 local uci  = require("luci.model.uci").cursor()
-local sys  = require("luci.sys")
 local util = require("luci.util")
 local dump = util.ubus("network.interface", "dump", {})
 
@@ -12,10 +11,6 @@ m = Map("adblock", translate("Adblock"),
 	.. translatef("For further information "
 	.. "<a href=\"%s\" target=\"_blank\">"
 	.. "check the online documentation</a>", "https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md"))
-
-function m.on_apply(self)
-	luci.sys.call("/etc/init.d/adblock reload >/dev/null 2>&1")
-end
 
 -- Main adblock options
 

--- a/applications/luci-app-adblock/luasrc/view/adblock/runtime.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/runtime.htm
@@ -6,7 +6,7 @@ This is free software, licensed under the Apache License, Version 2.0
 <style type="text/css">
 .runtime
 {
-	color: #0069d6;
+	color: #37c;
 	font-weight: bold;
 	display: inline-block;
 	width: 100%;
@@ -18,10 +18,12 @@ This is free software, licensed under the Apache License, Version 2.0
 //<![CDATA[
 	function status_update(json)
 	{
-			var view  = document.getElementById("value_1");
-			var btn1  = document.getElementById("btn1");
-			var btn2  = document.getElementById("btn2");
-			var input = json.data.adblock_status;
+			var view         = document.getElementById("value_1");
+			var btn1         = document.getElementById("btn1");
+			var btn1_running = document.getElementById("btn1_running");
+			var btn2         = document.getElementById("btn2");
+			var btn2_running = document.getElementById("btn2_running");
+			var input        = json.data.adblock_status;
 
 			view.innerHTML = input || "-";
 			if (input === "enabled")
@@ -126,7 +128,7 @@ This is free software, licensed under the Apache License, Version 2.0
 			btn2.value = "<%:Refresh%>";
 			btn2.name  = "do_refresh";
 			btn1.disabled = true;
-			btn2.disabled = false;
+			btn2.disabled = true;
 			return;
 		}
 		status_update(json_info)


### PR DESCRIPTION
during intense testing with different browsers (Chrome/Firefox/partly IE in a VM) I found & fixed some more minor things:

* remove needless hook & include from overview page
* fix possible JS error in Runtime Information
* Align CSS color with "LuCI standard"

Signed-off-by: Dirk Brenken <dev@brenken.org>