### PR TITLE
luci-app-travelmate[18.06]: "final" fixes

### DIFF
--- a/applications/luci-app-travelmate/luasrc/controller/travelmate.lua
+++ b/applications/luci-app-travelmate/luasrc/controller/travelmate.lua
@@ -39,7 +39,7 @@ function trm_action(name)
 	if name == "do_restart" then
 		luci.sys.call("/etc/init.d/travelmate restart >/dev/null 2>&1")
 	end
-	luci.http.prepare_content("text/plain")	
+	luci.http.prepare_content("text/plain")
 	luci.http.write("0")
 end
 

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
@@ -17,9 +17,10 @@ m = Map("travelmate", translate("Travelmate"),
 	.. "see online documentation</a>", "https://github.com/openwrt/packages/blob/master/net/travelmate/files/README.md"))
 m:chain("network")
 m:chain("firewall")
+m.apply_on_parse = true
 
 function m.on_apply(self)
-	luci.sys.call("env -i /etc/init.d/travelmate restart >/dev/null 2>&1")
+	luci.sys.call("/etc/init.d/travelmate restart >/dev/null 2>&1")
 end
 
 -- Interface Wizard

--- a/applications/luci-app-travelmate/luasrc/view/travelmate/runtime.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/runtime.htm
@@ -7,7 +7,6 @@ This is free software, licensed under the Apache License, Version 2.0
 	.runtime
 	{
 		color: #37c;
-		//#0069d6;
 		font-weight: bold;
 		display: inline-block;
 		width: 100%;
@@ -22,7 +21,7 @@ This is free software, licensed under the Apache License, Version 2.0
 			var btn1  = document.getElementById("btn1");
 			var view  = document.getElementById("value_1");
 			var input = json.data.travelmate_status;
-			
+
 			btn1.value = "<%:Restart%>";
 			btn1.name  = "do_restart";
 			view.innerHTML = input || "-";
@@ -41,8 +40,6 @@ This is free software, licensed under the Apache License, Version 2.0
 			view = document.getElementById("value_6");
 			input = json.data.last_rundate;
 			view.innerHTML = input || "-";
-			btn1.disabled = false;
-			running(btn1_running, 0);
 	}
 
 	function btn_action(action)
@@ -60,6 +57,8 @@ This is free software, licensed under the Apache License, Version 2.0
 			{
 				return;
 			}
+			btn1.disabled = false;
+			running(btn1_running, 0);
 		});
 	}
 
@@ -139,7 +138,7 @@ This is free software, licensed under the Apache License, Version 2.0
 <div class="cbi-value" id="button_1">
 	<label class="cbi-value-title" for="button_1"><%:Restart Travelmate%></label>
 	<div class="cbi-value-field">
-		<input class="cbi-button cbi-button-reset" id="btn1" type="button" value="" onclick="btn_action(this)" />
+		<input class="cbi-button cbi-button-reset" id="btn1" type="button" name="do_restart" value="<%:Restart%>" onclick="btn_action(this)" />
 		<span id="btn1_running" style="display:inline-block; width:16px; height:16px; margin:0 5px"></span>
 	</div>
 </div>


### PR DESCRIPTION
during intense testing with different browsers (Chrome/Firefox/partly IE
in a VM) I found & fixed some more minor things:

* re-add accidently removed "apply_on_parse" attribute in overview cbi
* fixed a corner case where the "Restart" button not works correctly
* Removed leftovers from last commit

Signed-off-by: Dirk Brenken <dev@brenken.org>