### PR TITLE
luci-mod-system: add id for software/freespace div

### DIFF
--- a/modules/luci-mod-system/luasrc/view/admin_system/packages.htm
+++ b/modules/luci-mod-system/luasrc/view/admin_system/packages.htm
@@ -88,7 +88,7 @@ end
 
 				<div class="cbi-value cbi-value-last">
 					<%:Free space%>: <strong><%=(100-used_perc)%>%</strong> (<strong><%=wa.byte_format(free_byte)%></strong>)
-					<div style="margin:3px 0; width:300px; height:10px; border:1px solid #000000; background-color:#80C080">
+					<div style="margin:3px 0; width:300px; height:10px; border:1px solid #000000; background-color:#80C080" id="swfreespace">
 						<div style="background-color:#F08080; border-right:1px solid #000000; height:100%; width:<%=used_perc%>%">&#160;</div>
 					</div>
 				</div>


### PR DESCRIPTION

Add **id** attribute for **software/freespace** div so that developers can control the css style in their theme.

@hnyman @jow- 

Signed-off-by: Rosy Song <rosysong@rosinson.com>