### PR TITLE
luci-mod-system: add user defined interface to netdev trigger

### DIFF
--- a/modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua
+++ b/modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua
@@ -55,7 +55,7 @@ delayoff = s:option(Value, "delayoff", translate ("Off-State Delay"))
 delayoff:depends("trigger", "timer")
 
 
-dev = s:option(ListValue, "_net_dev", translate("Device"))
+dev = s:option(Value, "_net_dev", translate("Device"))
 dev.rmempty = true
 dev:value("")
 dev:depends("trigger", "netdev")


### PR DESCRIPTION
Give the user the possibility to define and interface for the netdev
trigger which is not available at the moment. This is usefull if a
interface is not presented on configuration time.