### PR TITLE
luci-app-statistics: add support for cUrl

### DIFF
--- a/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
+++ b/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
@@ -29,6 +29,7 @@ function index()
 		cpu			= _("Processor"),
 		cpufreq		= _("CPU Frequency"),
 		csv			= _("CSV Output"),
+		curl		= _("cUrl"),
 		df			= _("Disk Space Usage"),
 		disk		= _("Disk Usage"),
 		dns			= _("DNS"),
@@ -63,7 +64,7 @@ function index()
 		general = { "apcups", "contextswitch", "cpu", "cpufreq", "df",
 			"disk", "email", "entropy", "exec", "irq", "load", "memory",
 			"nut", "processes", "sensors", "thermal", "uptime" },
-		network = { "conntrack", "dns", "interface", "iptables",
+		network = { "conntrack", "curl", "dns", "interface", "iptables",
 			"netlink", "olsrd", "openvpn", "ping",
 			"splash_leases", "tcpconns", "iwinfo" }
 	}

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua
@@ -1,0 +1,24 @@
+-- Copyright 2018 Chizhong Jin <pjincz@gmail.com>
+-- Licensed to the public under the BSD 3-clause license
+
+m = Map("luci_statistics",
+		translate("cUrl Plugin Configuration"))
+
+s = m:section(NamedSection, "collectd_curl")
+s_enable = s:option(Flag, "enable", translate("Enable this plugin"))
+s_enable.default = 0
+
+page = m:section(TypedSection, "collectd_curl_page")
+page.addremove = true
+page.anonymous = true
+page.template = "cbi/tblsection"
+page.sortable = true
+
+page_enable = page:option(Flag, "enable", translate("Enable"))
+page_enable.default = 1
+
+page_name = page:option(Value, "name", translate("Name"))
+
+page_addr = page:option(Value, "url", translate("URL"))
+
+return m

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/curl.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/curl.lua
@@ -1,0 +1,22 @@
+-- Copyright 2018 Chizhong Jin <pjincz@gmail.com>
+-- Licensed to the public under the BSD 3-clause license
+
+module("luci.statistics.rrdtool.definitions.curl", package.seeall)
+
+function rrdargs( graph, plugin, plugin_instance, dtype )
+	return {
+		title = "%H: cUrl Response Time for #%pi",
+		y_min = "0",
+		alt_autoscale_max = true,
+		vlabel = "Response Time",
+		number_format = "%5.1lf%Ss",
+		data = {
+			types = { "response_time" },
+			options = {
+				response_time = {
+					title = ""
+				}
+			}
+		}
+	}
+end

--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -66,6 +66,9 @@ config statistics 'collectd_cpu'
 config statistics 'collectd_cpufreq'
 	option enable '0'
 
+config statistics 'collectd_curl'
+	option enable '0'
+
 config statistics 'collectd_df'
 	option enable '0'
 	option Devices '/dev/mtdblock/4'

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -117,6 +117,21 @@ function config_exec( c )
 	return str
 end
 
+function config_curl( c )
+	local str = ""
+
+	for s in pairs(sections) do
+		if sections[s][".type"] == "collectd_curl_page" then
+			str = str .. "\t<Page \"" .. sections[s].name .. "\">\n" ..
+						 "\t\tURL \"" .. sections[s].url .. "\"\n" ..
+						 "\t\tMeasureResponseTime true\n" ..
+						 "\t</Page>\n"
+		end
+	end
+
+	return str
+end
+
 function config_iptables( c )
 	local str = ""
 
@@ -296,6 +311,8 @@ plugins = {
 		{ "StoreRates" },
 		{ }
 	},
+
+	curl = config_curl,
 
 	df	= {
 		{ },


### PR DESCRIPTION
Add collectd-mod-curl plugin support. Which can do some complex track,
such as grab stock, but by now, only response time are supported.

#2138 