### PR TITLE
luci-app-nlbwmon: Colons removed from input headers

### DIFF
--- a/applications/luci-app-nlbwmon/po/ja/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ja/nlbwmon.po
@@ -314,8 +314,8 @@ msgstr "復元"
 msgid "Restore Database Backup"
 msgstr "データベースの復元"
 
-msgid "Select accounting period:"
-msgstr "収集期間を選択:"
+msgid "Select accounting period"
+msgstr "収集期間を選択"
 
 msgid "Source IP"
 msgstr "アクセス元 IP"

--- a/applications/luci-app-nlbwmon/po/ru/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ru/nlbwmon.po
@@ -323,8 +323,8 @@ msgstr "Восстановить"
 msgid "Restore Database Backup"
 msgstr "Восстановление резервной копии базы данных"
 
-msgid "Select accounting period:"
-msgstr "Выберите отчетный период:"
+msgid "Select accounting period"
+msgstr "Выберите отчетный период"
 
 msgid "Source IP"
 msgstr "IP-адрес источника"

--- a/applications/luci-app-nlbwmon/po/templates/nlbwmon.pot
+++ b/applications/luci-app-nlbwmon/po/templates/nlbwmon.pot
@@ -284,7 +284,7 @@ msgstr ""
 msgid "Restore Database Backup"
 msgstr ""
 
-msgid "Select accounting period:"
+msgid "Select accounting period"
 msgstr ""
 
 msgid "Source IP"

--- a/applications/luci-app-nlbwmon/po/zh-cn/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/zh-cn/nlbwmon.po
@@ -302,7 +302,7 @@ msgstr "恢复"
 msgid "Restore Database Backup"
 msgstr "恢复数据库备份"
 
-msgid "Select accounting period:"
+msgid "Select accounting period"
 msgstr "选择统计周期："
 
 msgid "Source IP"

--- a/applications/luci-app-nlbwmon/po/zh-tw/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/zh-tw/nlbwmon.po
@@ -302,7 +302,7 @@ msgstr "恢復"
 msgid "Restore Database Backup"
 msgstr "恢復資料庫備份"
 
-msgid "Select accounting period:"
+msgid "Select accounting period"
 msgstr "選擇統計週期："
 
 msgid "Source IP"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.