### PR TITLE
luci-app-wol: Colons removed from input headers

### DIFF
--- a/applications/luci-app-wol/luasrc/model/cbi/wol.lua
+++ b/applications/luci-app-wol/luasrc/model/cbi/wol.lua
@@ -79,7 +79,7 @@ function host.write(self, s, val)
 		end
 
 		local msg = "<p><strong>%s</strong><br /><br /><code>%s<br /><br />" %{
-			translate("Starting WoL utility:"), utl.pcdata(cmd)
+			translate("Starting WoL utility"), utl.pcdata(cmd)
 		}
 
 		local p = io.popen(cmd .. " 2>&1")

--- a/applications/luci-app-wol/po/ca/wol.po
+++ b/applications/luci-app-wol/po/ca/wol.po
@@ -42,8 +42,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Especifica la interfície en que s'envia el paquet WoL"
 
-msgid "Starting WoL utility:"
-msgstr "Iniciant la utilitat WoL:"
+msgid "Starting WoL utility"
+msgstr "Iniciant la utilitat WoL"
 
 msgid "Wake on LAN"
 msgstr "Despert en LAN"

--- a/applications/luci-app-wol/po/cs/wol.po
+++ b/applications/luci-app-wol/po/cs/wol.po
@@ -40,8 +40,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Zde se nastaví síťové rozhraní, přes které budou zasílány WoL packety."
 
-msgid "Starting WoL utility:"
-msgstr "Spouštím nástroj WoL:"
+msgid "Starting WoL utility"
+msgstr "Spouštím nástroj WoL"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/de/wol.po
+++ b/applications/luci-app-wol/po/de/wol.po
@@ -42,8 +42,8 @@ msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 "Selektiert die Netzwerkschnittstelle auf der das WoL-Paket versendet wird"
 
-msgid "Starting WoL utility:"
-msgstr "Starte WoL-Programm:"
+msgid "Starting WoL utility"
+msgstr "Starte WoL-Programm"
 
 msgid "Wake on LAN"
 msgstr "Wake-on-LAN"

--- a/applications/luci-app-wol/po/el/wol.po
+++ b/applications/luci-app-wol/po/el/wol.po
@@ -35,7 +35,7 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr ""
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/en/wol.po
+++ b/applications/luci-app-wol/po/en/wol.po
@@ -35,8 +35,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Specifies the interface the WoL packet is sent on"
 
-msgid "Starting WoL utility:"
-msgstr "Starting WoL utility:"
+msgid "Starting WoL utility"
+msgstr "Starting WoL utility"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/es/wol.po
+++ b/applications/luci-app-wol/po/es/wol.po
@@ -40,8 +40,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Especifica la interfaz donde se envían los paquetes WoL"
 
-msgid "Starting WoL utility:"
-msgstr "Iniciando utilidad WoL:"
+msgid "Starting WoL utility"
+msgstr "Iniciando utilidad WoL"
 
 # Wake on LAN es un término habitualmente utilizado en el español para referirse a esa misma función de encendido remoto a través de la red
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/fr/wol.po
+++ b/applications/luci-app-wol/po/fr/wol.po
@@ -41,8 +41,8 @@ msgstr ""
 "Spécifie l'interface sur laquelle le paquet <abbr title=\"Wake on LAN\">WoL</"
 "abbr> est envoyé"
 
-msgid "Starting WoL utility:"
-msgstr "Démarrer l'utilitaire <abbr title=\"Wake on LAN\">WoL</abbr> :"
+msgid "Starting WoL utility"
+msgstr "Démarrer l'utilitaire <abbr title=\"Wake on LAN\">WoL</abbr> "
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/he/wol.po
+++ b/applications/luci-app-wol/po/he/wol.po
@@ -35,7 +35,7 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr ""
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/hu/wol.po
+++ b/applications/luci-app-wol/po/hu/wol.po
@@ -43,8 +43,8 @@ msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 "Megadja azt az interfészt amelyiken keresztül a WoL csomag kiküldésre kerül"
 
-msgid "Starting WoL utility:"
-msgstr "WoL segédprogram elindítása:"
+msgid "Starting WoL utility"
+msgstr "WoL segédprogram elindítása"
 
 msgid "Wake on LAN"
 msgstr "Felélesztés hálózaton keresztül"

--- a/applications/luci-app-wol/po/it/wol.po
+++ b/applications/luci-app-wol/po/it/wol.po
@@ -40,8 +40,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Specifica l'interfaccia su cui il pacchetto \"magico\" WoL è inviato"
 
-msgid "Starting WoL utility:"
-msgstr "Avvia l'utility WoL:"
+msgid "Starting WoL utility"
+msgstr "Avvia l'utility WoL"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/ja/wol.po
+++ b/applications/luci-app-wol/po/ja/wol.po
@@ -39,8 +39,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "WoLパケットを送信するインタフェースを指定"
 
