### PR TITLE
luci-mod-status: Typo in method name

### DIFF
--- a/modules/luci-mod-status/luasrc/view/admin_status/index.htm
+++ b/modules/luci-mod-status/luasrc/view/admin_status/index.htm
@@ -234,7 +234,7 @@
 						'<%:MAC-Address%>', (ifc6 && ifc6.ether) ? ifc6.mac : null)) ],
 					'<%:Protocol%>', ifc6.i18n ? (ifc6.i18n + (ifc6.proto === 'dhcp' && ifc6.ip6prefix ? '-PD' : '')) : E('em', '<%:Not connected%>'),
 					'<%:Prefix Delegated%>', ifc6.ip6prefix,
-					'<%:Address%>', (ifc6.ip6prefix) ? (ifc6.ip6addr || null) : (ifc6.ipaddr || '::'),
+					'<%:Address%>', (ifc6.ip6prefix) ? (ifc6.ip6addr || null) : (ifc6.ip6addr || '::'),
 					'<%:Gateway%>', (ifc6.gw6addr) ? ifc6.gw6addr : '::',
 					'<%:DNS%> 1', (ifc6.dns) ? ifc6.dns[0] : null,
 					'<%:DNS%> 2', (ifc6.dns) ? ifc6.dns[1] : null,


### PR DESCRIPTION
Fix method name to display IPv6-address on the status page: https://github.com/openwrt/luci/issues/2161