### PR TITLE
luci-admin-status:Add kicking clients function

### DIFF
--- a/modules/luci-base/luasrc/view/wifi_assoclist.htm
+++ b/modules/luci-base/luasrc/view/wifi_assoclist.htm
@@ -58,7 +58,10 @@
 							E('span', wifirate(bss, true)),
 							E('br'),
 							E('span', wifirate(bss, false))
-						])
+						]),
+						'<input class="cbi-button cbi-input-remove" type="button" value="Kick" onclick="kick_client(\'%s\', \'%s\')" />'.format(
+							bss.ifname, 
+							bss.bssid)
 					]);
 				});
 
@@ -68,6 +71,13 @@
 	);
 //]]></script>
 
+<script type="text/javascript">//<![CDATA[
+	function kick_client(iface, mac) {
+		(new XHR()).post('<%=url('admin/status/overview/kick')%>/', {token: '<%=token%>', iface: iface, mac: mac}, function(x) {
+		});
+	}
+//]]></script>
+
 <div class="table" id="wifi_assoclist_table">
 	<div class="tr table-titles">
 		<div class="th nowrap"><%:Network%></div>
@@ -75,6 +85,7 @@
 		<div class="th nowrap"><%:Host%></div>
 		<div class="th nowrap"><%:Signal%> / <%:Noise%></div>
 		<div class="th nowrap"><%:RX Rate%> / <%:TX Rate%></div>
+		<div class="th nowrap">Kick</div>
 	</div>
 	<div class="tr placeholder">
 		<div class="td"><em><%:Collecting data...%></em></div>

--- a/modules/luci-base/luasrc/view/wifi_assoclist.htm
+++ b/modules/luci-base/luasrc/view/wifi_assoclist.htm
@@ -16,6 +16,13 @@
 
 		return s;
 	}
+	
+	function handleDisconnect(ev) {
+		var iface = ev.target.getAttribute('data-iface');
+		var bssid = ev.target.getAttribute('data-bssid');
+		(new XHR()).post('<%=url('admin/status/overview/disconnect')%>', {token: '<%=token%>', iface: iface, bssid: bssid}, function(x) {
+		});
+	}
 
 	XHR.poll(5, '<%=url('admin/wireless_assoclist')%>', null,
 		function(x, st)
@@ -59,9 +66,14 @@
 							E('br'),
 							E('span', wifirate(bss, false))
 						]),
-						'<input class="cbi-button cbi-input-remove" type="button" value="Kick" onclick="kick_client(\'%s\', \'%s\')" />'.format(
-							bss.ifname, 
-							bss.bssid)
+						E('input', {
+							type: 'button',
+							class: 'cbi-button cbi-button-remove',
+							value: '<%:Disconnect%>',
+							'data-bssid': bss.bssid,
+							'data-iface': bss.ifname,
+							click: handleDisconnect
+						})
 					]);
 				});
 
@@ -71,13 +83,6 @@
 	);
 //]]></script>
 
-<script type="text/javascript">//<![CDATA[
-	function kick_client(iface, mac) {
-		(new XHR()).post('<%=url('admin/status/overview/kick')%>/', {token: '<%=token%>', iface: iface, mac: mac}, function(x) {
-		});
-	}
-//]]></script>
-
 <div class="table" id="wifi_assoclist_table">
 	<div class="tr table-titles">
 		<div class="th nowrap"><%:Network%></div>
@@ -85,7 +90,7 @@
 		<div class="th nowrap"><%:Host%></div>
 		<div class="th nowrap"><%:Signal%> / <%:Noise%></div>
 		<div class="th nowrap"><%:RX Rate%> / <%:TX Rate%></div>
-		<div class="th nowrap">Kick</div>
+		<div class="th nowrap"><%:Disconnect%></div>
 	</div>
 	<div class="tr placeholder">
 		<div class="td"><em><%:Collecting data...%></em></div>

--- a/modules/luci-mod-status/luasrc/controller/admin/status.lua
+++ b/modules/luci-mod-status/luasrc/controller/admin/status.lua
@@ -6,6 +6,7 @@ module("luci.controller.admin.status", package.seeall)
 
 function index()
 	entry({"admin", "status", "overview"}, template("admin_status/index"), _("Overview"), 1)
+	entry({"admin", "status", "overview", "kick"}, post("act_kick")).leaf = true
 
 	entry({"admin", "status", "iptables"}, template("admin_status/iptables"), _("Firewall"), 2).leaf = true
 	entry({"admin", "status", "iptables_dump"}, call("dump_iptables")).leaf = true
@@ -182,4 +183,14 @@ function action_nameinfo(...)
 		timeout = 5000,
 		limit = 1000
 	}) or { })
+end
+
+function act_kick()
+	local iface = luci.http.formvalue("iface")
+	local mac = luci.http.formvalue("mac")
+	if iface and mac then
+		local cmd = string.format("ubus call hostapd.%s del_client \"{'addr':'%s', 'reason':5, 'deauth':true, 'ban_time':60000}\"", iface, mac)
+		luci.sys.call(cmd)
+	end
+	luci.http.status(200, "OK")
 end


### PR DESCRIPTION
As the title, there is a more convenient way to kick some WIFI clients out.
![image](https://user-images.githubusercontent.com/14970752/48331889-b453c980-e68c-11e8-9783-66262b56d8e8.png)
Using `ubus call hostapd.wlan1 del_client "{'addr':'AC:0D:1B:D0:60:29', 'reason':5, 'deauth':true, 'ban_time':60000}"`
Deafult ban time: 60s
DeAuth: true
Thanks for reading.
