### PR TITLE
luci-mod-system: add support for additional filesystem

### DIFF
--- a/modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua
+++ b/modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua
@@ -136,6 +136,13 @@ for fs in io.lines("/proc/filesystems") do
 	end
 end
 
+local ok, lines = pcall(io.lines, "/etc/filesystem")
+if ok then
+	local fs
+	for fs in lines do
+		o:value(fs)
+	end
+end
 
 o = mount:taboption("advanced", Value, "options", translate("Mount options"),
 	translate("See \"mount\" manpage for details"))


### PR DESCRIPTION
The filesystem option doesn't include additional filesystem included with /etc/filesystems, this is usefull if someone have ntfs-3g installed and wants to force use the external utility to mount partition instead of the default present in the kernel (if it's supported)
@jow- 
Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>