### PR TITLE
luci-app-firewall: Colons removed from input headers

### DIFF
--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/zone-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/zone-details.lua
@@ -167,7 +167,7 @@ s2 = m:section(NamedSection, zone.sid, "fwd_out",
 	))
 
 out = s2:option(Value, "out",
-	translate("Allow forward to <em>destination zones</em>:"))
+	translate("Allow forward to <em>destination zones</em>"))
 
 out.nocreate = true
 out.widget = "checkbox"
@@ -175,7 +175,7 @@ out.exclude = zone:name()
 out.template = "cbi/firewall_zonelist"
 
 inp = s2:option(Value, "in",
-	translate("Allow forward from <em>source zones</em>:"))
+	translate("Allow forward from <em>source zones</em>"))
 
 inp.nocreate = true
 inp.widget = "checkbox"

--- a/applications/luci-app-firewall/po/ca/firewall.po
+++ b/applications/luci-app-firewall/po/ca/firewall.po
@@ -63,11 +63,11 @@ msgstr "Afegeix i edita..."
 msgid "Advanced Settings"
 msgstr "Ajusts avançats"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Permet el reenviament des dels <em>zones d'origen</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Permet el reenviament des dels <em>zones d'origen</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Permet el reenviament als <em>zones de destí</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Permet el reenviament als <em>zones de destí</em>"
 
 msgid "Any"
 msgstr "Qualsevol"

--- a/applications/luci-app-firewall/po/cs/firewall.po
+++ b/applications/luci-app-firewall/po/cs/firewall.po
@@ -59,11 +59,11 @@ msgstr "Přidat a upravit"
 msgid "Advanced Settings"
 msgstr "Pokročilé nastavení"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Povolit přesměrování ze <em>zdrojových oblastí</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Povolit přesměrování ze <em>zdrojových oblastí</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Povolit přesměrování do <em>zdrojových oblastí</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Povolit přesměrování do <em>zdrojových oblastí</em>"
 
 msgid "Any"
 msgstr "Libovolné"

--- a/applications/luci-app-firewall/po/de/firewall.po
+++ b/applications/luci-app-firewall/po/de/firewall.po
@@ -61,11 +61,11 @@ msgstr "Hinzufügen und bearbeiten..."
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Erlaube Weiterleitung von <em>Quellzone</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Erlaube Weiterleitung von <em>Quellzone</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Erlaube Weiterleitung zu <em>Zielzone</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Erlaube Weiterleitung zu <em>Zielzone</em>"
 
 msgid "Any"
 msgstr "beliebig"

--- a/applications/luci-app-firewall/po/el/firewall.po
+++ b/applications/luci-app-firewall/po/el/firewall.po
@@ -61,10 +61,10 @@ msgstr "Προσθήκη και επεξεργασία..."
 msgid "Advanced Settings"
 msgstr "Ρυθμίσεις για προχωρημένους"
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr ""
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr ""
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/en/firewall.po
+++ b/applications/luci-app-firewall/po/en/firewall.po
@@ -59,10 +59,10 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr ""
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr ""
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/es/firewall.po
+++ b/applications/luci-app-firewall/po/es/firewall.po
@@ -62,11 +62,11 @@ msgstr "Añadir y editar..."
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Permitir traspaso desde <em>zonas de origen</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Permitir traspaso desde <em>zonas de origen</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Permitir traspaso a <em>zonas de destino</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Permitir traspaso a <em>zonas de destino</em>"
 
 msgid "Any"
 msgstr "Cualquiera"

--- a/applications/luci-app-firewall/po/fr/firewall.po
+++ b/applications/luci-app-firewall/po/fr/firewall.po
@@ -61,11 +61,11 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Permettre la transmission des <em>zones source</em> :"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Permettre la transmission des <em>zones source</em> "
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Permettre la transmission vers les <em>zones destination</em> :"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Permettre la transmission vers les <em>zones destination</em> "
 
 msgid "Any"
 msgstr "N'importe lequel"

