### PR TITLE
luci-app-adblock: use placeholder in query tool

### DIFF
--- a/applications/luci-app-adblock/luasrc/view/adblock/query.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/query.htm
@@ -11,7 +11,7 @@ This is free software, licensed under the Apache License, Version 2.0
 
 	function update_status(data)
 	{
-		var domain = data.value;
+		var domain = data.value || data.placeholder;
 		var input  = document.getElementById('query_input');
 		var output = document.getElementById('query_output');
 
@@ -48,7 +48,7 @@ This is free software, licensed under the Apache License, Version 2.0
 		<div class="cbi-section">
 			<div class="cbi-section-descr"><%:This form allows you to query active block lists for certain domains, e.g. for whitelisting.%></div>
 			<div style="width:33%; float:left;">
-				<input type="text" value="google.com" name="input" />
+				<input type="text" placeholder="google.com" name="input" />
 				<input type="button" value="<%:Query%>" class="cbi-button cbi-button-apply" onclick="update_status(this.form.input)" />
 			</div>
 			<br style="clear:both" />


### PR DESCRIPTION
Use the `placeholder` property on the textbox in the query tool so it's more convenient.

Signed-off-by: Andrei Troie <andreitroie90@gmail.com>