### PR TITLE
i18n: update Simplified Chinese translation for openwrt-18.06

### DIFF
--- a/applications/luci-app-firewall/po/zh-cn/firewall.po
+++ b/applications/luci-app-firewall/po/zh-cn/firewall.po
@@ -1,5 +1,5 @@
 #
-# Yangfl <mmyangfl@gmail.com>, 2017.
+# Yangfl <mmyangfl@gmail.com>, 2017, 2018.
 #
 msgid ""
 msgstr ""
@@ -8,7 +8,7 @@ msgstr ""
 "Language-Team:  <debian-l10n-chinese@lists.debian.org>\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"PO-Revision-Date: 2017-10-28 18:56+0800\n"
+"PO-Revision-Date: 2018-11-14 08:40+0800\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
 msgid "%s in %s"
@@ -45,7 +45,7 @@ msgid "Accept input"
 msgstr "接受入站"
 
 msgid "Accept output"
-msgstr ""
+msgstr "接受出站"
 
 msgid "Action"
 msgstr "动作"
@@ -104,7 +104,7 @@ msgid "Discard input"
 msgstr "丢弃入站"
 
 msgid "Discard output"
-msgstr ""
+msgstr "丢弃出站"
 
 msgid "Do not rewrite"
 msgstr "不重写"
@@ -116,7 +116,7 @@ msgid "Do not track input"
 msgstr "不跟踪入站"
 
 msgid "Do not track output"
-msgstr ""
+msgstr "不跟踪出站"
 
 msgid "Drop invalid packets"
 msgstr "丢弃无效数据包"
@@ -185,13 +185,13 @@ msgid "From %s in %s with source %s and %s"
 msgstr "来自 %s 位于 %s 源端口 %s 源 MAC %s"
 
 msgid "From %s on <var>this device</var>"
-msgstr ""
+msgstr "来自 %s 在<var>此设备</var>上"
 
 msgid "From %s on <var>this device</var> with source %s"
-msgstr ""
+msgstr "来自 %s 在<var>此设备</var>上源于 %s"
 
 msgid "From %s on <var>this device</var> with source %s and %s"
-msgstr ""
+msgstr "来自 %s 在<var>此设备</var>上源端口 %s 源 MAC %s"
 
 msgid "General Settings"
 msgstr "基本设置"
@@ -320,7 +320,7 @@ msgid "Output"
 msgstr "出站数据"
 
 msgid "Output zone"
-msgstr ""
+msgstr "出站区域"
 
 msgid "Passes additional arguments to iptables. Use with care!"
 msgstr "传递到 iptables 的额外参数。小心使用！"
@@ -351,7 +351,7 @@ msgid "Refuse input"
 msgstr "拒绝入站"
 
 msgid "Refuse output"
-msgstr ""
+msgstr "拒绝出站"
 
 msgid "Requires hardware NAT support. Implemented at least for mt7621"
 msgstr "需要硬件 NAT 支持。目前 mt7621 已实现"
@@ -525,13 +525,13 @@ msgid "Tuesday"
 msgstr "星期二"
 
 msgid "Unnamed SNAT"
-msgstr ""
+msgstr "未命名的 SNAT"
 
 msgid "Unnamed forward"
-msgstr ""
+msgstr "未命名的转发"
 
 msgid "Unnamed rule"
-msgstr ""
+msgstr "未命名的规则"
 
 msgid "Via %s"
 msgstr "通过 %s"
@@ -590,7 +590,7 @@ msgid "minute"
 msgstr "分钟"
 
 msgid "not"
-msgstr ""
+msgstr "非"
 
 msgid "port"
 msgstr "端口"

