### PR TITLE
luci-app-commands: Colons removed from input headers

### DIFF
--- a/applications/luci-app-commands/po/ca/commands.po
+++ b/applications/luci-app-commands/po/ca/commands.po
@@ -24,14 +24,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Permet que l'usuari proveïa paràmetres de línia de consola addicionals"
 
-msgid "Arguments:"
-msgstr "Paràmetres:"
+msgid "Arguments"
+msgstr "Paràmetres"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Els dades binaris no es mostren, descarregueu-los."
 
-msgid "Code:"
-msgstr "Codi:"
+msgid "Code"
+msgstr "Codi"
 
 msgid "Collecting data..."
 msgstr "Recollint dades..."
@@ -54,7 +54,7 @@ msgstr "Línia d'ordre per executar"
 msgid "Command successful"
 msgstr "L'ordre ha tingut èxit"
 
-msgid "Command:"
+msgid "Command"
 msgstr "Ordre;"
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/cs/commands.po
+++ b/applications/luci-app-commands/po/cs/commands.po
@@ -22,14 +22,14 @@ msgstr "Povolit vykonání příkazu a stažení výstupu bez předchozí autent
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Povolit uživateli poskytnout dodatečné argumenty příkazového řádku"
 
-msgid "Arguments:"
-msgstr "Argumenty:"
+msgid "Arguments"
+msgstr "Argumenty"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Binární data nezobrazena, stáhněte si je."
 
-msgid "Code:"
-msgstr "Kód:"
+msgid "Code"
+msgstr "Kód"
 
 msgid "Collecting data..."
 msgstr "Sbírání dat..."
@@ -52,8 +52,8 @@ msgstr "Příkazový řádek k vykonání"
 msgid "Command successful"
 msgstr "Příkaz úspěšný."
 
-msgid "Command:"
-msgstr "Příkaz:"
+msgid "Command"
+msgstr "Příkaz"
 
 msgid "Configure"
 msgstr "Konfigurovat"

--- a/applications/luci-app-commands/po/de/commands.po
+++ b/applications/luci-app-commands/po/de/commands.po
@@ -24,14 +24,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Erlaube dem Nutzer zusätzliche Kommandozeilenargumente zu übergeben"
 
-msgid "Arguments:"
-msgstr "Argumente:"
+msgid "Arguments"
+msgstr "Argumente"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Binärdaten ausgeblendet, laden Sie die Ausgaben stattdessen herunter"
 
-msgid "Code:"
-msgstr "Rückgabewert:"
+msgid "Code"
+msgstr "Rückgabewert"
 
 msgid "Collecting data..."
 msgstr "Sammle Daten..."
@@ -54,8 +54,8 @@ msgstr "Auszuführende Kommandozeile"
 msgid "Command successful"
 msgstr "Kommando erfolgreich"
 
-msgid "Command:"
-msgstr "Kommando:"
+msgid "Command"
+msgstr "Kommando"
 
 msgid "Configure"
 msgstr "Konfigurieren"

--- a/applications/luci-app-commands/po/el/commands.po
+++ b/applications/luci-app-commands/po/el/commands.po
@@ -19,13 +19,13 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr ""
 
 msgid "Binary data not displayed, download instead."
 msgstr ""
 
-msgid "Code:"
+msgid "Code"
 msgstr ""
 
 msgid "Collecting data..."
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Command successful"
 msgstr ""
 
-msgid "Command:"
+msgid "Command"
 msgstr ""
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/en/commands.po
+++ b/applications/luci-app-commands/po/en/commands.po
@@ -25,14 +25,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Allow the user to provide additional command line arguments"
 
-msgid "Arguments:"
-msgstr "Arguments:"
+msgid "Arguments"
+msgstr "Arguments"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Binary data not displayed, download instead."
 
-msgid "Code:"
-msgstr "Code:"
+msgid "Code"
+msgstr "Code"
 
 msgid "Collecting data..."
 msgstr "Collecting data..."
@@ -55,8 +55,8 @@ msgstr "Command line to execute"
 msgid "Command successful"
 msgstr "Command successful"
 
-msgid "Command:"
-msgstr "Command:"
+msgid "Command"
+msgstr "Command"
 
 msgid "Configure"
 msgstr "Configure"

--- a/applications/luci-app-commands/po/es/commands.po
+++ b/applications/luci-app-commands/po/es/commands.po
@@ -23,14 +23,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Permitir al usuario añadir parámetros de línea de comandos"
 
