### PR TITLE
luci-theme-material: Monospace font for textarea elements

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1226,7 +1226,7 @@ td > .ifacebadge,
     min-height: 14rem;
     padding: 0.8rem;
     font-size: 0.8rem;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: monospace;
     color: black;
 }
 


### PR DESCRIPTION
This fixes LuttyYang/luci-theme-material#48