### PR TITLE
luci-lib-httpclient: Comply with RFC 2616 standard for Host header

### DIFF
--- a/libs/luci-lib-httpclient/luasrc/httpclient.lua
+++ b/libs/luci-lib-httpclient/luasrc/httpclient.lua
@@ -102,7 +102,9 @@ function request_raw(uri, options)
 		uri = uri .. '?' .. http.urlencode_params(options.params)
 	end
 
+	local ipv6_enabled = false
 	if uri:find("%[") then
+		ipv6_enabled = true
 		if uri:find("@") then
 			pr, auth, host, port, path = uri:match("(%w+)://(.+)@(%b[]):?([0-9]*)(.*)")
 			host = host:sub(2,-2)
@@ -162,7 +164,12 @@ function request_raw(uri, options)
 
 	-- Pre assemble fixes	
 	if protocol == "HTTP/1.1" then
-		headers.Host = headers.Host or host
+		if ipv6_enabled then
+			local ipv6_host = host:gmatch("[%w\\:]+")()
+			headers.Host = headers.Host or "[" .. ipv6_host .. "]:" .. port
+		else
+			headers.Host = headers.Host or host .. ':' .. port
+		end
 	end
 	
 	if type(options.body) == "table" then


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: ar71xx, GL-iNet AR750, OpenWrt master
Run tested: ar71xx, GL-iNet AR750, OpenWrt master

Description: According to the [RFC standard](https://tools.ietf.org/html/rfc2616#section-14.23) a Host header should always contain the host and the port. Also an IPv6 address could specify an interface (like %eth0). This commit adds the missing port to the Host header and ensures that IPv6 addresses are stripped of their interface before turned into a Host header.

Signed-off-by: hwinwuzhere <hwinwuzhere@hotmail.com>