### PR TITLE
luci-theme-material: fix theme for applyreboot page changes

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -23,11 +23,11 @@
  */
 @font-face {
     font-family: 'icomoon';
-    src: url('../fonts/font.eot');
-    src: url('../fonts/font.eot') format('embedded-opentype'),
-    url('../fonts/font.ttf') format('truetype'),
-    url('../fonts/font.woff') format('woff'),
-    url('../fonts/font.svg') format('svg');
+    src: url('fonts/font.eot');
+    src: url('fonts/font.eot') format('embedded-opentype'),
+    url('fonts/font.ttf') format('truetype'),
+    url('fonts/font.woff') format('woff'),
+    url('fonts/font.svg') format('svg');
     font-weight: normal;
     font-style: normal;
 }
@@ -285,12 +285,12 @@ header {
     color: white;
 }
 
-header > .container {
+header > .fill > .container {
     margin-top: 0.5rem;
     padding: 0.5rem 1rem 0 1rem;
 }
 
-header > .container > .brand {
+header > .fill > .container > .brand {
     font-size: 1.4rem;
     color: white;
     text-decoration: none;

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -203,7 +203,7 @@
 	<link rel="icon" href="<%=media%>/logo.png" sizes="144x144">
 	<link rel="apple-touch-icon-precomposed" href="<%=media%>/logo.png" sizes="144x144">
 
-	<link rel="stylesheet" href="<%=media%>/css/style.css">
+	<link rel="stylesheet" href="<%=media%>/cascade.css">
 	<link rel="shortcut icon" href="<%=media%>/favicon.ico">
 	<% if node and node.css then %>
 		<link rel="stylesheet" href="<%=resource%>/<%=node.css%>">
@@ -216,15 +216,17 @@
 </head>
 <body class="lang_<%=luci.i18n.context.lang%> <%- if node then %><%= striptags( node.title ) %><%- end %> <% if luci.dispatcher.context.authsession then %>logged-in<% end %>">
 <header>
-	<div class="container">
-		<span class="showSide"></span>
-		<a class="brand" href="#"><%=boardinfo.hostname or "?"%></a>
-		<div class="pull-right">
-			<% render_changes() %>
-			<span id="xhr_poll_status" style="display:none" onclick="XHR.running() ? XHR.halt() : XHR.run()">
-				<span class="label success" id="xhr_poll_status_on"><span class="mobile-hide"><%:Auto Refresh%></span> <%:on%></span>
-				<span class="label" id="xhr_poll_status_off" style="display:none"><span class="mobile-hide"><%:Auto Refresh%></span> <%:off%></span>
-			</span>
+	<div class="fill">
+		<div class="container">
+			<span class="showSide"></span>
+			<a class="brand" href="#"><%=boardinfo.hostname or "?"%></a>
+			<div class="pull-right">
+				<% render_changes() %>
+				<span id="xhr_poll_status" style="display:none" onclick="XHR.running() ? XHR.halt() : XHR.run()">
+					<span class="label success" id="xhr_poll_status_on"><span class="mobile-hide"><%:Auto Refresh%></span> <%:on%></span>
+					<span class="label" id="xhr_poll_status_off" style="display:none"><span class="mobile-hide"><%:Auto Refresh%></span> <%:off%></span>
+				</span>
+			</div>
 		</div>
 	</div>
 </header>


### PR DESCRIPTION
This rename style.css to casade.css (like the other themes) and fix the css to display the header even in the applyreboot page

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>