### PR TITLE
https_dns_proxy.lua:Fix the datatype of "subnet address".

### DIFF
--- a/applications/luci-app-https_dns_proxy/luasrc/model/cbi/https_dns_proxy.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/model/cbi/https_dns_proxy.lua
@@ -43,7 +43,7 @@ lp.rmempty     = true
 -- group.rmempty = true
 
 sa = s3:option(Value, "subnet_addr", translate("Subnet address"))
-sa.datatype = "ip4prefix"
+sa.datatype = "ip4addr"
 sa.rmempty  = true
 
 ps = s3:option(Value, "proxy_server", translate("Proxy server"))


### PR DESCRIPTION
The datatype ip4prefix only accept numbers from 0 to 32,not subnet/mask(i.e. 192.168.1.0/24),this affects option "-e".
https://github.com/openwrt/luci/wiki/Datatypes#ip4prefix the discription is wrong,according to src
http://luci.subsignal.org/trac/browser/luci/branches/luci-0.10/libs/web/luasrc/cbi/datatypes.lua#L76