### PR TITLE
luci-app-ddns: Colons removed from input headers

### DIFF
--- a/applications/luci-app-ddns/po/ca/ddns.po
+++ b/applications/luci-app-ddns/po/ca/ddns.po
@@ -621,7 +621,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/cs/ddns.po
+++ b/applications/luci-app-ddns/po/cs/ddns.po
@@ -619,7 +619,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/de/ddns.po
+++ b/applications/luci-app-ddns/po/de/ddns.po
@@ -716,8 +716,8 @@ msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 "kann lokale IP-Adresse nicht ermitteln. Bitte wählen Sie eine andere Quelle."
 
-msgid "can not resolve host:"
-msgstr "Konnte Server nicht finden:"
+msgid "can not resolve host"
+msgstr "Konnte Server nicht finden"
 
 msgid "config error"
 msgstr "Konfigurationsfehler"

--- a/applications/luci-app-ddns/po/el/ddns.po
+++ b/applications/luci-app-ddns/po/el/ddns.po
@@ -618,7 +618,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/es/ddns.po
+++ b/applications/luci-app-ddns/po/es/ddns.po
@@ -617,7 +617,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/fr/ddns.po
+++ b/applications/luci-app-ddns/po/fr/ddns.po
@@ -617,7 +617,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/he/ddns.po
+++ b/applications/luci-app-ddns/po/he/ddns.po
@@ -618,7 +618,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/hu/ddns.po
+++ b/applications/luci-app-ddns/po/hu/ddns.po
@@ -617,7 +617,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/it/ddns.po
+++ b/applications/luci-app-ddns/po/it/ddns.po
@@ -676,8 +676,8 @@ msgstr "cURL senza Supporto Proxy"
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr "non individuo l'IP locale. Per favore seleziona una combinazione Sorgente diversa"
 
-msgid "can not resolve host:"
-msgstr "non posso risolvere host:"
+msgid "can not resolve host"
+msgstr "non posso risolvere host"
 
 msgid "config error"
 msgstr "errore configurazione"

--- a/applications/luci-app-ddns/po/ja/ddns.po
+++ b/applications/luci-app-ddns/po/ja/ddns.po
@@ -617,7 +617,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/no/ddns.po
+++ b/applications/luci-app-ddns/po/no/ddns.po
@@ -616,7 +616,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/pl/ddns.po
+++ b/applications/luci-app-ddns/po/pl/ddns.po
@@ -618,7 +618,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/pt-br/ddns.po
+++ b/applications/luci-app-ddns/po/pt-br/ddns.po
@@ -689,8 +689,8 @@ msgstr ""
 "não pôde detectar IP local. Por favor selecione uma combinação de fonte "
 "diferente"
 
-msgid "can not resolve host:"
-msgstr "não pôde resolver host:"
+msgid "can not resolve host"
+msgstr "não pôde resolver host"
 
 msgid "config error"
 msgstr "erro de configuração"

--- a/applications/luci-app-ddns/po/pt/ddns.po
+++ b/applications/luci-app-ddns/po/pt/ddns.po
@@ -619,7 +619,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/ro/ddns.po
+++ b/applications/luci-app-ddns/po/ro/ddns.po
@@ -618,7 +618,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/ru/ddns.po
+++ b/applications/luci-app-ddns/po/ru/ddns.po
@@ -693,8 +693,8 @@ msgstr "cURL без поддержки прокси"
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr "Невозможно определить локальный IP-адрес. Выберите другой источник"
 
-msgid "can not resolve host:"
-msgstr "Невозможно разрешить хост:"
+msgid "can not resolve host"
+msgstr "Невозможно разрешить хост"
 
 msgid "config error"
 msgstr "Ошибка в config файле"

--- a/applications/luci-app-ddns/po/sv/ddns.po
+++ b/applications/luci-app-ddns/po/sv/ddns.po
@@ -612,8 +612,8 @@ msgstr ""
 "kan inte upptäcka lokal IP-adress. Vänligen välj en annorlunda Käll-"
 "kombination"
 
-msgid "can not resolve host:"
-msgstr "kan inte avgöra värd:"
+msgid "can not resolve host"
+msgstr "kan inte avgöra värd"
 
 msgid "config error"
 msgstr "konfigurationsfel"

--- a/applications/luci-app-ddns/po/templates/ddns.pot
+++ b/applications/luci-app-ddns/po/templates/ddns.pot
@@ -604,7 +604,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/tr/ddns.po
+++ b/applications/luci-app-ddns/po/tr/ddns.po
@@ -615,7 +615,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/uk/ddns.po
+++ b/applications/luci-app-ddns/po/uk/ddns.po
@@ -620,7 +620,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/vi/ddns.po
+++ b/applications/luci-app-ddns/po/vi/ddns.po
@@ -618,7 +618,7 @@ msgstr ""
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr ""
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr ""
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/zh-cn/ddns.po
+++ b/applications/luci-app-ddns/po/zh-cn/ddns.po
@@ -643,7 +643,7 @@ msgstr "cURL 没有包含代理支持"
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr "无法确定本地 IP。请更换 IP 来源。"
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr "无法解析主机："
 
 msgid "config error"

--- a/applications/luci-app-ddns/po/zh-tw/ddns.po
+++ b/applications/luci-app-ddns/po/zh-tw/ddns.po
@@ -643,7 +643,7 @@ msgstr "cURL 沒有包含代理支援"
 msgid "can not detect local IP. Please select a different Source combination"
 msgstr "無法確定本地 IP。請更換 IP 來源。"
 
-msgid "can not resolve host:"
+msgid "can not resolve host"
 msgstr "無法解析主機："
 
 msgid "config error"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.