### PR TITLE
[openwrt-18.06] luci-app-openvpn: fix template based config creation

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
@@ -59,7 +59,7 @@ function s.create(self, name)
 	if #name > 3 and not name:match("[^a-zA-Z0-9_]") then
 		uci:section(
 			"openvpn", "openvpn", name,
-			uci:get_all( "openvpn_recipes", recipe )
+			{ uci:get_all( "openvpn_recipes", recipe ) }
 		)
 
 		uci:delete("openvpn", name, "_role")


### PR DESCRIPTION
@dibdot This should also got to openwrt-18.06 next point release

> * minimal fix to bring back openvpn config creation based on
> openvpn_recipes template, fix for #2146
> 
> Signed-off-by: Dirk Brenken <dev@brenken.org>
> (cherry picked from commit 1eb3f734c7f4830022f99e304d38156c2520c676)