### PR TITLE
luci-app-olsr-services: Don't use the nameservice with a specific ver…

### DIFF
--- a/applications/luci-app-olsr-services/luasrc/controller/services.lua
+++ b/applications/luci-app-olsr-services/luasrc/controller/services.lua
@@ -4,7 +4,7 @@ function index()
 	local uci = require "luci.model.uci".cursor()
 
 	uci:foreach("olsrd", "LoadPlugin", function(s)
-		if s.library == "olsrd_nameservice.so.0.3" then
+		if s.library == "olsrd_nameservice" then
 			has_serv = true
 		end
 	end)


### PR DESCRIPTION
…sion.

The "Services" menu option of olsr on the top of the web interface
is not there.

A specific version of the App name was in the controller service
Removing the limitation will fix the problem

https://github.com/freifunk-berlin/firmware/issues/594