### PR TITLE
luci-app-openvpn: more changes & fixes

### DIFF
--- a/applications/luci-app-openvpn/luasrc/controller/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/controller/openvpn.lua
@@ -18,7 +18,7 @@ function ovpn_upload()
 	local util   = require("luci.util")
 	local uci    = require("luci.model.uci").cursor()
 	local upload = http.formvalue("ovpn_file")
-	local name   = string.gsub(util.shellquote(http.formvalue("instance_name2")), "'", "")
+	local name   = http.formvalue("instance_name2")
 	local file   = "/etc/openvpn/" ..name.. ".ovpn"
 
 	if name and upload then

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
@@ -14,8 +14,8 @@ s.template_addremove = "openvpn/cbi-select-input-add"
 s.addremove = true
 s.add_select_options = { }
 
-file_cfg = s:option(DummyValue, "config")
-function file_cfg.cfgvalue(self, section)
+local cfg = s:option(DummyValue, "config")
+function cfg.cfgvalue(self, section)
 	local file_cfg = self.map:get(section, "config")
 	if file_cfg then
 		s.extedit = luci.dispatcher.build_url("admin", "services", "openvpn", "file", "%s")
@@ -73,7 +73,9 @@ function s.create(self, name)
 				end
 			end
 			uci:save("openvpn")
-			luci.http.redirect( self.extedit:format(name) )
+			if extedit then
+				luci.http.redirect( self.extedit:format(name) )
+			end
 		end
 	elseif #name > 0 then
 		self.invalid_cts = true


### PR DESCRIPTION
* fix possible exception in template based ovpn creation
* remove needless shellquote function in controller,
  the filename will be checked on client side with JS
* enhance FileUpload behaviour in basic/advanced mode:
  - change "auth_user_pass" to FileUpload
  - cfg entries (even with default values) will be shown
  - existing entries are now removable (incl. file unlink),
    simply clear the appropriate textbox
* change "key_direction" option to boolean ListValue
* add "config" option to basic/advanced edit, to make it possible to change the upload path in LuCI

Signed-off-by: Dirk Brenken <dev@brenken.org>