### PR TITLE
luci-app-unbound: add zone-details combined tab

### DIFF
--- a/applications/luci-app-unbound/luasrc/controller/unbound.lua
+++ b/applications/luci-app-unbound/luasrc/controller/unbound.lua
@@ -28,7 +28,8 @@ function index()
 
     if (valman == "0") then
         entry({"admin", "services", "unbound", "zones"},
-            cbi("unbound/zones"), _("Zones"), 15)
+            arcombine(cbi("unbound/zones"), cbi("unbound/zone-details")),
+            _("Zones"), 15).leaf = true
     end
 
 
@@ -106,7 +107,7 @@ end
 
 
 function QuerySysLog()
-    local lcldata = luci.util.exec("logread | grep -i unbound")
+    local lcldata = luci.util.exec("logread -e 'unbound'")
     local lcldesc = luci.i18n.translate(
         "This shows syslog filtered for events involving Unbound.")
 

--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/uciedit.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/uciedit.lua
@@ -12,7 +12,7 @@ m6.submit = translate("Save")
 m6.reset = false
 s6 = m6:section(SimpleSection, "",
     translatef("Edit '" .. filename .. "' "
-    .. "and help can be found in OpenWrt "
+    .. "and recipes can be found in OpenWrt "
     .. "<a href=\"%s\" target=\"_blank\">Guides</a> "
     .. "and <a href=\"%s\" target=\"_blank\">Github</a>.",
     "https://openwrt.org/docs/guide-user/services/dns/unbound",

--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/zone-details.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/zone-details.lua
@@ -1,0 +1,95 @@
+-- Copyright 2018 Eric Luehrsen <ericluehrsen@gmail.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local sy = require "luci.sys"
+local ds = require "luci.dispatcher"
+local hp = require "luci.http"
+local m7, s7
+local ena, flb, zty, znm, srv, rlv, tlu
+local prt, tlp, tli, url
+
+arg[1] = arg[1] or ""
+m7 = Map("unbound")
+m7.redirect = ds.build_url("admin/services/unbound/zones")
+
+
+if (arg[1] == "") then
+    hp.redirect(m7.redirect)
+    return
+
+else
+    s7 = m7:section(NamedSection, arg[1], "zone",
+        translatef("Directed Zone"),
+        translatef("Edit a forward, stub, or zone-file-cache zone "
+        .. "for Unbound to use instead of recursion."))
+
+    s7.anonymous = true
+    s7.addremove = false
+
+    ena = s7:option(Flag, "enabled", translate("Enabled"),
+        translate("Enable this directed zone"))
+    ena.rmempty = false
+
+    flb = s7:option(Flag, "fallback", translate("Fall Back"),
+        translate("Allow open recursion when record not in zone"))
+    flb.rmempty = false
+
+    zty = s7:option(ListValue, "zone_type", translate("Zone Type"))
+    zty:value("auth_zone", translate("Authoritative (zone file)"))
+    zty:value("stub_zone", translate("Stub (forced recursion)"))
+    zty:value("forward_zone", translate("Forward (simple handoff)"))
+    zty.rmempty = false
+
+    znm = s7:option(DynamicList, "zone_name", translate("Zone Names"),
+        translate("Zone (Domain) names included in this zone combination"))
+    znm.placeholder="new.example.net."
+
+    srv = s7:option(DynamicList, "server", translate("Servers"),
+        translate("Servers for this zone; see README.md for optional form"))
+    srv.placeholder="192.0.2.53"
+
+    rlv = s7:option(Flag, "resolv_conf", translate("Use 'resolv.conf.auto'"),
+        translate("Forward to upstream nameservers (ISP)"))
+    rlv:depends("zone_type", "forward_zone")
+
+    tlu = s7:option(Flag, "tls_upstream", translate("DNS over TLS"),
+        translate("Connect to servers using TLS"))
+    tlu:depends("zone_type", "forward_zone")
+
+    prt = s7:option(Value, "port", translate("Server Port"),
+        translate("Port servers will receive queries on"))
+    prt:depends("tls_upstream", false)
+    prt.datatype = "port"
+    prt.placeholder="53"
+
+    tlp = s7:option(Value, "tls_port", translate("Server TLS Port"),
+        translate("Port servers will receive queries on"))
+    tlp:depends("tls_upstream", true)
+    tlp.datatype = "port"
+    tlp.placeholder="853"
+
+    tli = s7:option(Value, "tls_index", translate("TLS Name Index"),
+        translate("Domain name to verify TLS certificate"))
+    tli:depends("tls_upstream", true)
+    tli.placeholder="dns.example.net"
+
+    url = s7:option(Value, "url_dir", translate("Zone Download URL"),
+        translate("Directory only part of URL"))
+    url:depends("zone_type", "auth_zone")
+    url.placeholder="https://www.example.net/dl/zones/"
+end
+
+
+function m7.on_commit(self)
+    if sy.init.enabled("unbound") then
+        -- Restart Unbound with configuration
+        sy.call("/etc/init.d/unbound restart >/dev/null 2>&1")
+
+    else
+        sy.call("/etc/init.d/unbound stop >/dev/null 2>&1")
+    end
+end
+
+
+return m7
+


### PR DESCRIPTION
maintainer: me
tested: TL-Archer-C7v2 OpenWrt master
description: 
This polishes off the LuCI app' for forward, stub, and auth- zones including DNS over TLS. The interface is similar to firewall. The openssl API notice pushed into syslog is also flag as a special message on the zones tab.