-msgid "Arguments:"
-msgstr "Parámetros:"
+msgid "Arguments"
+msgstr "Parámetros"
 
 msgid "Binary data not displayed, download instead."
 msgstr "No se pueden mostrar datos binarios, descárguelos."
 
-msgid "Code:"
-msgstr "Código:"
+msgid "Code"
+msgstr "Código"
 
 msgid "Collecting data..."
 msgstr "Recuperando datos..."
@@ -53,8 +53,8 @@ msgstr "Comando a ejecutar"
 msgid "Command successful"
 msgstr "OK"
 
-msgid "Command:"
-msgstr "Comando:"
+msgid "Command"
+msgstr "Comando"
 
 msgid "Configure"
 msgstr "Configurar"

--- a/applications/luci-app-commands/po/fr/commands.po
+++ b/applications/luci-app-commands/po/fr/commands.po
@@ -26,13 +26,13 @@ msgstr ""
 "Autoriser l'utilisateur à fournir des arguments de ligne de commande "
 "supplémentaires"
 
-msgid "Arguments:"
-msgstr "Arguments :"
+msgid "Arguments"
+msgstr "Arguments "
 
 msgid "Binary data not displayed, download instead."
 msgstr "Données binaires non affichables, elle peuvent être téléchargées."
 
-msgid "Code:"
+msgid "Code"
 msgstr "Code : "
 
 msgid "Collecting data..."
@@ -56,8 +56,8 @@ msgstr "Ligne de commande à exécuter"
 msgid "Command successful"
 msgstr "Commande réussie"
 
-msgid "Command:"
-msgstr "Commande :"
+msgid "Command"
+msgstr "Commande "
 
 msgid "Configure"
 msgstr "Configurer"

--- a/applications/luci-app-commands/po/he/commands.po
+++ b/applications/luci-app-commands/po/he/commands.po
@@ -19,13 +19,13 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr ""
 
 msgid "Binary data not displayed, download instead."
 msgstr ""
 
-msgid "Code:"
+msgid "Code"
 msgstr ""
 
 msgid "Collecting data..."
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Command successful"
 msgstr ""
 
-msgid "Command:"
+msgid "Command"
 msgstr ""
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/hu/commands.po
+++ b/applications/luci-app-commands/po/hu/commands.po
@@ -24,14 +24,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "A felhasználó által további parancsori argumentumok adhatók meg"
 
-msgid "Arguments:"
-msgstr "Argumentumok:"
+msgid "Arguments"
+msgstr "Argumentumok"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Bináris adat nem jelenik meg, töltse le helyette."
 
-msgid "Code:"
-msgstr "Kód:"
+msgid "Code"
+msgstr "Kód"
 
 msgid "Collecting data..."
 msgstr "Adatgyűjtés..."
@@ -54,8 +54,8 @@ msgstr "Futtatandó parancssor"
 msgid "Command successful"
 msgstr "Parancs végrehajtás sikeres"
 
-msgid "Command:"
-msgstr "Parancs:"
+msgid "Command"
+msgstr "Parancs"
 
 msgid "Configure"
 msgstr "Beállítás"

--- a/applications/luci-app-commands/po/it/commands.po
+++ b/applications/luci-app-commands/po/it/commands.po
@@ -25,14 +25,14 @@ msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 "Consente all'utente di fornire ulteriori argomenti della riga di comando"
 
-msgid "Arguments:"
-msgstr "Argomenti:"
+msgid "Arguments"
+msgstr "Argomenti"
 
 msgid "Binary data not displayed, download instead."
 msgstr "I dati binari non vengono visualizzati, ma possono essere scaricati."
 
-msgid "Code:"
-msgstr "Codice:"
+msgid "Code"
+msgstr "Codice"
 
 msgid "Collecting data..."
 msgstr "Raccolta dei dati..."
@@ -55,8 +55,8 @@ msgstr "Riga di comando da eseguire"
 msgid "Command successful"
 msgstr "Comando riuscito"
 
-msgid "Command:"
-msgstr "Comando:"
+msgid "Command"
+msgstr "Comando"
 
 msgid "Configure"
 msgstr "Configura"

--- a/applications/luci-app-commands/po/ja/commands.po
+++ b/applications/luci-app-commands/po/ja/commands.po
@@ -23,14 +23,14 @@ msgstr "事前認証無しでのコマンドの実行と、結果出力のダウ
 msgid "Allow the user to provide additional command line arguments"
 msgstr "コマンドラインに対する引数の追記を許可するか設定します"
 
