### PR TITLE
luci-app-fwknopd: Colons removed from input headers

### DIFF
--- a/applications/luci-app-fwknopd/po/en/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/en/fwknopd.po
@@ -109,8 +109,8 @@ msgstr "access.conf stanzas"
 msgid "fwknopd.conf config options"
 msgstr "fwknopd.conf config options"
 
-#~ msgid "Enter custom access.conf variables below:"
-#~ msgstr "Enter custom access.conf variables below:"
+#~ msgid "Enter custom access.conf variables below"
+#~ msgstr "Enter custom access.conf variables below"
 
-#~ msgid "Enter custom fwknopd.conf variables below:"
-#~ msgstr "Enter custom fwknopd.conf variables below:"
+#~ msgid "Enter custom fwknopd.conf variables below"
+#~ msgstr "Enter custom fwknopd.conf variables below"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.