### PR TITLE
luci-app-snmpd: Allow turning off agentx

### DIFF
--- a/applications/luci-app-snmpd/luasrc/model/cbi/snmpd.lua
+++ b/applications/luci-app-snmpd/luasrc/model/cbi/snmpd.lua
@@ -26,11 +26,12 @@ s.anonymous = true
 p = s:option(Value, "agentaddress", "The address the agent should listen on",
 	[[Eg: UDP:161, or UDP:10.5.4.3:161 to only listen on a given interface]])
 
-s = m:section(TypedSection, "agentx", "AgentX settings")
+s = m:section(TypedSection, "agentx", "AgentX settings", "Delete this section to disable agentx")
 s.anonymous = true
 p = s:option(Value, "agentxsocket", "The address the agent should allow agentX connections to",
     [[This is only necessary if you have subagents using the agentX socket protocol.
-    Note that agentX requires TCP transport]])
+    Eg: /var/run/agentx.sock]])
+s.addremove=true
 
 s = m:section(TypedSection, "com2sec", "com2sec security")
 p = s:option(Value, "secname", "secname")


### PR DESCRIPTION
AgentX support doesn't actually require TCP, it also works over unix
domain sockets, and UDS is the only method that's compiled in by
default.  Remove that misleading text, and make the section
add/removable so that you can remove it to disable agentx support.
Behaviour with multiple sections is undefined. (don't do that!)

This matches the current behaviour of the snmpd init script, which will
enable agentx with the compile time default settings if the agentx
socket config is blank/missing.

Signed-off-by: Karl Palsson <karlp@etactica.com>