### PR TITLE
Parse method fixed in cbi.lua

### DIFF
--- a/modules/luci-base/luasrc/cbi.lua
+++ b/modules/luci-base/luasrc/cbi.lua
@@ -1200,7 +1200,7 @@ function TypedSection.parse(self, novld)
 				-- Ignore if it already exists
 				if self:cfgvalue(name) then
 					name = nil;
-					self.err_invalid = tru
+					self.err_invalid = true
 				else
 					name = self:checkscope(name)
 

--- a/modules/luci-base/luasrc/cbi.lua
+++ b/modules/luci-base/luasrc/cbi.lua
@@ -1200,18 +1200,19 @@ function TypedSection.parse(self, novld)
 				-- Ignore if it already exists
 				if self:cfgvalue(name) then
 					name = nil;
-				end
+					self.err_invalid = tru
+				else
+					name = self:checkscope(name)
 
-				name = self:checkscope(name)
+					if not name then
+						self.err_invalid = true
+					end
 
-				if not name then
-					self.err_invalid = true
-				end
-
-				if name and #name > 0 then
-					created = self:create(name, origin) and name
-					if not created then
-						self.invalid_cts = true
+					if name and #name > 0 then
+						created = self:create(name, origin) and name
+						if not created then
+							self.invalid_cts = true
+						end
 					end
 				end
 			end


### PR DESCRIPTION
*	Method "parse" fixed. It's not necessary to execute all code if section already exists.

Signed-off-by: Darius Joksas <jok.darius@gmail.com>