### PR TITLE
luci-ssl-nginx: fix dependencies

### DIFF
--- a/collections/luci-ssl-nginx/Makefile
+++ b/collections/luci-ssl-nginx/Makefile
@@ -16,7 +16,7 @@ LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
 LUCI_DEPENDS:= \
 	+nginx-ssl +nginx-mod-luci-ssl +luci-mod-admin-full +luci-theme-bootstrap \
 	+luci-app-firewall +luci-proto-ppp +libiwinfo-lua +IPV6:luci-proto-ipv6 \
-	+rpcd-mod-rrdns +libustream-openssl +openssl-util
+	+rpcd-mod-rrdns +openssl-util
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
Remove libustream-openssl because Nginx doesn't depend on it.