--- a/applications/luci-app-uhttpd/po/zh-cn/uhttpd.po
+++ b/applications/luci-app-uhttpd/po/zh-cn/uhttpd.po
@@ -1,0 +1,197 @@
+#
+# Zheng Qian <sotux82@gmail.com>, 2018.
+#
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Zheng Qian <sotux82@gmail.com>\n"
+"Language-Team: 汉语 <sotux82@gmail.com>\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"PO-Revision-Date: 2018-11-14 09:25+0800\n"
+"X-Generator: Gtranslator 2.91.7\n"
+
+msgid ""
+"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
+msgstr "（/old/path=/new/path）或 (仅把 /old/path 改为 /cgi-prefix/old/path）"
+
+msgid "404 Error"
+msgstr "404 错误"
+
+msgid "A lightweight single-threaded HTTP(S) server"
+msgstr "一个轻量级单线程 HTTP(S) 服务器"
+
+msgid "Advanced Settings"
+msgstr "高级设置"
+
+msgid "Aliases"
+msgstr "别名"
+
+msgid "Base directory for files to be served"
+msgstr "要提供文件服务的基本目录"
+
+msgid "Bind to specific interface:port (by specifying interface address"
+msgstr "绑定到指定 interface:port（通过指定接口地址"
+
+msgid "CGI filetype handler"
+msgstr "CGI 文件类型处理器"
+
+msgid "CGI is disabled if not present."
+msgstr "如果不存在，CGI 将被禁用。"
+
+msgid "Config file (e.g. for credentials for Basic Auth)"
+msgstr "配置文件（如：基本身份验证凭据）"
+
+msgid "Connection reuse"
+msgstr "连接重用"
+
+msgid "Country"
+msgstr "国家"
+
+msgid "Disable JSON-RPC authorization via ubus session API"
+msgstr "通过 ubus 会话 API 禁用 JSON-RPC 授权"
+
+msgid "Do not follow symlinks outside document root"
+msgstr "禁止跳转文档根目录外的符号链接"
+
+msgid "Do not generate directory listings."
+msgstr "禁止列出目录"
+
+msgid "Document root"
+msgstr "文档根目录"
+
+msgid "E.g specify with index.html and index.php when using PHP"
+msgstr "如：在使用 PHP 时指定 index.html 和 index.php"
+
+msgid "Embedded Lua interpreter is disabled if not present."
+msgstr "如果不存在，嵌入式 Lua 解释器将被禁用。"
+
+msgid "Enable JSON-RPC Cross-Origin Resource Support"
+msgstr "启用 JSON-RPC 跨源资源支持"
+
+msgid "For settings primarily geared to serving more than the web UI"
+msgstr "主要用于 Web UI 服务的设置"
+
+msgid "Full Web Server Settings"
+msgstr "完整的 Web 服务器设置"
+
+msgid "Full real path to handler for Lua scripts"
+msgstr "Lua 脚本处理程序的完整真实路径"
+
+msgid "General Settings"
+msgstr "基本设置"
+
+msgid "HTTP listeners (address:port)"
+msgstr "HTTP 监听器（address:port）"
+
+msgid "HTTPS Certificate (DER Encoded)"
+msgstr "HTTPS 证书（DER 编码）"
+
+msgid "HTTPS Private Key (DER Encoded)"
+msgstr "HTTPS 私钥（DER 编码）"
+
+msgid "HTTPS listener (address:port)"
+msgstr "HTTP 监听器（address:port）"
+
+msgid "Ignore private IPs on public interface"
+msgstr "忽略公共接口上的私有 IP"
+
+msgid "Index page(s)"
+msgstr "索引页面"
+
+msgid ""
+"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
+"usr/bin/php-cgi')"
+msgstr ""
+"与文件结尾相关联的解释器（'suffix=handler'，如：'.php=/usr/bin/php-cgi'）"
+
+msgid "Length of key in bits"
+msgstr "密钥长度"
+
+msgid "Location"
+msgstr "位置"
+
+msgid "Maximum number of connections"
+msgstr "最大连接数"
+
+msgid "Maximum number of script requests"
+msgstr "最大脚本请求数"
+
+msgid "Maximum wait time for Lua, CGI, or ubus execution"
+msgstr "Lua，CGI 或 ubus 执行的最长等待时间"
+
+msgid "Maximum wait time for network activity"
+msgstr "网络活动最长等待时间"
+
+msgid "Override path for ubus socket"
+msgstr "覆盖 ubus 套接字的路径"
+
+msgid "Path prefix for CGI scripts"
+msgstr "CGI 脚本路径前缀"
+
+msgid ""
+"Prevent access from private (RFC1918) IPs on an interface if it has an "
+"public IP address"
+msgstr "如果接口上具有公共 IP 地址，则阻止从接口上的私有 IP 访问（RFC1918）"
+
+msgid "Realm for Basic Auth"
+msgstr "基本身份验证领域"
+
+msgid "Redirect all HTTP to HTTPS"
+msgstr "将所有 HTTP 重定向到 HTTPS"
+
+msgid "Remove configuration for certificate and key"
+msgstr "删除证书和密钥的配置"
+
+msgid "Remove old certificate and key"
+msgstr "删除旧证书和密钥"
+
+msgid "Server Hostname"
+msgstr "服务器主机名"
+
+msgid ""
+"Settings which are either rarely needed or which affect serving the WebUI"
+msgstr "很少需要或影响 WebUI 服务的设置"
+
+msgid "State"
+msgstr "状态"
+
+msgid "TCP Keepalive"
+msgstr "TCP Keepalive"
+
+msgid "This permanently deletes the cert, key, and configuration to use same."
+msgstr "这将永久删除证书、密钥和配置。"
+
+msgid "Valid for # of Days"
+msgstr "适用于 # 的天数"
+
+msgid ""
+"Virtual URL or CGI script to display on status '404 Not Found'. Must begin "
+"with '/'"
+msgstr "要在“404 Not Found”状态时显示的虚拟 URL 或 CGI 脚本。必须以“/”开头"
+
+msgid "Virtual path prefix for Lua scripts"
+msgstr "Lua 脚本的虚拟路径前缀"
+
+msgid "Virtual path prefix for ubus via JSON-RPC integration"
+msgstr "通过 JSON-RPC 集成 ubus 虚拟路径前缀"
+
+msgid "Will not use HTTP authentication if not present"
+msgstr "如果不存在，将不使用 HTTP 身份验证"
+
+msgid "a.k.a CommonName"
+msgstr "a.k.a CommonName"
+
+msgid "uHTTPd"
+msgstr "uHTTPd"
+
+msgid "uHTTPd Self-signed Certificate Parameters"
+msgstr "uHTTPd 自签名证书参数"
+
+msgid ""
+"uHTTPd will generate a new self-signed certificate using the configuration "
+"shown below."
+msgstr "uHTTPd 将使用下面显示的配置生成新的自签名证书。"
+
+msgid "ubus integration is disabled if not present"
+msgstr "如果不存在，则禁用 ubus 集成"

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -1453,7 +1453,7 @@ msgid "IP Addresses"
 msgstr "IP 地址"
 
 msgid "IP Protocol"
-msgstr ""
+msgstr "IP 协议"
 
 msgid "IP address"
 msgstr "IP 地址"
@@ -1501,7 +1501,7 @@ msgid "IPv4 prefix length"
 msgstr "IPv4 地址前缀长度"
 
 msgid "IPv4+IPv6"
-msgstr ""
+msgstr "IPv4+IPv6"
 
 msgid "IPv4-Address"
 msgstr "IPv4 地址"
@@ -2041,10 +2041,10 @@ msgid "Model"
 msgstr "主机型号"
 
 msgid "Modem default"
-msgstr ""
+msgstr "调制解调器默认"
 
 msgid "Modem device"
-msgstr "调制解调器节点"
+msgstr "调制解调器设备"
 
 msgid "Modem information query failed"
 msgstr "调制解调器信息查询失败"


### PR DESCRIPTION
This PR contains three commits below:

i18n: luci-app-firewall: update Simplified Chinese translation 
i18n: luci-base: update Simplified Chinese translation
i18n: luci-app-uhttpd: add initial Simplified Chinese translation