### PR TITLE
luci-proto-3g: add missed option name for IPv6 address obtain mode

### DIFF
--- a/protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua
+++ b/protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua
@@ -47,7 +47,9 @@ dialnumber.placeholder = "*99***1#"
 
 if luci.model.network:has_ipv6() then
 
-	ipv6 = section:taboption("advanced", ListValue, "ipv6")
+	ipv6 = section:taboption("advanced", ListValue, "ipv6",
+		translate("Obtain IPv6-Address"))
+
 	ipv6:value("auto", translate("Automatic"))
 	ipv6:value("0", translate("Disabled"))
 	ipv6:value("1", translate("Manual"))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13316680/46878186-50e73980-ce4b-11e8-8341-2c7be6518bf2.png)
