### PR TITLE
luci-app-unbound: Colons removed from input headers

### DIFF
--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
@@ -250,7 +250,7 @@ if (valman == "0") then
     qrs:depends("query_minimize", true)
 
     eds = s1:taboption("resource", Value, "edns_size",
-        translate("EDNS Size:"),
+        translate("EDNS Size"),
         translate("Limit extended DNS packet size"))
     eds.datatype = "and(uinteger,min(512),max(4096))"
     eds.placeholder = "1280"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.