### PR TITLE
luci-base: fix table align for mount-points

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/button.htm
+++ b/modules/luci-base/luasrc/view/cbi/button.htm
@@ -1,5 +1,5 @@
 <%+cbi/valueheader%>
-	<% if self:cfgvalue(section) ~= false then %>
+	<% if self:cfgvalue(section) ~= false and self.inputstyle ~= "placeholder" then %>
 		<input class="cbi-button cbi-button-<%=self.inputstyle or "button" %>" type="submit"<%= attr("name", cbid) .. attr("id", cbid) .. attr("value", self.inputtitle or self.title)%> />
 	<% else %>
 		-

--- a/modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua
+++ b/modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua
@@ -121,8 +121,10 @@ unmount.render = function(self, section, scope)
 	if non_system_mounts[section].umount then
 		self.title = translate("Unmount")
 		self.inputstyle = "remove"
-        	Button.render(self, section, scope)
+	else
+		self.inputstyle = "placeholder"
 	end
+	Button.render(self, section, scope)
 end
 
 unmount.write = function(self, section)


### PR DESCRIPTION
This commit fix the table align issue of mount-points module.

**Before**
![fix-table-align-for-mount-points-before](https://user-images.githubusercontent.com/37688994/45925407-132b7b00-bf47-11e8-8ad3-53e9eadf5989.png)

**After**
![fix-table-align-for-mount-points](https://user-images.githubusercontent.com/37688994/45925413-23dbf100-bf47-11e8-88b2-e92fd0feca27.png)



Signed-off-by: Rosy Song <rosysong@rosinson.com>