### PR TITLE
Luci-Themes-Bootstrap: Update cascade.css to set ComboBox  width to auto

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1746,9 +1746,12 @@ table table td,
 
 .table.cbi-section-table input[type="password"],
 .table.cbi-section-table input[type="text"],
-.table.cbi-section-table textarea,
-.table.cbi-section-table select {
+.table.cbi-section-table textarea{
 	width: 100%;
+}
+
+.table.cbi-section-table select {
+	width: auto;
 }
 
 .table.cbi-section-table .td.cbi-section-table-cell {


### PR DESCRIPTION
The IPv4 Address ComboBox does not size correctly on the DHCP and DNS page.
changing the width to auto.

https://github.com/openwrt/luci/issues/2132#issuecomment-419686859