--- a/applications/luci-app-firewall/po/he/firewall.po
+++ b/applications/luci-app-firewall/po/he/firewall.po
@@ -56,10 +56,10 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr ""
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr ""
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/hu/firewall.po
+++ b/applications/luci-app-firewall/po/hu/firewall.po
@@ -59,11 +59,11 @@ msgstr "Hozzáadás és szerkesztés..."
 msgid "Advanced Settings"
 msgstr "Haladó beállítások"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Továbbítás engedélyezése ezekből a <em>forrás zónákból</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Továbbítás engedélyezése ezekből a <em>forrás zónákból</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Továbbítás engedélyezése ezekbe a <em>cél zónákba</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Továbbítás engedélyezése ezekbe a <em>cél zónákba</em>"
 
 msgid "Any"
 msgstr "Bármelyik"

--- a/applications/luci-app-firewall/po/it/firewall.po
+++ b/applications/luci-app-firewall/po/it/firewall.po
@@ -61,11 +61,11 @@ msgstr "Aggiungi e modifica..."
 msgid "Advanced Settings"
 msgstr "Opzioni Avanzate"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Permetti routing da <em>zone di origine</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Permetti routing da <em>zone di origine</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Permetti rounting a <em>zone di destinazione</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Permetti rounting a <em>zone di destinazione</em>"
 
 msgid "Any"
 msgstr "Qualsiasi"

--- a/applications/luci-app-firewall/po/ja/firewall.po
+++ b/applications/luci-app-firewall/po/ja/firewall.po
@@ -62,11 +62,11 @@ msgstr "追加及び編集..."
 msgid "Advanced Settings"
 msgstr "詳細設定"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "<em>送信元ゾーン</em>からの転送を許可する:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "<em>送信元ゾーン</em>からの転送を許可する"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "<em>宛先ゾーン</em>への転送を許可する:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "<em>宛先ゾーン</em>への転送を許可する"
 
 msgid "Any"
 msgstr "全て"

--- a/applications/luci-app-firewall/po/ko/firewall.po
+++ b/applications/luci-app-firewall/po/ko/firewall.po
@@ -61,11 +61,11 @@ msgstr "추가 후 수정..."
 msgid "Advanced Settings"
 msgstr ""
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "<em>Source zone</em> 로부터의 forward 허용:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "<em>Source zone</em> 로부터의 forward 허용"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "<em>Destination zone</em> 으로 forward 허용:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "<em>Destination zone</em> 으로 forward 허용"
 
 msgid "Any"
 msgstr ""

--- a/applications/luci-app-firewall/po/ms/firewall.po
+++ b/applications/luci-app-firewall/po/ms/firewall.po
@@ -55,10 +55,10 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr ""
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr ""
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/no/firewall.po
+++ b/applications/luci-app-firewall/po/no/firewall.po
@@ -56,11 +56,11 @@ msgstr "Legg til og redigere..."
 msgid "Advanced Settings"
 msgstr "Avanserte Innstillinger"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Tillat videresending fra <em>kilde soner</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Tillat videresending fra <em>kilde soner</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Tillat videresending til <em>destinasjon soner</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Tillat videresending til <em>destinasjon soner</em>"
 
 msgid "Any"
 msgstr "Enhver"

--- a/applications/luci-app-firewall/po/pl/firewall.po
+++ b/applications/luci-app-firewall/po/pl/firewall.po
@@ -63,11 +63,11 @@ msgstr "Dodaj i edytuj..."
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Zezwól na przekazywanie z <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Zezwól na przekazywanie z <em>source zones</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Zezwól na przekazywanie do <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Zezwól na przekazywanie do <em>destination zones</em>"
 
 msgid "Any"
 msgstr "Każdy"

--- a/applications/luci-app-firewall/po/pt-br/firewall.po
+++ b/applications/luci-app-firewall/po/pt-br/firewall.po
@@ -61,11 +61,11 @@ msgstr "Adicionar e editar..."
 msgid "Advanced Settings"
 msgstr "Configurações Avançadas"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Permite o encaminhamento da <em>zona de origem</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Permite o encaminhamento da <em>zona de origem</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Permite o encaminhamento para a <em>zona de destino</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Permite o encaminhamento para a <em>zona de destino</em>"
 
 msgid "Any"
 msgstr "Qualquer"

