### PR TITLE
luci-app-noddos: Colons removed from input headers

### DIFF
--- a/applications/luci-app-noddos/po/ja/noddos.po
+++ b/applications/luci-app-noddos/po/ja/noddos.po
@@ -95,7 +95,7 @@ msgid ""
 "The following clients have been discovered on the network. The last "
 "discovery was completed at"
 msgstr ""
-"以下のクライアントがネットワーク内で見つかりました。探索の最終実行日時:"
+"以下のクライアントがネットワーク内で見つかりました。探索の最終実行日時"
 
 msgid "Unrecognized Clients"
 msgstr "未識別クライアント"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.

Signed-off-by: Ameer Dawood <ameer1234567890@gmail.com>