### PR TITLE
luci-app-setup-wizard: add new application

### DIFF
--- a/applications/luci-app-setup-wizard/Makefile
+++ b/applications/luci-app-setup-wizard/Makefile
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+# Copyright (C) 2018 Rosy Song <rosysong@rosinson.com>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Setup Wizard
+LUCI_DEPENDS:=+luci-base
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-setup-wizard/luasrc/controller/setup-wizard/setup-wizard.lua
+++ b/applications/luci-app-setup-wizard/luasrc/controller/setup-wizard/setup-wizard.lua
@@ -1,0 +1,15 @@
+-- Copyright 2018 Rosy Song <rosysong@rosinson.com>
+-- Licensed to the public under the Apache License 2.0.
+
+module("luci.controller.setup-wizard.setup-wizard", package.seeall)
+
+function index()
+	entry({"admin", "system", "setup-wizard"}, form("setup-wizard/setup-wizard"),
+		_("Setup Wizard"), 3)
+	entry({"admin", "system", "setup-wizard", "internet"}, form("setup-wizard/internet"),
+		_("Internet Access"), 10).leaf = true
+	entry({"admin", "system", "setup-wizard", "wireless"}, form("setup-wizard/wireless"),
+		_("WiFi Configuration"), 20).leaf = true
+	entry({"admin", "system", "setup-wizard", "complete"}, form("setup-wizard/complete"),
+		_("Completion"), 30).leaf = true
+end

--- a/applications/luci-app-setup-wizard/luasrc/model/cbi/setup-wizard/complete.lua
+++ b/applications/luci-app-setup-wizard/luasrc/model/cbi/setup-wizard/complete.lua
@@ -1,0 +1,30 @@
+-- Copyright 2018 Rosy Song <rosysong@rosinson.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local uci = require "luci.model.uci".cursor()
+--local fromurl = luci.http.formvalue("fromurl")
+local has_wan_changes = luci.http.formvalue("has_wan_changes")
+local has_wifi_changes = luci.http.formvalue("has_wifi_changes")
+
+m = SimpleForm("setup-wizard", translate("Setup Wizard - Completion"),
+	translate("Congratulation! Setup wizard is about to complete, click 'Complete' to apply your changes"))
+--m.back = translate("Back")
+--m.redirect = luci.dispatcher.build_url("admin/system/setup-wizard/" .. fromurl)
+m.submit = translate("Complete")
+m.reset = false
+
+function m.handle(self, state, data)
+	if state == FORM_VALID then
+		if uci:changes() then
+			uci:save("network")
+			uci:save("wireless")
+			uci:commit("network")
+			uci:commit("wireless")
+			luci.util.exec("/etc/init.d/network restart")
+		end
+		luci.http.redirect(luci.dispatcher.build_url("admin/status/overview"))
+	end
+	return true
+end
+
+return m

