### PR TITLE
luci-app-openvpn: "final" changeset

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -158,10 +158,6 @@ local knownParams = {
 			"script_security",
 			{ 0, 1, 2, 3 },
 			translate("Policy level over usage of external programs and scripts") },
-		{ Value,
-			"config",
-			"/etc/openvpn/ovpn-file.ovpn",
-			translate("Local OVPN configuration file") },
 	} },
 
 	{ "Networking", {

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua
@@ -87,10 +87,6 @@ local basicParams = {
 		"key",
 		"/etc/easy-rsa/keys/some-client.key",
 		translate("Local private key") },
-	{ Value,
-		"config",
-		"/etc/openvpn/ovpn-file.ovpn",
-		translate("Local OVPN configuration file") },
 }
 
 

--- a/applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm
+++ b/applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm
@@ -3,7 +3,7 @@
 //<![CDATA[
 	function vpn_add()
 	{
-		var vpn_name     = div_add.querySelector("#instance_name1").value.replace(/[^\x00-\x7F]|[\s!@#$%^&*()+=\[\]{};':"\\|,<>\/?]/g,'');
+		var vpn_name     = div_add.querySelector("#instance_name1").value.replace(/[^\x00-\x7F]|[\s!@#$%^&*()\-+=\[\]{};':"\\|,<>\/?]/g,'');
 		var vpn_template = div_add.querySelector("#instance_template").value;
 		var form         = document.getElementsByName('cbi')[0];
 
@@ -31,7 +31,7 @@
 
 	function vpn_upload()
 	{
-		var vpn_name = div_upload.querySelector("#instance_name2").value.replace(/[^\x00-\x7F]|[\s!@#$%^&*()+=\[\]{};':"\\|,<>\/?]/g,'');
+		var vpn_name = div_upload.querySelector("#instance_name2").value.replace(/[^\x00-\x7F]|[\s!@#$%^&*()\-+=\[\]{};':"\\|,<>\/?]/g,'');
 		var vpn_file = document.getElementById("ovpn_file").value;
 		var form     = document.getElementsByName('cbi')[0];
 
@@ -77,10 +77,10 @@
 	<div class="table cbi-section-table">
 		<h4><%:Template based configuration%></h4>
 		<div class="tr cbi-section-table-row" id="div_add">
-			<div class="td">
+			<div class="td left">
 				<input type="text" maxlength="20" placeholder="Instance name" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.text" id="instance_name1" />
 			</div>
-			<div class="td">
+			<div class="td left">
 				<select id="instance_template" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.select">
 					<option value="" selected="selected" disabled="disabled"><%:Select template ...%></option>
 					<%- for k, v in luci.util.kspairs(self.add_select_options) do %>
@@ -88,19 +88,19 @@
 					<% end -%>
 				</select>
 			</div>
-			<div class="td">
+			<div class="td left">
 				<input class="cbi-button cbi-button-add" type="submit" onclick="vpn_add(); return false;" value="<%:Add%>" title="<%:Add template based configuration%>" /><br />
 			</div>
 		</div>
 		<h4><%:OVPN configuration file upload%></h4>
 		<div class="tr cbi-section-table-row" id="div_upload">
-			<div class="td">
+			<div class="td left">
 				<input type="text" maxlength="20" placeholder="Instance name" name="instance_name2" id="instance_name2" />
 			</div>
-			<div class="td">
+			<div class="td left">
 				<input type="file" name="ovpn_file" id="ovpn_file" accept="application/x-openvpn-profile,.ovpn" />
 			</div>
-			<div class="td">
+			<div class="td left">
 				<input class="cbi-button cbi-button-add" type="submit" onclick="vpn_upload(); return false;" value="<%:Upload%>" title="<%:Upload ovpn file%>" />
 			</div>
 		</div>

--- a/applications/luci-app-openvpn/luasrc/view/openvpn/ovpn_css.htm
+++ b/applications/luci-app-openvpn/luasrc/view/openvpn/ovpn_css.htm
@@ -10,12 +10,6 @@
 		border: 0px;
 		text-align: left;
 	}
-	.td
-	{
-		text-align: left;
-		border-top: 0px;
-		margin: 5px;
-	}
 	.vpn-output
 	{
 		box-shadow: none;

--- a/applications/luci-app-openvpn/luasrc/view/openvpn/pageswitch.htm
+++ b/applications/luci-app-openvpn/luasrc/view/openvpn/pageswitch.htm
@@ -11,17 +11,11 @@
 		<a href="<%=url('admin/services/openvpn')%>"><%:Overview%></a> &#187;
 		<%=luci.i18n.translatef("Instance \"%s\"", self.instance)%>
 	</h3>
-	<% if self.mode == "file" then %>
-		<a href="<%=url('admin/services/openvpn/basic', self.instance)%>"><%:Switch to basic configuration%> &#187;</a><p/>
-		<a href="<%=url('admin/services/openvpn/advanced', self.instance, "Service")%>"><%:Switch to advanced configuration%> &#187;</a>
-		<hr />
-	<% elseif self.mode == "basic" then %>
+	<% if self.mode == "basic" then %>
 		<a href="<%=url('admin/services/openvpn/advanced', self.instance, "Service")%>"><%:Switch to advanced configuration%> &#187;</a><p/>
-		<a href="<%=url('admin/services/openvpn/file', self.instance)%>"><%:Switch to file based configuration%> &#187;</a>
 		<hr />
 	<% elseif self.mode == "advanced" then %>
 		<a href="<%=url('admin/services/openvpn/basic', self.instance)%>"><%:Switch to basic configuration%> &#187;</a><p/>
-		<a href="<%=url('admin/services/openvpn/file', self.instance)%>"><%:Switch to file based configuration%> &#187;</a>
 		<hr />
 		<%:Configuration category%>:
 		<% for i, c in ipairs(self.categories) do %>


### PR DESCRIPTION
* add 'auth-user-pass' edit section in file mode (see screenshot)
* add port & protocol detection in file mode (see screenshot)
* don't mix file & normal edit modes any longer
* add CC compatibility fix (for turris devices)
* fix/refine JS instance name filter
* remove needless CSS rules
* unlink ovpn/auth files on section removal
* commit changes instantly (Add/Upload/Delete)

Signed-off-by: Dirk Brenken <dev@brenken.org>