### PR TITLE
update luci-app-olsr to the new jsoninfo library

### DIFF
--- a/applications/luci-app-olsr/luasrc/controller/olsr.lua
+++ b/applications/luci-app-olsr/luasrc/controller/olsr.lua
@@ -318,13 +318,14 @@ function action_smartgw()
 
 	local function compare(a,b)
 		if a.proto == b.proto then
-			return a.tcPathCost < b.tcPathCost
+			return a.cost < b.cost
 		else
 			return a.proto < b.proto
 		end
 	end
 
-	table.sort(data, compare)
+	table.sort(data.ipv4, compare)
+	table.sort(data.ipv6, compare)
 	luci.template.render("status-olsr/smartgw", {gws=data, has_v4=has_v4, has_v6=has_v6})
 end
 

--- a/applications/luci-app-olsr/luasrc/controller/olsr.lua
+++ b/applications/luci-app-olsr/luasrc/controller/olsr.lua
@@ -300,7 +300,7 @@ function action_mid()
 
 	local function compare(a,b)
 		if a.proto == b.proto then
-			return a.ipAddress < b.ipAddress
+			return a.main.ipAddress < b.main.ipAddress
 		else
 			return a.proto < b.proto
 		end

--- a/applications/luci-app-olsr/luasrc/controller/olsr.lua
+++ b/applications/luci-app-olsr/luasrc/controller/olsr.lua
@@ -87,8 +87,8 @@ function action_json()
 	local v4_port = tonumber(uci:get("olsrd", "olsrd_jsoninfo", "port") or "") or 9090
 	local v6_port = tonumber(uci:get("olsrd6", "olsrd_jsoninfo", "port") or "") or 9090
 
-	jsonreq4 = utl.exec("(echo /status | nc 127.0.0.1 %d | sed -n '/^[}{ ]/p') 2>/dev/null" % v4_port)
-	jsonreq6 = utl.exec("(echo /status | nc ::1 %d | sed -n '/^[}{ ]/p') 2>/dev/null" % v6_port)
+	jsonreq4 = utl.exec("(echo /all | nc 127.0.0.1 %d | sed -n '/^[}{ ]/p') 2>/dev/null" % v4_port)
+	jsonreq6 = utl.exec("(echo /all | nc ::1 %d | sed -n '/^[}{ ]/p') 2>/dev/null" % v6_port)
 	http.prepare_content("application/json")
 	if not jsonreq4 or jsonreq4 == "" then
 		jsonreq4 = "{}"

--- a/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua
+++ b/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins.lua
@@ -227,6 +227,7 @@ else
 	-- create a loadplugin section for each found plugin
 	for v in fs.dir("/usr/lib") do
 		if v:sub(1, 6) == "olsrd_" then
