### PR TITLE
luci-mod-system: add feature that allow users to eject scsi devices safely

### DIFF
--- a/modules/luci-base/luasrc/sys.lua
+++ b/modules/luci-base/luasrc/sys.lua
@@ -70,6 +70,32 @@ function mounts()
 	return data
 end
 
+function scsis()
+	local data = {}
+	local ps = luci.util.execi("lsblk -d -n -P -S -o NAME,TYPE,VENDOR,MODEL,REV,TRAN,SIZE")
+
+	if not ps then
+		return
+	end
+
+	for line in ps do
+		local n, t, v, m, r, tr, s = line:match('^NAME="([^"]+)"%s+TYPE="([^"]+)"%s+VENDOR="([^"]+)"%s+MODEL="([^"]+)"%s+REV="([^"]+)"%s+TRAN="([^"]+)"%s+SIZE="([^"]+)"')
+		if n and s then
+			local row = {}
+			row.name = n
+			row.type = t
+			row.vendor = v
+			row.model = m
+			row.rev = r
+			row.tran = tr
+			row.size = s
+			table.insert(data, row)
+		end
+	end
+
+	return data
+end
+
 function mtds()
 	local data = {}
 

--- a/modules/luci-mod-system/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-system/luasrc/controller/admin/system.lua
@@ -21,7 +21,7 @@ function index()
 	entry({"admin", "system", "crontab"}, form("admin_system/crontab"), _("Scheduled Tasks"), 46)
 
 	if fs.access("/sbin/block") and fs.access("/etc/config/fstab") then
-		entry({"admin", "system", "fstab"}, cbi("admin_system/fstab"), _("Mount Points"), 50)
+		entry({"admin", "system", "fstab"}, cbi("admin_system/fstab"), _("Mount Points / SCSI Devices"), 50)
 		entry({"admin", "system", "fstab", "mount"}, cbi("admin_system/fstab/mount"), nil).leaf = true
 		entry({"admin", "system", "fstab", "swap"},  cbi("admin_system/fstab/swap"),  nil).leaf = true
 	end


### PR DESCRIPTION
Hi all, 
    As we all known, there is a **"Safely Eject"** feature in desktop OS, but why not implement it in OpenWrt ? :-), This commit can help us to safely Eject the SCSI devices(USB, TF Card, SATA HD, ....) and also prevent from unplug them incorrectly, otherwise you will always see the below warning in logread:

......
**kern.warn kernel: [   11.900086] FAT-fs (sda1): Volume was not properly unmounted. Some data may be corrupt. Please run fsck.**

......


![eject-on-desktop](https://user-images.githubusercontent.com/37688994/45925457-2ab73380-bf48-11e8-807e-0fe774ea6bd0.png)


**Here is the screenshot:** 

![eject](https://user-images.githubusercontent.com/37688994/45925437-d57b2200-bf47-11e8-9721-820a63afb11f.gif)



**NOTE:**
This commit depends on the lsblk and eject utilities in util-linux (https://github.com/openwrt/openwrt/pull/1403). I also tested 
the simplified version provided by busybox, but they always delay or failed. 
Thanks @diizzyy for reminding me.

Signed-off-by: Rosy Song <rosysong@rosinson.com>