### PR TITLE
themes: fix double-escaped menu entry titles (#1410)

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -98,7 +98,7 @@
 				local nnode = node.nodes[r]
 				write('<li><a href="%s">%s</a></li>' %{
 					nodeurl(prefix, r, nnode.query),
-					pcdata(striptags(translate(nnode.title)))
+					striptags(translate(nnode.title))
 				})
 			end
 
@@ -116,13 +116,13 @@
 				local grandchildren = disp.node_childs(nnode)
 
 				if #grandchildren > 0 then
-					write('<li class="dropdown"><a class="menu" href="#">%s</a>' % pcdata(striptags(translate(nnode.title))))
+					write('<li class="dropdown"><a class="menu" href="#">%s</a>' % striptags(translate(nnode.title)))
 					render_submenu(category .. "/" .. r, nnode)
 					write('</li>')
 				else
 					write('<li><a href="%s">%s</a></li>' %{
 						nodeurl(category, r, nnode.query),
-						pcdata(striptags(translate(nnode.title)))
+						striptags(translate(nnode.title))
 					})
 				end
 			end

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -109,7 +109,7 @@
 
 			for i, r in ipairs(childs) do
 				local nnode = node.nodes[r]
-				local title = pcdata(striptags(translate(nnode.title)))
+				local title = striptags(translate(nnode.title))
 
 				write('<li><a data-title="%s" href="%s">%s</a></li>' %{
 					title,
@@ -132,7 +132,7 @@
 				local grandchildren = disp.node_childs(nnode)
 
 				if #grandchildren > 0 then
-					local title = pcdata(striptags(translate(nnode.title)))
+					local title = striptags(translate(nnode.title))
 
 					write('<li class="slide"><a class="menu" data-title="%s" href="#">%s</a>' %{
 						title,
@@ -142,7 +142,7 @@
 					render_submenu(category .. "/" .. r, nnode)
 					write('</li>')
 				else
-					local title = pcdata(striptags(translate(nnode.title)))
+					local title = striptags(translate(nnode.title))
 
 					write('<li><a data-title="%s" href="%s">%s</a></li>' %{
 						title,


### PR DESCRIPTION
- escaping title with striptags is sufficient; calling pcdata is not needed
- fixes e.g. apostrophe in French translation displays as `&#39;`