-msgid "Arguments:"
-msgstr "引数:"
+msgid "Arguments"
+msgstr "引数"
 
 msgid "Binary data not displayed, download instead."
 msgstr "バイナリデータは表示されずにダウンロードされます。"
 
-msgid "Code:"
-msgstr "コード:"
+msgid "Code"
+msgstr "コード"
 
 msgid "Collecting data..."
 msgstr "データ収集中です..."
@@ -42,7 +42,7 @@ msgid "Command executed successfully."
 msgstr "コマンドの実行に成功しました。"
 
 msgid "Command exited with status code"
-msgstr "コマンドは次のステータス コードで終了しました:"
+msgstr "コマンドは次のステータス コードで終了しました"
 
 msgid "Command failed"
 msgstr "コマンド失敗"
@@ -53,8 +53,8 @@ msgstr "実行するコマンドラインを記載します"
 msgid "Command successful"
 msgstr "コマンド成功"
 
-msgid "Command:"
-msgstr "コマンド:"
+msgid "Command"
+msgstr "コマンド"
 
 msgid "Configure"
 msgstr "設定"
@@ -75,7 +75,7 @@ msgid "Download"
 msgstr "ダウンロード"
 
 msgid "Download execution result"
-msgstr "実行結果のダウンロード:"
+msgstr "実行結果のダウンロード"
 
 msgid "Failed to execute command!"
 msgstr "コマンドの実行に失敗しました!"
@@ -87,7 +87,7 @@ msgid "Loading"
 msgstr "読み込み中"
 
 msgid "Or display result"
-msgstr "または結果の表示:"
+msgstr "または結果の表示"
 
 msgid "Public access"
 msgstr "パブリック・アクセス"

--- a/applications/luci-app-commands/po/ms/commands.po
+++ b/applications/luci-app-commands/po/ms/commands.po
@@ -18,13 +18,13 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr ""
 
 msgid "Binary data not displayed, download instead."
 msgstr ""
 
-msgid "Code:"
+msgid "Code"
 msgstr ""
 
 msgid "Collecting data..."
@@ -48,7 +48,7 @@ msgstr ""
 msgid "Command successful"
 msgstr ""
 
-msgid "Command:"
+msgid "Command"
 msgstr ""
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/no/commands.po
+++ b/applications/luci-app-commands/po/no/commands.po
@@ -24,14 +24,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Tillat brukeren å gi ytterligere kommandolinjeargumenter"
 
-msgid "Arguments:"
-msgstr "Argumenter:"
+msgid "Arguments"
+msgstr "Argumenter"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Binære data vises ikke, last ned i stedet."
 
-msgid "Code:"
-msgstr "Kode:"
+msgid "Code"
+msgstr "Kode"
 
 msgid "Collecting data..."
 msgstr "Henter data..."
@@ -54,8 +54,8 @@ msgstr "Kommandolinje å utføre"
 msgid "Command successful"
 msgstr "Kommando vellykket"
 
-msgid "Command:"
-msgstr "Kommando:"
+msgid "Command"
+msgstr "Kommando"
 
 msgid "Configure"
 msgstr "Konfigurer"

--- a/applications/luci-app-commands/po/pl/commands.po
+++ b/applications/luci-app-commands/po/pl/commands.po
@@ -25,17 +25,17 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Pozwól użytkownikowi dodać argumenty wiersza poleceń"
 
-msgid "Arguments:"
-msgstr "Argumenty:"
+msgid "Arguments"
+msgstr "Argumenty"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Nie wyświetlono danych binarnych, możesz je pobrać."
 
-msgid "Code:"
-msgstr "Kod:"
+msgid "Code"
+msgstr "Kod"
 
 msgid "Collecting data..."
-msgstr "Zbieram dane:"
+msgstr "Zbieram dane"
 
 msgid "Command"
 msgstr "Komenda"
@@ -55,8 +55,8 @@ msgstr "Linia Komendy do wykonania"
 msgid "Command successful"
 msgstr "Komenda Wykonana"
 
-msgid "Command:"
-msgstr "Komenda:"
+msgid "Command"
+msgstr "Komenda"
 
 msgid "Configure"
 msgstr "Konfiguracja"

--- a/applications/luci-app-commands/po/pt-br/commands.po
+++ b/applications/luci-app-commands/po/pt-br/commands.po
@@ -25,14 +25,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Permitir ao usuário inserir argumentos de linha de comando adicionais"
 
