### PR TITLE
luci-app-dump1090: Fix typo of a dumb option

### DIFF
--- a/applications/luci-app-dump1090/luasrc/model/cbi/dump1090.lua
+++ b/applications/luci-app-dump1090/luasrc/model/cbi/dump1090.lua
@@ -136,8 +136,8 @@ no_crc_check.default = false
 phase_enhance=s:option(Flag, "phase_enhance", translate("Enable phase enhancement"))
 phase_enhance.default = false
 
-agressive=s:option(Flag, "agressive", translate("More CPU for more messages"))
-agressive.default = false
+aggressive=s:option(Flag, "aggressive", translate("More CPU for more messages"))
+aggressive.default = false
 
 mlat=s:option(Flag, "mlat", translate("Display raw messages in Beast ascii mode"))
 mlat.default = false


### PR DESCRIPTION
Option `aggressive` is supported by dump1090 binary, but oddly missing in
dump1090.init. Nevertheless, neither of them support the wrong
`agressive`.

Signed-off-by: David Yang <mmyangfl@gmail.com>