### PR TITLE
luci-app-dynapoint: Colons removed from input headers

### DIFF
--- a/applications/luci-app-dynapoint/luasrc/model/cbi/dynapoint.lua
+++ b/applications/luci-app-dynapoint/luasrc/model/cbi/dynapoint.lua
@@ -87,7 +87,7 @@ mode = aps:option(DummyValue, "mode", translate("Mode"))
 ssid = aps:option(DummyValue, "ssid", translate("SSID"))
 
 
-action = aps:option(ListValue, "dynapoint_rule", translate("Activate this wVIF if status is:"))
+action = aps:option(ListValue, "dynapoint_rule", translate("Activate this wVIF if status is"))
 action.widget="select"
 action:value("internet",translate("Online"))
 action:value("!internet",translate("Offline"))

--- a/applications/luci-app-dynapoint/po/de/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/de/dynapoint.po
@@ -9,8 +9,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Activate this wVIF if status is:"
-msgstr "Aktiviere diese drahtlose Schnittstelle wenn:"
+msgid "Activate this wVIF if status is"
+msgstr "Aktiviere diese drahtlose Schnittstelle wenn"
 
 msgid "Append hostname to ssid"
 msgstr "Anfügen des hostname zur SSID"

--- a/applications/luci-app-dynapoint/po/ja/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/ja/dynapoint.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Language: ja\n"
 
-msgid "Activate this wVIF if status is:"
-msgstr "wVIFを有効化する接続ステータス:"
+msgid "Activate this wVIF if status is"
+msgstr "wVIFを有効化する接続ステータス"
 
 msgid "Append hostname to ssid"
 msgstr "ホスト名をSSIDに追加する"

--- a/applications/luci-app-dynapoint/po/pt-br/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/pt-br/dynapoint.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Language: pt_BR\n"
 
-msgid "Activate this wVIF if status is:"
-msgstr "Aivar este wVIF se o estado for:"
+msgid "Activate this wVIF if status is"
+msgstr "Aivar este wVIF se o estado for"
 
 msgid "Append hostname to ssid"
 msgstr "Sufixar o nome do equipamento ao SSID"

--- a/applications/luci-app-dynapoint/po/ru/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/ru/dynapoint.po
@@ -15,7 +15,7 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-msgid "Activate this wVIF if status is:"
+msgid "Activate this wVIF if status is"
 msgstr "Применение DynaPoint-а"
 
 msgid "Append hostname to ssid"
@@ -58,7 +58,7 @@ msgstr ""
 "считаться разорванным."
 
 msgid "List of Wireless Virtual Interfaces (wVIF)"
-msgstr "Список беспроводных сетей (точек доступа):"
+msgstr "Список беспроводных сетей (точек доступа)"
 
 msgid "List of host addresses"
 msgstr "HTTP-адреса"

--- a/applications/luci-app-dynapoint/po/templates/dynapoint.pot
+++ b/applications/luci-app-dynapoint/po/templates/dynapoint.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-msgid "Activate this wVIF if status is:"
+msgid "Activate this wVIF if status is"
 msgstr ""
 
 msgid "Append hostname to ssid"

--- a/applications/luci-app-dynapoint/po/zh-cn/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/zh-cn/dynapoint.po
@@ -11,7 +11,7 @@ msgstr ""
 "PO-Revision-Date: 2018-08-07 18:48+0800\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-msgid "Activate this wVIF if status is:"
+msgid "Activate this wVIF if status is"
 msgstr "激活此 wVIF 如果状态为："
 
 msgid "Append hostname to ssid"

--- a/applications/luci-app-dynapoint/po/zh-tw/dynapoint.po
+++ b/applications/luci-app-dynapoint/po/zh-tw/dynapoint.po
@@ -11,7 +11,7 @@ msgstr ""
 "PO-Revision-Date: 2018-08-07 18:49+0800\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-msgid "Activate this wVIF if status is:"
+msgid "Activate this wVIF if status is"
 msgstr "啟用此 wVIF 如果狀態為："
 
 msgid "Append hostname to ssid"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.