-msgid "Arguments:"
-msgstr "Argumentos:"
+msgid "Arguments"
+msgstr "Argumentos"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Dados binários não mostrados, mas podem ser baixados."
 
-msgid "Code:"
-msgstr "Código:"
+msgid "Code"
+msgstr "Código"
 
 msgid "Collecting data..."
 msgstr "Adquirindo dados..."
@@ -55,8 +55,8 @@ msgstr "Linha de comandos a executar"
 msgid "Command successful"
 msgstr "Comando executado com sucesso"
 
-msgid "Command:"
-msgstr "Comando:"
+msgid "Command"
+msgstr "Comando"
 
 msgid "Configure"
 msgstr "Configurar"

--- a/applications/luci-app-commands/po/pt/commands.po
+++ b/applications/luci-app-commands/po/pt/commands.po
@@ -25,14 +25,14 @@ msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 "Permitir que o utilizador forneça argumentos adicionais na linha de comandos"
 
-msgid "Arguments:"
-msgstr "Argumentos:"
+msgid "Arguments"
+msgstr "Argumentos"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Dados binários não mostrados, mas pode descarregar."
 
-msgid "Code:"
-msgstr "Código:"
+msgid "Code"
+msgstr "Código"
 
 msgid "Collecting data..."
 msgstr "A obter dados..."
@@ -55,8 +55,8 @@ msgstr "Linha de comandos a executar"
 msgid "Command successful"
 msgstr "Comando executado com sucesso"
 
-msgid "Command:"
-msgstr "Comando:"
+msgid "Command"
+msgstr "Comando"
 
 msgid "Configure"
 msgstr "Configurar"

--- a/applications/luci-app-commands/po/ro/commands.po
+++ b/applications/luci-app-commands/po/ro/commands.po
@@ -25,14 +25,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Permite utilizatorului sa adauge parametrii in linia de comanda"
 
-msgid "Arguments:"
-msgstr "Parametrii:"
+msgid "Arguments"
+msgstr "Parametrii"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Datele binare nu sunt afisate, descarcale in schimb"
 
-msgid "Code:"
-msgstr "Cod:"
+msgid "Code"
+msgstr "Cod"
 
 msgid "Collecting data..."
 msgstr "Colectare date..."
@@ -55,8 +55,8 @@ msgstr "Linie de comanda pentru a executa"
 msgid "Command successful"
 msgstr "Comanda reusita"
 
-msgid "Command:"
-msgstr "Comanda:"
+msgid "Command"
+msgstr "Comanda"
 
 msgid "Configure"
 msgstr "Configureaza"

--- a/applications/luci-app-commands/po/ru/commands.po
+++ b/applications/luci-app-commands/po/ru/commands.po
@@ -30,14 +30,14 @@ msgstr ""
 "Разрешить пользователю предоставлять дополнительные аргументы командной "
 "строки"
 
-msgid "Arguments:"
-msgstr "Аргументы:"
+msgid "Arguments"
+msgstr "Аргументы"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Двоичные данные не отображаются, вместо этого загружаются."
 
-msgid "Code:"
-msgstr "Код:"
+msgid "Code"
+msgstr "Код"
 
 msgid "Collecting data..."
 msgstr "Сбор данных..."
@@ -60,8 +60,8 @@ msgstr "Командная строка<br />для выполнения"
 msgid "Command successful"
 msgstr "Команда выполнена"
 
-msgid "Command:"
-msgstr "Команда:"
+msgid "Command"
+msgstr "Команда"
 
 msgid "Configure"
 msgstr "Настройка панели управления"

--- a/applications/luci-app-commands/po/sk/commands.po
+++ b/applications/luci-app-commands/po/sk/commands.po
@@ -19,13 +19,13 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr ""
 
 msgid "Binary data not displayed, download instead."
 msgstr ""
 
-msgid "Code:"
+msgid "Code"
 msgstr ""
 
 msgid "Collecting data..."
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Command successful"
 msgstr ""
 
-msgid "Command:"
+msgid "Command"
 msgstr ""
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/sv/commands.po
+++ b/applications/luci-app-commands/po/sv/commands.po
@@ -22,14 +22,14 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr "Tillåt användaren att tillge extra kommandoradsargument"
 
-msgid "Arguments:"
-msgstr "Argument:"
+msgid "Arguments"
+msgstr "Argument"
 
 msgid "Binary data not displayed, download instead."
 msgstr "Binärdatan visades inte, ladda ner istället."
 
