### PR TITLE
luci-mod-network: show bridges in ifacelist when the interface itself is not a bridge

### DIFF
--- a/modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua
@@ -284,7 +284,7 @@ if not net:is_floating() then
 	ifname_single = s:taboption("physical", Value, "ifname_single", translate("Interface"))
 	ifname_single.template = "cbi/network_ifacelist"
 	ifname_single.widget = "radio"
-	ifname_single.nobridges = true
+	ifname_single.nobridges = net:is_bridge()
 	ifname_single.noaliases = false
 	ifname_single.rmempty = false
 	ifname_single.network = arg[1]
@@ -341,7 +341,7 @@ end
 if not net:is_virtual() then
 	ifname_multi = s:taboption("physical", Value, "ifname_multi", translate("Interface"))
 	ifname_multi.template = "cbi/network_ifacelist"
-	ifname_multi.nobridges = true
+	ifname_multi.nobridges = net:is_bridge()
 	ifname_multi.noaliases = true
 	ifname_multi.rmempty = false
 	ifname_multi.network = arg[1]


### PR DESCRIPTION
It's completely OK to select a bridge as the underlying interface of
other interfaces, say a tunnel or PPPoE. The only case which should be
forbidden is bridge over bridge.

Signed-off-by: David Yang <mmyangfl@gmail.com>