### PR TITLE
luci-app-mwan3: Colons removed from input headers

### DIFF
--- a/applications/luci-app-mwan3/po/zh-cn/mwan3.po
+++ b/applications/luci-app-mwan3/po/zh-cn/mwan3.po
@@ -554,8 +554,8 @@ msgstr "不可达（拒绝）"
 #~ msgid "Interface Status"
 #~ msgstr "接口状态"
 
-#~ msgid "Last 50 MWAN systemlog entries. Newest entries sorted at the top :"
-#~ msgstr "最近 50 条 MWAN 系统日志，最新条目排在顶部："
+#~ msgid "Last 50 MWAN systemlog entries. Newest entries sorted at the top"
+#~ msgstr "最近 50 条 MWAN 系统日志，最新条目排在顶部"
 
 #~ msgid "MWAN Detailed Status"
 #~ msgstr "MWAN 详细状态"

--- a/applications/luci-app-mwan3/po/zh-tw/mwan3.po
+++ b/applications/luci-app-mwan3/po/zh-tw/mwan3.po
@@ -554,8 +554,8 @@ msgstr "不可達（拒絕）"
 #~ msgid "Interface Status"
 #~ msgstr "介面狀態"
 
-#~ msgid "Last 50 MWAN systemlog entries. Newest entries sorted at the top :"
-#~ msgstr "最近 50 條 MWAN 系統日誌，最新條目排在頂部："
+#~ msgid "Last 50 MWAN systemlog entries. Newest entries sorted at the top"
+#~ msgstr "最近 50 條 MWAN 系統日誌，最新條目排在頂部"
 
 #~ msgid "MWAN Detailed Status"
 #~ msgstr "MWAN 詳細狀態"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.