### PR TITLE
luci-app-aria2: add button for to AriaNg

### DIFF
--- a/applications/luci-app-aria2/luasrc/controller/aria2.lua
+++ b/applications/luci-app-aria2/luasrc/controller/aria2.lua
@@ -34,7 +34,8 @@ function status()
 	local status = {
 		running = (sys.call("pidof aria2c > /dev/null") == 0),
 		yaaw = ipkg.installed("yaaw"),
-		webui = ipkg.installed("webui-aria2")
+		webui = ipkg.installed("webui-aria2"),
+		ariang = (ipkg.installed("ariang") or ipkg.installed("ariang-nginx"))
 	}
 
 	http.prepare_content("application/json")

--- a/applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm
+++ b/applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm
@@ -11,6 +11,9 @@ XHR.poll(5, '<%=luci.dispatcher.build_url("admin/services/aria2/status")%>', nul
 				if (data.webui) {
 					links += '<input class="cbi-button mar-10" type="button" value="<%:Open WebUI-Aria2%>" onclick="openWebUI(\'webui-aria2\');" />';
 				}
+				if (data.ariang) {
+					links += '<input class="cbi-button mar-10" type="button" value="<%:Open AriaNg%>" onclick="openWebUI(\'ariang\');" />';
+				}
 				tb.innerHTML = links;
 			} else {
 				tb.innerHTML = '<em><%:The Aria2 service is not running.%></em>';

--- a/applications/luci-app-aria2/po/pt-br/aria2.po
+++ b/applications/luci-app-aria2/po/pt-br/aria2.po
@@ -41,7 +41,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Configurações do Aria2"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:74
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
 msgid "Aria2 Status"
 msgstr "Estado do Aria2"
 
@@ -65,7 +65,7 @@ msgstr "Configurações do BitTorrent"
 msgid "BitTorrent listen port"
 msgstr "Porta de escuta do BitTorrent"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:76
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
 msgid "Collecting data..."
 msgstr "Coletando dados..."
 
@@ -174,6 +174,10 @@ msgstr "Aviso"
 msgid "Off"
 msgstr "Desligado"
 
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:15
+msgid "Open AriaNg"
+msgstr ""
+
 #: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:12
 msgid "Open WebUI-Aria2"
 msgstr "Abrir WebUI-Aria2"
@@ -260,7 +264,7 @@ msgstr "Segurança"
 msgid "Task Settings"
 msgstr "Configurações das tarefas"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:16
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:19
 msgid "The Aria2 service is not running."
 msgstr "O serviço Aria2 está parado."
 

--- a/applications/luci-app-aria2/po/ru/aria2.po
+++ b/applications/luci-app-aria2/po/ru/aria2.po
@@ -40,7 +40,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Настройка Aria2"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:74
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
 msgid "Aria2 Status"
 msgstr "Состояние Aria2"
 
@@ -64,7 +64,7 @@ msgstr "Настройки BitTorrent-а"
 msgid "BitTorrent listen port"
 msgstr "Порты BitTorrent-а"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:76
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
 msgid "Collecting data..."
 msgstr "Сбор данных..."
 
@@ -172,6 +172,10 @@ msgstr "Заметка"
 msgid "Off"
 msgstr "Выключено"
 
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:15
+msgid "Open AriaNg"
+msgstr ""
+
 #: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:12
 msgid "Open WebUI-Aria2"
 msgstr "Открыть WebUI-Aria2"
@@ -248,7 +252,7 @@ msgstr "Секунды"
 msgid "Task Settings"
 msgstr "Настройки задач"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:16
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:19
 msgid "The Aria2 service is not running."
 msgstr "Aria2 сервис не запущен."
 

--- a/applications/luci-app-aria2/po/sv/aria2.po
+++ b/applications/luci-app-aria2/po/sv/aria2.po
@@ -26,7 +26,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Inställningar för Aria2"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:74
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
 msgid "Aria2 Status"
 msgstr "Status för Aria2"
 
@@ -48,7 +48,7 @@ msgstr "Inställningar för BitTorrent"
 msgid "BitTorrent listen port"
 msgstr "Lyssningsport för BitTorrent"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:76
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
 msgid "Collecting data..."
 msgstr "Samlar in data..."
 
@@ -156,6 +156,10 @@ msgstr "Avisering"
 msgid "Off"
 msgstr "Av"
 
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:15
+msgid "Open AriaNg"
+msgstr ""
+
 #: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:12
 msgid "Open WebUI-Aria2"
 msgstr "Öppna WebUI-Aria2"
@@ -232,7 +236,7 @@ msgstr "Sek"
 msgid "Task Settings"
 msgstr "Inställningar för uppgifter"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:16
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:19
 msgid "The Aria2 service is not running."
 msgstr "Aria2-tjänsten körs inte."
 

--- a/applications/luci-app-aria2/po/templates/aria2.pot
+++ b/applications/luci-app-aria2/po/templates/aria2.pot
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Aria2 Settings"
 msgstr ""
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:74
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
 msgid "Aria2 Status"
 msgstr ""
 
@@ -48,7 +48,7 @@ msgstr ""
 msgid "BitTorrent listen port"
 msgstr ""
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:76
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
 msgid "Collecting data..."
 msgstr ""
 
@@ -156,6 +156,10 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:15
+msgid "Open AriaNg"
+msgstr ""
+
 #: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:12
 msgid "Open WebUI-Aria2"
 msgstr ""
@@ -232,7 +236,7 @@ msgstr ""
 msgid "Task Settings"
 msgstr ""
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:16
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:19
 msgid "The Aria2 service is not running."
 msgstr ""
 

--- a/applications/luci-app-aria2/po/zh-cn/aria2.po
+++ b/applications/luci-app-aria2/po/zh-cn/aria2.po
@@ -36,7 +36,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Aria2 配置"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:74
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
 msgid "Aria2 Status"
 msgstr "Aria2 状态"
 
@@ -58,7 +58,7 @@ msgstr "BitTorrent 设置"
 msgid "BitTorrent listen port"
 msgstr "BitTorrent 监听端口"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:76
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
 msgid "Collecting data..."
 msgstr "正在收集数据..."
 
@@ -166,6 +166,10 @@ msgstr "注意"
 msgid "Off"
 msgstr "关闭"
 
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:15
+msgid "Open AriaNg"
+msgstr "打开 AriaNg"
+
 #: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:12
 msgid "Open WebUI-Aria2"
 msgstr "打开 WebUI-Aria2"
@@ -242,7 +246,7 @@ msgstr "秒"
 msgid "Task Settings"
 msgstr "任务设置"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:16
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:19
 msgid "The Aria2 service is not running."
 msgstr "Aria2 未运行"
 

--- a/applications/luci-app-aria2/po/zh-tw/aria2.po
+++ b/applications/luci-app-aria2/po/zh-tw/aria2.po
@@ -36,7 +36,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Aria2 配置"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:74
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
 msgid "Aria2 Status"
 msgstr "Aria2 狀態"
 
@@ -58,7 +58,7 @@ msgstr "BitTorrent 設定"
 msgid "BitTorrent listen port"
 msgstr "BitTorrent 監聽埠"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:76
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
 msgid "Collecting data..."
 msgstr "正在收集資料..."
 
@@ -166,6 +166,10 @@ msgstr "注意"
 msgid "Off"
 msgstr "關閉"
 
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:15
+msgid "Open AriaNg"
+msgstr "開啟 AriaNg"
+
 #: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:12
 msgid "Open WebUI-Aria2"
 msgstr "開啟 WebUI-Aria2"
@@ -242,7 +246,7 @@ msgstr "秒"
 msgid "Task Settings"
 msgstr "任務設定"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:16
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:19
 msgid "The Aria2 service is not running."
 msgstr "Aria2 未執行"
 


### PR DESCRIPTION
As AriaNg is another web UI for aria2, I add a button to open AriaNg if installed package ariang or ariang-nginx