### PR TITLE
luci-app-adblock: fix chinese translation

### DIFF
--- a/applications/luci-app-adblock/po/zh-cn/adblock.po
+++ b/applications/luci-app-adblock/po/zh-cn/adblock.po
@@ -151,7 +151,7 @@ msgstr ""
 msgid ""
 "For further information <a href=\"%s\" target=\"_blank\">check the online "
 "documentation</a>"
-msgstr "进一步信息<a href=\"%s\" target=\"_blank\">请访问在线文档"
+msgstr "进一步信息<a href=\"%s\" target=\"_blank\">请访问在线文档</a>"
 
 msgid ""
 "For further performance improvements you can raise this value, e.g. '8' or "


### PR DESCRIPTION
simply add a </a> tag to stop the link filling the whole page

Signed-off-by: Kagurazaka Kotori <kagurazakakotori@gmail.com>