### PR TITLE
luci-app-privoxy: Colons removed from input headers

### DIFF
--- a/applications/luci-app-privoxy/po/de/privoxy.po
+++ b/applications/luci-app-privoxy/po/de/privoxy.po
@@ -319,8 +319,8 @@ msgstr "Start/Stopp Privoxy WEB Proxy"
 msgid "Startup banner and warnings."
 msgstr "Protokolliert Start-Meldungen und Warnungen"
 
-msgid "Syntax:"
-msgstr "Syntax:"
+msgid "Syntax"
+msgstr "Syntax"
 
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Syntax: Client header Namen getrennt durch Leerzeichen."

--- a/applications/luci-app-privoxy/po/pt-br/privoxy.po
+++ b/applications/luci-app-privoxy/po/pt-br/privoxy.po
@@ -314,8 +314,8 @@ msgstr "Inicia / Para o Privoxy Web Proxy"
 msgid "Startup banner and warnings."
 msgstr "Mensagens e avisos iniciais."
 
-msgid "Syntax:"
-msgstr "Sintaxe:"
+msgid "Syntax"
+msgstr "Sintaxe"
 
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Sintaxe: nomes de cabeçalho do cliente delimitados por espaços."

--- a/applications/luci-app-privoxy/po/ru/privoxy.po
+++ b/applications/luci-app-privoxy/po/ru/privoxy.po
@@ -318,8 +318,8 @@ msgstr "Запуск и остановка Privoxy WEB proxy."
 msgid "Startup banner and warnings."
 msgstr "Баннер запуска и предупреждения."
 
-msgid "Syntax:"
-msgstr "Синтаксис:"
+msgid "Syntax"
+msgstr "Синтаксис"
 
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Синтаксис: имя заголовка клиента, разделенное пробелами."

--- a/applications/luci-app-privoxy/po/sv/privoxy.po
+++ b/applications/luci-app-privoxy/po/sv/privoxy.po
@@ -270,8 +270,8 @@ msgstr "Starta/Stoppa Privoxy WEB-proxy"
 msgid "Startup banner and warnings."
 msgstr ""
 
-msgid "Syntax:"
-msgstr "Syntax:"
+msgid "Syntax"
+msgstr "Syntax"
 
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""

--- a/applications/luci-app-privoxy/po/templates/privoxy.pot
+++ b/applications/luci-app-privoxy/po/templates/privoxy.pot
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Startup banner and warnings."
 msgstr ""
 
-msgid "Syntax:"
+msgid "Syntax"
 msgstr ""
 
 msgid "Syntax: Client header names delimited by spaces."

--- a/applications/luci-app-privoxy/po/zh-cn/privoxy.po
+++ b/applications/luci-app-privoxy/po/zh-cn/privoxy.po
@@ -285,8 +285,8 @@ msgstr "启动/停止 Privoxy 网络代理"
 msgid "Startup banner and warnings."
 msgstr "启动标语和警告。"
 
-msgid "Syntax:"
-msgstr "格式:"
+msgid "Syntax"
+msgstr "格式"
 
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "格式: 由空格分隔的客户端请求头名称。"


### PR DESCRIPTION
Most OpenWrt applications do not have a colon in input headers.
This has been explained in #1566 as well.
This commit removes the said colons.