### PR TITLE
luci-mod-network: fix invalid translate() argument pass

### DIFF
--- a/modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm
+++ b/modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm
@@ -4,7 +4,7 @@
 			for i, net in ipairs(self.netlist) do
 				local z = net[3]
 				local c = z and z:get_color() or "#EEEEEE"
-				local t = z and translate("Part of zone %q" % z:name()) or translate("No zone assigned")
+				local t = z and translate("Part of zone %q") % z:name() or translate("No zone assigned")
 				local disabled = (net[4]:get("auto") == "0")
 				local dynamic = net[4]:is_dynamic()
 		%>


### PR DESCRIPTION
We must pass to the translate() a string without substituted zone name.

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>