+			v = string.match(v, "^(olsrd.*)%.so%..*")
 			if not plugins[v] then
 				mpi.uci:section(
 					"olsrd", "LoadPlugin", nil,

--- a/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua
+++ b/applications/luci-app-olsr/luasrc/model/cbi/olsr/olsrdplugins6.lua
@@ -227,6 +227,7 @@ else
 	-- create a loadplugin section for each found plugin
 	for v in fs.dir("/usr/lib") do
 		if v:sub(1, 6) == "olsrd_" then
+			v=string.match(v, "^(olsrd_.*)%.so%..*")
 			if not plugins[v] then
 				mpi.uci:section(
 					"olsrd6", "LoadPlugin", nil,

--- a/applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm
+++ b/applications/luci-app-olsr/luasrc/view/status-olsr/interfaces.htm
@@ -33,12 +33,12 @@ local i = 1
 
 		<div class="tr cbi-section-table-row cbi-rowstyle-<%=i%> proto-<%=iface.proto%>">
 			<div class="td cbi-section-table-cell"><%=iface.name%></div>
-			<div class="td cbi-section-table-cell"><%=iface.state%></div>
-			<div class="td cbi-section-table-cell"><%=iface.olsrMTU%></div>
-			<div class="td cbi-section-table-cell"><%=iface.wireless and luci.i18n.translate('yes') or luci.i18n.translate('no')%></div>
-			<div class="td cbi-section-table-cell"><%=iface.ipv4Address or iface.ipv6Address%></div>
-			<div class="td cbi-section-table-cell"><%=iface.netmask%></div>
-			<div class="td cbi-section-table-cell"><%=iface.broadcast or iface.multicast%></div>
+			<div class="td cbi-section-table-cell"><%=iface.olsrInterface.up and luci.i18n.translate('up') or luci.i18n.translate('down')%></div>
+			<div class="td cbi-section-table-cell"><%=iface.olsrInterface.mtu%></div>
+			<div class="td cbi-section-table-cell"><%=iface.olsrInterface.wireless and luci.i18n.translate('yes') or luci.i18n.translate('no')%></div>
+			<div class="td cbi-section-table-cell"><%=iface.olsrInterface.ipAddress%></div>
+			<div class="td cbi-section-table-cell"><%=iface.olsrInterface.ipv4Address ~= '0.0.0.0' and iface.olsrInterface.ipv4Netmask%></div>
+			<div class="td cbi-section-table-cell"><%=iface.olsrInterface.ipv4Address ~= '0.0.0.0' and iface.olsrInterface.ipv4Broadcast or iface.olsrInterface.ipv6Multicast%></div>
 		</div>
 		<% i = ((i % 2) + 1)
 		end %>

--- a/applications/luci-app-olsr/luasrc/view/status-olsr/mid.htm
+++ b/applications/luci-app-olsr/luasrc/view/status-olsr/mid.htm
@@ -31,14 +31,14 @@ local i = 1
 				end
 				aliases = v.ipAddress .. sep .. aliases
 			end
-			local host = mid.ipAddress
+			local host = mid.main.ipAddress
 			if mid.proto == '6' then
-				host = '[' .. mid.ipAddress .. ']'
+				host = '[' .. mid.main.ipAddress .. ']'
 			end
 		%>
 
 		<div class="tr cbi-section-table-row cbi-rowstyle-<%=i%> proto-<%=mid.proto%>">
-			<div class="td cbi-section-table-cell"><a href="http://<%=host%>/cgi-bin-status.html"><%=mid.ipAddress%></a></div>
+			<div class="td cbi-section-table-cell"><a href="http://<%=host%>/cgi-bin-status.html"><%=mid.main.ipAddress%></a></div>
 			<div class="td cbi-section-table-cell"><%=aliases%></div>
 		</div>
 

--- a/applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm
+++ b/applications/luci-app-olsr/luasrc/view/status-olsr/overview.htm
@@ -61,12 +61,12 @@ XHR.poll(10, '<%=REQUEST_URI%>/json', { },
 		if (e = document.getElementById('version'))
 			var version;
 			var date;
-			if (info.v4.config.olsrdVersion != undefined) {
-				version = info.v4.config.olsrdVersion
-				date = info.v4.config.olsrdBuildDate
-			} else if (info.v6.config.olsrdVersion != undefined) {
-				version = info.v6.config.olsrdVersion
-				date = info.v6.config.olsrdBuildDate
+			if (info.v4.version.version != undefined) {
+				version = info.v4.version.version
+				date = info.v4.version.date
+			} else if (info.v6.version.version != undefined) {
+				version = info.v6.version.version
+				date = info.v6.version.date
 			} else {
 				version = 'unknown'
 				date = 'unknown'

--- a/applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm
+++ b/applications/luci-app-olsr/luasrc/view/status-olsr/smartgw.htm
@@ -17,23 +17,23 @@ end)
 
 if luci.http.formvalue("status") == "1" then
 	local rv = {}
-	for k, gw in ipairs(gws) do
-		gw.tcPathCost = tonumber(gw.tcPathCost)/1024 or 0
-                if gw.tcPathCost == 4096 then
-                        gw.tcPathCost = 0
+	for k, gw in ipairs(gws.ipv4, gws.ipv6) do
+		gw.cost = tonumber(gw.cost)/1024 or 0
+                if gw.cost == 4096 then
+                        gw.cost = 0
                 end
 
 		rv[#rv+1] = {
-			proto = gw.proto,
-			ipAddress = gw.ipAddress,
-			status = gw.ipv4Status or gw.ipv6Status,
-			tcPathCost = string.format("%.3f", gw.tcPathCost),
-			hopCount = gw.hopCount,
-			uplinkSpeed = gw.uplinkSpeed,
-			downlinkSpeed = gw.downlinkSpeed,
-			v4 = gw.ipv4 and luci.i18n.translate('yes') or luci.i18n.translate('no'),
-			v6 = gw.ipv6 and luci.i18n.translate('yes') or luci.i18n.translate('no'),
-			externalPrefix = gw.externalPrefix
+			proto = gw.IPv4 and '4' or '6',
+			originator = gw.originator,
+			selected = gw.selected and luci.i18n.translate('yes') or luci.i18n.translate('no'),
+			cost = string.format("%.3f", gw.cost),
+			hops = gw.hops,
+			uplink = gw.uplink,
+			downlink = gw.downlink,
+			v4 = gw.IPv4 and luci.i18n.translate('yes') or luci.i18n.translate('no'),
+			v6 = gw.IPv6 and luci.i18n.translate('yes') or luci.i18n.translate('no'),
+			prefix = gw.prefix
 			}
 	end
 	luci.http.prepare_content("application/json")
@@ -58,9 +58,9 @@ XHR.poll(10, '<%=REQUEST_URI%>', { status: 1 },
 			var linkgw;
 			s += '<div class="tr cbi-section-table-row cbi-rowstyle-'+(1 + (idx % 2))+' proto-' + smartgw.proto + '">'
 			if (smartgw.proto == '6') {
-				linkgw = '<a href="http://[' + smartgw.ipAddress + ']/cgi-bin-status.html">' + smartgw.ipAddress + '</a>'
+				linkgw = '<a href="http://[' + smartgw.originator + ']/cgi-bin-status.html">' + smartgw.originator + '</a>'
 			} else {
-				linkgw = '<a href="http://' + smartgw.ipAddress + '/cgi-bin-status.html">' + smartgw.ipAddress + '</a>'
+				linkgw = '<a href="http://' + smartgw.originator + '/cgi-bin-status.html">' + smartgw.originator + '</a>'
 			}
 
 			s += String.format(
@@ -73,7 +73,7 @@ XHR.poll(10, '<%=REQUEST_URI%>', { status: 1 },
                                 '<div class="td cbi-section-table-cell">%s</div>' +
                                 '<div class="td cbi-section-table-cell">%s</div>' +
                                 '<div class="td cbi-section-table-cell">%s</div>',
-				linkgw, smartgw.status, smartgw.tcPathCost, smartgw.hopCount, smartgw.uplinkSpeed, smartgw.downlinkSpeed, smartgw.v4, smartgw.v6, smartgw.externalPrefix
+				linkgw, smartgw.selected, smartgw.cost, smartgw.hops, smartgw.uplink, smartgw.downlink, smartgw.v4, smartgw.v6, smartgw.prefix
                                 )
 			s += '</div>'
 		}
@@ -98,7 +98,7 @@ XHR.poll(10, '<%=REQUEST_URI%>', { status: 1 },
 			<div class="thead">
 			<div class="tr cbi-section-table-titles">
 				<div class="th cbi-section-table-cell"><%:Gateway%></div>
-				<div class="th cbi-section-table-cell"><%:Status%></div>
+				<div class="th cbi-section-table-cell"><%:Selected%></div>
 				<div class="th cbi-section-table-cell"><%:ETX%></div>
 				<div class="th cbi-section-table-cell"><%:Hops%></div>
 				<div class="th cbi-section-table-cell"><%:Uplink%></div>
@@ -113,27 +113,27 @@ XHR.poll(10, '<%=REQUEST_URI%>', { status: 1 },
 			<div class="tbody" id="olsrd_smartgw">
 			<% for k, gw in ipairs(gws) do 
 
-			gw.tcPathCost = tonumber(gw.tcPathCost)/1024 or 0
-               		if gw.tcPathCost == 4096 then
-	                        gw.tcPathCost = 0
+			gw.cost = tonumber(gw.cost)/1024 or 0
+               		if gw.cost == 4096 then
+	                        gw.cost = 0
                		end
 			%>
 
 			<div class="tr cbi-section-table-row cbi-rowstyle-<%=i%> proto-<%=proto%>">
 				<% if gw.proto == '6' then %>
-					<div class="td cbi-section-table-cell"><a href="http://[<%=gw.ipAddress%>]/cgi-bin-status.html"><%=gw.ipAddress%></a></div>
+					<div class="td cbi-section-table-cell"><a href="http://[<%=gw.originator%>]/cgi-bin-status.html"><%=gw.originator%></a></div>
 				<% else %>
-					<div class="td cbi-section-table-cell"><a href="http://<%=gw.ipAddress%>/cgi-bin-status.html"><%=gw.ipAddress%></a></div>
+					<div class="td cbi-section-table-cell"><a href="http://<%=gw.originator%>/cgi-bin-status.html"><%=gw.originator%></a></div>
 				<% end %>
 
-				<div class="td cbi-section-table-cell"><%=gw.ipv4Status or gw.ipv6Status or '-' %></div>
-				<div class="td cbi-section-table-cell"><%=string.format("%.3f", gw.tcPathCost)%></div>
-				<div class="td cbi-section-table-cell"><%=gw.hopCount%></div>
-				<div class="td cbi-section-table-cell"><%=gw.uplinkSpeed%></div>
-				<div class="td cbi-section-table-cell"><%=gw.downlinkSpeed%></div>
-				<div class="td cbi-section-table-cell"><%=gw.ipv4 and luci.i18n.translate('yes') or luci.i18n.translate('no')%></div>
-				<div class="td cbi-section-table-cell"><%=gw.ipv6 and luci.i18n.translate('yes') or luci.i18n.translate('no')%></div>
-				<div class="td cbi-section-table-cell"><%=gw.externalPrefix%></div>
+				<div class="td cbi-section-table-cell"><%=gw.selected and luci.i18n.translate('yes') or luci.i18n.translate('no')%></div>
+				<div class="td cbi-section-table-cell"><%=string.format("%.3f", gw.cost)%></div>
+				<div class="td cbi-section-table-cell"><%=gw.hops%></div>
+				<div class="td cbi-section-table-cell"><%=gw.uplink%></div>
+				<div class="td cbi-section-table-cell"><%=gw.downlink%></div>
+				<div class="td cbi-section-table-cell"><%=gw.IPv4 and luci.i18n.translate('yes') or luci.i18n.translate('no')%></div>
+				<div class="td cbi-section-table-cell"><%=gw.IPv6 and luci.i18n.translate('yes') or luci.i18n.translate('no')%></div>
+				<div class="td cbi-section-table-cell"><%=gw.prefix%></div>
 			</div>
 
 			<% i = ((i % 2) + 1)

--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -855,6 +855,14 @@ function get_status_by_address(self, addr)
 					end
 				end
 			end
+			if s and s['ipv6-prefix-assignment'] then
+				local a
+				for _, a in ipairs(s['ipv6-prefix-assignment']) do
+					if a and a['local-address'] and a['local-address'].address == addr then
+						return net, s
+					end
+				end
+			end
 		end
 	end
 end


### PR DESCRIPTION
* On the configuration page for the plugins, the library version number is now dropped.  This conforms to the change in openwrt-routing/packages@f4bc87d
* The network.lua function get_status_by_address now checks to see if the ip address is listed by ubus as ipv6-prefix-assignment in addition to ipv6-address and ipv4-address.  The interface is now properly shown in the olsr neighbor status page for ipv6 interfaces (previouls it was "undefined").
* The olsr status pages now function with the latest version of the jsoninfo plugin.

19b640b53 luci-app-olsr: cbi remove library version numbers in library search results
4fc3ab473 luci-base: network.lua add ipv6-prefix-assignment support to get_status_by_address
6ef3a00f6 luci-app-olsr: convert olsr.lua and overview.htm to new json plugin
9e7557b60 luci-app-olsr: convert interfaces.htm to new json plugin
7fb197c luci-app-olsr: convert mid.htm to new json plugin
5fd51f0 luci-app-olsr: convert olsr.lua and smartgw.htm to new json plugin

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>