--- a/applications/luci-app-setup-wizard/luasrc/model/cbi/setup-wizard/internet.lua
+++ b/applications/luci-app-setup-wizard/luasrc/model/cbi/setup-wizard/internet.lua
@@ -1,0 +1,61 @@
+-- Copyright 2018 Rosy Song <rosysong@rosinson.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local fs = require "nixio.fs"
+local uci = require "luci.model.uci".cursor()
+local has_wifi =  ((fs.stat("/etc/config/wireless", "size") or 0) > 0)
+local nurl = "complete"
+
+if has_wifi then nurl = "wireless" end
+
+m = SimpleForm("internet", translate("Setup Wizard - Internet Access"))
+m.submit = translate("Next")
+
+-- m.back = translate("Back")
+-- m.redirect = luci.dispatcher.build_url("admin/system/setup-wizard")
+
+m.reset = false
+m.flow = { skip = true }
+
+o = m:field(ListValue, "proto", translate("Protocol"))
+o.default = "pppoe"
+o:value("pppoe", "PPPoE")
+o:value("dhcp", "DHCP client")
+
+username = m:field(Value, "username", translate("PAP/CHAP username"))
+username:depends("proto", "pppoe")
+
+password = m:field(Value, "password", translate("PAP/CHAP password"))
+password.password = true
+password:depends("proto", "pppoe")
+
+dc = m:field(DummyValue, "dhcp", translate("Tips"))
+dc.default = translate("Enterprises and Organizations often use this approach")
+dc:depends("proto", "dhcp")
+
+function m.handle(self, state, data)
+	return true
+end
+
+function m.parse(sf)
+	local state = SimpleForm.parse(sf)
+	if state == FORM_SKIP then
+		luci.http.redirect(luci.dispatcher.build_url("admin/system/setup-wizard/" .. nurl) .. "?fromurl=internet")
+	else
+		local p = luci.http.formvalue("cbid.internet.1.proto")
+		local u = luci.http.formvalue("cbid.internet.1.username")
+		local k = luci.http.formvalue("cbid.internet.1.password")
+		if p then
+			if u and k and #u > 0 and #k > 0 then
+				uci:set("network", "wan", "proto", "pppoe")
+				uci:set("network", "wan", "username", u)
+				uci:set("network", "wan", "password", k)
+			else
+				uci:set("network", "wan", "proto", "dhcp")
+			end
+			luci.http.redirect(luci.dispatcher.build_url("admin/system/setup-wizard/" .. nurl) .. "?has_wan_changes=1&fromurl=internet")
+		end
+	end
+end
+
+return m

--- a/applications/luci-app-setup-wizard/luasrc/model/cbi/setup-wizard/setup-wizard.lua
+++ b/applications/luci-app-setup-wizard/luasrc/model/cbi/setup-wizard/setup-wizard.lua
@@ -1,0 +1,34 @@
+-- Copyright 2018 Rosy Song <rosysong@rosinson.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local fs = require "nixio.fs"
+local ntm = require "luci.model.network".init()
+local has_wifi =  ((fs.stat("/etc/config/wireless", "size") or 0) > 0)
+local has_wan = false
+local nurl = "complete"
+
+for _, net in ipairs(ntm:get_networks()) do
+	if net:name() == "wan" or net:name() == "wan6" then
+		has_wan = true
+		nurl = "internet"
+		break
+	end
+end
+
+if not has_wan and has_wifi then
+	nurl = "wireless"
+end
+
+m = SimpleForm("setup-wizard", translate("Setup Wizard - Start"),
+	translate("Setting parameters has never been so easy as it is now, this setup wizard will guide you set the basic parameters related to the network, click 'Next' to start it. If you want to set a specific function or parameter in detail, click the relevant column on the navigation bar."))
+m.submit = translate("Next")
+m.reset = false
+
+function m.handle(self, state, data)
+	if state == FORM_VALID then
+		luci.http.redirect(luci.dispatcher.build_url("admin/system/setup-wizard/" .. nurl) .. "?fromurl=setup-wizard")
+	end
+	return true
+end
+
+return m

