### PR TITLE
luci-base: improve firewall zone forwarding list

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/firewall_zoneforwards.htm
+++ b/modules/luci-base/luasrc/view/cbi/firewall_zoneforwards.htm
@@ -63,7 +63,7 @@
 		if empty then
 	%>
 		<label class="zonebadge zonebadge-empty">
-			<strong><%=zone:forward():upper()%></strong>
+			<strong><%=translate("empty"):upper()%></strong>
 		</label>
 	<% end %>
 	</div>


### PR DESCRIPTION
Remove the zone forward option displayed when the forwarding list
is empty. It seemed to imply the option was used for forwardings
to all destination zones, when it in reality is used only between
the zone's interfaces.

Signed-off-by: Mikael Magnusson <mikma@users.sourceforge.net>