-msgid "Code:"
-msgstr "Kod:"
+msgid "Code"
+msgstr "Kod"
 
 msgid "Collecting data..."
 msgstr "Samlar in data..."
@@ -52,8 +52,8 @@ msgstr "Kommandorad att exekvera"
 msgid "Command successful"
 msgstr "Kommandot lyckades"
 
-msgid "Command:"
-msgstr "Kommando:"
+msgid "Command"
+msgstr "Kommando"
 
 msgid "Configure"
 msgstr "Ställ in"

--- a/applications/luci-app-commands/po/templates/commands.pot
+++ b/applications/luci-app-commands/po/templates/commands.pot
@@ -12,13 +12,13 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr ""
 
 msgid "Binary data not displayed, download instead."
 msgstr ""
 
-msgid "Code:"
+msgid "Code"
 msgstr ""
 
 msgid "Collecting data..."
@@ -42,7 +42,7 @@ msgstr ""
 msgid "Command successful"
 msgstr ""
 
-msgid "Command:"
+msgid "Command"
 msgstr ""
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/tr/commands.po
+++ b/applications/luci-app-commands/po/tr/commands.po
@@ -19,13 +19,13 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr ""
 
 msgid "Binary data not displayed, download instead."
 msgstr ""
 
-msgid "Code:"
+msgid "Code"
 msgstr ""
 
 msgid "Collecting data..."
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Command successful"
 msgstr ""
 
-msgid "Command:"
+msgid "Command"
 msgstr ""
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/uk/commands.po
+++ b/applications/luci-app-commands/po/uk/commands.po
@@ -25,14 +25,14 @@ msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 
 #, fuzzy
-msgid "Arguments:"
-msgstr "Аргументи:"
+msgid "Arguments"
+msgstr "Аргументи"
 
 msgid "Binary data not displayed, download instead."
 msgstr ""
 
-msgid "Code:"
-msgstr "Код:"
+msgid "Code"
+msgstr "Код"
 
 msgid "Collecting data..."
 msgstr "Збирання даних..."
@@ -55,7 +55,7 @@ msgstr ""
 msgid "Command successful"
 msgstr ""
 
-msgid "Command:"
+msgid "Command"
 msgstr ""
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/vi/commands.po
+++ b/applications/luci-app-commands/po/vi/commands.po
@@ -19,13 +19,13 @@ msgstr ""
 msgid "Allow the user to provide additional command line arguments"
 msgstr ""
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr ""
 
 msgid "Binary data not displayed, download instead."
 msgstr ""
 
-msgid "Code:"
+msgid "Code"
 msgstr ""
 
 msgid "Collecting data..."
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Command successful"
 msgstr ""
 
-msgid "Command:"
+msgid "Command"
 msgstr ""
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/zh-cn/commands.po
+++ b/applications/luci-app-commands/po/zh-cn/commands.po
@@ -26,13 +26,13 @@ msgstr "允许直接执行命令并获取其输出，无须事先验证。"
 msgid "Allow the user to provide additional command line arguments"
 msgstr "允许用户提供额外的命令行参数"
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr "参数："
 
 msgid "Binary data not displayed, download instead."
 msgstr "二进制数据未显示，以下载替代。"
 
-msgid "Code:"
+msgid "Code"
 msgstr "状态码："
 
 msgid "Collecting data..."
@@ -56,7 +56,7 @@ msgstr "执行命令行"
 msgid "Command successful"
 msgstr "执行命令成功"
 
-msgid "Command:"
+msgid "Command"
 msgstr "命令："
 
 msgid "Configure"

--- a/applications/luci-app-commands/po/zh-tw/commands.po
+++ b/applications/luci-app-commands/po/zh-tw/commands.po
@@ -27,13 +27,13 @@ msgstr "允許直接執行指令並獲取其輸出，無須事先驗證。"
 msgid "Allow the user to provide additional command line arguments"
 msgstr "允許使用者提供額外的指令列引數"
 
-msgid "Arguments:"
+msgid "Arguments"
 msgstr "引數："
 
 msgid "Binary data not displayed, download instead."
 msgstr "二進位資料未顯示，以下載替代。"
 
-msgid "Code:"
+msgid "Code"
 msgstr "狀態碼："
 
 msgid "Collecting data..."
@@ -57,7 +57,7 @@ msgstr "執行指令列"
 msgid "Command successful"
 msgstr "執行指令成功"
 
-msgid "Command:"
+msgid "Command"
 msgstr "指令："
 
 msgid "Configure"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.