### PR TITLE
Backup: add firmware backup for mtdblock devices

### DIFF
--- a/modules/luci-base/luasrc/sys.lua
+++ b/modules/luci-base/luasrc/sys.lua
@@ -70,6 +70,24 @@ function mounts()
 	return data
 end
 
+function mtds()
+	local data = {}
+
+	if fs.access("/proc/mtd") then
+		for l in io.lines("/proc/mtd") do
+			local d, s, e, n = l:match('^([^%s]+)%s+([^%s]+)%s+([^%s]+)%s+"([^%s]+)"')
+			if s and n then
+				local d = {}
+				d.size = tonumber(s, 16)
+				d.name = n
+				table.insert(data, d)
+			end
+		end
+	end
+
+	return data
+end
+
 -- containing the whole environment is returned otherwise this function returns
 -- the corresponding string value for the given name or nil if no such variable
 -- exists.

--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
@@ -59,6 +59,40 @@
 			<div class="cbi-section-error"><%:The backup archive does not appear to be a valid gzip file.%></div>
 		<% end %>
 	</div>
+
+	<% local mtds = require("luci.sys").mtds(); if #mtds > 0 then -%>
+	<h3><%:Save mtdblock contents%></h3>
+	<div class="cbi-section-descr"><%:Click "Save mtdblock" to download specified mtdblock file. (NOTE: THIS FEATURE IS FOR PROFESSIONALS! )%></div>
+	<div class="cbi-section-node">
+		<form class="inline" method="post" action="<%=url('admin/system/flashops/backupmtdblock')%>">
+			<input type="hidden" name="token" value="<%=token%>" />
+			<div class="cbi-value">
+				<label class="cbi-value-title" for="mtdblockname"><%:Choose mtdblock%></label>
+				<div class="cbi-value-field">
+					<select class="cbi-input-select" data-update="change" name="mtdblockname" id="mtdblockname">
+						<% for i, key in ipairs(mtds) do
+							if key and key.name ~= "rootfs_data" then -%>
+								<option<%=
+									attr("id", "mtdblockname-" .. key.name) ..
+									attr("value", key.name .. '/'.. key.size .. '/' .. i - 1) ..
+									attr("data-index", i) ..
+									ifattr(key.name == "linux" or key.name == "firmware", "selected", "selected")
+								%>><%=pcdata(key.name)%></option>
+						<%	end
+						 end -%>
+					</select>
+				</div>
+			</div>
+			<div class="cbi-value cbi-value-last<% if reset_avail then %> cbi-value-error<% end %>">
+				<label class="cbi-value-title" for="image"><%:Download mtdblock%></label>
+				<div class="cbi-value-field">
+					<input type="submit" class="cbi-button cbi-button-action important" value="<%:Save mtdblock%>" />
+				</div>
+			</div>
+		</form>
+	</div>
+	<% end %>
+
 </div>
 
 <div class="cbi-section">


### PR DESCRIPTION

This commit add the feature that allow user to backup the image of the flash. 

![backup](https://user-images.githubusercontent.com/37688994/44906774-7101e400-ad48-11e8-926e-77e50980a5e4.gif)


