### PR TITLE
luci-app-advanced-reboot: Colons removed from input headers

### DIFF
--- a/applications/luci-app-advanced-reboot/po/ru/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/ru/advanced-reboot.po
@@ -31,8 +31,8 @@ msgstr "Подтвердить"
 msgid "Current"
 msgstr "Текущий"
 
-msgid "ERROR:"
-msgstr "ОШИБКА:"
+msgid "ERROR"
+msgstr "ОШИБКА"
 
 msgid "Firmware/OS (Kernel)"
 msgstr "Прошивка/ОС (Ядро)"

--- a/applications/luci-app-advanced-reboot/po/sv/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/sv/advanced-reboot.po
@@ -19,7 +19,7 @@ msgstr "Bekräfta"
 msgid "Current"
 msgstr "Nuvarande"
 
-msgid "ERROR:"
+msgid "ERROR"
 msgstr ""
 
 msgid "Firmware/OS (Kernel)"

--- a/applications/luci-app-advanced-reboot/po/templates/advanced-reboot.pot
+++ b/applications/luci-app-advanced-reboot/po/templates/advanced-reboot.pot
@@ -19,7 +19,7 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-msgid "ERROR:"
+msgid "ERROR"
 msgstr ""
 
 msgid "Firmware/OS (Kernel)"

--- a/applications/luci-app-advanced-reboot/po/zh-cn/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/zh-cn/advanced-reboot.po
@@ -29,7 +29,7 @@ msgstr "确认"
 msgid "Current"
 msgstr "当前"
 
-msgid "ERROR:"
+msgid "ERROR"
 msgstr "错误："
 
 msgid "Firmware/OS (Kernel)"

--- a/applications/luci-app-advanced-reboot/po/zh-tw/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/zh-tw/advanced-reboot.po
@@ -29,7 +29,7 @@ msgstr "確認"
 msgid "Current"
 msgstr "當前"
 
-msgid "ERROR:"
+msgid "ERROR"
 msgstr "錯誤："
 
 msgid "Firmware/OS (Kernel)"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.