### PR TITLE
luci-app-firewall v2: Ease creation of multiple day traffic rules

### DIFF
--- a/applications/luci-app-adblock/luasrc/view/adblock/query.htm
+++ b/applications/luci-app-adblock/luasrc/view/adblock/query.htm
@@ -11,7 +11,7 @@ This is free software, licensed under the Apache License, Version 2.0
 
 	function update_status(data)
 	{
-		var domain = data.value;
+		var domain = data.value || data.placeholder;
 		var input  = document.getElementById('query_input');
 		var output = document.getElementById('query_output');
 
@@ -48,7 +48,7 @@ This is free software, licensed under the Apache License, Version 2.0
 		<div class="cbi-section">
 			<div class="cbi-section-descr"><%:This form allows you to query active block lists for certain domains, e.g. for whitelisting.%></div>
 			<div style="width:33%; float:left;">
-				<input type="text" value="google.com" name="input" />
+				<input type="text" placeholder="google.com" name="input" />
 				<input type="button" value="<%:Query%>" class="cbi-button cbi-button-apply" onclick="update_status(this.form.input)" />
 			</div>
 			<br style="clear:both" />

--- a/applications/luci-app-firewall/luasrc/model/cbi/firewall/rule-details.lua
+++ b/applications/luci-app-firewall/luasrc/model/cbi/firewall/rule-details.lua
@@ -375,10 +375,10 @@ o = s:option(Value, "start_time", translate("Start Time (hh:mm:ss)"))
 o.datatype = "timehhmmss"
 o = s:option(Value, "stop_time", translate("Stop Time (hh:mm:ss)"))
 o.datatype = "timehhmmss"
-o = s:option(Value, "start_date", translate("Start Date (yyyy-mm-dd)"))
-o.datatype = "dateyyyymmdd"
-o = s:option(Value, "stop_date", translate("Stop Date (yyyy-mm-dd)"))
-o.datatype = "dateyyyymmdd"
+o = s:option(Value, "start_date", translate("Start Date (yyyy-mm-ddThh:mm:ss)"))
+o.datatype = "dateyyyymmdd(1)"
+o = s:option(Value, "stop_date", translate("Stop Date (yyyy-mm-ddThh:mm:ss)"))
+o.datatype = "dateyyyymmdd(1)"
 
 o = s:option(Flag, "utc_time", translate("Time in UTC"))
 o.default = o.disabled

--- a/applications/luci-app-firewall/po/ca/firewall.po
+++ b/applications/luci-app-firewall/po/ca/firewall.po
@@ -449,13 +449,13 @@ msgstr "Port d'origen"
 msgid "Source zone"
 msgstr "Zona d'origen"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/cs/firewall.po
+++ b/applications/luci-app-firewall/po/cs/firewall.po
@@ -446,13 +446,13 @@ msgstr "Zdrojový port"
 msgid "Source zone"
 msgstr "Zdrojová zóna"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/de/firewall.po
+++ b/applications/luci-app-firewall/po/de/firewall.po
@@ -446,13 +446,13 @@ msgstr "Quellport"
 msgid "Source zone"
 msgstr "Quell-Zone"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/el/firewall.po
+++ b/applications/luci-app-firewall/po/el/firewall.po
@@ -437,13 +437,13 @@ msgstr "Θύρα πηγής"
 msgid "Source zone"
 msgstr "Θύρα πηγής"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/en/firewall.po
+++ b/applications/luci-app-firewall/po/en/firewall.po
@@ -464,13 +464,13 @@ msgstr "Source port"
 msgid "Source zone"
 msgstr "Source zone"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/es/firewall.po
+++ b/applications/luci-app-firewall/po/es/firewall.po
@@ -448,13 +448,13 @@ msgstr "Puerto origen"
 msgid "Source zone"
 msgstr "Zona origen"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/fr/firewall.po
+++ b/applications/luci-app-firewall/po/fr/firewall.po
@@ -473,13 +473,13 @@ msgstr "Port source"
 msgid "Source zone"
 msgstr "Zone source"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/he/firewall.po
+++ b/applications/luci-app-firewall/po/he/firewall.po
@@ -424,13 +424,13 @@ msgstr ""
 msgid "Source zone"
 msgstr ""
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/hu/firewall.po
+++ b/applications/luci-app-firewall/po/hu/firewall.po
@@ -450,13 +450,13 @@ msgstr "Forrás port"
 msgid "Source zone"
 msgstr "Forrás zóna"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/it/firewall.po
+++ b/applications/luci-app-firewall/po/it/firewall.po
@@ -467,14 +467,14 @@ msgstr "Porta di origine"
 msgid "Source zone"
 msgstr "Zona di origine"
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "Data di Inizio (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Data di Inizio (yyyy-mm-ddThh:mm:ss)"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "Ora di Inizio (hh:mm:ss)"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "Data di Stop (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Data di Stop (yyyy-mm-ddThh:mm:ss)"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "Ora di Stop (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/ja/firewall.po
+++ b/applications/luci-app-firewall/po/ja/firewall.po
@@ -487,14 +487,14 @@ msgstr "送信元ポート"
 msgid "Source zone"
 msgstr "送信元ゾーン"
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "開始日 (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "開始日 (yyyy-mm-ddThh:mm:ss)"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "開始時刻 (hh:mm:ss)"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "停止日 (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "停止日 (yyyy-mm-ddThh:mm:ss)"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "停止時刻 (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/ko/firewall.po
+++ b/applications/luci-app-firewall/po/ko/firewall.po
@@ -437,14 +437,14 @@ msgstr ""
 msgid "Source zone"
 msgstr ""
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "시작 날짜 (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "시작 날짜 (yyyy-mm-ddThh:mm:ss)"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "시작 시간 (hh:mm:ss)"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "종료 날짜 (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "종료 날짜 (yyyy-mm-ddThh:mm:ss)"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "종료 시간 (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/ms/firewall.po
+++ b/applications/luci-app-firewall/po/ms/firewall.po
@@ -423,13 +423,13 @@ msgstr ""
 msgid "Source zone"
 msgstr ""
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/no/firewall.po
+++ b/applications/luci-app-firewall/po/no/firewall.po
@@ -445,13 +445,13 @@ msgstr "Kilde port"
 msgid "Source zone"
 msgstr "Kilde sone"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/pl/firewall.po
+++ b/applications/luci-app-firewall/po/pl/firewall.po
@@ -460,13 +460,13 @@ msgstr "Port źródłowy"
 msgid "Source zone"
 msgstr "Strefa źródłowa"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/pt-br/firewall.po
+++ b/applications/luci-app-firewall/po/pt-br/firewall.po
@@ -449,14 +449,14 @@ msgstr "Porta de origem"
 msgid "Source zone"
 msgstr "Zona de origem"
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "Dia inicial (aaaa-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Dia inicial (aaaa-mm-ddThh:mm:ss)"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "Hora inicial (hh:mm:ss)"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "Dia final (aaaa-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Dia final (aaaa-mm-ddThh:mm:ss)"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "Hora final (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/pt/firewall.po
+++ b/applications/luci-app-firewall/po/pt/firewall.po
@@ -449,13 +449,13 @@ msgstr "Porta de origem"
 msgid "Source zone"
 msgstr "Zona de origem"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/ro/firewall.po
+++ b/applications/luci-app-firewall/po/ro/firewall.po
@@ -428,13 +428,13 @@ msgstr "Port sursa"
 msgid "Source zone"
 msgstr "Zona sursa"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/ru/firewall.po
+++ b/applications/luci-app-firewall/po/ru/firewall.po
@@ -457,14 +457,14 @@ msgstr "Порт источника"
 msgid "Source zone"
 msgstr "Зона источника"
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "Дата начала (год-мес-день)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Дата начала (гггг-мм-ддTчч:мм:сс)"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "Время начала (чч:мм:сс)"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "Дата окончания (год-мес-день)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Дата окончания (гггг-мм-ддTчч:мм:сс)"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "Время окончания (чч:мм:сс)"

--- a/applications/luci-app-firewall/po/sk/firewall.po
+++ b/applications/luci-app-firewall/po/sk/firewall.po
@@ -424,13 +424,13 @@ msgstr ""
 msgid "Source zone"
 msgstr ""
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/sv/firewall.po
+++ b/applications/luci-app-firewall/po/sv/firewall.po
@@ -430,14 +430,14 @@ msgstr ""
 msgid "Source zone"
 msgstr ""
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "Startdatum (åååå-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Startdatum (åååå-mm-ddThh:mm:ss)"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "Starttid (tt:mm:ss)"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "Stopptid (åååå-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Stopptid (åååå-mm-ddThh:mm:ss)"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "Stopptid (tt:mm:ss)"

--- a/applications/luci-app-firewall/po/templates/firewall.pot
+++ b/applications/luci-app-firewall/po/templates/firewall.pot
@@ -417,13 +417,13 @@ msgstr ""
 msgid "Source zone"
 msgstr ""
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/tr/firewall.po
+++ b/applications/luci-app-firewall/po/tr/firewall.po
@@ -424,13 +424,13 @@ msgstr ""
 msgid "Source zone"
 msgstr ""
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/uk/firewall.po
+++ b/applications/luci-app-firewall/po/uk/firewall.po
@@ -448,14 +448,14 @@ msgstr "Порт джерела"
 msgid "Source zone"
 msgstr "Зона джерела"
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "Дата початку (рррр-мм-дд)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Дата початку (рррр-мм-ддTгг:хх:сс)"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "Час початку (гг:хх:сс)"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "Дата зупинки (рррр-мм-дд)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "Дата зупинки (рррр-мм-ддTгг:хх:сс)"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "Час зупинки (гг:хх:сс)"

--- a/applications/luci-app-firewall/po/vi/firewall.po
+++ b/applications/luci-app-firewall/po/vi/firewall.po
@@ -437,13 +437,13 @@ msgstr "Cổng nguồn"
 msgid "Source zone"
 msgstr "Cổng nguồn"
 
-msgid "Start Date (yyyy-mm-dd)"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Start Time (hh:mm:ss)"
 msgstr ""
 
-msgid "Stop Date (yyyy-mm-dd)"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
 msgstr ""
 
 msgid "Stop Time (hh:mm:ss)"

--- a/applications/luci-app-firewall/po/zh-cn/firewall.po
+++ b/applications/luci-app-firewall/po/zh-cn/firewall.po
@@ -432,14 +432,14 @@ msgstr "源端口"
 msgid "Source zone"
 msgstr "源区域"
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "开始日期（yyyy-mm-dd）"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "开始日期（yyyy-mm-ddThh:mm:ss）"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "开始时间（hh:mm:ss）"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "停止日期（yyyy-mm-dd）"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "停止日期（yyyy-mm-ddThh:mm:ss）"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "停止时间（hh:mm:ss）"

--- a/applications/luci-app-firewall/po/zh-tw/firewall.po
+++ b/applications/luci-app-firewall/po/zh-tw/firewall.po
@@ -431,14 +431,14 @@ msgstr "源埠"
 msgid "Source zone"
 msgstr "源區域"
 
-msgid "Start Date (yyyy-mm-dd)"
-msgstr "開始日期（yyyy-mm-dd）"
+msgid "Start Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "開始日期（yyyy-mm-ddThh:mm:ss）"
 
 msgid "Start Time (hh:mm:ss)"
 msgstr "開始時間（hh:mm:ss）"
 
-msgid "Stop Date (yyyy-mm-dd)"
-msgstr "停止日期（yyyy-mm-dd）"
+msgid "Stop Date (yyyy-mm-ddThh:mm:ss)"
+msgstr "停止日期（yyyy-mm-ddThh:mm:ss）"
 
 msgid "Stop Time (hh:mm:ss)"
 msgstr "停止時間（hh:mm:ss）"

--- a/modules/luci-base/luasrc/cbi/datatypes.lua
+++ b/modules/luci-base/luasrc/cbi/datatypes.lua
@@ -421,9 +421,15 @@ function timehhmmss(val)
 	return (val:match("^[0-6][0-9]:[0-6][0-9]:[0-6][0-9]$") ~= nil)
 end
 
-function dateyyyymmdd(val)
+function dateyyyymmdd(val, allow_time)
 	if val ~= nil then
-		yearstr, monthstr, daystr = val:match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
+		datestr_postfix = "$"
+
+		if allow_time then
+			datestr_postfix = ""
+		end
+
+		yearstr, monthstr, daystr = val:match("^(%d%d%d%d)-(%d%d)-(%d%d)" .. datestr_postfix)
 		if (yearstr == nil) or (monthstr == nil) or (daystr == nil) then
 			return false;
 		end
@@ -456,6 +462,29 @@ function dateyyyymmdd(val)
 		if ((day == 0) or (day > get_days_in_month(month, year))) then
 			return false
 		end
+
+		-- The date part of the string (yyyy-mm-dd) is ten characthers long, so
+		-- there is no point checking for time is length is shorter than 11
+		if not allow_time or (val:len() < 11) then
+			return true
+		end
+
+		timestr = val:sub(11)
+
+		hourstr, minutestr, secstr = timestr:match("^T(%d%d):(%d%d):(%d%d)$")
+
+		if (hourstr == nil) or (minutestr == nil) or (secstr == nil) then
+			return false
+		end
+
+		hour = tonumber(hourstr)
+		minute = tonumber(minutestr)
+		sec = tonumber(secstr)
+
+		if ((hour > 23) or (minute > 59) or (sec > 59)) then
+			return false
+		end
+
 		return true
 	end
 	return false


### PR DESCRIPTION
Creating a traffic rule that spans multiple days currently requires
creating three rules, unless the rule only covers complete days. You
need to create one rule for the first day, one rule for the complete
days, and then one rule for the final day. In addition to making
creating multi day-rules a bit of as hassle, performance suffers when
many multi day-rules are present on a system.

The --datestart/--datestop arguments to iptables, which is what
Start/Stop Date maps to, supports specifying a time of day. This PR
extends Start/Stop Date to also accept an optional time. The format of
the fields are now either yyyy-mm-dd or yyyy-mm-ddThh:mm:ss. As before,
Start/Stop Time will override the time specified in Start/Stop Date.

The translations are also updated, with the exception of Russian and
Ukrainian. My knowledge of the cyrillic alphabet is a bit limit, to say
the least.

v1->v2:
* Update commit message
* Remove markup from translation strings.
* Extend existing datatype instead of adding a new type. I have added a
flag "allow_time" to "dateyyyymmdd" that, when set, enables users to
pass a time in addition to date.
* The time-part of "dateyyyymmdd" is optional. I decided to check if
time is passed or not by checking the length of val. By checking length,
we save a potentially redundant call to match.

Signed-off-by: Kristian Evensen <kristian.evensen@gmail.com>