### PR TITLE
luci-app-mjpg-stream: Colons removed from input headers

### DIFF
--- a/applications/luci-app-mjpg-streamer/po/pt-br/mjpg-streamer.po
+++ b/applications/luci-app-mjpg-streamer/po/pt-br/mjpg-streamer.po
@@ -34,7 +34,7 @@ msgid "Check to save the stream to an mjpeg file"
 msgstr "Marque para salvar o fluxo em um arquivo MJPEG"
 
 msgid "Command to run"
-msgstr "Comando para executar:"
+msgstr "Comando para executar"
 
 msgid "Device"
 msgstr "Dispositivo"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.