### PR TITLE
luci-theme-bootstrap: fix tabs rendering

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1020,6 +1020,7 @@ header .dropdown-menu a.hover,
 	padding: 0 2px;
 	list-style: none;
 	display: flex;
+	flex-wrap: wrap;
 	background: linear-gradient(#ddd 0%, #ddd 100%) repeat-x;
 	background-size: 1px 1px;
 	background-position: left bottom;


### PR DESCRIPTION
If we have a lot of tabs that do not fit in width, we must wrap
tabs to next line.

Before:  
![image](https://user-images.githubusercontent.com/13316680/49045163-27a72080-f1e1-11e8-9871-fecdc2361cff.png)

After:  
![image](https://user-images.githubusercontent.com/13316680/49045169-2c6bd480-f1e1-11e8-9f09-3731da578987.png)