### PR TITLE
luci-app-statistics: quote : in filenames for DEF

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
@@ -136,7 +136,7 @@ function Graph._generic( self, opts, plugin, plugin_instance, dtype, index )
 	function __def(source)
 
 		local inst = source.sname
-		local rrd  = source.rrd
+		local rrd  = source.rrd:gsub(":", "\\:")
 		local ds   = source.ds
 
 		if not ds or ds:len() == 0 then ds = "value" end


### PR DESCRIPTION
: is used to delimit fields in DEF: rrd instructions, so when it appears in a filename it [must be escaped using `\`](https://oss.oetiker.ch/rrdtool/doc/rrdgraph_data.en.html#IDEF).  This commit adds the escaping.

I discovered the issue after configuring collectd-mod-ping to monitor an IPv6 host (2001:19f0:5:727:5b56:205d:ff55:2208).  Accessing https://192.168.0.1/cgi-bin/luci/admin/statistics/graph/ping would cause the following messages to be logged:

    Wed Nov 14 23:04:33 2018 daemon.err uhttpd[30261]: ERROR: can't parse DEF '2ping_avg_raw=/tmp/rrd/openwrthost/ping/ping-2001:19f0:5:727:5b56:205d:ff55:2208.rrd:value:AVERAGE' -2
    Wed Nov 14 23:04:33 2018 daemon.err uhttpd[30261]: ERROR: can't parse DEF '2ping_droprate_avg_raw=/tmp/rrd/openwrthost/ping/ping_droprate-2001:19f0:5:727:5b56:205d:ff55:2208.rrd:value:AVERAGE' -2

and the graphs would not display.  After applying this commit, the graphs display correctly and no messages are logged.

Thanks for considering,
Kevin