### PR TITLE
luci-app-lxc: add i686 to target map

### DIFF
--- a/applications/luci-app-lxc/luasrc/controller/lxc.lua
+++ b/applications/luci-app-lxc/luasrc/controller/lxc.lua
@@ -152,6 +152,7 @@ function lxc_get_arch_target(url)
 			armv6  = "armel",
 			armv7  = "armhf",
 			armv8  = "arm64",
+			i686   = "i386",
 			x86_64 = "amd64"
 		}
 		local k, v


### PR DESCRIPTION
Add i686 to target map so i386 container templates are usable.