### PR TITLE
luci-mod-network: disable wifi config on new wifi-iface add

### DIFF
--- a/modules/luci-mod-network/luasrc/controller/admin/network.lua
+++ b/modules/luci-mod-network/luasrc/controller/admin/network.lua
@@ -175,7 +175,8 @@ function wifi_add()
 		local net = dev:add_wifinet({
 			mode       = "ap",
 			ssid       = "OpenWrt",
-			encryption = "none"
+			encryption = "none",
+			disabled   = 1
 		})
 
 		ntm:save("wireless")


### PR DESCRIPTION
If we add a new wifi-iface to the config then the iface will start at once.
But normaly we would configure the wireless security in the next step.
So do not start wifi iface on add.