### PR TITLE
Create profile_fuerstenwalde

### DIFF
--- a/contrib/package/community-profiles/files/etc/config/profile_fuerstenwalde
+++ b/contrib/package/community-profiles/files/etc/config/profile_fuerstenwalde
@@ -1,0 +1,38 @@
+config 'community' 'profile'
+	option 'name' 'Freifunk Fürstenwalde'
+	option 'homepage' 'http://fuerstenwalde.freifunk.net'
+	option 'ssid' 'fuerstenwalde.freifunk.net'
+	option 'ssid_scheme' 'addchannelbefore'
+	option 'mesh_network' '10.0.0.0/8'
+	option 'splash_network' '10.104.0.0/16'
+	option 'splash_prefix' '27'
+	option 'latitude' '52.35844'
+	option 'longitude' '14.063696'
+	option 'owm_api' 'http://util.berlin.freifunk.net'
+
+config 'defaults' 'wifi_device'
+	option 'channel' '13'
+
+config 'defaults' 'wifi_device_5'
+	option 'channel' '36'
+
+config 'defaults' 'wifi_iface'
+	option 'mcast_rate' '6000'
+
+config 'defaults' 'wifi_iface_5'
+	option 'mcast_rate' '12000'
+
+config 'defaults' 'bssidscheme'
+	option '13'	'D2:CA:FF:EE:BA:BE'
+	option '36'	'02:36:CA:FF:EE:EE'
+
+config 'defaults' 'ssidscheme'
+	option '13'	'intern-ch13.freifunk.net'
+	option '36'	'intern-ch36.freifunk.net'
+
+config 'defaults' 'interface'
+	option 'netmask' '255.255.255.255'
+	option 'dns' '85.214.20.141 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12'
+
+config 'dhcp' 'dhcp'
+option leasetime '5m'


### PR DESCRIPTION
New profile for Freifunk Fürstenwalde. At the moment we use parts of the Berlin-infrastructure. Thus I have not changed the ip-address-related things. Feel free to correct.

Signed-off-by: Martin Hübner martin.hubner@web.de