### PR TITLE
luci-app-mwan3: fix typo

### DIFF
--- a/applications/luci-app-mwan3/luasrc/controller/mwan3.lua
+++ b/applications/luci-app-mwan3/luasrc/controller/mwan3.lua
@@ -117,7 +117,7 @@ function diagnosticsData(interface, task)
 		end
 	end
 
-	function get_gateway(inteface)
+	function get_gateway(interface)
 		local gateway = nil
 		local dump = nil
 


### PR DESCRIPTION
This has worked before because the interface variable is global. But
this is not nice. So this commit will fix this.

This was already mentioned in https://github.com/openwrt/luci/pull/2197#issuecomment-426211483




