### PR TITLE
luci-app-samba4: add macOS and Apple Timemachine support

### DIFF
--- a/applications/luci-app-samba4/luasrc/model/cbi/samba4.lua
+++ b/applications/luci-app-samba4/luasrc/model/cbi/samba4.lua
@@ -15,9 +15,20 @@ h = s:taboption("general", Flag, "homes", translate("Share home-directories"),
         translate("Allow system users to reach their home directories via " ..
                 "network shares"))
 h.rmempty = false
-s:taboption("general", Flag, "disable_netbios", translate("Disable Netbios"))
-s:taboption("general", Flag, "disable_ad_dc", translate("Disable Active Directory Domain Controller"))
-s:taboption("general", Flag, "disable_winbind", translate("Disable Winbind"))
+
+macos = s:taboption("general", Flag, "macos", translate("Enable macOS compatible shares"),
+	translate("Enables Apple's AAPL extension globally and adds macOS compatibility options to all shares."))
+macos.rmempty = false
+
+if nixio.fs.access("/usr/sbin/nmbd") then
+	s:taboption("general", Flag, "disable_netbios", translate("Disable Netbios"))
+end
+if nixio.fs.access("/usr/sbin/samba") then
+	s:taboption("general", Flag, "disable_ad_dc", translate("Disable Active Directory Domain Controller"))
+end
+if nixio.fs.access("/usr/sbin/winbindd") then
+	s:taboption("general", Flag, "disable_winbind", translate("Disable Winbind"))
+end
 
 tmpl = s:taboption("template", Value, "_tmpl",
 	translate("Edit the template that is used for generating the samba configuration."), 
@@ -49,42 +60,53 @@ if nixio.fs.access("/etc/config/fstab") then
 	pth.titleref = luci.dispatcher.build_url("admin", "system", "fstab")
 end
 
-s:option(Value, "users", translate("Allowed users")).rmempty = true
-
-ro = s:option(Flag, "read_only", translate("Read-only"))
-ro.rmempty = false
-ro.enabled = "yes"
-ro.disabled = "no"
-
-br = s:option(Flag, "browseable", translate("Browseable"))
-br.rmempty = false
-br.default = "yes"
+br = s:option(Flag, "browseable", translate("Browse-able"))
 br.enabled = "yes"
 br.disabled = "no"
+br.default = "yes"
+
+ro = s:option(Flag, "read_only", translate("Read-only"))
+ro.enabled = "yes"
+ro.disabled = "no"
+ro.default = "yes"
+
+s:option(Flag, "force_root", translate("Force Root"))
+
+au = s:option(Value, "users", translate("Allowed users"))
+au.rmempty = true
 
 go = s:option(Flag, "guest_ok", translate("Allow guests"))
-go.rmempty = false
 go.enabled = "yes"
 go.disabled = "no"
+go.default = "no"
 
 gon = s:option(Flag, "guest_only", translate("Guests only"))
-gon.rmempty = false
 gon.enabled = "yes"
 gon.disabled = "no"
+gon.default = "no"
 
-io = s:option(Flag, "inherit_owner", translate("Inherit owner"))
-io.rmempty = false
-io.enabled = "yes"
-io.disabled = "no"
+iown = s:option(Flag, "inherit_owner", translate("Inherit owner"))
+iown.enabled = "yes"
+iown.disabled = "no"
+iown.default = "no"
 
 cm = s:option(Value, "create_mask", translate("Create mask"))
 cm.rmempty = true
-cm.size = 4
+cm.maxlength = 4
+cm.placeholder = "0666"
 
 dm = s:option(Value, "dir_mask", translate("Directory mask"))
 dm.rmempty = true
-dm.size = 4
+dm.maxlength = 4
+dm.placeholder = "0777"
 
-s:option(Value, "vfs_objects", translate("Vfs objects")).rmempty = true
+vfs = s:option(Value, "vfs_objects", translate("Vfs objects"))
+vfs.rmempty = true
+
+s:option(Flag, "timemachine", translate("Apple Time-machine share"))
+
+tms = s:option(Value, "timemachine_maxsize", translate("Time-machine size in GB"))
+tms.rmempty = true
+tms.maxlength = 5
 
 return m

--- a/applications/luci-app-samba4/po/ca/samba4.po
+++ b/applications/luci-app-samba4/po/ca/samba4.po
@@ -26,7 +26,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Usuaris permesos"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -52,6 +55,17 @@ msgstr "Edita plantilla"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Edita la plantilla que s'usa per generar la configuració de samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Ajusts generals"
@@ -98,6 +112,9 @@ msgstr ""
 "vostra configuració de samba es generarà. Valors encerclats per símbols de "
 "barra ('|') no es deuen canviar. Reben els seus valors de la pestanya "
 "'Ajusts generals'."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/cs/samba4.po
+++ b/applications/luci-app-samba4/po/cs/samba4.po
@@ -22,7 +22,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Povolení uživatelé"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -50,6 +53,17 @@ msgid "Edit the template that is used for generating the samba configuration."
 msgstr ""
 "Editovat šablonu, která je použita pro generování konfiguračního souboru pro "
 "sambu."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Obecné nastavení"
@@ -95,6 +109,9 @@ msgstr ""
 "Toto je obsah souboru \"/etc/samba/smb.conf.template\", ze kterého je "
 "konfigurace samby generována. Hodnoty uzavřené rourou (\"|\"), by se neměly "
 "měnit. Tyto hodnoty jsou brány ze záložky \"Obecná nastavení\"."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/de/samba4.po
+++ b/applications/luci-app-samba4/po/de/samba4.po
@@ -24,17 +24,20 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Legitimierte Benutzer"
 
-msgid "Browseable"
-msgstr "Suchbar"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
+msgstr "Durchsuchbar"
 
 msgid "Create mask"
-msgstr "Berechtigungsmaske für neue Dateien"
+msgstr "Berechtigungs-maske für neue Dateien"
 
 msgid "Description"
 msgstr "Beschreibung"
 
 msgid "Directory mask"
-msgstr "Verzeichnismaske"
+msgstr "Verzeichnis-maske"
 
 msgid "Disable Active Directory Domain Controller"
 msgstr "Deaktiviere Active Directory Domain Controller"
@@ -53,6 +56,17 @@ msgstr ""
 "Hier kann das Template bearbeitet werden, das zur Erstellung der Samba-"
 "Konfigurationsdateien verwendet wird."
 
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
+
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
@@ -69,7 +83,7 @@ msgid "Name"
 msgstr "Name"
 
 msgid "Network Shares"
-msgstr "Netzwerkfreigaben"
+msgstr "Netzwerk-freigaben"
 
 msgid "Path"
 msgstr "Pfad"
@@ -83,7 +97,7 @@ msgid "Read-only"
 msgstr "Nur Lesen"
 
 msgid "Share home-directories"
-msgstr "Heimatverzeichnisse freigeben"
+msgstr "Heimat-verzeichnisse freigeben"
 
 msgid "Shared Directories"
 msgstr "Freigegebene Verzeichnisse"
@@ -100,11 +114,17 @@ msgstr ""
 "werden, da diese beim Erstellen der Konfiguration mit den Werten aus dem Tab "
 "'Allgemeine Einstellungen' ersetzt werden."
 
+msgid "Time-machine size in GB"
+msgstr ""
+
 msgid "Vfs objects"
-msgstr "Virtuelle Filesystem Module"
+msgstr ""
 
 msgid "Workgroup"
 msgstr "Arbeitsgruppe"
+
+#~ msgid "Browseable"
+#~ msgstr "Suchbar"
 
 #~ msgid "Mask for new directories"
 #~ msgstr "Maske für neue Verzeichnisse"

--- a/applications/luci-app-samba4/po/el/samba4.po
+++ b/applications/luci-app-samba4/po/el/samba4.po
@@ -22,7 +22,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr ""
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -47,6 +50,17 @@ msgid "Edit Template"
 msgstr ""
 
 msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
 msgstr ""
 
 msgid "General Settings"
@@ -89,6 +103,9 @@ msgid ""
 "your samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
+msgstr ""
+
+msgid "Time-machine size in GB"
 msgstr ""
 
 msgid "Vfs objects"

--- a/applications/luci-app-samba4/po/en/samba4.po
+++ b/applications/luci-app-samba4/po/en/samba4.po
@@ -22,7 +22,10 @@ msgstr "Allow system users to reach their home directories via network shares"
 msgid "Allowed users"
 msgstr "Allowed users"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -48,6 +51,17 @@ msgstr "Edit template"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Edit the template that is used for generating the Samba configuration."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "General settings"
@@ -94,6 +108,9 @@ msgstr ""
 "your Samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "settings' tab."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/es/samba4.po
+++ b/applications/luci-app-samba4/po/es/samba4.po
@@ -24,7 +24,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Usuarios permitidos"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -50,6 +53,17 @@ msgstr "Editar plantilla"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Editar la plantilla usada para generar la configuración de samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Configuración general"
@@ -95,6 +109,9 @@ msgstr ""
 "Contenido del fichero '/etc/samba/smb.conf.template' desde el que se "
 "generará la configuración de samba. Los valores entre tuberías ('|') no "
 "deben cambiarse. Su valor se toma desde la pestaña 'Configuración General'."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/fr/samba4.po
+++ b/applications/luci-app-samba4/po/fr/samba4.po
@@ -24,7 +24,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Utilisateurs autorisés"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -50,6 +53,17 @@ msgstr "Éditer le modèle"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Éditer le modèle utilisé pour générer la configuration Samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Paramètres généraux"
@@ -96,6 +110,9 @@ msgstr ""
 "votre configuration Samba. Les valeurs entre les symboles barre-verticale "
 " (« | ») ne doivent pas être modifiées, elles proviennent de l'onglet "
 "« Paramètres généraux »."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/he/samba4.po
+++ b/applications/luci-app-samba4/po/he/samba4.po
@@ -17,7 +17,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr ""
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -42,6 +45,17 @@ msgid "Edit Template"
 msgstr ""
 
 msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
 msgstr ""
 
 msgid "General Settings"
@@ -84,6 +98,9 @@ msgid ""
 "your samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
+msgstr ""
+
+msgid "Time-machine size in GB"
 msgstr ""
 
 msgid "Vfs objects"

--- a/applications/luci-app-samba4/po/hu/samba4.po
+++ b/applications/luci-app-samba4/po/hu/samba4.po
@@ -22,7 +22,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Engedélyezett felhasználók"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -50,6 +53,17 @@ msgid "Edit the template that is used for generating the samba configuration."
 msgstr ""
 "Itt szerkesztheti a sablont, ami a végleges samba konfiguráció "
 "elkészítéséhez kerül felhasználásra."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Általános beállítások"
@@ -96,6 +110,9 @@ msgstr ""
 "konfiguráció előállításához kerül felhasználásra. A pipe szimbólumok ('|') "
 "közé zárt értékek módosítása nem szükséges, az értéküket az általános "
 "beállítások fülről kapják."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/it/samba4.po
+++ b/applications/luci-app-samba4/po/it/samba4.po
@@ -24,8 +24,11 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Utenti ammessi"
 
-msgid "Browseable"
-msgstr "Sfogliabile"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
+msgstr ""
 
 msgid "Create mask"
 msgstr "Crea maschera"
@@ -51,6 +54,17 @@ msgstr "Modifica Template"
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr ""
 "Modifica il template utilizzato per generare la configurazione di samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Opzioni Generali"
@@ -100,11 +114,17 @@ msgstr ""
 "('|') non dovrebbero essere toccati. Essi vengono generati dalla schermata "
 "'Opzioni Generali'."
 
+msgid "Time-machine size in GB"
+msgstr ""
+
 msgid "Vfs objects"
 msgstr ""
 
 msgid "Workgroup"
 msgstr "Gruppo di lavoro"
+
+#~ msgid "Browseable"
+#~ msgstr "Sfogliabile"
 
 #~ msgid "Mask for new directories"
 #~ msgstr "Maschera per le nuove cartelle"

--- a/applications/luci-app-samba4/po/ja/samba4.po
+++ b/applications/luci-app-samba4/po/ja/samba4.po
@@ -22,7 +22,10 @@ msgstr "sambaを介してユーザーのホームディレクトリへのアク�
 msgid "Allowed users"
 msgstr "許可されたユーザー"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -48,6 +51,17 @@ msgstr "テンプレートの編集"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "samba設定を生成するテンプレートを編集します。"
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "一般設定"
@@ -95,6 +109,9 @@ msgstr ""
 "これは、samba設定を生成するための'/etc/samba/smb.conf.template' ファイルの内"
 "容です。パイプ('|')で閉じられた値は変更しないでください。これらの値は'一般設"
 "定'タブ内の値によって置き換えられます。"
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/ms/samba4.po
+++ b/applications/luci-app-samba4/po/ms/samba4.po
@@ -16,7 +16,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr ""
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -41,6 +44,17 @@ msgid "Edit Template"
 msgstr ""
 
 msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
 msgstr ""
 
 msgid "General Settings"
@@ -83,6 +97,9 @@ msgid ""
 "your samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
+msgstr ""
+
+msgid "Time-machine size in GB"
 msgstr ""
 
 msgid "Vfs objects"

--- a/applications/luci-app-samba4/po/no/samba4.po
+++ b/applications/luci-app-samba4/po/no/samba4.po
@@ -13,7 +13,10 @@ msgstr "Tillat systembrukere å nå sine hjemmekataloger via nettverks mapper."
 msgid "Allowed users"
 msgstr "Tillatte brukere"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -39,6 +42,17 @@ msgstr "Rediger Mal"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Rediger malen som brukes til å generere samba konfigurasjonen."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Generelle Innstillinger"
@@ -84,6 +98,9 @@ msgstr ""
 "Dette er innholdet av filen '/etc/samba/smb.conf.template' som din samba "
 "konfigurasjon vil bli generert fra. Verdier omsluttet av ('|') bør ikke "
 "endres. De får sine verdier fra 'Generelle Innstillinger' fanen."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/pl/samba4.po
+++ b/applications/luci-app-samba4/po/pl/samba4.po
@@ -23,7 +23,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Użytkownicy z prawem dostępu"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -49,6 +52,17 @@ msgstr "Edytuj szablon"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Edytuj szablon, który jest używany do generowania konfiguracji samby."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Ustawienia ogólne"
@@ -95,6 +109,9 @@ msgstr ""
 "którego zostanie wygenerowana konfiguracja samby. Wartości otoczone symbolem "
 "kreski pionowej ('|') nie powinny być zmieniane. Wartości ich zostaną "
 "pobrane z zakładki \"Ustawienia ogólne\"."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/pt-br/samba4.po
+++ b/applications/luci-app-samba4/po/pt-br/samba4.po
@@ -24,7 +24,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Usuários permitidos"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -50,6 +53,17 @@ msgstr "Editar modelo"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Edita o modelo que é usado para gerar a configuração do samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Configurações Gerais"
@@ -96,6 +110,9 @@ msgstr ""
 "sua configuração do samba será gerada. Valores entre simbolos de pipe ('|') "
 "não devem ser alterados. Estes valores serão obtidos a partir da aba "
 "'Configurações Gerais'."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/pt/samba4.po
+++ b/applications/luci-app-samba4/po/pt/samba4.po
@@ -24,7 +24,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Utilizadores Permitidos"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -50,6 +53,17 @@ msgstr "Editar Template"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Editar a template que é utilizada para gerar a configuração samba"
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Definições Gerais"
@@ -96,6 +110,9 @@ msgstr ""
 "será gerado o ficheiro de configuração do samba. Os valores entre o símbolo "
 "| não devem ser alterados. Eles recebem os valores do separador 'Definições "
 "Gerais'."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/ro/samba4.po
+++ b/applications/luci-app-samba4/po/ro/samba4.po
@@ -23,7 +23,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Utilizatori acceptati"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -49,6 +52,17 @@ msgstr "Editeaza sablon"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Editeaza sablonul care e folosit pentru generarea configuratiei samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Setari generale"
@@ -94,6 +108,9 @@ msgstr ""
 "Acesta este continutul fisierului '/etc/samba/smb.conf.template' din care se "
 "genereaza configuratia samba. Valorile dintre liniuta verticala ('|') n-ar "
 "trebui schimbate, ele iau valorile direct din tab-ul de \"Setari generale\"."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/ru/samba4.po
+++ b/applications/luci-app-samba4/po/ru/samba4.po
@@ -26,8 +26,11 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Разрешенные пользователи"
 
-msgid "Browseable"
-msgstr "Виден в списке доступных ресурсов"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
+msgstr ""
 
 msgid "Create mask"
 msgstr "Создать маску"
@@ -52,6 +55,17 @@ msgstr "Настройка config файла"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "Настройка config<br />файла samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Основные настройки"
@@ -101,11 +115,17 @@ msgstr ""
 "('|'), не должны быть изменены.<br />Они будут автоматически заменены на "
 "значения со страницы 'Основные настройки'."
 
+msgid "Time-machine size in GB"
+msgstr ""
+
 msgid "Vfs objects"
 msgstr ""
 
 msgid "Workgroup"
 msgstr "Рабочая группа"
+
+#~ msgid "Browseable"
+#~ msgstr "Виден в списке доступных ресурсов"
 
 #~ msgid "Mask for new directories"
 #~ msgstr "Маска для новых папок"

--- a/applications/luci-app-samba4/po/sk/samba4.po
+++ b/applications/luci-app-samba4/po/sk/samba4.po
@@ -17,7 +17,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr ""
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -42,6 +45,17 @@ msgid "Edit Template"
 msgstr ""
 
 msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
 msgstr ""
 
 msgid "General Settings"
@@ -84,6 +98,9 @@ msgid ""
 "your samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
+msgstr ""
+
+msgid "Time-machine size in GB"
 msgstr ""
 
 msgid "Vfs objects"

--- a/applications/luci-app-samba4/po/sv/samba4.po
+++ b/applications/luci-app-samba4/po/sv/samba4.po
@@ -18,7 +18,10 @@ msgstr "Tillåt systemanvändare att nå deras hem-mappar via nätverksdelningar
 msgid "Allowed users"
 msgstr "Tillåtna användare"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -45,6 +48,17 @@ msgstr "Redigera mall"
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr ""
 "Redigera mallen som används för att generera konfigurationen för samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Generella inställningar"
@@ -86,6 +100,9 @@ msgid ""
 "your samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
+msgstr ""
+
+msgid "Time-machine size in GB"
 msgstr ""
 
 msgid "Vfs objects"

--- a/applications/luci-app-samba4/po/templates/samba4.pot
+++ b/applications/luci-app-samba4/po/templates/samba4.pot
@@ -10,7 +10,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr ""
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -35,6 +38,17 @@ msgid "Edit Template"
 msgstr ""
 
 msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
 msgstr ""
 
 msgid "General Settings"
@@ -77,6 +91,9 @@ msgid ""
 "your samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
+msgstr ""
+
+msgid "Time-machine size in GB"
 msgstr ""
 
 msgid "Vfs objects"

--- a/applications/luci-app-samba4/po/tr/samba4.po
+++ b/applications/luci-app-samba4/po/tr/samba4.po
@@ -17,7 +17,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr ""
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -42,6 +45,17 @@ msgid "Edit Template"
 msgstr ""
 
 msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
 msgstr ""
 
 msgid "General Settings"
@@ -84,6 +98,9 @@ msgid ""
 "your samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
+msgstr ""
+
+msgid "Time-machine size in GB"
 msgstr ""
 
 msgid "Vfs objects"

--- a/applications/luci-app-samba4/po/uk/samba4.po
+++ b/applications/luci-app-samba4/po/uk/samba4.po
@@ -23,7 +23,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Дозволені користувачі"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 msgid "Create mask"
@@ -50,6 +53,17 @@ msgstr "Редагувати шаблон"
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr ""
 "Редагувати шаблон, який використовується для створення конфігурації samba."
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "Загальні настройки"
@@ -96,6 +110,9 @@ msgstr ""
 "ваша конфігурація samba. Значення, укладені в символи \"вертикальна риска"
 "\" (\"|\") не повинні змінюватися. Вони отримують свої значення з вкладки "
 "\"Загальні налаштування\"."
+
+msgid "Time-machine size in GB"
+msgstr ""
 
 msgid "Vfs objects"
 msgstr ""

--- a/applications/luci-app-samba4/po/vi/samba4.po
+++ b/applications/luci-app-samba4/po/vi/samba4.po
@@ -28,7 +28,10 @@ msgstr ""
 msgid "Allowed users"
 msgstr "Người sử dụng được cho phép"
 
-msgid "Browseable"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
 msgstr ""
 
 #, fuzzy
@@ -55,6 +58,17 @@ msgid "Edit Template"
 msgstr ""
 
 msgid "Edit the template that is used for generating the samba configuration."
+msgstr ""
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
 msgstr ""
 
 msgid "General Settings"
@@ -98,6 +112,9 @@ msgid ""
 "your samba configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
+msgstr ""
+
+msgid "Time-machine size in GB"
 msgstr ""
 
 msgid "Vfs objects"

--- a/applications/luci-app-samba4/po/zh-cn/samba4.po
+++ b/applications/luci-app-samba4/po/zh-cn/samba4.po
@@ -25,8 +25,11 @@ msgstr "允许系统用户通过网络共享访问他们的家目录"
 msgid "Allowed users"
 msgstr "允许用户"
 
-msgid "Browseable"
-msgstr "可浏览"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
+msgstr ""
 
 msgid "Create mask"
 msgstr "创建权限掩码"
@@ -51,6 +54,17 @@ msgstr "编辑模板"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "编辑用来生成 samba 设置的模板"
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "基本设置"
@@ -96,11 +110,17 @@ msgstr ""
 "这是将从其上生成 samba 配置的文件“/etc/samba/smb.conf.template”的内容。由管道"
 "符（“|”）包围的值不应更改。它们将从“常规设置”标签中获取其值。"
 
+msgid "Time-machine size in GB"
+msgstr ""
+
 msgid "Vfs objects"
 msgstr "VFS 对象"
 
 msgid "Workgroup"
 msgstr "工作组"
+
+#~ msgid "Browseable"
+#~ msgstr "可浏览"
 
 #~ msgid "Mask for new directories"
 #~ msgstr "新目录权限掩码"

--- a/applications/luci-app-samba4/po/zh-tw/samba4.po
+++ b/applications/luci-app-samba4/po/zh-tw/samba4.po
@@ -25,8 +25,11 @@ msgstr "允許系統使用者通過網路共享訪問他們的家目錄"
 msgid "Allowed users"
 msgstr "允許使用者"
 
-msgid "Browseable"
-msgstr "可瀏覽"
+msgid "Apple Time-machine share"
+msgstr ""
+
+msgid "Browse-able"
+msgstr ""
 
 msgid "Create mask"
 msgstr "建立權限掩碼"
@@ -51,6 +54,17 @@ msgstr "編輯模板"
 
 msgid "Edit the template that is used for generating the samba configuration."
 msgstr "編輯用來生成 samba 設定的模板"
+
+msgid "Enable macOS compatible shares"
+msgstr ""
+
+msgid ""
+"Enables Apple's AAPL extension globally and adds macOS compatibility options "
+"to all shares."
+msgstr ""
+
+msgid "Force Root"
+msgstr ""
 
 msgid "General Settings"
 msgstr "基本設定"
@@ -96,11 +110,17 @@ msgstr ""
 "這是將從其上生成 samba 配置的檔案“/etc/samba/smb.conf.template”的內容。由管道"
 "符（“|”）包圍的值不應更改。它們將從“常規設定”標籤中獲取其值。"
 
+msgid "Time-machine size in GB"
+msgstr ""
+
 msgid "Vfs objects"
 msgstr "VFS 物件"
 
 msgid "Workgroup"
 msgstr "工作組"
+
+#~ msgid "Browseable"
+#~ msgstr "可瀏覽"
 
 #~ msgid "Mask for new directories"
 #~ msgstr "新目錄權限掩碼"


### PR DESCRIPTION
* add macOS compatibility option
* adds Apple Timemachine support
* dynamically disable invalid options

depends on openwrt/packages#6772