### PR TITLE
luci-theme-material: add missing css cbi-section-error definitions

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -853,6 +853,29 @@ td > table > tbody > tr > td,
     line-height: 1.25;
 }
 
+.cbi-input-invalid,
+.cbi-value-error input {
+    color: #f00;
+    border-color: #f00;
+}
+
+.cbi-section-error {
+    border: 1px solid #f00;
+    border-radius: 3px;
+    background-color: #fce6e6;
+    padding: 5px;
+    margin: 18px;
+}
+
+.cbi-section-error ul {
+    margin: 0 0 0 20px;
+}
+
+.cbi-section-error ul li {
+    color: #f00;
+    font-weight: bold;
+}
+
 .cbi-value-helpicon > img {
     display: none;
 }


### PR DESCRIPTION
Add the missing error css class definitions.
Highlights the wrong inputs detected by the cbi validation function.