-msgid "Starting WoL utility:"
-msgstr "WoLユーティリティを起動:"
+msgid "Starting WoL utility"
+msgstr "WoLユーティリティを起動"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/ms/wol.po
+++ b/applications/luci-app-wol/po/ms/wol.po
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr ""
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/no/wol.po
+++ b/applications/luci-app-wol/po/no/wol.po
@@ -31,8 +31,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Angir grensesnittet som WoL pakken blir sendt ut på"
 
-msgid "Starting WoL utility:"
-msgstr "Starter WoL:"
+msgid "Starting WoL utility"
+msgstr "Starter WoL"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/pl/wol.po
+++ b/applications/luci-app-wol/po/pl/wol.po
@@ -41,8 +41,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Definiuje interfejs, na który będzie wysłany pakiet WoL"
 
-msgid "Starting WoL utility:"
-msgstr "Uruchamianie narzędzia WoL:"
+msgid "Starting WoL utility"
+msgstr "Uruchamianie narzędzia WoL"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/pt-br/wol.po
+++ b/applications/luci-app-wol/po/pt-br/wol.po
@@ -39,8 +39,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Especifica a interface para onde os pacotes de WoL serão enviados"
 
-msgid "Starting WoL utility:"
-msgstr "Iniciando utilitário WoL:"
+msgid "Starting WoL utility"
+msgstr "Iniciando utilitário WoL"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/pt/wol.po
+++ b/applications/luci-app-wol/po/pt/wol.po
@@ -38,7 +38,7 @@ msgstr "Às vezes só uma das ferramentas funciona. Se uma falhar, tente a outra
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Especifica a interface pela qual é enviado o pacota WoL"
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr "A iniciar a ferramenta WoL"
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/ro/wol.po
+++ b/applications/luci-app-wol/po/ro/wol.po
@@ -41,8 +41,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Specifica interfata prin care pachetele WoL sunt trimise"
 
-msgid "Starting WoL utility:"
-msgstr "Pornire utilitar WoL:"
+msgid "Starting WoL utility"
+msgstr "Pornire utilitar WoL"
 
 msgid "Wake on LAN"
 msgstr "Activarea pe LAN"

--- a/applications/luci-app-wol/po/ru/wol.po
+++ b/applications/luci-app-wol/po/ru/wol.po
@@ -41,8 +41,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Задать сетевой интерфейс, по которому будут посланы пакеты WoL."
 
-msgid "Starting WoL utility:"
-msgstr "Запуск WoL утилиты:"
+msgid "Starting WoL utility"
+msgstr "Запуск WoL утилиты"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/sk/wol.po
+++ b/applications/luci-app-wol/po/sk/wol.po
@@ -30,7 +30,7 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr ""
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/sv/wol.po
+++ b/applications/luci-app-wol/po/sv/wol.po
@@ -35,8 +35,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Anger gränssnittet som fjärrstartspaketet skickas med"
 
-msgid "Starting WoL utility:"
-msgstr "Startar hjälpprogrammet för fjärrstyrning av uppstart:"
+msgid "Starting WoL utility"
+msgstr "Startar hjälpprogrammet för fjärrstyrning av uppstart"
 
 msgid "Wake on LAN"
 msgstr "Fjärrstyrning av uppstart"

--- a/applications/luci-app-wol/po/templates/wol.pot
+++ b/applications/luci-app-wol/po/templates/wol.pot
@@ -23,7 +23,7 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr ""
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/tr/wol.po
+++ b/applications/luci-app-wol/po/tr/wol.po
@@ -35,7 +35,7 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr ""
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/uk/wol.po
+++ b/applications/luci-app-wol/po/uk/wol.po
@@ -38,8 +38,8 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "Визначає інтерфейс, яким буде надіслано пакет WoL"
 
-msgid "Starting WoL utility:"
-msgstr "Запуск утиліти WoL:"
+msgid "Starting WoL utility"
+msgstr "Запуск утиліти WoL"
 
 msgid "Wake on LAN"
 msgstr "Wake on LAN"

--- a/applications/luci-app-wol/po/vi/wol.po
+++ b/applications/luci-app-wol/po/vi/wol.po
@@ -35,7 +35,7 @@ msgstr ""
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr ""
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr ""
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/zh-cn/wol.po
+++ b/applications/luci-app-wol/po/zh-cn/wol.po
@@ -38,7 +38,7 @@ msgstr "这两个工具有时只有一个生效。如果其中一个失效，请
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "限定将发送网络唤醒数据包的接口"
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr "正在启动网络唤醒工具："
 
 msgid "Wake on LAN"

--- a/applications/luci-app-wol/po/zh-tw/wol.po
+++ b/applications/luci-app-wol/po/zh-tw/wol.po
@@ -38,7 +38,7 @@ msgstr "這兩個工具有時只有一個生效。如果其中一個失效，請
 msgid "Specifies the interface the WoL packet is sent on"
 msgstr "限定將傳送網路喚醒資料包的介面"
 
-msgid "Starting WoL utility:"
+msgid "Starting WoL utility"
 msgstr "正在啟動網路喚醒工具："
 
 msgid "Wake on LAN"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.