--- a/applications/luci-app-setup-wizard/luasrc/model/cbi/setup-wizard/wireless.lua
+++ b/applications/luci-app-setup-wizard/luasrc/model/cbi/setup-wizard/wireless.lua
@@ -1,0 +1,76 @@
+-- Copyright 2018 Rosy Song <rosysong@rosinson.com>
+-- Licensed to the public under the Apache License 2.0.
+
+local uci = require "luci.model.uci".cursor()
+local ntm = require "luci.model.network".init()
+--local fromurl = luci.http.formvalue("fromurl")
+local has_wan_changes = luci.http.formvalue("has_wan_changes") or "0"
+
+m = SimpleForm("wireless", translate("Setup Wizard - WiFi"))
+--m.back = translate("Back")
+--m.redirect = luci.dispatcher.build_url("admin/system/setup-wizard/" .. fromurl)
+m.submit = translate("Next")
+m.reset = false
+m.flow = { skip = true }
+
+iface = m:field(ListValue, "iface", translate("WiFi Interface"))
+uci.cursor():foreach("wireless", "wifi-device",
+	function (section)
+			local hwmode = uci:get("wireless", section[".name"], "hwmode")
+			if hwmode == "11g" then
+				iface:value(section[".name"], "WiFi - 2.4G")
+			else
+				iface:value(section[".name"], "WiFi - 5G")
+			end
+	end
+)
+iface.titleref = luci.dispatcher.build_url("admin", "network", "wireless")
+
+ssid = m:field(Value, "ssid",
+	translate("WiFi <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"))
+ssid.default = "OpenWrt"
+ssid.datatype = "maxlength(32)"
+
+encr = m:field(ListValue, "encryption", translate("Encryption"))
+encr:value("none", "No Encryption")
+encr:value("psk-mixed", "Has Encryption")
+
+key = m:field(Value, "key", translate("Key"))
+key:depends("encryption", "psk-mixed")
+key.password = true
+key.datatype = "wpakey"
+
+function m.handle(self, state, data)
+	return true
+end
+
+function m.parse(sf)
+	local state = SimpleForm.parse(sf)
+	local r = luci.http.formvalue("cbid.wireless.1.iface")
+	local s = luci.http.formvalue("cbid.wireless.1.ssid")
+	local e = luci.http.formvalue("cbid.wireless.1.encr")
+	local k = luci.http.formvalue("cbid.wireless.1.key")
+	local args = nil
+
+	if state == FORM_SKIP then
+		args = string.format("?has_wan_changes=%s,has_wifi_changes=0&fromurl=wireless", has_wan_changes)
+		luci.http.redirect(luci.dispatcher.build_url("admin/system/setup-wizard/complete") .. args)
+	end
+
+	if r then
+		if s and #s > 0 then
+			uci:set("wireless", radio, "ssid", s)
+			if e and #e > 0 then uci:set("wireless", "default_" .. r, "encryption", e) end
+			if k and #k > 0 then uci:set("wireless", "default_" .. r, "key", k) end
+			uci:set("wireless", "default_" .. r, "disabled", 0)
+			uci:set("wireless", r, "disabled", 0)
+			args = string.format("?has_wan_changes=%s,has_wifi_changes=1&fromurl=wireless", has_wan_changes)
+			luci.http.redirect(luci.dispatcher.build_url("admin/system/setup-wizard/complete") .. args)
+		else
+			args = string.format("?has_wan_changes=%s,has_wifi_changes=0&fromurl=wireless", has_wan_changes)
+			luci.http.redirect(luci.dispatcher.build_url("admin/system/setup-wizard/complete") .. args)
+		end
+	end
+end
+
+return m


### PR DESCRIPTION
This application is design for the users who are new to OpenWrt or the people want to use OpenWrt but do not have professional background.

Setting parameters of OpenWrt devices has never been so easy as it is now, this app can guide users to initialize their device within 2 steps, including Internet Access, WiFi. That's most family users need (gain pppoe account from isp and use it connect to internet).

## Notes
![notes](https://user-images.githubusercontent.com/37688994/48604916-42de8880-e9b6-11e8-9009-57c45d5af4c6.png)

## Internet Access
![internet](https://user-images.githubusercontent.com/37688994/48604924-470aa600-e9b6-11e8-9565-1daa9b29e331.png)

## WiFi
![wifi](https://user-images.githubusercontent.com/37688994/48604937-4f62e100-e9b6-11e8-99b6-fd045a5ac58f.png)

## Done
![done](https://user-images.githubusercontent.com/37688994/48604948-538efe80-e9b6-11e8-8355-877dc42b004e.png)



Enjoy it!!!

Signed-off-by: Rosy Song <rosysong@rosinson.com>