### PR TITLE
luci-mod-admin-full: applyreboot doesn't reload page

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/applyreboot.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/applyreboot.htm
@@ -16,6 +16,7 @@
 		
 				img.onload = function() {
 					window.clearInterval(interval);
+					window.location.replace(target);
 				};
 				
 				img.src = target + '<%=resource%>/icons/loading.gif?' + Math.random();


### PR DESCRIPTION
The applyreboot page doesn't reload the page onload of the loding gif. This adds the right function.
@jow- 
Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>