### PR TITLE
Correct grammar in apply_widget.htm

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/apply_widget.htm
+++ b/modules/luci-base/luasrc/view/cbi/apply_widget.htm
@@ -158,7 +158,7 @@
 
 			uci_status_message('notice',
 				'<img src="<%=resource%>/icons/loading.gif" alt="" style="vertical-align:middle" /> ' +
-				'<%:Waiting for configuration to get applied… %ds%>'.format(Math.max(Math.floor((deadline - Date.now()) / 1000), 0)));
+				'<%:Waiting for configuration to be applied… %ds%>'.format(Math.max(Math.floor((deadline - Date.now()) / 1000), 0)));
 
 			if (now >= deadline)
 				return;

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -3744,7 +3744,7 @@ msgstr "Esperant que s'apliquin els canvis..."
 msgid "Waiting for command to complete..."
 msgstr "Esperant que s'acabi l'ordre..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -3776,7 +3776,7 @@ msgstr "Čekání na realizaci změn..."
 msgid "Waiting for command to complete..."
 msgstr "Čekání na dokončení příkazu..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -3940,7 +3940,7 @@ msgstr "Änderungen werden angewandt..."
 msgid "Waiting for command to complete..."
 msgstr "Der Befehl wird ausgeführt..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr "Warte auf das Anwenden der Konfigurationsänderungen... %d Sekunden"
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -3740,7 +3740,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -3699,7 +3699,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -3804,7 +3804,7 @@ msgstr "Esperando a que se realicen los cambios..."
 msgid "Waiting for command to complete..."
 msgstr "Esperando a que termine el comando..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -3822,7 +3822,7 @@ msgstr "En attente de l'application des changements..."
 msgid "Waiting for command to complete..."
 msgstr "En attente de la fin de la commande..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -3650,7 +3650,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -3809,7 +3809,7 @@ msgstr "Várakozás a változtatások alkalmazására..."
 msgid "Waiting for command to complete..."
 msgstr "Várakozás a parancs befejezésére..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -3778,7 +3778,7 @@ msgstr "In attesa delle modifiche da applicare ..."
 msgid "Waiting for command to complete..."
 msgstr "In attesa del comando da completare..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -3845,7 +3845,7 @@ msgstr "変更を適用中です..."
 msgid "Waiting for command to complete..."
 msgstr "コマンド実行中です..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr "設定を適用中です... %d 秒"
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -3703,7 +3703,7 @@ msgstr "변경 사항이 적용되기를 기다리는 중입니다..."
 msgid "Waiting for command to complete..."
 msgstr "실행한 명령이 끝나기를 기다리는 중입니다..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -3670,7 +3670,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -3775,7 +3775,7 @@ msgstr "Venter på at endringer utføres..."
 msgid "Waiting for command to complete..."
 msgstr "Venter på at kommando fullføres..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -3864,7 +3864,7 @@ msgstr "Trwa wprowadzenie zmian..."
 msgid "Waiting for command to complete..."
 msgstr "Trwa wykonanie polecenia..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr "Oczekiwanie na zastosowanie konfiguracji… %ds"
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -3950,7 +3950,7 @@ msgstr "Esperando a aplicação das mudanças..."
 msgid "Waiting for command to complete..."
 msgstr "Esperando o término do comando..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -3769,7 +3769,7 @@ msgstr "A aguardar que as mudanças sejam aplicadas..."
 msgid "Waiting for command to complete..."
 msgstr "A aguardar que o comando termine..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -3646,7 +3646,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -3921,7 +3921,7 @@ msgstr "Ожидание применения изменений..."
 msgid "Waiting for command to complete..."
 msgstr "Ожидание завершения выполнения команды..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr "Ожидание применения конфигурации... %d сек."
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -3614,7 +3614,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -3641,7 +3641,7 @@ msgstr "Väntar på att ändringarna ska tillämpas..."
 msgid "Waiting for command to complete..."
 msgstr "Väntar på att kommandot ska avsluta..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -3607,7 +3607,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -3944,7 +3944,7 @@ msgstr "Очікуємо, доки зміни наберуть чинності.
 msgid "Waiting for command to complete..."
 msgstr "Очікуємо завершення виконання команди..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr "Чекаємо на застосування конфігурації… %d c"
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -3669,7 +3669,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -3729,7 +3729,7 @@ msgstr "正在应用更改…"
 msgid "Waiting for command to complete..."
 msgstr "等待命令执行完成…"
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr "等待应用配置… %d 秒"
 
 msgid "Waiting for device..."

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -3701,7 +3701,7 @@ msgstr "等待修改被啟用..."
 msgid "Waiting for command to complete..."
 msgstr "等待完整性指令..."
 
-msgid "Waiting for configuration to get applied… %ds"
+msgid "Waiting for configuration to be applied… %ds"
 msgstr ""
 
 msgid "Waiting for device..."


### PR DESCRIPTION
This patch corrects "to get" to "to be" in apply_widget.htm
This shell command was used to find and make the change in
all impacted files:

find . -type f -exec sed -i 's/Waiting for configuration to get applied/Waiting for configuration to be applied/g' {} +

Signed-off-by: Gregory L. Dietsche <gregory.dietsche@cuw.edu>