### PR TITLE
luci-mod-admin-full: allow forced upgrade (revised)

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/controller/admin/system.lua
@@ -269,15 +269,17 @@ function action_sysupgrade()
 	--
 	-- Initiate firmware flash
 	--
-	local step = tonumber(http.formvalue("step") or 1)
+	local step = tonumber(http.formvalue("step")) or 1
 	if step == 1 then
-		if image_supported(image_tmp) then
+		local force = http.formvalue("force")
+		if image_supported(image_tmp) or force then
 			luci.template.render("admin_system/upgrade", {
 				checksum = image_checksum(image_tmp),
 				sha256ch = image_sha256_checksum(image_tmp),
 				storage  = storage_size(),
 				size     = (fs.stat(image_tmp, "size") or 0),
-				keep     = (not not http.formvalue("keep"))
+				keep     = (not not http.formvalue("keep")),
+				force    = (not not http.formvalue("force"))
 			})
 		else
 			fs.unlink(image_tmp)
@@ -287,17 +289,19 @@ function action_sysupgrade()
 				image_invalid = true
 			})
 		end
+
 	--
 	-- Start sysupgrade flash
 	--
 	elseif step == 2 then
 		local keep = (http.formvalue("keep") == "1") and "" or "-n"
+		local force = (http.formvalue("force") == "1") and "" or "-F"
 		luci.template.render("admin_system/applyreboot", {
 			title = luci.i18n.translate("Flashing..."),
 			msg   = luci.i18n.translate("The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It might be necessary to renew the address of your computer to reach the device again, depending on your settings."),
-			addr  = (#keep > 0) and "192.168.1.1" or nil
+			addr  = (#keep > 0) and (#force > 0) and "192.168.1.1" or nil
 		})
-		fork_exec("sleep 1; killall dropbear uhttpd; sleep 1; /sbin/sysupgrade %s %q" %{ keep, image_tmp })
+		fork_exec("sleep 1; killall dropbear uhttpd; sleep 1; /sbin/sysupgrade %s %s %q" %{ keep, force, image_tmp })
 	end
 end
 

--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
@@ -20,7 +20,7 @@
 		<form class="inline" method="post" action="<%=url('admin/system/flashops/backup')%>">
 			<input type="hidden" name="token" value="<%=token%>" />
 			<div class="cbi-value<% if not reset_avail then %> cbi-value-last<% end %>">
-				<label class="cbi-value-title" for="image"><%:Download backup%>:</label>
+				<label class="cbi-value-title" for="image"><%:Download backup%></label>
 				<div class="cbi-value-field">
 					<input class="cbi-button cbi-button-action important" type="submit" name="backup" value="<%:Generate archive%>" />
 				</div>
@@ -35,7 +35,7 @@
 		<form class="inline" method="post" action="<%=url('admin/system/flashops/reset')%>">
 			<input type="hidden" name="token" value="<%=token%>" />
 			<div class="cbi-value cbi-value-last">
-				<label class="cbi-value-title"><%:Reset to defaults%>:</label>
+				<label class="cbi-value-title"><%:Reset to defaults%></label>
 				<div class="cbi-value-field">
 					<input onclick="return confirm('<%:Really reset all changes?%>')" class="cbi-button cbi-button-reset" type="submit" name="reset" value="<%:Perform reset%>" />
 				</div>
@@ -44,7 +44,7 @@
 		<% end %>
 		<form class="inline" method="post" action="<%=url('admin/system/flashops/restore')%>" enctype="multipart/form-data">
 			<div class="cbi-value cbi-value-last">
-				<label class="cbi-value-title" for="archive"><%:Restore backup%>:</label>
+				<label class="cbi-value-title" for="archive"><%:Restore backup%></label>
 				<div class="cbi-value-field">
 					<input type="hidden" name="token" value="<%=token%>" />
 					<input type="file" name="archive" id="archive" />
@@ -69,22 +69,31 @@
 			<div class="cbi-section-descr"><%:Upload a sysupgrade-compatible image here to replace the running firmware. Check "Keep settings" to retain the current configuration (requires a compatible firmware image).%></div>
 			<div class="cbi-section-node">
 				<div class="cbi-value">
-					<label class="cbi-value-title" for="keep"><%:Keep settings%>:</label>
+					<label class="cbi-value-title" for="keep"><%:Keep settings%></label>
 					<div class="cbi-value-field">
 						<input type="checkbox" name="keep" id="keep" checked="checked" />
 					</div>
 				</div>
+				<% if image_invalid then %>
+				<div class="cbi-value">
+					<label class="cbi-value-title" for="force"><%:Force upgrade%></label>
+					<div class="cbi-value-field">
+						<input type="checkbox" name="force" id="force" />
+					</div>
+					<div class="cbi-section-error">
+						<%:The uploaded image file does not contain a supported format. Make sure that you choose the generic image format for your platform. %>
+						<%:Select 'Force upgrade' to flash the image even if the image format check fails. Use only if you are sure that the firmware is correct and meant for your device! %>
+					</div>
+				</div>
+				<% end %>
 				<div class="cbi-value cbi-value-last<% if image_invalid then %> cbi-value-error<% end %>">
-					<label class="cbi-value-title" for="image"><%:Image%>:</label>
+					<label class="cbi-value-title" for="image"><%:Image%></label>
 					<div class="cbi-value-field">
 						<input type="file" name="image" id="image" />
 						<input type="submit" class="cbi-button cbi-button-action important" value="<%:Flash image...%>" />
 					</div>
 				</div>
 			</div>
-			<% if image_invalid then %>
-				<div class="cbi-section-error"><%:The uploaded image file does not contain a supported format. Make sure that you choose the generic image format for your platform. %></div>
-			<% end %>
 		</form>
 	<% else %>
 		<div class="cbi-section-descr"><%:Sorry, there is no sysupgrade support present; a new firmware image must be flashed manually. Please refer to the wiki for device specific install instructions.%></div>

--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/upgrade.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/upgrade.htm
@@ -22,7 +22,7 @@
 
 </p>
 
-<fieldset class="cbi-section">
+<div class="cbi-section">
 	<ul>
 		<li><%:Checksum%><br />
 		<%:MD5%>: <code><%=checksum%></code><br />
@@ -39,18 +39,24 @@
 			end
 		%></li>
 		<li><% if keep then %>
-			<%:Configuration files will be kept.%>
+			<%:Configuration files will be kept%>
 		<% else %>
-			<%:Note: Configuration files will be erased.%>
+			<%:Caution: Configuration files will be erased%>
 		<% end %></li>
+		<% if force then %>
+		<li>
+			<%:Caution: System upgrade will be forced%>
+		</li>
+		<% end %>
 	</ul>
-</fieldset>
+</div>
 
 <div class="cbi-page-actions right">
 	<form class="inline" action="<%=REQUEST_URI%>" method="post">
 		<input type="hidden" name="token" value="<%=token%>" />
 		<input type="hidden" name="step" value="2" />
 		<input type="hidden" name="keep" value="<%=keep and "1" or ""%>" />
+		<input type="hidden" name="force" value="<%=force and "1" or ""%>" />
 		<input class="cbi-button cbi-button-reset" name="cancel" type="submit" value="<%:Cancel%>" />
 		<input class="cbi-button cbi-button-apply" type="submit" value="<%:Proceed%>" />
 	</form>


### PR DESCRIPTION
* allow 'forced' firmware upgrades, even if the image format check fails. Useful where flashing back to the OEM versions or switching between ar71xx and ath79 builds
* option is only visible after first/failed image check
* added warning info (see screenshots below)

Signed-off-by: Dirk Brenken <dev@brenken.org>