--- a/applications/luci-app-firewall/po/pt/firewall.po
+++ b/applications/luci-app-firewall/po/pt/firewall.po
@@ -61,10 +61,10 @@ msgstr "Adicionar e editar..."
 msgid "Advanced Settings"
 msgstr "Definições Avançadas"
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr "Permitir encaminhamento de <em>zonas de origem</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr "Permitir encaminhamento para <em>zonas de destino</em>"
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/ro/firewall.po
+++ b/applications/luci-app-firewall/po/ro/firewall.po
@@ -60,10 +60,10 @@ msgstr "Adaugă şi editează..."
 msgid "Advanced Settings"
 msgstr "Setări avansate"
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr "Permite trecerea din <em>zonele sursa</em>."
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr "Permite trecerea catre <em>zonele sursa</em>."
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/ru/firewall.po
+++ b/applications/luci-app-firewall/po/ru/firewall.po
@@ -63,11 +63,11 @@ msgstr "Добавить и редактировать..."
 msgid "Advanced Settings"
 msgstr "Дополнительные настройки"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Разрешить перенаправление из <em>'зон-источников'</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Разрешить перенаправление из <em>'зон-источников'</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Разрешить перенаправление в <em>'зоны назначения'</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Разрешить перенаправление в <em>'зоны назначения'</em>"
 
 msgid "Any"
 msgstr "Любой"

--- a/applications/luci-app-firewall/po/sk/firewall.po
+++ b/applications/luci-app-firewall/po/sk/firewall.po
@@ -56,10 +56,10 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr ""
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr ""
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/sv/firewall.po
+++ b/applications/luci-app-firewall/po/sv/firewall.po
@@ -57,11 +57,11 @@ msgstr "Lägg till och redigera..."
 msgid "Advanced Settings"
 msgstr "Avancerade inställningar"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Tillåt vidarebefordring från <em>källzonerna</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Tillåt vidarebefordring från <em>källzonerna</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Till vidarebefordring till <em>destinationszonerna:</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Till vidarebefordring till <em>destinationszonerna:</em>"
 
 msgid "Any"
 msgstr "Alla"

--- a/applications/luci-app-firewall/po/templates/firewall.pot
+++ b/applications/luci-app-firewall/po/templates/firewall.pot
@@ -49,10 +49,10 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr ""
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr ""
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/tr/firewall.po
+++ b/applications/luci-app-firewall/po/tr/firewall.po
@@ -56,10 +56,10 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr ""
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr ""
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/uk/firewall.po
+++ b/applications/luci-app-firewall/po/uk/firewall.po
@@ -59,11 +59,11 @@ msgstr "Додати та редагувати..."
 msgid "Advanced Settings"
 msgstr "Розширені настройки"
 
-msgid "Allow forward from <em>source zones</em>:"
-msgstr "Дозволити переспрямовування від <em>зон джерела</em>:"
+msgid "Allow forward from <em>source zones</em>"
+msgstr "Дозволити переспрямовування від <em>зон джерела</em>"
 
-msgid "Allow forward to <em>destination zones</em>:"
-msgstr "Дозволити переспрямовування до <em>зон призначення</em>:"
+msgid "Allow forward to <em>destination zones</em>"
+msgstr "Дозволити переспрямовування до <em>зон призначення</em>"
 
 msgid "Any"
 msgstr "Будь-який"

--- a/applications/luci-app-firewall/po/vi/firewall.po
+++ b/applications/luci-app-firewall/po/vi/firewall.po
@@ -61,10 +61,10 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr ""
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr ""
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/zh-cn/firewall.po
+++ b/applications/luci-app-firewall/po/zh-cn/firewall.po
@@ -59,10 +59,10 @@ msgstr "添加并编辑…"
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr "允许从<em>源区域</em>转发："
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr "允许转发到<em>目标区域</em>："
 
 msgid "Any"

--- a/applications/luci-app-firewall/po/zh-tw/firewall.po
+++ b/applications/luci-app-firewall/po/zh-tw/firewall.po
@@ -59,10 +59,10 @@ msgstr "新增並編輯…"
 msgid "Advanced Settings"
 msgstr "高階設定"
 
-msgid "Allow forward from <em>source zones</em>:"
+msgid "Allow forward from <em>source zones</em>"
 msgstr "允許從<em>源區域</em>轉發："
 
-msgid "Allow forward to <em>destination zones</em>:"
+msgid "Allow forward to <em>destination zones</em>"
 msgstr "允許轉發到<em>目標區域</em>："
 
 msgid "Any"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.