### PR TITLE
luci-theme-material: partial style overhaul

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -428,13 +428,16 @@ header > .fill > .container {
 	user-select: none;
 }
 
-header > .fill > .container > img {
-	width: calc(0% + 10rem);
-	margin: -.1rem 3.5rem 0 1.5rem;
-	pointer-events: none;
+header > .fill > .container > #logo {
+	margin: 0 3.5rem 0 1.5rem;
 }
 
-body:not(.logged-in) > header > .fill > .container > img {
+header > .fill > .container > #logo > img {
+	width: calc(0% + 10rem);
+	margin-top: -.1rem;
+}
+
+body:not(.logged-in) > header > .fill > .container > #logo {
 	display: none;
 }
 
@@ -2373,7 +2376,7 @@ input[name="nslookup"] {
 
 [data-page^="admin-system-commands"] .panel-title,
 [data-page^="command-cfg"] .mobile-hide,
-[data-page^="command-cfg"] header > .fill > .container > img {
+[data-page^="command-cfg"] header > .fill > .container > #logo {
 	display: none;
 }
 
@@ -2395,8 +2398,8 @@ input[name="nslookup"] {
 }
 
 @media screen and (max-width: 1600px) {
-	header > .fill > .container > img {
-		margin: -.1rem 2.5rem 0 .5rem;
+	header > .fill > .container > #logo {
+		margin: 0 2.5rem 0 .5rem;
 	}
 
 	.main-left {
@@ -2522,7 +2525,7 @@ input[name="nslookup"] {
 }
 
 @media screen and (max-width: 1152px) {
-	header > .fill > .container > img {
+	header > .fill > .container > #logo {
 		display: none;
 	}
 

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1,653 +1,896 @@
 /**
- *  Material is a clean HTML5 theme for LuCI. It is based on luci-theme-bootstrap and MUI
+ *	Material is a clean HTML5 theme for LuCI. It is based on luci-theme-bootstrap and MUI
  *
- *  luci-theme-material
- *      Copyright 2015 Lutty Yang <lutty@wcan.in>
+ *	luci-theme-material
+ *		Copyright 2015 Lutty Yang <lutty@wcan.in>
  *
- *  Have a bug? Please create an issue here on GitHub!
- *      https://github.com/LuttyYang/luci-theme-material/issues
+ *	Have a bug? Please create an issue here on GitHub!
+ *		https://github.com/LuttyYang/luci-theme-material/issues
  *
- *  luci-theme-bootstrap:
- *      Copyright 2008 Steven Barth <steven@midlink.org>
- *      Copyright 2008 Jo-Philipp Wich <jow@openwrt.org>
- *      Copyright 2012 David Menting <david@nut-bolt.nl>
+ *	luci-theme-bootstrap:
+ *		Copyright 2008 Steven Barth <steven@midlink.org>
+ *		Copyright 2008 Jo-Philipp Wich <jow@openwrt.org>
+ *		Copyright 2012 David Menting <david@nut-bolt.nl>
  *
- *  MUI:
- *      https://github.com/muicss/mui
+ *	MUI:
+ *		https://github.com/muicss/mui
  *
- *  Licensed to the public under the Apache License 2.0
+ *	Pure CSS ripple effect:
+ *		https://github.com/mladenplavsic/css-ripple-effect
+ *
+ *	Licensed to the public under the Apache License 2.0
  */
 
 /*
- *  Include custom css
+ *	Include custom css
  */
 @import url("custom.css");
 
 /*
- *  Font generate by Icomoon<icomoon.io>
+ *	Font generate by Icomoon<icomoon.io>
  */
 @font-face {
-    font-family: 'icomoon';
-    src: url('fonts/font.eot');
-    src: url('fonts/font.eot') format('embedded-opentype'),
-    url('fonts/font.ttf') format('truetype'),
-    url('fonts/font.woff') format('woff'),
-    url('fonts/font.svg') format('svg');
-    font-weight: normal;
-    font-style: normal;
+	font-family: "icomoon";
+	font-weight: normal;
+	font-style: normal;
+	src: url("fonts/font.eot");
+	src: url("fonts/font.eot") format("embedded-opentype"),
+	url("fonts/font.ttf") format("truetype"),
+	url("fonts/font.woff") format("woff"),
+	url("fonts/font.svg") format("svg");
 }
 
-.table { display: table; position: relative; }
-.tr    { display: table-row; }
-.thead { display: table-header-group; }
-.tbody { display: table-row-group; }
-.tfoot { display: table-footer-group; }
-.td, .th {
-    vertical-align: middle;
-    text-align: center;
-    display: table-cell;
-    padding: .5em;
+::-webkit-scrollbar {
+	width: 10px;
+	height: 10px;
+	background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+	background: #9e9e9e;
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background: #757575;
+}
+
+::-webkit-scrollbar-thumb:active {
+	background: #424242;
+}
+
+.table {
+	position: relative;
+	display: table;
+}
+
+.tr {
+	display: table-row;
+}
+.thead {
+	display: table-header-group;
+}
+
+.tbody {
+	display: table-row-group;
+}
+
+.tfoot {
+	display: table-footer-group;
+}
+
+.td,
+.th {
+	line-height: normal;
+	display: table-cell;
+	padding: .5em;
+	text-align: center;
+	vertical-align: middle;
 }
 
 .th {
-    font-weight: bold;
+	font-weight: bold;
 }
 
 .tr.placeholder {
-    height: 4em;
+	height: 4em;
 }
 
 .tr.placeholder > .td {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    text-align: center;
-    line-height: 3em;
-    background: inherit;
+	line-height: 3;
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	text-align: center !important;
+	background: inherit;
 }
 
-.table[width="33%"], .th[width="33%"], .td[width="33%"] { width: 33%; }
-.table[width="100%"], .th[width="100%"], .td[width="100%"] { width: 100%; }
+.td[width="33%"] {
+	padding: 1.1em;
+}
 
-.col-1 { flex: 1 1 30px !important; -webkit-flex: 1 1 30px !important; }
-.col-2 { flex: 2 2 60px !important; -webkit-flex: 2 2 60px !important; }
-.col-3 { flex: 3 3 90px !important; -webkit-flex: 3 3 90px !important; }
-.col-4 { flex: 4 4 120px !important; -webkit-flex: 4 4 120px !important; }
-.col-5 { flex: 5 5 150px !important; -webkit-flex: 5 5 150px !important; }
-.col-6 { flex: 6 6 180px !important; -webkit-flex: 6 6 180px !important; }
-.col-7 { flex: 7 7 210px !important; -webkit-flex: 7 7 210px !important; }
-.col-8 { flex: 8 8 240px !important; -webkit-flex: 8 8 240px !important; }
-.col-9 { flex: 9 9 270px !important; -webkit-flex: 9 9 270px !important; }
-.col-10 { flex: 10 10 300px !important; -webkit-flex: 10 10 300px !important; }
+.table[width="33%"],
+.th[width="33%"],
+.td[width="33%"] {
+	width: 33%;
+}
+
+.table[width="100%"],
+.th[width="100%"],
+.td[width="100%"] {
+	width: 100%;
+}
+
+.col-1 {
+	flex: 1 1 30px !important;
+}
+
+.col-2 {
+	flex: 2 2 60px !important;
+}
+
+.col-3 {
+	flex: 3 3 90px !important;
+}
+
+.col-4 {
+	flex: 4 4 120px !important;
+}
+
+.col-5 {
+	flex: 5 5 150px !important;
+}
+
+.col-6 {
+	flex: 6 6 180px !important;
+}
+
+.col-7 {
+	flex: 7 7 210px !important;
+}
+
+.col-8 {
+	flex: 8 8 240px !important;
+}
+
+.col-9 {
+	flex: 9 9 270px !important;
+}
+
+.col-10 {
+	flex: 10 10 300px !important;
+}
 
 .cbi-button-up,
 .cbi-button-down,
 .cbi-value-helpicon,
-.showSide,
-.main > .loading > span {
-    font-family: 'icomoon' !important;
-    speak: none;
-    font-style: normal !important;
-    font-weight: normal !important;
-    font-variant: normal !important;
-    text-transform: none !important;
-    line-height: 1;
-
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+.showSide {
+	font-family: "icomoon" !important;
+	font-weight: normal;
+	font-style: normal;
+	font-variant: normal;
+	line-height: 1;
+	text-transform: none;
+	-webkit-font-smoothing: antialiased;
+	speak: none;
 }
 
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
 }
 
-.h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
-    font-family: inherit;
-    font-weight: 400;
-    line-height: 1.1;
-    color: inherit;
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	font-family: inherit;
+	font-weight: normal;
+	line-height: 1.1 !important;
+	color: inherit;
 }
 
 html {
-    -webkit-text-size-adjust: 100%;
-    -ms-text-size-adjust: 100%;
+	overflow-y: hidden;
+	-webkit-text-size-adjust: 100%;
+	-ms-text-size-adjust: 100%;
 }
 
 body {
-    font-size: 0.8rem;
-    background-color: #EEE;
+	font-size: .8rem;
+	background-color: #eee;
 }
 
-html, body {
-    margin: 0px;
-    padding: 0px;
-    height: 100%;
-    font-family: var(--font-body, "Microsoft Yahei", "WenQuanYi Micro Hei", "sans-serif", "Helvetica Neue", "Helvetica", "Hiragino Sans GB");
+html,
+body {
+	font-family: "Microsoft Yahei", "WenQuanYi Micro Hei", "sans-serif", "Helvetica Neue", "Helvetica", "Hiragino Sans GB";
+	font-family: var(--font-body);
+	height: 100%;
+	margin: 0;
+	padding: 0;
 }
 
 select {
-    padding: 0.36rem 0.8rem;
-    color: #555;
-    background-color: #fff;
-    background-image: none;
-    border: 1px solid #ccc;
+	padding: .36rem .8rem;
+	color: #555;
+	border: thin solid #ccc;
+	background-color: #fff;
+	background-image: none;
 }
 
+.btn,
+button,
 select,
 input,
 .cbi-dropdown {
-    background-color: transparent;
-    color: rgba(0, 0, 0, .87);
-    border: none;
-    border-bottom: 2px solid rgba(0, 0, 0, .26);
-    outline: 0;
-    padding: 0;
-    box-shadow: none;
-    border-radius: 0;
-    background-image: none;
-    height: 1.8rem;
-    font-size: 0.8rem;
+	height: 1.8rem;
+	padding: 0;
+	color: rgba(0, 0, 0, .87);
+	border: 0;
+	border-bottom: 2px solid rgba(0, 0, 0, .26);
+	border-radius: 0;
+	outline: 0;
+	background-color: transparent;
+	background-image: none;
+	box-shadow: none;
+}
+
+select,
+.cbi-dropdown {
+	width: inherit;
 }
 
 select:not([multiple="multiple"]):focus,
-input:focus,
+input:not(.cbi-button):focus,
 .cbi-dropdown:focus,
 .cbi-dynlist > .item:focus {
-    border-color: var(--main-color, #0099CC);
+	border-color: #09c;
+	border-color: var(--main-color);
 }
 
 select[multiple="multiple"] {
-    height: auto;
+	height: auto;
+}
+
+pre {
+	overflow: auto;
 }
 
 code {
-    color: var(--main-color, #0099CC);
+	font-size: 1rem;
+	font-size-adjust: .35;
+	padding: 1px 3px;
+	color: #101010;
+	border: thin solid #999;
+	border-radius: 2px;
+	background: #ddd;
 }
 
 abbr {
-    color: #005470;
-    text-decoration: underline;
-    cursor: help;
+	cursor: help;
+	text-decoration: underline;
+	color: #005470;
 }
 
 hr {
-    margin: 1rem 0;
-    border-color: #EEE;
-    opacity: 0.1;
+	margin: 1rem 0;
+	opacity: .1;
+	border-color: #eee;
 }
 
-header, .main {
-    width: 100%;
-    position: absolute;
+header,
+.main {
+	position: absolute;
+	width: 100%;
 }
 
 header {
-    box-shadow: 0 2px 5px rgba(0, 0, 0, .26);
-    transition: box-shadow .2s;
-    float: left;
-    position: fixed;
-    z-index: 2000;
+	position: fixed;
+	z-index: 2000;
+	float: left;
+	height: 4rem;
+	transition: box-shadow .2s;
+	box-shadow: 0 2px 5px rgba(0, 0, 0, .26);
 }
 
 footer {
-    text-align: right;
-    padding: 1rem;
-    color: #aaa;
-    font-size: 0.8rem;
-    text-shadow: 0px 0px 2px #BBB;
+	font-size: .8rem;
+	overflow: hidden;
+	padding: 1rem;
+	text-align: right;
+	white-space: nowrap;
+	color: #aaa;
+	text-shadow: 0 0 2px #bbb;
 }
 
 footer > a {
-    color: #aaa;
-    text-decoration: none;
+	text-decoration: none;
+	color: #aaa;
 }
 
 .main {
-    top: 5rem;
-    bottom: 0rem;
-    position: relative;
-    height: 100%;
-    height: calc(100% - 4rem);
+	position: relative;
+	top: 4rem;
+	bottom: 0;
+	overflow-y: auto;
+	height: 100%;
+	height: calc(100% - 4rem);
 }
 
 .main > .loading {
-    position: fixed;
-    width: 100%;
-    height: 100%;
-    z-index: 1000;
-    display: block;
-    background-color: rgb(240, 240, 240);
-    top: 0;
+	position: fixed;
+	z-index: 1000;
+	top: 0;
+	display: block;
+	width: 100%;
+	height: 100%;
+	pointer-events: none;
+	background-color: rgb(240, 240, 240);
 }
 
 .main > .loading > span {
-    display: block;
-    text-align: center;
-    margin-top: 2rem;
-    color: #888;
-    font-size: 1.2rem;
+	font-family: monospace;
+	font-size: 2.0rem;
+	font-size-adjust: .35;
+	position: relative;
+	top: 12.5%;
+	display: block;
+	text-align: center;
+	color: #888;
 }
 
 .main > .loading > span > .loading-img:before {
-    content: "\e603";
+	content: "\e603";
 }
 
 .main > .loading > span > .loading-img {
-    animation: anim-rotate 2s infinite linear;
-    display: inline-block;
-    margin: 5rem;
+	font-family: "icomoon" !important;
+	font-size: 1.0rem;
+	font-size-adjust: .6;
+	display: inline-block;
+	margin-right: 1rem;
+	animation: anim-rotate 2s infinite linear;
 }
 
 @keyframes anim-rotate {
-    0% {
-        -webkit-transform: rotate(0);
-        -ms-transform: rotate(0);
-        transform: rotate(0);
-    }
-    100% {
-        -webkit-transform: rotate(360deg);
-        -ms-transform: rotate(360deg);
-        transform: rotate(360deg)
-    }
+	0% {
+		-webkit-transform: rotate(0);
+		-ms-transform: rotate(0);
+		transform: rotate(0);
+	}
+	100% {
+		-webkit-transform: rotate(360deg);
+		-ms-transform: rotate(360deg);
+		transform: rotate(360deg);
+	}
 }
 
 .main-left {
-    float: left;
-    top: 5rem;
-    width: 15%;
-    width: calc(0% + 15rem);
-    height: 100%;
-    height: calc(100% - 4rem);
-    background-color: var(--menu-bg-color, #FFFFFF);
-    overflow-x: auto;
-    position: fixed;
+	position: fixed;
+	top: 4rem;
+	float: left;
+	overflow-x: auto;
+	width: 15%;
+	width: calc(0% + 15rem);
+	height: 100%;
+	height: calc(100% - 4rem);
+	background-color: #fff;
+	background-color: var(--menu-bg-color);
 }
 
 .main-right {
-    width: 85%;
-    width: calc(100% - 15rem);
-    float: right;
-    height: 100%;
-    background-color: #EEE;
+	float: right;
+	width: 85%;
+	width: calc(100% - 15rem);
+	height: 100%;
+	background-color: #eee;
 }
 
 .main-right > #maincontent {
-    background-color: #EEE;
+	background-color: #eee;
 }
 
 .pull-right {
-    float: right;
+	float: right;
 }
 
 .pull-left {
-    float: left;
+	float: left;
+}
+
+.nowrap:not(.td) {
+	white-space: nowrap;
+}
+
+[disabled="disabled"] {
+	pointer-events: none;
 }
 
 header {
-    background: var(--header-bg, #0099CC);
-    color: var(--header-color, #FFFFFF);
-    height: 5rem;
+	color: #fff;
+	color: var(--header-color);
+	background: #09c;
+	background: var(--header-bg);
 }
 
 header > .fill > .container {
-    padding-top: 0.25rem;
-    padding-right: 1rem;
-    padding-bottom: 0.25rem;
-    display: flex;
-    align-items: center;
-    height: 5rem;
+	margin-top: .5rem;
+	padding: .5rem 1rem 0 1rem;
+	user-select: none;
+}
+
+header > .fill > .container > img {
+	width: calc(0% + 10rem);
+	margin: -.1rem 3.5rem 0 1.5rem;
+	pointer-events: none;
+}
+
+body:not(.logged-in) > header > .fill > .container > img {
+	display: none;
 }
 
 header > .fill > .container > .brand {
-    font-size: 2rem;
-    color: var(--header-color, #FFFFFF);
-    text-decoration: none;
-    cursor: default;
-    margin-left: 1rem;
-}
-
-header > .fill > .container > img{
-    max-height: 4.5rem;
-    width: calc(0% + 13rem);
-    margin: 1rem;
+	font-size: 1.4rem;
+	position: absolute;
+	cursor: default;
+	vertical-align: text-bottom;
+	text-decoration: none;
+	color: #fff;
+	color: var(--header-color);
 }
 
 header > .fill > .container > .status {
-    display: flex;
-    justify-content: flex-end;
-    flex-grow: 8;
+	position: absolute;
+	top: 25%;
+	right: 1em;
+	float: right;
+}
+
+header > .fill > .container > .status > * {
+	position: relative;
+	top: .2rem;
+	float: left;
+	margin-left: .3rem;
+	cursor: pointer;
+}
+
+#xhr_poll_status {
+	display: flex;
 }
 
 .danger {
-    background-color: #FA8072 !important;
-    color: black;
+	background-color: #ff7d60 !important;
 }
 
 .warning {
-    background-color:  #F0E68C !important;
-    color: black;
+	background-color: #f0e68c !important;
 }
 
 .success {
-    background-color: #90EE90 !important;
-    color: black;
+	background-color: #5cb85c !important;
 }
 
-.alert-message {
-    margin: 2rem 0 0 0;
-    padding: 1rem;
-    border: 0;
-    font-weight: normal;
-    font-style: normal;
-    line-height: 1;
-    font-family: inherit;
-    min-width: inherit;
-    overflow: auto;
-    border-radius: 0;
-    background-color: #FFF;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
+.notice {
+	background-color: #5bc0de !important;
 }
 
 .error {
-    color: red;
+	color: #f00;
+}
+
+.alert,
+.alert-message {
+	font-weight: bold;
+	margin-bottom: 1em;
+	padding: 1rem;
+	border: 0;
+	border-radius: 0 !important;
+	background-color: #fff;
+	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
+	text-shadow: 1px 1px rgba(0, 0, 0, .1);
 }
 
 .alert-message > h4 {
-    font-weight: bold;
-    font-size: 110%;
+	font-size: 110%;
+	font-weight: bold;
 }
 
 .alert-message > * {
-    margin: .5rem 0;
+	margin: .5rem 0;
 }
 
-#maincontent > .container > div:nth-child(1).alert-message.warning > a {
-    font: inherit;
-    overflow: visible;
-    text-transform: none;
-    display: inline-block;
-    margin-bottom: 0;
-    font-weight: 400;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: middle;
-    touch-action: manipulation;
-    cursor: pointer;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    background-image: none;
-    min-width: 6rem;
-    padding: 0.5rem 1rem;
-    font-size: 0.9rem;
-    line-height: 1.42857143;
-    color: #fff;
-    background-color: #5bc0de;
-    border-color: #46b8da;
-    margin-top: 2rem;
-    text-decoration: inherit;
+.alert-message .btn {
+	padding: .3rem .6rem;
+}
+
+.container .alert,
+.container .alert-message {
+	margin-top: 1rem;
 }
 
 .main > .main-left > .nav {
-    margin-top: 0.5rem;
-}
-
-.main > .main-left > .nav > li a {
-    color: var(--menu-color, #404040);
-    display: block;
-}
-
-.main > .main-left > .nav > li:nth-last-child(1) {
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-    font-size: 1.2rem;
+	margin-top: .5rem;
 }
 
 .main > .main-left > .nav > li {
-    padding: 0.5rem 1rem;
-    cursor: pointer;
+	padding: .5rem 1rem;
+	cursor: pointer;
+}
+
+.main > .main-left > .nav > li:nth-last-child(1) {
+	font-size: 1.2rem;
+	margin-top: 1rem;
+	margin-bottom: 1rem;
+}
+
+.main > .main-left > .nav > li a {
+	display: block;
+	color: #5f6368;
+	color: var(--menu-color);
 }
 
 .main > .main-left > .nav > .slide {
-    padding: 0;
+	padding: 0;
 }
 
 .main > .main-left > .nav > .slide > ul {
-    display: none;
+	display: none;
+}
+
+.main > .main-left > .nav > .slide > .menu::before {
+	font-weight: 900;
+	position: absolute;
+	right: 17px;
+	content: "\2228";
+	transform: scale(1.3, .75);
+}
+
+.main > .main-left > .nav > .slide > .menu.active::before {
+	content: "\2227";
+}
+
+.main > .main-left[style$="overflow: hidden;"] > .nav > .slide > .menu::before {
+	display: none;
 }
 
 .main > .main-left > .nav > .slide > .menu {
-    display: block;
-    padding: 0.5rem 1rem;
-    text-decoration: none;
-    cursor: default;
-    font-size: 1.15rem;
+	font-size: 1.15rem;
+	font-weight: 500;
+	display: block;
+	padding: .5rem 1rem;
+	text-decoration: none;
+	color: #202124;
 }
 
 .main > .main-left > .nav > li:hover,
 .main > .main-left > .nav > .slide > .menu:hover {
-    background: var(--submenu-bg-hover, #D4D4D4)
+	background: #d4d4d4;
+	background: var(--submenu-bg-hover);
 }
 
 .main > .main-left > .nav > .slide:hover {
-    background: none;
+	background: none;
 }
 
 .main > .main-left > .nav > .slide > .slide-menu > li {
-    padding: 0.4rem 2rem;
+	padding: .4rem 2rem;
 }
 
 .main > .main-left > .nav > .slide > .slide-menu > .active {
-    background-color: var(--submenu-bg-hover-active, #0099CC);
+	background-color: #09c;
+	background-color: var(--submenu-bg-hover-active);
 }
 
 .main > .main-left > .nav > .slide > .slide-menu > li > a {
-    text-decoration: none;
-    white-space: nowrap;
+	white-space: nowrap;
+	text-decoration: none;
 }
 
 .main > .main-left > .nav > .slide > .slide-menu > .active > a {
-    color: white;
+	color: #fff;
 }
 
 .main > .main-left > .nav > .slide > .slide-menu > li:hover {
-    background: var(--submenu-bg-hover, #D4D4D4)
+	background: #d4d4d4;
+	background: var(--submenu-bg-hover);
+}
+
+.main > .main-left > .nav > .slide > .slide-menu > li:not(.active):hover > a {
+	color: #202124;
+	color: var(--menu-color-hover);
 }
 
 .main > .main-left > .nav > .slide > .slide-menu > .active:hover {
-    background-color: var(--main-color, #0099CC);
-    cursor: hand;
+	cursor: hand;
+	background-color: #09c;
+	background-color: var(--main-color);
 }
 
-li {
-    list-style-type: none;
+/* ripple effect */
+.main > .main-left > .nav > .slide > .menu,
+.main > .main-left > .nav > .slide > .slide-menu > li {
+	position: relative;
+	overflow: hidden;
+	transform: translate3d(0, 0, 0);
+}
+
+.main > .main-left > .nav > .slide > .menu:after,
+.main > .main-left > .nav > .slide > .slide-menu > li:after {
+	position: absolute;
+	top: 0;
+	left: 0;
+	display: block;
+	width: 100%;
+	height: 100%;
+	content: "";
+	transition: transform .5s, opacity 1s;
+	transform: scale(10, 10);
+	pointer-events: none;
+	opacity: 0;
+	background-image: radial-gradient(circle, #000 10%, transparent 10.01%);
+	background-repeat: no-repeat;
+	background-position: 50%;
+}
+
+.main > .main-left > .nav > .slide > .menu:active:after,
+.main > .main-left > .nav > .slide > .slide-menu > li:active:after {
+	transition: 0s;
+	transform: scale(0, 0);
+	opacity: .2;
 }
 
 #maincontent > .container {
-    margin: 0 2rem 1rem 2rem;
+	margin: 0 2rem 1rem 2rem;
+}
+
+.Processes #maincontent > .container {
+	margin-right: 0;
+}
+
+ul {
+	line-height: normal;
+}
+
+li {
+	list-style-type: none;
 }
 
 h1 {
-    font-size: 2rem;
-    padding-bottom: 10px;
-    border-bottom: 1px solid #eee;
+	font-size: 2rem;
+	padding-bottom: 10px;
+	border-bottom: thin solid #eee;
 }
 
 h2 {
-    margin: 2rem 0 0 0;
-    font-size: 1.8rem;
-    padding-bottom: 10px;
-    border-bottom: 1px solid #eee;
+	font-size: 1.8rem;
+	margin: 2rem 0 0 0;
+	padding-bottom: 10px;
+	border-bottom: thin solid #eee;
 }
 
 h3 {
-    margin: 2rem 0 0 0;
-    font-size: 1.4rem;
-    padding-bottom: 10px;
+	font-size: 1.4rem;
+	margin: 2rem 0 0 0;
+	padding-bottom: 10px;
 }
 
 h4 {
-    margin: 1.5rem 0 0 0;
-    font-size: 1.2rem;
-    padding-bottom: 10px;
+	font-size: 1.2rem;
+	margin: 2rem 0 0 0;
+	padding-bottom: 10px;
 }
 
-.cbi-section {
-    margin: 1rem 0 0 0;
-    padding: 2rem;
-    border: 0;
-    font-weight: normal;
-    font-style: normal;
-    line-height: 1;
-    font-family: inherit;
-    min-width: inherit;
-    border-radius: 0;
-    background-color: #FFF;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
+h5 {
+	font-size: 1rem;
+	margin: 2rem 0 0 0;
+	padding-bottom: 10px;
+}
 
-    -webkit-overflow-scrolling: touch;
+.cbi-section,
+.cbi-section-error,
+#cbi-network > .cbi-section-node,
+#cbi-wireless > .cbi-section-node,
+#cbi-wireless > #wifi_assoclist_table,
+[data-page^="admin-system-admin"]:not(.node-main-login) .cbi-map:not(#cbi-dropbear),
+[data-page="admin-system-opkg"] #maincontent > .container {
+	font-family: inherit;
+	font-weight: normal;
+	font-style: normal;
+	line-height: normal;
+	min-width: inherit;
+	margin: 1rem 0 0 0;
+	padding: 2rem;
+	border: 0;
+	border-radius: 0;
+	background-color: #fff;
+	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
 }
 
 .cbi-map-descr + fieldset {
-    margin-top: 1rem;
+	margin-top: 1rem;
 }
 
 .cbi-section > legend {
-    display: none !important;
+	display: none !important;
 }
 
-fieldset > fieldset {
-    margin: 0;
-    padding: 0;
-    border: none;
-    box-shadow: none;
+fieldset > fieldset,
+.cbi-section > .cbi-section {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	box-shadow: none;
 }
 
 .cbi-section > h3:first-child,
 .panel-title {
-    width: 100%;
-    display: block;
-    line-height: 1;
-    color: #404040;
-    font-size: 1.4rem;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid #eee;
-    margin: 0;
+	font-size: 1.4rem;
+	line-height: 1;
+	display: block;
+	width: 100%;
+	margin: 0;
+	margin-bottom: .5rem;
+	padding-bottom: 1rem;
+	color: #404040;
+	border-bottom: thin solid #eee;
 }
 
 table {
-    border-spacing: 0;
-    border-collapse: collapse;
+	border-spacing: 0;
+	border-collapse: collapse;
 }
 
-table, .table {
-    width: 100%;
-    border: 1px solid #eee;
+table,
+.table {
+	overflow-y: hidden;
+	width: 100%;
+	box-shadow: 0 0 0 1px #ddd;
 }
 
-table > tbody > tr > td, table > tbody > tr > th, table > tfoot > tr > td, table > tfoot > tr > th, table > thead > tr > td, table > thead > tr > th,
-.table > .tbody > .tr > .td, .table > .tbody > .tr > .th, .table > .tfoot > .tr > .td, .table > .tfoot > .tr > .th, .table > .thead > .tr > .td, .table > .thead > .tr > .th {
-    padding: .5rem;
-    border-top: 1px solid #ddd;
-    white-space: nowrap;
+table > tbody > tr > td,
+table > tbody > tr > th,
+table > tfoot > tr > td,
+table > tfoot > tr > th,
+table > thead > tr > td,
+table > thead > tr > th,
+.table > .tbody > .tr > .td,
+.table > .tbody > .tr > .th,
+.table > .tfoot > .tr > .td,
+.table > .tfoot > .tr > .th,
+.table > .thead > .tr > .td,
+.table > .thead > .tr > .th,
+.table > .tr > .td.cbi-value-field,
+.table > .tr > .th.cbi-section-table-cell {
+	padding: .5rem;
+}
+
+.container > .cbi-section:first-of-type > .table[width="100%"] > .tr > .td {
+	padding: .6rem;
 }
 
 .cbi-section-table-cell {
-    white-space: nowrap;
-    align-self: flex-end;
-    flex: 1 1 auto;
+	line-height: 1.1;
+	align-self: flex-end;
+	flex: 1 1 auto;
 }
 
-.cbi-section-table {
-    border: none;
+tr > td,
+tr > th,
+.tr > .td,
+.tr > .th,
+.cbi-section-table-row::before,
+#cbi-wireless > #wifi_assoclist_table > .tr:nth-child(2) {
+	border-top: thin solid #ddd;
+}
+
+tr:first-child > td
+.tr:first-child > .td,
+#cbi-wireless .td,
+#cbi-network .tr:first-child > .td,
+.table[width="100%"] > .tr:first-child > .td,
+[data-page="admin-network-diagnostics"] .tr > .td,
+.tr.table-titles > .th,
+.tr.cbi-section-table-titles > .th {
+	border-top: 0 !important;
 }
 
 .cbi-section-table-row {
-    text-align: center;
-    margin-bottom: 1rem;
-    background: #f4f4f4;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
+	margin-bottom: 1rem;
+	text-align: center !important;
+	background: #f4f4f4;
 }
 
 .cbi-section-table-row:last-child {
-    margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .cbi-section-table-row > .cbi-value-field .cbi-input-select,
 .cbi-section-table-row > .cbi-value-field .cbi-input-text,
 .cbi-section-table-row > .cbi-value-field .cbi-input-password,
 .cbi-section-table-row > .cbi-value-field .cbi-dropdown {
-    width: 100%;
+	width: 100%;
 }
 
 .cbi-section-table-row > .cbi-value-field [data-dynlist] > input,
 .cbi-section-table-row > .cbi-value-field input.cbi-input-password {
-    width: calc(100% - 1.5rem);
+	width: calc(100% - 1.5rem);
+}
+
+.cbi-section-table-row .td {
+	text-align: center !important;
 }
 
 div > table > tbody > tr:nth-of-type(2n),
-div > .table > .tbody > .tr:nth-of-type(2n) {
-    background-color: #f9f9f9;
-}
-
-div > table > tbody > tr:nth-of-type(2n),
-div > .table > .tbody > .tr:nth-of-type(2n) {
-    background-color: #f9f9f9;
+div > .table > .tr:nth-of-type(2n) {
+	background-color: #f9f9f9;
 }
 
 /* fix multiple table */
-
 table table,
 .table .table {
-    border: none;
+	border: 0;
 }
 
 .cbi-value-field table,
 .cbi-value-field .table {
-    border: none;
+	border: 0;
 }
 
 td > table > tbody > tr > td,
 .td > .table > .tbody > .tr > .td {
-    border: none;
+	border: 0;
 }
 
 .cbi-value-field > table > tbody > tr > td,
 .cbi-value-field > .table > .tbody > .tr > .td {
-    border: none;
+	border: 0;
 }
 
 /* button style */
+.btn,
+.cbi-button,
+.item::after {
+	font-size: .8rem;
+	display: inline-block;
+	width: auto !important;
+	padding: 0 .8rem;
+	cursor: pointer;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	transition: all .2s ease-in-out;
+	text-align: center;
+	vertical-align: middle;
+	white-space: nowrap;
+	text-decoration: none;
+	text-transform: uppercase;
+	color: rgba(0, 0, 0, .87);
+	border: 0;
+	border-radius: .2rem;
+	background-color: #f0f0f0;
+	background-image: none;
+	-webkit-appearance: none;
+	-ms-touch-action: manipulation;
+	touch-action: manipulation;
+}
 
-.btn, .cbi-button, .item::after {
-    -webkit-appearance: none;
-    text-transform: uppercase;
-    color: rgba(0, 0, 0, 0.87);
-    background-color: #F0F0F0;
-    transition: all 0.2s ease-in-out;
-    display: inline-block;
-    padding: 0 0.8rem;
-    border: none;
-    border-radius: 0.2rem;
-    cursor: pointer;
-    -ms-touch-action: manipulation;
-    touch-action: manipulation;
-    background-image: none;
-    text-align: center;
-    vertical-align: middle;
-    white-space: nowrap;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    font-size: 0.8rem;
-    width: auto !important;
-    display: inline-block;
-    text-decoration: none;
+.cbi-button:not(select) {
+	-webkit-appearance: none !important;
+}
+
+form[method="post"] + form[method="post"],
+.cbi-button + .cbi-button {
+	margin-left: .6rem;
 }
 
 .btn:hover,
@@ -657,420 +900,513 @@ td > table > tbody > tr > td,
 .cbi-button:focus,
 .cbi-button:active,
 .item:hover::after,
+.item:focus::after,
+.item:active::after,
 .cbi-page-actions .cbi-button-apply + .cbi-button-save:hover,
 .cbi-page-actions .cbi-button-apply + .cbi-button-save:focus,
 .cbi-page-actions .cbi-button-apply + .cbi-button-save:active {
-    outline: 0;
-    text-decoration: none;
-    background-color: rgba(250, 250, 250, 0.7);
+	text-decoration: none;
+	outline: 0;
 }
 
 .btn:hover,
 .btn:focus,
 .cbi-button:hover,
 .cbi-button:focus {
-    box-shadow: 0 0px 2px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.2);
+	box-shadow: 0 0 2px rgba(0, 0, 0, .12), 0 2px 2px rgba(0, 0, 0, .2);
 }
 
 .btn:active,
 .cbi-button:active {
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+	box-shadow: 0 10px 20px rgba(0, 0, 0, .19), 0 6px 6px rgba(0, 0, 0, .23);
 }
 
 .btn:disabled,
 .cbi-button:disabled {
-    cursor: not-allowed;
-    pointer-events: none;
-    opacity: 0.60;
-    box-shadow: none;
+	cursor: not-allowed;
+	pointer-events: none;
+	opacity: .5;
+	box-shadow: none;
 }
 
-.cbi-page-actions .cbi-button-apply,
-.cbi-section-actions .cbi-button-edit,
-.cbi-button-edit.important,
-.cbi-button-apply.important,
-.cbi-button-reload.important,
-.cbi-button-action.important {
-    color: #fff;
-    background-color: #337ab7;
-}
-
-.cbi-page-actions .cbi-button-save,
-.cbi-button-add.important,
-.cbi-button-save.important,
-.cbi-button-positive.important {
-    color: #fff;
-    background-color: #5bc0de;
-}
-
-.cbi-button-remove.important,
-.cbi-button-reset.important,
-.cbi-button-negative.important {
-    color: #fff;
-    background-color: #d9534f;
-}
-
+/* gray */
+.alert-message [class="btn"],
+.modal div[class="btn"],
 .cbi-button-find,
 .cbi-button-link,
 .cbi-button-up,
 .cbi-button-down,
-.cbi-button-neutral {
-    border: 1px solid #bfbfbf;
-    background-color: transparent;
+.cbi-button-neutral,
+.cbi-button[name="zero"],
+.cbi-button[name="restart"],
+.cbi-button[onclick="hide_empty(this)"] {
+	font-weight: bold;
+	border: thin solid #bfbfbf;
+	background-color: #d4d4d4;
 }
 
-.cbi-button-edit,
-.cbi-button-apply,
-.cbi-button-reload,
-.cbi-button-action {
-    color: #2e6da4;
-    border: 1px solid #2e6da4;
-    background-color: transparent;
-}
-
+/* dark blue */
+.btn.primary,
+.cbi-page-actions .cbi-button-save,
 .cbi-page-actions .cbi-button-apply + .cbi-button-save,
 .cbi-button-add,
 .cbi-button-save,
-.cbi-button-positive {
-    color: #46b8da;
-    border: 1px solid #46b8da;
-    background-color: transparent;
+.cbi-button-positive,
+.cbi-button-link,
+.cbi-button[value="Enable"],
+.cbi-button[value="Scan"],
+.cbi-button[value^="Back"],
+.cbi-button-neutral[onclick="handleConfig(event)"] {
+	font-weight: normal;
+	color: #fff;
+	border: thin solid #2e6da4;
+	background-color: #337ab7;
 }
 
+/* light blue */
+.cbi-page-actions .cbi-button-apply,
+.cbi-section-actions .cbi-button-edit,
+.cbi-button-edit,
+.cbi-button-apply,
+.cbi-button-reload,
+.cbi-button-action,
+.cbi-button[value="Submit"],
+.cbi-button[value$="Apply"],
+.cbi-button[onclick="addKey(event)"] {
+	font-weight: normal;
+	color: #fff;
+	border: thin solid #46b8da;
+	background-color: #5bc0de;
+}
+
+/* red */
+.btn.danger,
 .cbi-section-remove > .cbi-button,
 .cbi-button-remove,
 .cbi-button-reset,
-.cbi-button-negative {
-    color: #d43f3a;
-    border: 1px solid #d43f3a;
-    background-color: transparent;
+.cbi-button-negative,
+.cbi-button[value="Stop"],
+.cbi-button[value="Kill"],
+.cbi-button[onclick="reboot(this)"],
+.cbi-button-neutral[value="Restart"] {
+	font-weight: normal;
+	color: #fff;
+	border: thin solid #d43f3a;
+	background-color: #d9534f;
+}
+
+/* yellow */
+.btn[value="Dismiss"],
+.cbi-button[value="Terminate"],
+.cbi-button[value="Reset"],
+.cbi-button[value="Disabled"],
+.cbi-button[onclick^="iface_reconnect"],
+.cbi-button[onclick="handleReset(event)"],
+.cbi-button-neutral[value="Disable"] {
+	font-weight: normal;
+	color: #fff;
+	border: thin solid #eea236;
+	background-color: #f0ad4e;
+}
+
+/* green */
+.cbi-button-success,
+.cbi-button-download,
+.cbi-button[name="backup"],
+.cbi-button[value="Upload"],
+.cbi-button[value="Save mtdblock"] {
+	font-weight: normal;
+	color: #fff;
+	border: thin solid #4cae4c;
+	background-color: #5cb85c;
 }
 
 .cbi-page-actions .cbi-button-link:first-child {
-    float: left;
+	float: left;
 }
 
 .a-to-btn {
-    text-decoration: none;
+	text-decoration: none;
+}
+
+.cbi-value-field .cbi-button-add {
+	font-weight: bold;
+	padding: 1px 6px;
+}
+
+.cbi-value-field .cbi-button-neutral {
+	padding: 1px 8px;
 }
 
 /* table */
-
 .tabs {
-    margin: 0 -2rem;
-    padding-left: 0.5rem;
-    background-color: #FFFFFF;
+	margin: 0 -2rem;
+	padding-left: .5rem;
+	background-color: #fff;
 }
 
 .cbi-tabmenu > li,
 .tabs > li {
-    display: inline-block;
-    padding: 0.6rem 0rem;
+	display: inline-block;
+	padding: .6rem 0;
 }
 
 .cbi-tabmenu > li > a,
 .tabs > li > a {
-    text-decoration: none;
-    color: #404040;
-    padding: 0.5rem 0.8rem;
+	padding: .5rem .8rem;
+	text-decoration: none;
+	color: #404040;
 }
 
 .tabs > li[class~="active"],
 .tabs > li:hover {
-    cursor: pointer;
-    border-bottom: 0.2rem solid var(--main-color, #0099CC);
-    color: var(--main-color, #0099CC);
-    margin-bottom: -0.18751rem;
+	margin-bottom: -.18751rem;
+	cursor: pointer;
+	color: #09c;
+	color: var(--main-color);
+	border-bottom: #09c;
+	border-bottom: .2rem solid var(--main-color);
 }
 
 .tabs > li[class~="active"] > a {
-    color: var(--main-color, #0099CC);
+	color: #09c;
+	color: var(--main-color);
 }
 
 .tabs > li:hover {
-    border-bottom: 0.18751rem solid #C9C9C9;
+	border-bottom: .18751rem solid #c9c9c9;
 }
 
 .cbi-tabmenu {
-    border-top: 1px solid #D4D4D4;
-    border-left: 1px solid #D4D4D4;
-    border-right: 1px solid #D4D4D4;
+	border: thin solid #d4d4d4;
+	border-bottom: 0;
 }
 
 .cbi-tabmenu > li:hover {
-    background-color: #F1F1F1;
+	background-color: #f1f1f1;
 }
 
 .cbi-tabmenu > li[class~="cbi-tab"] {
-    background-color: white;
+	background-color: #fff;
 }
 
 .cbi-tabmenu {
-    background-color: #D4D4D4;
+	background-color: #d4d4d4;
 }
 
-.cbi-section-remove:nth-of-type(2n),
-.cbi-section-node:nth-of-type(2n){
-    background-color: #f9f9f9;
+.cbi-section .cbi-section-remove:nth-of-type(2n),
+.container > .cbi-section .cbi-section-node:nth-of-type(2n) {
+	background-color: #f9f9f9;
+}
+
+.cbi-section[id] .cbi-section-remove:nth-of-type(4n+3),
+.cbi-section[id] .cbi-section-node:nth-of-type(4n+4) {
+	background-color: #f9f9f9;
 }
 
 .cbi-section-node-tabbed {
-    padding: 0;
-    margin-top: 0;
-    border-bottom: 1px solid #D4D4D4;
-    border-left: 1px solid #D4D4D4;
-    border-right: 1px solid #D4D4D4;
+	margin-top: 0;
+	padding: 0;
+	border: thin solid #d4d4d4;
+	border-top: 0;
 }
 
 .cbi-tabcontainer > .cbi-value:nth-of-type(2n) {
-    background-color: #f9f9f9;
+	background-color: #f9f9f9;
 }
 
 .cbi-value-field,
 .cbi-value-description {
-    display: table-cell;
-    line-height: 1.25;
+	line-height: 1.25;
+	display: table-cell;
 }
 
-.cbi-input-invalid,
-.cbi-value-error input {
-    color: #f00;
-    border-color: #f00;
+.cbi-input-invalid {
+	color: #f00;
+	border-color: #f00;
 }
 
 .cbi-section-error {
-    border: 1px solid #f00;
-    border-radius: 3px;
-    background-color: #fce6e6;
-    padding: 5px;
-    margin: 18px;
+	font-weight: bold;
+	line-height: 1.42857143;
+	margin: 18px;
+	padding: 6px;
+	border: thin solid #f00;
+	border-radius: 3px;
+	background-color: #fce6e6;
 }
 
 .cbi-section-error ul {
-    margin: 0 0 0 20px;
+	margin: 0 0 0 20px;
 }
 
 .cbi-section-error ul li {
-    color: #f00;
-    font-weight: bold;
+	font-weight: bold;
+	color: #f00;
 }
 
 .cbi-value-helpicon > img {
-    display: none;
+	display: none;
 }
 
 .cbi-value-helpicon:before {
-    content: "\f059";
+	content: "\f059";
 }
 
 .cbi-value-description {
-    font-size: small;
-    opacity: 0.5;
-    padding: 0.5rem 0 0 0;
+	font-size: small;
+	padding: .5rem 0 0 0;
+	opacity: .5;
 }
 
 .cbi-value-title {
-    word-wrap: break-word;
-    padding-top: 0.6rem;
-    width: 23rem;
-    float: left;
-    text-align: right;
-    padding-right: 2rem;
-    display: table-cell;
+	display: table-cell;
+	float: left;
+	width: 23rem;
+	padding-top: .4rem;
+	padding-right: 2rem;
+	text-align: right;
+	word-wrap: break-word;
 }
 
 .cbi-value {
-    padding: 0.3rem 1rem;
-    display: inline-block;
-    width: 100%;
+	display: inline-block;
+	width: 100%;
+	padding: .3rem 1rem;
 }
 
-.cbi-section-table-descr > .cbi-section-table-cell,
-.cbi-section-table-titles > .cbi-section-table-cell {
-    border: none;
+.cbi-value ul {
+	line-height: 1.25;
 }
 
 .td[data-title]::before {
-    content: attr(data-title) ":\20";
-    font-weight: bold;
-    text-align: left;
-    display: none;
-    padding: .25rem 0;
-    white-space: nowrap;
+	font-weight: bold;
+	display: none;
+	padding: .25rem 0;
+	content: attr(data-title) ":\20";
+	text-align: left;
+	white-space: nowrap;
 }
 
 .tr.placeholder .td[data-title]::before {
-    display: none;
+	display: none;
 }
 
 .tr[data-title]::before,
 .tr.cbi-section-table-titles.named::before {
-    content: attr(data-title) "\20";
-    font-weight: bold;
-    text-align: center;
-    display: table-cell;
-    align-self: center;
-    flex: 1 1 5%;
-    padding: .25rem;
-    white-space: normal;
-    word-wrap: break-word;
-    vertical-align: middle;
+	font-weight: bold;
+	display: table-cell;
+	align-self: center;
+	flex: 1 1 5%;
+	padding: .25rem;
+	content: attr(data-title) "\20";
+	text-align: center;
+	vertical-align: middle;
+	white-space: normal;
+	word-wrap: break-word;
 }
 
 .cbi-rowstyle-1 {
-    background-color: #f9f9f9;
+	background-color: #f9f9f9;
 }
 
 .cbi-rowstyle-2 {
-    background-color: #eee;
+	background-color: #eee;
 }
 
 .cbi-rowstyle-2 .cbi-button-up,
-.cbi-rowstyle-2 .cbi-button-down {
-    background-color: #FFF !important;
+.cbi-rowstyle-2 .cbi-button-down,
+.cbi-rowstyle-2:first-child {
+	background-color: #fff !important;
 }
 
 .cbi-section-table .cbi-section-table-titles .cbi-section-table-cell {
-    width: auto !important;
+	width: auto !important;
 }
 
 .td.cbi-section-actions {
-    text-align: right;
-    vertical-align: middle;
+	text-align: right !important;
+	vertical-align: middle;
 }
 
 .td.cbi-section-actions > * {
-    display: flex;
+	display: inline-flex;
 }
 
 .td.cbi-section-actions > * > *,
 .td.cbi-section-actions > * > form > * {
-    flex: 1 1 4em;
-    margin: 0 1px;
+	margin: 0 5px;
 }
 
 .td.cbi-section-actions > * > form {
-    display: inline-flex;
-    margin: 0;
+	display: inline-flex;
+	margin: 0;
 }
 
 /* desc */
 .cbi-section-descr,
 .cbi-map-descr {
-    padding: 0.5rem;
-    color: #999;
-    font-size: small;
+	font-size: small;
+	line-height: 1.42857143;
+	padding: .5rem;
+	color: #999;
 }
 
+.cbi-dynlist {
+	line-height: 1.3;
+	flex-direction: column;
+	min-height: 30px;
+}
+
+.cbi-dynlist > .item {
+	position: relative;
+	max-width: 24.9rem;
+	margin: 0 2em 4px 0;
+	padding: 2px 4px;
+	cursor: default;
+	pointer-events: none;
+	color: #666;
+	border-bottom: 2px solid rgba(0, 0, 0, .26);
+}
+
+.cbi-dynlist[name="sshkeys"] > .item {
+	max-width: none;
+}
+
+.cbi-dynlist > .item::after {
+	font-weight: bold;
+	position: absolute;
+	right: -2em;
+	bottom: 0;
+	display: inline-flex;
+	min-height: 17px;
+	padding: 0 6px;
+	content: "\00D7";
+	pointer-events: auto;
+	color: #fff;
+	border: thin solid #d43f3a;
+	background-color: #d9534f;
+}
+
+.cbi-dynlist > .item > span {
+	white-space: normal;
+	word-break: break-word;
+}
 
 .cbi-dynlist,
 .cbi-dropdown {
-    display: inline-flex;
-    cursor: pointer;
-    position: relative;
-    padding: 0;
-    height: auto;
+	position: relative;
+	display: inline-flex;
+	height: auto;
+	padding: 0;
+	cursor: default;
 }
 
 .cbi-dropdown > ul {
-    margin: 0 !important;
-    padding: 0;
-    list-style: none;
-    overflow-x: hidden;
-    overflow-y: auto;
-    display: flex;
-    width: 100%;
+	display: flex;
+	overflow-x: hidden;
+	overflow-y: auto;
+	width: 100%;
+	margin: 0 !important;
+	padding: 0;
+	list-style: none;
 }
 
 .cbi-dropdown > ul.preview {
-    display: none;
+	display: none;
 }
 
 .cbi-dropdown > .open {
-    border: 2px outset #eee;
-    flex-basis: 15px;
-    background: #eee;
+	flex-basis: 15px;
 }
 
 .cbi-dropdown > .open,
 .cbi-dropdown > .more {
-    flex-grow: 0;
-    flex-shrink: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    text-align: center;
-    line-height: 2em;
-    padding: 0 .25em;
+	font-size: 1rem;
+	font-weight: 900;
+	line-height: 2;
+	display: flex;
+	flex-direction: column;
+	flex-grow: 0;
+	flex-shrink: 0;
+	justify-content: center;
+	padding: 0 .25em;
+	text-align: center;
 }
 
 .cbi-dropdown > .more,
 .cbi-dropdown > ul > li[placeholder] {
-    color: #777;
-    font-weight: bold;
-    text-shadow: 1px 1px 0px #fff;
-    display: none;
+	font-weight: bold;
+	display: none;
+	color: #777;
+	text-shadow: 1px 1px 0 #fff;
 }
 
 .cbi-dropdown > ul > li {
-    display: none;
-    padding: .25em;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex-shrink: 1;
-    flex-grow: 1;
-    align-items: center;
-    align-self: center;
-    min-height: 20px;
+	display: none;
+	overflow: hidden;
+	align-items: center;
+	align-self: center;
+	flex-grow: 1;
+	flex-shrink: 1;
+	min-height: 20px;
+	padding: .25em;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
-.cbi-dropdown > ul > li .hide-open { display: initial; }
-.cbi-dropdown > ul > li .hide-close { display: none; }
+.cbi-dropdown > ul > li .hide-open {
+	display: initial;
+}
+
+.cbi-dropdown > ul > li .hide-close {
+	display: none;
+}
 
 .cbi-dropdown > ul > li[display]:not([display="0"]) {
-    border-left: 1px solid #ccc;
+	border-left: thin solid #ccc;
 }
 
 .cbi-dropdown[empty] > ul {
-    max-width: 1px;
+	max-width: 1px;
 }
 
 .cbi-dropdown > ul > li > form {
-    display: none;
-    margin: 0;
-    padding: 0;
-    pointer-events: none;
+	display: none;
+	margin: 0;
+	padding: 0;
+	pointer-events: none;
 }
 
 .cbi-dropdown > ul > li img {
-    vertical-align: middle;
-    margin-right: .25em;
+	margin-right: .25em;
+	vertical-align: middle;
 }
 
 .cbi-dropdown > ul > li > form > input[type="checkbox"] {
-    margin: 0;
-    height: auto;
+	height: auto;
+	margin: 0;
 }
 
 .cbi-dropdown > ul > li input[type="text"] {
-    height: 20px;
+	height: 20px;
 }
 
 .cbi-dropdown[open] {
-    position: relative;
+	position: relative;
 }
 
 .cbi-dropdown[open] > ul.dropdown {
-    display: block;
-    background: #f6f6f5;
-    border: 1px solid #918e8c;
-    box-shadow: 0 0 4px #918e8c;
-    position: absolute;
-    z-index: 1100;
-    max-width: none;
-    min-width: 100%;
-    width: auto;
+	position: absolute;
+	z-index: 1100;
+	display: block;
+	width: auto;
+	min-width: 100%;
+	max-width: none;
+	max-height: 200px !important;
+	border: thin solid #918e8c;
+	background: #f6f6f6;
+	box-shadow: 0 0 4px #918e8c;
 }
 
 .cbi-dropdown > ul > li[display],
@@ -1080,207 +1416,149 @@ td > table > tbody > tr > td,
 .cbi-dropdown[multiple][open] > ul.dropdown > li,
 .cbi-dropdown[multiple][more] > .more,
 .cbi-dropdown[multiple][empty] > .more {
-    flex-grow: 1;
-    display: flex;
-    align-items: center;
+	display: flex;
+	align-items: center;
+	flex-grow: 1;
 }
 
 .cbi-dropdown[empty] > ul > li,
 .cbi-dropdown[optional][open] > ul.dropdown > li[placeholder],
 .cbi-dropdown[multiple][open] > ul.dropdown > li > form {
-    display: block;
+	display: block;
 }
 
-.cbi-dropdown[open] > ul.dropdown > li .hide-open { display: none; }
-.cbi-dropdown[open] > ul.dropdown > li .hide-close { display: initial; }
+.cbi-dropdown[open] > ul.dropdown > li .hide-open {
+	display: none;
+}
+
+.cbi-dropdown[open] > ul.dropdown > li .hide-close {
+	display: initial;
+}
 
 .cbi-dropdown[open] > ul.dropdown > li {
-    border-bottom: 1px solid #ccc;
+	border-bottom: thin solid #ccc;
 }
 
 .cbi-dropdown[open] > ul.dropdown > li[selected] {
-    background: #b0d0f0;
+	background: #b0d0f0;
 }
 
 .cbi-dropdown[open] > ul.dropdown > li.focus {
-    background: linear-gradient(90deg, #a3c2e8 0%, #84aad9 100%);
+	background: linear-gradient(90deg, #a3c2e8 0%, #84aad9 100%);
 }
 
 .cbi-dropdown[open] > ul.dropdown > li:last-child {
-    margin-bottom: 0;
-    border-bottom: none;
+	margin-bottom: 0;
+	border-bottom: 0;
 }
 
 .cbi-dropdown[open] > ul.dropdown > li[unselectable] {
-    opacity: 0.7;
+	opacity: .7;
 }
 
 .cbi-dropdown[open] > ul.dropdown > li > input.create-item-input:first-child:last-child {
-    width: 100%;
-}
-
-.cbi-dropdown[open] > ul.dropdown > li[unselectable] {
-    opacity: 0.7;
-}
-
-.cbi-dropdown[open] > ul.dropdown > li > input.create-item-input:first-child:last-child {
-    width: 100%;
+	width: 100%;
 }
 
 .cbi-dropdown[disabled] {
-    pointer-events: none;
-    opacity: .6;
+	pointer-events: none;
+	opacity: .6;
 }
 
 .cbi-dropdown .zonebadge {
-    width: 100%;
+	width: 100%;
 }
 
 .cbi-dropdown[open] .zonebadge {
-    width: auto;
-}
-
-.cbi-dynlist {
-    height: auto;
-    min-height: 30px;
-    display: inline-flex;
-    flex-direction: column;
-}
-
-.cbi-dynlist > .item {
-    margin: 0 2em 4px 0;
-    padding: 2px 4px;
-    border-bottom: 2px solid rgba(0, 0, 0, .26);
-    position: relative;
-    pointer-events: none;
-    cursor: default;
-}
-
-.cbi-dynlist > .item::after {
-    content: "×";
-    position: absolute;
-    display: inline-flex;
-    align-items: center;
-    top: 0;
-    right: -2em;
-    bottom: 0;
-    padding: 0 6px;
-    border: 1px solid #c44;
-    font-weight: bold;
-    color: #c44;
-    pointer-events: auto;
-}
-
-.cbi-dynlist {
-    height: auto;
-    min-height: 30px;
-    display: inline-flex;
-    flex-direction: column;
-}
-
-.cbi-dynlist > .item {
-    margin: 0 2em 4px 0;
-    padding: 2px 4px;
-    border-bottom: 2px solid rgba(0, 0, 0, .26);
-    position: relative;
-    pointer-events: none;
-    cursor: default;
-}
-
-.cbi-dynlist > .item::after {
-    content: "×";
-    position: absolute;
-    display: inline-flex;
-    align-items: center;
-    top: 0;
-    right: -2em;
-    bottom: 0;
-    padding: 0 6px;
-    border: 1px solid #c44;
-    font-weight: bold;
-    color: #c44;
-    pointer-events: auto;
+	width: auto;
 }
 
 #modal_overlay {
 	position: fixed;
-	top: 5rem;
+	z-index: 900;
+	top: 4rem;
+	right: 10000px;
 	bottom: 0;
 	left: -10000px;
-	right: 10000px;
-	background: rgba(0, 0, 0, 0.7);
-	z-index: 900;
 	overflow-y: scroll;
-	-webkit-overflow-scrolling: touch;
 	transition: opacity .125s ease-in;
 	opacity: 0;
+	background: rgba(0, 0, 0, .7);
+	-webkit-overflow-scrolling: touch;
 }
 
 .modal {
-	width: 90%;
-	margin: 5em auto;
 	display: flex;
-	flex-wrap: wrap;
-	min-height: 32px;
-	max-width: 600px;
 	align-items: center;
-	border-radius: 3px;
-	background: #fff;
-	box-shadow: 0 0 3px #444;
-	padding: 1em 1em .5em 1em;
-	max-height: 2400px;
+	flex-wrap: wrap;
+	width: 90%;
 	min-width: 270px;
+	max-width: 600px;
+	min-height: 32px;
+	max-height: 2400px;
+	margin: 5em auto;
+	padding: 1em;
+	border-radius: 3px !important;
+	background: #fff;
+	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
 }
 
 .modal > * {
-	flex-basis: 100%;
 	line-height: normal;
-	margin-bottom: .5em;
+	flex-basis: 100%;
 }
 
 .modal > pre,
 .modal > textarea {
-	white-space: pre-wrap;
+	font-size: 1rem;
+	font-size-adjust: .35;
 	overflow: auto;
-}
-
-body.modal-overlay-active {
-	overflow: hidden;
-	height: 100vh;
-}
-
-body.modal-overlay-active #modal_overlay {
-	left: 0;
-	right: 0;
-	opacity: 1;
-}
-
-#modal_overlay > .modal {
-	width: 90%;
-	margin: 5em auto;
-	display: flex;
-	flex-wrap: wrap;
-	min-height: 32px;
-	max-width: 600px;
-	align-items: center;
-	border-radius: 3px;
-	background: #fff;
-	box-shadow: 0 0 3px #444;
-	padding: 1em 1em 1em 1em;
-	max-height: 2400px;
-	min-width: 270px;
-}
-
-#modal_overlay .modal > * {
-	flex-basis: 100%;
-	line-height: normal;
 	margin-bottom: .5em;
+	padding: 8.5px;
+	white-space: pre-wrap;
+	color: #eee;
+	outline: 0;
+	background-color: #101010;
+	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
 }
 
-#modal_overlay .modal > pre,
-#modal_overlay .modal > textarea {
-	white-space: pre-wrap;
-	overflow: auto;
+.modal > h4 {
+	margin: .5em 0;
+}
+
+.modal ul {
+	margin-left: 2.2em;
+}
+
+.modal li {
+	list-style-type: square;
+	color: #808080;
+}
+
+.modal p {
+	padding-left: .25rem;
+	word-break: break-word;
+}
+
+.modal .label {
+	font-size: .6rem;
+	font-weight: normal;
+	padding: .1rem .3rem;
+	padding-bottom: 0;
+	cursor: default;
+	border-radius: 0;
+}
+
+.modal .label.warning {
+	background-color: #f0ad4e !important;
+}
+
+.modal .btn {
+	padding: .3rem .6rem;
+}
+
+.modal .spinning {
+	margin-bottom: 2em;
 }
 
 body.modal-overlay-active {
@@ -1289,8 +1567,8 @@ body.modal-overlay-active {
 }
 
 body.modal-overlay-active #modal_overlay {
-	left: 0;
 	right: 0;
+	left: 0;
 	opacity: 1;
 }
 
@@ -1302,8 +1580,8 @@ body.modal-overlay-active #modal_overlay {
 .spinning::before {
 	position: absolute;
 	top: 0;
-	left: 0;
 	bottom: 0;
+	left: .2em;
 	width: 32px;
 	content: " ";
 	background: url(../resources/icons/loading.gif) no-repeat center;
@@ -1311,1096 +1589,1369 @@ body.modal-overlay-active #modal_overlay {
 }
 
 /* luci */
-
 .hidden {
-    display: none
+	display: none;
 }
 
-.left, .left::before {
-    text-align: left !important;
+.left,
+.left::before {
+	text-align: left !important;
 }
 
-.right, .right::before {
-    text-align: right !important;
+.right,
+.right::before {
+	text-align: right !important;
 }
 
-.center, .center::before {
-    text-align: center !important;
+.center,
+.center::before {
+	text-align: center !important;
 }
 
 .top {
-    align-self: flex-start !important;
-    vertical-align: top !important;
+	align-self: flex-start !important;
+	vertical-align: top !important;
 }
 
 .bottom {
-    align-self: flex-end !important;
-    vertical-align: bottom !important;
+	align-self: flex-end !important;
+	vertical-align: bottom !important;
 }
 
 .inline {
-    display: inline;
+	display: inline;
 }
 
 .cbi-page-actions {
-    border-top: 1px solid #eee;
-    padding-top: 1rem;
-    text-align: right;
+	padding-top: 1rem;
+	text-align: right;
+}
+
+.cbi-page-actions > form[method="post"] {
+	display: inline-block;
 }
 
 /* input */
 .cbi-value input[type="password"],
 .cbi-value input[type="text"] {
-    min-width: 15rem;
+	min-width: 15rem;
 }
 
 /* select */
-.cbi-value-field .cbi-dropdown {
-    min-width: 15rem;
+.cbi-value-field .cbi-dropdown,
+.cbi-value-field .cbi-input-select {
+	min-width: 15rem;
+}
+
+.cbi-value-field .cbi-input-invalid {
+	color: #f00;
+	border-bottom-color: #f00;
 }
 
 /* progressbar */
 .cbi-progressbar {
-	border: 1px solid #ccc;
-	border-radius: 3px;
 	position: relative;
 	min-width: 170px;
 	height: 20px;
-	margin: 0;
-	background: #fff;
+	margin: 4px 0;
+	border: thin solid #999;
+	background: #eee;
 }
 
 .cbi-progressbar > div {
-	background: var(--main-color, #0099CC);
+	width: 0;
 	height: 100%;
 	transition: width .25s ease-in;
-	width: 0%;
+	background: #5bc0de;
+	background: var(--bar-bg);
 }
 
 .cbi-progressbar::after {
+	font-family: monospace;
+	font-size: 1.3em;
+	font-weight: bold;
+	font-size-adjust: .38;
+	line-height: normal;
 	position: absolute;
-	bottom: 2px;
 	top: 2px;
 	right: 0;
+	bottom: 2px;
 	left: 0;
-	text-align: center;
-	text-shadow: 0 0 2px #fff;
-	content: attr(title);
-	white-space: pre;
 	overflow: hidden;
+	content: attr(title);
+	text-align: center;
+	white-space: pre;
 	text-overflow: ellipsis;
+	text-shadow: 0 0 2px #eee;
 }
 
-.cbi-value-field .cbi-input-select {
-    width: 15rem;
-}
-
-.cbi-value-field .cbi-input-invalid {
-    border-bottom-color: #f00;
-    color: #f00;
-}
-
-.th[data-type="button"], .td[data-type="button"],
-.th[data-type="fvalue"], .td[data-type="fvalue"] {
-    flex: 1 1 2em;
-    text-align: center;
+.th[data-type="button"],
+.td[data-type="button"],
+.th[data-type="fvalue"],
+.td[data-type="fvalue"] {
+	flex: 1 1 2em;
+	text-align: center;
 }
 
 .ifacebadge {
-    display: inline-flex;
-    border-bottom: 1px solid #CCCCCC;
-    padding: 0.5rem 1rem;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
-    background: #fff;
+	display: inline-flex;
+	padding: .5rem .8rem;
+	border-bottom: thin solid #ccc;
+	background: #eee;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, .2), 0 1px 2px rgba(0, 0, 0, .05);
 }
 
 td > .ifacebadge,
 .td > .ifacebadge {
-    background-color: #F0F0F0;
-    font-size: 0.9rem;
+	font-size: .8rem;
+	background-color: #f0f0f0;
 }
 
 .ifacebadge > em,
 .ifacebadge > img {
-    display: inline-block;
-    margin: 0 .2rem;
-    align-self: flex-start;
+	display: inline-block;
+	align-self: flex-start;
+	margin: 0 .2rem;
 }
 
 .ifacebadge > img + img {
-    margin: 0 .2rem 0 0;
+	margin: 0 .2rem 0 0;
 }
 
 .network-status-table {
-    display: flex;
-    flex-wrap: wrap;
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .network-status-table .ifacebox {
-    margin: .5em;
-    flex-grow: 1;
+	flex-grow: 1;
+	margin: .5em;
 }
 
 .network-status-table .ifacebox-body {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 }
 
 .network-status-table .ifacebox-body > span {
-    flex: 10 10 auto;
+	flex: 10 10 auto;
 }
 
 .network-status-table .ifacebox-body > div {
-    display: flex;
-    flex-wrap: wrap;
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .network-status-table .ifacebox-body .ifacebadge {
-    flex: 1 1 auto;
-    margin: .5em .25em 0 .25em;
-    padding: .5em;
-    min-width: 220px;
-    background-color: #fff;
-    align-items: center;
+	align-items: center;
+	flex: 1 1 auto;
+	min-width: 220px;
+	margin: .5em .25em 0 .25em;
+	padding: .5em;
+	background-color: #fff;
 }
 
-/*textarea*/
-
+/* textarea */
 .cbi-input-textarea {
-    width: 100%;
-    min-height: 14rem;
-    padding: 0.8rem;
-    font-size: 0.8rem;
-    font-family: monospace;
-    color: black;
+	font-family: monospace;
+	width: 100%;
+	min-height: 14rem;
+	padding: .8rem;
+	color: #000;
 }
 
 #syslog {
-    width: 100%;
-    min-height: 15rem;
-    padding: 1rem;
-    font-size: small;
-    color: #5F5F5F;
-
-    margin-bottom: 20px;
-    border-radius: 0;
-    background-color: #FFF;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
-    border: none;
+	font-size: small;
+	width: 100%;
+	min-height: 15rem;
+	margin-bottom: 20px;
+	padding: 1rem;
+	resize: none;
+	color: #eee;
+	border: 0;
+	border-radius: 0;
+	background-color: #101010;
+	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
 }
 
-/* change */
+#syslog:focus {
+	outline: 0;
+}
 
+/* config changes */
 .uci-change-list {
-    font-family: monospace;
+	font-family: monospace;
 }
 
 .uci-change-list ins,
 .uci-change-legend-label ins {
-    text-decoration: none;
-    border: 1px solid #00FF00;
-    background-color: #CCFFCC;
-    display: block;
-    padding: 2px;
+	display: block;
+	padding: 2px;
+	text-decoration: none;
+	border: thin solid #0f0;
+	background-color: #cfc;
 }
 
 .uci-change-list del,
 .uci-change-legend-label del {
-    text-decoration: none;
-    border: 1px solid #FF0000;
-    background-color: #FFCCCC;
-    display: block;
-    font-style: normal;
-    padding: 2px;
+	font-style: normal;
+	display: block;
+	padding: 2px;
+	text-decoration: none;
+	border: thin solid #f00;
+	background-color: #fcc;
 }
 
 .uci-change-list var,
 .uci-change-legend-label var {
-    text-decoration: none;
-    border: 1px solid #CCCCCC;
-    background-color: #EEEEEE;
-    display: block;
-    font-style: normal;
-    padding: 2px;
+	font-style: normal;
+	display: block;
+	padding: 2px;
+	text-decoration: none;
+	border: thin solid #ccc;
+	background-color: #eee;
 }
 
 .uci-change-list var ins,
 .uci-change-list var del {
-    border: none;
-    white-space: pre;
-    font-style: normal;
-    padding: 0px;
+	font-style: normal;
+	padding: 0;
+	white-space: pre;
+	border: 0;
 }
 
 .uci-change-legend {
-    padding: 5px;
+	padding: 5px;
 }
 
 .uci-change-legend-label {
-    width: 150px;
-    float: left;
+	float: left;
+	width: 150px;
 }
 
 .uci-change-legend-label > ins,
 .uci-change-legend-label > del,
 .uci-change-legend-label > var {
-    float: left;
-    margin-right: 4px;
-    width: 10px;
-    height: 10px;
-    display: block;
+	display: block;
+	float: left;
+	width: 10px;
+	height: 10px;
+	margin-right: 4px;
 }
 
 .uci-change-legend-label var ins,
 .uci-change-legend-label var del {
-    line-height: 6px;
-    border: none;
+	line-height: .4;
+	border: 0;
 }
 
 .uci-change-list var,
 .uci-change-list del,
 .uci-change-list ins {
-    padding: 0.5rem;
+	padding: .5rem;
 }
 
 /* other fix */
 #iwsvg,
 #iwsvg2,
 #bwsvg {
-    border: 1px solid #D4D4D4 !important;
-    border-top: none !important;
+	border: thin solid #d4d4d4 !important;
+}
+
+#iwsvg,
+[data-page="admin-status-realtime-bandwidth"] #bwsvg {
+	border-top: 0 !important;
 }
 
 .ifacebox {
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 2px rgba(0, 0, 0, 0.2);
-    border-bottom: 1px solid #ccc;
-    background-color: #f9f9f9;
-    display: inline-flex;
-    flex-direction: column;
-    line-height: 1.2em;
-    min-width: 100px;
+	line-height: 1.25;
+	display: inline-flex;
+	flex-direction: column;
+	min-width: 100px;
+	border-bottom: thin solid #ccc;
+	background-color: #f9f9f9;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, .4), 0 1px 2px rgba(0, 0, 0, .2);
 }
 
 .ifacebox-head {
-    padding: .25em;
-    background: #eee;
+	padding: .25em;
+	background: #eee;
 }
 
 .ifacebox-head.active {
-    background: #90c0e0;
+	background: #5bc0de;
+	background: var(--bar-bg);
 }
 
 .ifacebox-body {
-    padding: .25em;
+	padding: .25em;
 }
 
 .cbi-image-button {
-    margin-left: 0.5rem;
+	margin-left: .5rem;
 }
 
 .zonebadge {
-    padding: 0.2rem 0.5rem;
-    display: inline-block;
+	display: inline-block;
+	padding: .2rem .5rem;
 }
 
 .zonebadge .ifacebadge {
-    padding: .2rem .3rem;
-    margin: 0.1rem 0.2rem;
-    border: 1px solid #6C6C6C;
+	margin: .1rem .2rem;
+	padding: .2rem .3rem;
+	border: thin solid #6c6c6c;
 }
 
 .zonebadge > input[type="text"] {
-    padding: 0.16rem 1rem;
-    min-width: 10rem;
-    margin-top: 0.3rem;
+	min-width: 10rem;
+	margin-top: .3rem;
+	padding: .16rem 1rem;
 }
 
 .zonebadge > em,
 .zonebadge > strong {
-    margin: 0 0.2rem;
-    display: inline-block;
+	display: inline-block;
+	margin: 0 .2rem;
 }
 
 .cbi-value-field .cbi-input-checkbox,
 .cbi-value-field .cbi-input-radio {
-    margin-top: 0.5rem;
-    height: 1rem;
-}
-
-.td .cbi-input-checkbox,
-.td .cbi-input-radio {
-    margin-top: 0;
-}
-
-.cbi-value-field > input + .cbi-value-description {
-    padding: 0;
+	margin-top: .15rem;
 }
 
 .cbi-value-field > ul > li {
-    display: flex;
+	display: flex;
 }
 
 .cbi-value-field > ul > li > label {
-    margin-top: 0.5rem;
+	margin-top: .5rem;
 }
 
 .cbi-value-field > ul > li .ifacebadge {
-    background-color: #eee;
-    margin-left: 0.4rem;
-    margin-top: -0.5rem;
+	margin-top: -.5rem;
+	margin-left: .4rem;
+	background-color: #eee;
 }
 
 .cbi-section-table-row > .cbi-value-field .cbi-dropdown {
-    min-width: 7rem;
+	min-width: 7rem;
 }
 
 .cbi-section-create {
-    margin: .5rem -3px;
-    display: inline-flex;
-    align-items: center;
+	display: inline-flex;
+	align-items: center;
+	margin: .5rem -3px;
 }
 
 .cbi-section-create > * {
-    margin: 0.5rem;
+	margin: .5rem;
 }
 
 .cbi-section-remove {
-    padding: 0.5rem;
+	padding: .5rem;
 }
 
-div.cbi-value var, td.cbi-value-field var, .td.cbi-value-field var {
-    font-style: italic;
-    color: #0069D6;
+div.cbi-value var,
+td.cbi-value-field var,
+.td.cbi-value-field var {
+	font-style: italic;
+	color: #0069d6;
 }
 
 small {
-    font-size: 90%;
-    white-space: normal;
-    line-height: 1.42857143;
+	font-size: 90%;
+	line-height: 1.42857143;
+	white-space: normal;
 }
 
 .cbi-button-up,
 .cbi-button-down {
-    display: inline-block;
-    min-width: 0;
-    padding: 0.2rem 0.3rem;
-    font-size: 1.2rem;
+	font-size: 1.2rem;
+	display: inline-block;
+	min-width: 0;
+	padding: .2rem .3rem;
 }
 
 .cbi-optionals {
-    padding: 1rem 1rem 0 1rem;
-    border-top: 1px solid #CCC;
+	padding: 1rem 1rem 0 1rem;
+	border-top: thin solid #ccc;
 }
 
 .cbi-dropdown-container {
-    position: relative;
+	position: relative;
 }
 
-.cbi-tooltip-container {
-    cursor: help;
+.cbi-tooltip-container,
+span[data-tooltip],
+span[data-tooltip] .label {
+	cursor: help !important;
 }
 
 .cbi-tooltip {
-    position: absolute;
-    z-index: 1000;
-    left: -1000px;
-    border-radius: 3px;
-    background: #fff;
-    padding: 2px 5px;
-    white-space: pre;
-    opacity: 0;
-    transition: opacity .25s ease-out;
-    pointer-events: none;
-    box-shadow: 0 0 2px #444;
+	position: absolute;
+	z-index: 1000;
+	left: -1000px;
+	padding: 2px 5px;
+	transition: opacity .25s ease-out;
+	white-space: pre;
+	pointer-events: none;
+	opacity: 0;
+	border-radius: 3px;
+	background: #fff;
+	box-shadow: 0 0 2px #444;
 }
 
 .cbi-tooltip-container:hover .cbi-tooltip {
-    left: auto;
-    opacity: 1;
-    transition: opacity .25s ease-in;
+	left: auto;
+	transition: opacity .25s ease-in;
+	opacity: 1;
 }
 
 .zonebadge .cbi-tooltip {
-    padding: .25rem;
-    background: inherit;
-    margin: -1.5rem 0 0 -.5rem;
+	margin: -1.5rem 0 0 -.5rem;
+	padding: .25rem;
+	background: inherit;
 }
 
 .zonebadge-empty {
-    background: repeating-linear-gradient(45deg,rgba(204,204,204,0.5),rgba(204,204,204,0.5) 5px,rgba(255,255,255,0.5) 5px,rgba(255,255,255,0.5) 10px);
-    color: #404040;
+	color: #404040;
+	background: repeating-linear-gradient(45deg, rgba(204, 204, 204, .5), rgba(204, 204, 204, .5) 5px, rgba(255, 255, 255, .5) 5px, rgba(255, 255, 255, .5) 10px);
 }
 
 .zone-forwards {
-    display: flex;
-    min-width: 10rem;
+	display: flex;
+	min-width: 10rem;
 }
 
 .zone-forwards > * {
-    flex: 1 1 45%;
+	flex: 1 1 45%;
 }
 
 .zone-forwards > span {
-    flex-basis: 10%;
-    text-align: center;
-    padding: 0 .25rem;
+	flex-basis: 10%;
+	padding: 0 .25rem;
+	text-align: center;
 }
 
 .zone-forwards .zone-src,
 .zone-forwards .zone-dest {
-    display: flex;
-    flex-direction: column;
+	display: flex;
+	flex-direction: column;
 }
 
-#diag-rc-output > pre {
-    background-color: #f5f5f5;
-    display: block;
-    padding: 8.5px;
-    margin: 0 0 18px;
-    line-height: 1.5rem;
-    -moz-border-radius: 3px;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    font-size: 1.4rem;
-    color: #404040;
+.label {
+	font-size: .8rem;
+	font-weight: bold;
+	padding: .3rem .8rem;
+	white-space: nowrap;
+	text-decoration: none;
+	text-transform: uppercase;
+	color: #fff !important;
+	-webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
+	background-color: #bfbfbf;
+	text-shadow: none;
+}
+
+label > input[type="checkbox"],
+label > input[type="radio"] {
+	position: relative;
+	top: .4rem;
+	right: .2rem;
+	margin: 0;
+	vertical-align: bottom;
+}
+
+.showSide {
+	display: none;
+}
+
+.darkMask {
+	position: fixed;
+	z-index: 99;
+	display: none;
+	width: 100%;
+	height: 100%;
+	content: "";
+	background-color: rgba(0, 0, 0, .56);
+}
+
+/* diagnostics */
+#diag-rc-output > pre,
+#command-rc-output > pre {
+	font-size: 1.2rem;
+	font-size-adjust: .35;
+	line-height: normal;
+	display: block;
+	width: 100%;
+	padding: 8.5px;
+	white-space: pre;
+	color: #eee;
+	background-color: #101010;
+	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
+}
+
+[data-page="admin-network-diagnostics"] .table {
+	box-shadow: none;
 }
 
 input[name="ping"],
 input[name="traceroute"],
 input[name="nslookup"] {
-    width: 80%;
+	width: 80%;
 }
 
-header > .container > .pull-right > * {
-    position: relative;
-    top: 0.45rem;
-    cursor: pointer;
-}
-
-#xhr_poll_status > .label.success {
-    background-color: #14CE14;
-}
-
-#xhr_poll_status {
-    display: flex;
-}
-
-.label {
-    padding: 0.3rem 0.8rem;
-    font-size: 0.8rem;
-    font-weight: bold;
-    color: #ffffff !important;
-    text-transform: uppercase;
-    white-space: nowrap;
-    background-color: #bfbfbf;
-    -webkit-border-radius: 3px;
-    -moz-border-radius: 3px;
-    border-radius: 3px;
-    text-shadow: none;
-    text-decoration: none;
-}
-
-label > input[type="checkbox"],
-label > input[type="radio"] {
-	vertical-align: bottom;
-	margin: 0;
-}
-
-.notice {
-    background-color: #5BC0DE !important;
-}
-
-.showSide {
-    display: none;
-}
-
-.darkMask {
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    background-color: rgba(0, 0, 0, 0.56);
-    content: "";
-    z-index: 99;
-    display: none;
-}
-
-/* fix Main Login*/
+/* fix Main Login */
 .node-main-login > .main > .main-left {
-    display: none;
+	display: none;
 }
 
 .node-main-login > .main > .main-right {
-    width: 100%;
+	width: 100%;
 }
 
 .node-main-login > .main fieldset {
-    padding: 0.5rem;
-    margin-bottom: 1rem;
-    display: inline;
-    background: none;
-    border: none;
-    box-shadow: none;
-    overflow: hidden;
+	display: inline;
+	overflow: hidden;
+	margin-bottom: 1rem;
+	padding: .5rem;
+	border: 0;
+	background: none;
+	box-shadow: none;
 }
 
 .node-main-login > .main .cbi-value-title {
-    width: 8rem;
+	width: 9.5rem;
 }
 
 .node-main-login > .main #maincontent {
-
-    text-align: center;
+	text-align: center;
 }
 
 .node-main-login > .main .container {
-    display: inline-block;
-    padding: 2rem 4rem;
-    margin-top: 2rem !important;
-    background-color: #FFF;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
-    text-align: left;
+	display: inline-block;
+	margin-top: 2rem !important;
+	padding: 1rem 3.5rem 2rem;
+	text-align: left;
+	background-color: #fff;
+	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
 }
 
 .node-main-login > .main form > div:nth-last-child(1) {
-    float: right;
+	float: right;
 }
 
 .node-main-login > .main .cbi-value {
-    display: block;
+	display: block;
 }
 
 .node-main-login > .main .cbi-value > * {
-    display: inline-block !important;
+	display: inline-block !important;
 }
 
-.node-main-login > .main .cbi-input-user,
-.node-main-login > .main .cbi-input-password {
-    min-width: 15rem;
+.node-main-login > .main .cbi-input-text {
+	min-width: 15rem;
 }
 
-.node-main-login footer {
-    bottom: 0;
-    position: absolute;
-    width: 100%;
+.node-main-login .cbi-section {
+	box-shadow: none;
+}
+
+@media screen and (min-height: 585px) {
+	.node-main-login footer {
+		position: absolute;
+		bottom: 0;
+		width: 100%;
+	}
 }
 
 /* fix status overview */
-
 .node-status-overview > .main fieldset:nth-child(4) .td:nth-child(2) {
-    white-space: normal;
+	white-space: normal;
 }
 
 /* fix status processes */
-
 .node-status-processes > .main .table .tr .td:nth-child(3) {
-    white-space: normal;
+	white-space: normal;
 }
 
-.node-status-iptables > .main div > .cbi-map > form {
-    margin: 2rem 2rem 0 0;
+.node-admin-status form {
+	margin: 2rem 2rem 0 0;
 }
 
 /* fix system reboot */
-
-.node-system-reboot > .main > .main-right p,
-.node-system-reboot > .main > .main-right h3 {
-    padding-left: 2rem;
+[data-page="admin-system-reboot"] p {
+	padding-left: 2rem;
 }
 
-/* fix Services  Network Shares*/
-.node-services-samba > .main .cbi-tabcontainer:nth-child(3) .cbi-value-title {
-    margin-bottom: 1rem;
-    width: auto;
+[data-page="admin-system-reboot"] p > span {
+	position: relative;
+	top: .1rem;
+	left: 1rem;
 }
 
-.node-services-samba > .main .cbi-tabcontainer:nth-child(3) .cbi-value-field {
-    display: list-item;
+/* samba */
+#cbi-samba .cbi-value-last .cbi-value-field {
+	display: block;
 }
 
-.node-services-samba > .main .cbi-tabcontainer:nth-child(3) .cbi-value-description {
-    padding-top: 1rem;
+#cbi-samba .cbi-value-last .cbi-value-title {
+	width: auto;
+	padding-bottom: .6rem;
 }
 
-/* fix System Software*/
-.node-system-packages > .main table tr td:nth-child(1) {
-    width: auto !important;
+/* software */
+.controls > * > .btn:not([aria-label$="page"]) {
+	flex-grow: initial !important;
+	margin-top: .1rem;
 }
 
-.node-system-packages > .main table tr td:nth-last-child(1) {
-    white-space: normal;
-    font-size: small;
-    color: #404040;
+.controls > #pager > .btn[aria-label$="page"] {
+	font-size: 1.4rem;
+	font-weight: bold;
 }
 
-.node-system-packages > .main .cbi-tabmenu > li > a, .tabs > li > a {
-    padding: 0.5rem 0.8rem;
+.controls > * > label {
+	margin-bottom: .2rem;
 }
 
-.node-system-packages > .main .cbi-value > pre {
-    background-color: #eee;
-    padding: 0.5rem;
-    overflow: auto;
+[data-page="admin-system-opkg"] div.btn {
+	line-height: 3;
+	display: inline;
+	padding: .3rem .6rem;
+}
+
+[data-page^="admin-system-admin"]:not(.node-main-login) .cbi-map:not(#cbi-dropbear),
+[data-page="admin-system-opkg"] #maincontent > .container {
+	margin-top: 2rem;
+	padding-top: .1rem;
+}
+
+[data-page="admin-system-opkg"] #maincontent > .container {
+	margin: 2rem;
+	margin-bottom: 1rem;
+}
+
+.td.version,
+.td.size {
+	white-space: normal !important;
+	word-break: break-word;
 }
 
 .cbi-tabmenu + .cbi-section {
-    margin-top: 0;
+	margin-top: 0;
 }
 
-.node-status-iptables fieldset,
-.node-system-packages fieldset,
-.node-system-flashops fieldset {
-    margin-top: 0;
+/* wireless overview */
+#cbi-wireless > #wifi_assoclist_table > .tr {
+	box-shadow: inset 1px -1px 0 #ddd, inset -1px -1px 0 #ddd;
 }
 
-.node-status-iptables .cbi-tabmenu,
-.node-system-packages .cbi-tabmenu,
-.node-system-flashops .cbi-tabmenu {
-    border: none;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
+#cbi-wireless > #wifi_assoclist_table > .tr.placeholder > .td {
+	right: 33px;
+	bottom: 33px;
+	left: 33px;
+	border-top: thin solid #ddd !important;
 }
 
-.node-system-flashops form.inline + form.inline {
-    margin-left: 0;
+#cbi-wireless > #wifi_assoclist_table > .tr.table-titles {
+	box-shadow: inset 1px 0 0 #ddd, inset -1px 0 0 #ddd;
+}
+
+#cbi-wireless > #wifi_assoclist_table > .tr.table-titles > .th {
+	border-bottom: thin solid #ddd;
+	box-shadow: 0 -1px 0 0 #ddd;
+}
+
+#wifi_assoclist_table > .tr > .td[data-title="RX Rate / TX Rate"] {
+	width: 23rem;
+}
+
+/* firewall */
+#iptables {
+	font-family: inherit;
+	font-weight: normal;
+	font-style: normal;
+	line-height: 1;
+	min-width: inherit;
+	margin: 0 0 2rem 0;
+	padding: 2rem;
+	border: 0;
+	border-radius: 0;
+	background-color: #fff;
 }
 
 #cbi-firewall-redirect table *,
 #cbi-network-switch_vlan table *,
 #cbi-firewall-zone table * {
-    font-size: small;
+	font-size: small;
 }
 
 #cbi-firewall-redirect table input[type="text"],
 #cbi-network-switch_vlan table input[type="text"],
 #cbi-firewall-zone table input[type="text"] {
-    width: 5rem;
+	width: 5rem;
 }
 
 #cbi-firewall-redirect table select,
 #cbi-network-switch_vlan table select,
 #cbi-firewall-zone table select {
-    min-width: 3.5rem;
+	min-width: 3.5rem;
 }
 
 #cbi-network-switch_vlan .th,
 #cbi-network-switch_vlan .td {
-    flex-basis: 12%;
+	flex-basis: 12%;
 }
 
-/* language fix */
-body.lang_pl.node-main-login .cbi-value-title {
-    width: 12rem;
+#cbi-firewall-zone .table,
+#cbi-network-switch_vlan .table {
+	display: block;
+}
+
+#cbi-firewall-zone .td.cbi-section-actions {
+	width: 100%;
 }
 
 /* applyreboot fix */
-
 #applyreboot-container {
 	margin: 2rem;
 }
 
 #applyreboot-section {
-	margin: 2rem;
 	line-height: 300%;
+	margin: 2rem;
+}
+
+/* openvpn bug fix */
+.OpenVPN a {
+	line-height: initial !important;
+}
+
+/* custom commands */
+.commandbox {
+	width: 24% !important;
+	padding: .5rem 1rem;
+	border-bottom: thin solid #ccc;
+	background: #eee;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, .2), 0 1px 2px rgba(0, 0, 0, .05);
+}
+
+.commandbox h3 {
+	line-height: normal !important;
+	overflow: hidden;
+	margin: 6px 0 !important;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.commandbox div {
+	left: auto !important;
+}
+
+.commandbox code {
+	position: absolute;
+	overflow-x: hidden;
+	overflow-y: auto;
+	max-width: 60%;
+	max-height: 55px;
+	margin-top: -3px;
+	margin-left: 4px;
+	padding: 2px 3px;
+	text-overflow: ellipsis;
+}
+
+.commandbox p:first-of-type {
+	margin-top: -6px;
+}
+
+.commandbox p:nth-of-type(2) {
+	margin-top: 2px;
+}
+
+[data-page^="admin-system-commands"] .panel-title,
+[data-page^="command-cfg"] .mobile-hide,
+[data-page^="command-cfg"] header > .fill > .container > img {
+	display: none;
+}
+
+#command-rc-output .alert-message {
+	line-height: 1.42857143;
+	position: absolute;
+	top: 40px;
+	right: 32px;
+	max-width: 40%;
+	margin: 0;
+	animation: anim-fade-in 1.5s forwards;
+	opacity: 0;
+}
+
+@keyframes anim-fade-in {
+	100% {
+		opacity: 1;
+	}
 }
 
 @media screen and (max-width: 1600px) {
-    .btn,
-    .cbi-button {
-        padding: 0.3rem 0.6rem;
-        font-size: 0.8rem;
-    }
+	header > .fill > .container > img {
+		margin: -.1rem 2.5rem 0 .5rem;
+	}
 
-    header > .container > .pull-right > * {
-        top: 0.35rem;
-    }
+	.main-left {
+		width: calc(0% + 13rem);
+	}
 
-    .label {
-        padding: 0.2rem 0.6rem;
-    }
+	.main-right {
+		width: calc(100% - 13rem);
+	}
 
-    .cbi-value-title {
-        width: 15rem;
-        padding-right: 0.6rem;
-    }
+	.cbi-dynlist > .item {
+		max-width: 21.9rem;
+	}
 
-    fieldset {
-        padding: 1rem;
-    }
+	.btn:not(button),
+	.cbi-button {
+		font-size: .8rem;
+		padding: .3rem .6rem;
+	}
 
-    .cbi-input-textarea {
-        font-size: small;
-    }
+	.label {
+		padding: .2rem .6rem;
+	}
 
-    .node-status-iptables > .main fieldset li > a {
-        padding: 0.3rem 0.6rem;
-    }
+	.cbi-value-title {
+		width: 15rem;
+		padding-right: .6rem;
+	}
+
+	fieldset,
+	.cbi-section {
+		padding: 1rem;
+	}
+
+	.cbi-input-textarea {
+		font-size: small;
+	}
+
+	.node-admin-status > .main fieldset li > a {
+		padding: .3rem .6rem;
+	}
+
+	#cbi-firewall-zone > .table {
+		display: block;
+	}
 }
 
-@media screen and (max-width: 1280px) {
-    header > .container {
-        margin-top: 0.25rem;
-    }
+@media screen and (max-width: 1366px) {
+	header {
+		height: 3.5rem;
+	}
 
-    .cbi-tabmenu > li > a, .tabs > li > a {
-        padding: 0.2rem 0.5rem;
-    }
+	header > .fill > .container {
+		margin-top: .25rem;
+		cursor: default;
+	}
 
-    .panel-title {
-        font-size: 1.1rem;
-        padding-bottom: 1rem;
-    }
+	.main {
+		top: 3.5rem;
+		height: calc(100% - 3.5rem);
+	}
 
-    table {
-        font-size: 0.7rem !important;
-        width: 100% !important;
-    }
+	.main-left {
+		top: 3.5rem;
+		width: calc(0% + 13rem);
+		height: calc(100% - 3.5rem);
+	}
+
+	.main-right {
+		width: calc(100% - 13rem);
+	}
+
+	.cbi-dynlist > .item {
+		max-width: 19.9rem;
+	}
+
+	.cbi-tabmenu > li > a,
+	.tabs > li > a {
+		padding: .2rem .5rem;
+	}
+
+	.panel-title {
+		font-size: 1.1rem;
+		padding-bottom: 1rem;
+	}
+
+	table {
+		font-size: .7rem !important;
+		width: 100% !important;
+	}
+
+	.table .cbi-input-text {
+		width: 100%;
+	}
+
+	.main > .main-left > .nav > li,
+	.main > .main-left > .nav > li a,
+	.main > .main-left > .nav > .slide > .menu {
+		font-size: .9rem;
+	}
+
+	.main > .main-left > .nav > .slide > .slide-menu > li > a {
+		font-size: .7rem;
+	}
+
+	#modal_overlay {
+		top: 3.5rem;
+	}
+
+	[data-page="admin-network-firewall-forwards"] .table:not(.cbi-section-table) {
+		display: block;
+	}
+
+	[data-page="admin-network-firewall-forwards"] .table:not(.cbi-section-table),
+	[data-page="admin-network-firewall-rules"] .table:not(.cbi-section-table),
+	[data-page="admin-network-hosts"] .table {
+		overflow-y: visible;
+	}
+
+	.commandbox {
+		width: 32% !important;
+	}
 }
 
-@media screen and (max-width: 992px) {
-    header > .fill > .container > img {
-        display: none;
-    }
+@media screen and (max-width: 1152px) {
+	header > .fill > .container > img {
+		display: none;
+	}
 
-    .main-left {
-        width: 0;
-        position: fixed;
-        z-index: 100;
-    }
+	header > .fill > .container > .brand {
+		position: relative;
+	}
 
-    .main-right {
-        width: 100%;
-    }
+	[data-page^="command-cfg"] header > .fill > .container > .brand {
+		display: block;
+		margin-top: -1.75rem;
+	}
 
-    .showSide {
-        padding: 0.1rem;
-        margin-right: 0.5rem;
-        display: inline-block;
-    }
+	html,
+	.main {
+		overflow-y: visible;
+	}
 
-    .showSide:before {
-        content: "\e20e";
-        font-size: 1.7rem;
-    }
+	.main-left {
+		position: fixed;
+		z-index: 100;
+		width: 0;
+	}
 
-    .node-main-login .showSide {
-        display: none !important;
-    }
+	.main-right {
+		width: 100%;
+	}
 
-    .cbi-value-title {
-        width: 9rem;
-        padding-right: 1rem;
-    }
+	.cbi-dynlist > .item {
+		max-width: 14.9rem;
+	}
 
-    .node-network-diagnostics > .main .cbi-map fieldset > div * {
-        width: 100% !important;
-    }
+	.showSide {
+		display: inline-block;
+		overflow: visible;
+		margin-right: .5rem;
+		padding: .1rem;
+		cursor: pointer;
+		border-radius: 50%;
+	}
 
-    .node-network-diagnostics > .main .cbi-map fieldset > div input[type="text"] {
-        margin: 3rem 0 0 0 !important;
-    }
+	.showSide:before {
+		font-size: 1.7rem;
+		content: "\e20e";
+	}
 
-    .node-network-diagnostics > .main .cbi-map fieldset > div:nth-child(4) input[type="text"] {
-        margin: 0 !important;
-    }
+	body:not(.logged-in) .showSide {
+		visibility: hidden;
+		width: 0;
+		margin: 0;
+		padding: 0;
+	}
 
-    .node-network-diagnostics > .main .cbi-map fieldset > div select,
-    .node-network-diagnostics > .main .cbi-map fieldset > div input[type="button"] {
-        margin: 1rem 0 0 0;
-    }
+	.node-main-login > .main .cbi-value-title {
+		text-align: left;
+	}
 
-    .node-network-diagnostics > .main .cbi-map fieldset > div {
-        width: 100% !important;
-    }
+	.cbi-value-title {
+		width: 9rem;
+		padding-right: 1rem;
+	}
 
-    #diag-rc-output > pre {
-        font-size: 1rem;
-    }
+	#diag-rc-output > pre,
+	#command-rc-output > pre {
+		font-size: 1rem;
+	}
 
-    .node-main-login > .main .cbi-value-title {
-        text-align: left;
-    }
+	.table {
+		display: block;
+	}
 
-    .tr {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-    }
+	#packages.table {
+		display: grid;
+	}
 
-    .th, .td {
-        flex: 2 2 25%;
-        align-self: flex-start;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        word-wrap: break-word;
-        display: inline-block;
-    }
+	.tr {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+	}
 
-    .td select,
-    .td input[type="text"] {
-        word-wrap: normal;
-        width: 100%;
-    }
+	.Overview .table[width="100%"] > .tr {
+		flex-wrap: nowrap;
+	}
 
-    .td [data-dynlist] > input,
-    .td input.cbi-input-password {
-        width: calc(100% - 1.5rem);
-    }
+	.tr.placeholder {
+		border-bottom: thin solid #ddd;
+	}
 
-    .td[data-type="button"],
-    .td[data-type="fvalue"] {
-        flex: 1 1 12.5%;
-        text-align: left;
-    }
+	.tr.placeholder > .td,
+	#cbi-firewall .tr > .td,
+	#iptables .tr:nth-child(2) > .td,
+	#cbi-network .tr:nth-child(2) > .td,
+	.cbi-section #wifi_assoclist_table .tr > .td {
+		border-top: 0;
+	}
 
-    .th.cbi-value-field,
-    .td.cbi-value-field,
-    .th.cbi-section-table-cell,
-    .td.cbi-section-table-cell {
-        flex-basis: auto;
-    }
+	.th,
+	.td {
+		display: inline-block;
+		align-self: flex-start;
+		flex: 2 2 25%;
+		text-overflow: ellipsis;
+		word-wrap: break-word;
+	}
 
-    .cbi-section-table-row {
-        display: flex;
-        flex-wrap: wrap;
-        flex-direction: row;
-        justify-content: space-between;
-    }
+	.td select,
+	.td input[type="text"] {
+		width: 100%;
+		word-wrap: normal;
+	}
 
-    .td.cbi-value-field,
-    .cbi-section-table-cell {
-        text-align: center;
-        display: inline-block;
-        flex: 10 10 auto;
-    }
+	.td [data-dynlist] > input,
+	.td input.cbi-input-password {
+		width: calc(100% - 1.5rem);
+	}
 
-    .td.cbi-section-actions {
-        text-align: right;
-        align-self: flex-end;
-        vertical-align: bottom;
-    }
+	.td[data-type="button"],
+	.td[data-type="fvalue"] {
+		flex: 1 1 12.5%;
+		text-align: left;
+	}
 
-    .tr.table-titles,
-    .tr.cbi-section-table-titles,
-    .tr.cbi-section-table-descr {
-        display: none;
-    }
+	.th.cbi-value-field,
+	.td.cbi-value-field,
+	.th.cbi-section-table-cell,
+	.td.cbi-section-table-cell {
+		flex-basis: auto;
+		padding-top: 1rem;
+	}
 
-    .tr[data-title]::before,
-    .tr.cbi-section-table-titles.named::before {
-        display: block;
-        flex: 1 1 100%;
-        background: #eef;
-        font-size: .9rem;
-        border-bottom: 1px solid rgba(0, 0, 0, .26);
-    }
+	.cbi-section-table-row {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
+	}
 
-    .td[data-title] {
-        text-align: left;
-    }
+	.td.cbi-value-field,
+	.cbi-section-table-cell {
+		display: inline-block;
+		flex: 10 10 auto;
+		flex-basis: 50%;
+		text-align: center;
+	}
 
-    .td[data-title]::before {
-        display: block;
-    }
+	.td.cbi-section-actions {
+		vertical-align: bottom;
+	}
 
-    .hide-sm,
-    .hide-xs {
-        display: none;
-    }
+	.tr.table-titles,
+	.tr.cbi-section-table-titles,
+	.tr.cbi-section-table-descr {
+		display: none;
+	}
+
+	.tr[data-title]::before,
+	.tr.cbi-section-table-titles.named::before {
+		font-size: .9rem;
+		display: block;
+		flex: 1 1 100%;
+		border-bottom: thin solid rgba(0, 0, 0, .26);
+		background: #90c0e0;
+	}
+
+	.td[data-title],
+	[data-page^="admin-status-realtime"] .td[id] {
+		text-align: left;
+	}
+
+	.td[data-title]::before {
+		display: block;
+	}
+
+	.cbi-button + .cbi-button {
+		margin-left: 0;
+	}
+
+	.td.cbi-section-actions > * > *,
+	.td.cbi-section-actions > * > form > * {
+		margin: 2.1px 3px;
+	}
+
+	.Firewall form {
+		font-family: inherit;
+		font-weight: normal;
+		font-style: normal;
+		line-height: normal;
+		position: static !important;
+		min-width: inherit;
+		margin: 0 0 2rem 0;
+		padding: 2rem;
+		border: 0;
+		border-radius: 0;
+		background-color: #fff;
+		box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
+	}
+
+	.Firewall form input {
+		width: 100% !important;
+		margin: 0;
+		margin-top: 1rem;
+	}
+
+	.Firewall .center,
+	.Firewall .center::before {
+		text-align: left !important;
+	}
+
+	.commandbox {
+		width: 100% !important;
+	}
 }
 
-@media screen and (max-width: 480px) {
-    body {
-        font-size: 1rem;
-    }
+@media screen and (max-width: 600px) {
+	body {
+		font-size: .8rem;
+	}
 
-    fieldset {
-        padding: 1rem;
-        margin: 1rem 0 0 0;
-    }
+	.cbi-progressbar::after {
+		font-size: .95em;
+		line-height: 1.5;
+	}
 
-    .tabs {
-        margin: 0 -1rem;
-    }
+	fieldset,
+	.cbi-section {
+		margin: 1rem 0 0 0;
+		padding: 1rem;
+	}
 
-    #maincontent > .container {
-        margin: 0 1rem 1.5rem 1rem;
-    }
+	.tabs {
+		margin: 0 -1rem;
+	}
 
-    .main > .main-left > .nav > .slide > .menu {
-        font-size: 1.3rem;
-    }
+	#maincontent > .container {
+		margin: 0 1rem 1.5rem 1rem;
+	}
 
-    .main > .main-left > .nav > .slide > .slide-menu > li > a {
-        font-size: 1.1rem;
-    }
+	.main > .main-left > .nav > .slide > .menu {
+		font-size: 1.2rem;
+	}
 
-    .cbi-value-title {
-        width: 100%;
-        min-width: 0rem !important;
-        display: block;
-        margin-top: 1rem;
-        margin-bottom: 0.5rem;
-        text-align: left;
-    }
+	.main > .main-left > .nav > .slide > .slide-menu > li > a {
+		font-size: 1rem;
+	}
 
-    .cbi-value-field, .cbi-value-description {
-        width: 100%;
-    }
+	.cbi-value-title {
+		display: block;
+		width: 100%;
+		min-width: 0 !important;
+		margin-top: 1rem;
+		margin-bottom: .5rem;
+		text-align: left;
+	}
 
-    .cbi-value > .cbi-value-field {
-        display: inline-block;
-    }
+	.cbi-value-field,
+	.cbi-value-description {
+		width: 100%;
+	}
 
-    .cbi-tabmenu > li, .tabs > li {
-        padding: 0.6rem 0rem;
-    }
+	.cbi-value > .cbi-value-field {
+		display: inline-block;
+	}
 
-    .cbi-tabmenu > li > a, .tabs > li > a {
-        padding: 0.2rem 0.3rem;
-        font-size: 0.9rem;
-    }
+	.cbi-tabmenu > li,
+	.tabs > li {
+		padding: .6rem 0;
+	}
 
-    .cbi-page-actions > div > input {
-        display: none;
-    }
+	.cbi-tabmenu > li > a,
+	.tabs > li > a {
+		font-size: .9rem;
+		padding: .2rem .3rem;
+	}
 
-    .node-main-login > .main .container {
-        padding: 0.5rem 1rem 2rem 1rem;
-    }
+	.cbi-page-actions > div > input {
+		display: none;
+	}
 
-    .node-main-login > .main .cbi-value {
-        padding: 0;
-    }
+	.cbi-page-actions > .cbi-button {
+		margin-top: .2rem;
+	}
 
-    .node-main-login > .main form > div:nth-last-child(1) {
-        margin-top: 2rem;
-    }
+	.node-main-login > .main .container {
+		margin: 2rem 1.2rem 1.5rem 1.2rem !important;
+		padding: .3rem 1.7rem 2rem 1.6rem;
+	}
 
-    .node-main-login > .main .cbi-value-title {
-        width: 100% !important;
-        font-size: 1.2rem;
-    }
+	.node-main-login > .main .cbi-value {
+		padding: 0;
+	}
 
-    .node-main-login > .main fieldset {
-        margin: 0;
-        padding: 0.5rem;
-    }
+	.node-main-login > .main form > div:nth-last-child(1) {
+		margin-top: 2rem;
+	}
 
-    h2 {
-        font-size: 2rem;
-    }
+	.node-main-login > .main .cbi-value-title {
+		font-size: 1.2rem;
+		width: 100% !important;
+	}
 
-    .tabs > li > a {
-        font-size: 0.9rem;
-    }
+	.node-main-login > .main fieldset {
+		margin: 0;
+		padding: .5rem;
+	}
 
-    select,
-    input {
-        font-size: 0.9rem;
-    }
+	.commandbox p:first-of-type {
+		margin-top: -8px;
+	}
 
-    .mobile-hide {
-        display: none;
-    }
+	#diag-rc-output > pre,
+	#command-rc-output > pre {
+		font-size: .8rem;
+	}
 
-    .panel-title {
-        font-size: 1.4rem;
-        padding-bottom: 1rem;
-    }
+	h2 {
+		font-size: 2rem;
+	}
 
-    .node-system-packages > .main .cbi-value.cbi-value-last > div {
-        width: 100% !important;
-    }
+	.tabs > li > a {
+		font-size: .9rem;
+	}
 
-    .node-system-packages > .main .cbi-value .cbi-value-field input {
-        width: 100%;
-    }
+	select,
+	input {
+		font-size: .9rem;
+	}
 
-    .node-status-iptables > .main div > .cbi-map > form {
-        position: static !important;
-        margin: 0 0 2rem 0;
-        padding: 2rem;
-        border: 0;
-        font-weight: normal;
-        font-style: normal;
-        line-height: 1;
-        font-family: inherit;
-        min-width: inherit;
-        border-radius: 0;
-        background-color: #FFF;
-        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .16), 0 0 2px 0 rgba(0, 0, 0, .12);
-        -webkit-overflow-scrolling: touch;
-    }
+	code {
+		font-size: .8rem;
+	}
 
-    .node-status-iptables > .main div > .cbi-map > form input[type="submit"] {
-        width: 100% !important;
-        margin: 0;
-    }
+	.mobile-hide {
+		display: none;
+	}
 
-    .node-status-iptables > .main div > .cbi-map > form input[type="submit"] + input[type="submit"] {
-        margin-top: 1rem;
-    }
+	.panel-title {
+		font-size: 1.4rem;
+		padding-bottom: 1rem;
+	}
 
-    .th, .td {
-        flex-basis: 50%;
-    }
+	.node-system-packages > .main .cbi-value.cbi-value-last > div {
+		width: 100% !important;
+	}
 
-    .td.cbi-value-field {
-        flex-basis: 100%;
-    }
+	.node-system-packages > .main .cbi-value .cbi-value-field input {
+		width: 100%;
+	}
 
-    .td.cbi-value-field[data-type="dvalue"] {
-        flex-basis: 50%;
-    }
+	.th,
+	.td {
+		flex-basis: 50%;
+	}
 
-    .td.cbi-value-field[data-type="button"],
-    .td.cbi-value-field[data-type="fvalue"] {
-        flex-basis: 25%;
-        text-align: left;
-    }
+	.td.cbi-value-field {
+		flex-basis: 100%;
+	}
 
-    .tr[data-title]::before,
-    .tr.cbi-section-table-titles.named::before {
-        font-size: 1rem;
-    }
+	.td.cbi-value-field[data-type="button"],
+	.td.cbi-value-field[data-type="fvalue"] {
+		flex-basis: 25%;
+		text-align: left;
+	}
 
-    .hide-xs {
-        display: none;
-    }
+	.tr[data-title]::before,
+	.tr.cbi-section-table-titles.named::before {
+		font-size: 1rem;
+	}
+
+	td > .ifacebadge,
+	.td > .ifacebadge {
+		font-size: .62rem;
+	}
+
+	#cbi-wireless .td {
+		overflow: hidden;
+	}
+
+	.hide-sm,
+	.hide-xs:not([data-title="MAC-Address"]) {
+		display: none;
+	}
 }
 
-@media screen and (min-width: 992px) {
-    .cbi-value input[type="password"],
-    .cbi-value input[type="text"],
-    .cbi-value-field .cbi-input-select {
-        width: 20rem;
-    }
+@media screen and (min-width: 1152px) {
+	.cbi-value input[type="password"],
+	.cbi-value input[type="text"] {
+		min-width: 20rem;
+	}
 
-    .cbi-value-field .cbi-dropdown {
-        min-width: 20rem;
-    }
+	.cbi-value-field .cbi-input-select {
+		width: 20rem;
+	}
+
+	.cbi-value-field .cbi-dropdown {
+		min-width: 20rem;
+	}
+
+	.cbi-section-node .tr {
+		overflow: hidden;
+	}
 }
 
-@media screen and (min-width: 1280px) {
-    .cbi-value input[type="password"],
-    .cbi-value input[type="text"],
-    .cbi-value-field .cbi-input-select {
-        width: 22rem;
-    }
+@media screen and (min-width: 1366px) {
+	.cbi-value input[type="password"],
+	.cbi-value input[type="text"] {
+		min-width: 22rem;
+	}
 
-    .cbi-value-field .cbi-dropdown {
-        min-width: 22rem;
-    }
+	.cbi-value-field .cbi-input-select {
+		width: 22rem;
+	}
+
+	.cbi-value-field .cbi-dropdown {
+		min-width: 22rem;
+	}
 }
 
 @media screen and (min-width: 1600px) {
-    .cbi-value input[type="password"],
-    .cbi-value input[type="text"],
-    .cbi-value-field .cbi-input-select {
-        width: 25rem;
-    }
+	.cbi-value input[type="password"],
+	.cbi-value input[type="text"] {
+		min-width: 25rem;
+	}
 
-    .cbi-value-field .cbi-dropdown {
-        min-width: 25rem;
-    }
+	.cbi-value-field .cbi-input-select {
+		width: 25rem;
+	}
+
+	.cbi-value-field .cbi-dropdown {
+		min-width: 25rem;
+	}
 }

--- a/themes/luci-theme-material/htdocs/luci-static/material/custom.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/custom.css
@@ -1,11 +1,12 @@
-
 :root {
-	--main-color: #0099CC;
-	--header-bg: #0099CC;
-	--header-color: #FFFFFF;
-	--menu-bg-color: #FFFFFF;
-	--menu-color: #404040;
-	--submenu-bg-hover: #D4D4D4;
-	--submenu-bg-hover-active: #0099CC;
+	--main-color: #09c;
+	--header-bg: #09c;
+	--header-color: #fff;
+	--bar-bg: #5bc0de;
+	--menu-bg-color: #fff;
+	--menu-color: #5f6368;
+	--menu-color-hover: #202124;
+	--submenu-bg-hover: #d4d4d4;
+	--submenu-bg-hover-active: #09c;
 	--font-body: "Microsoft Yahei", "WenQuanYi Micro Hei", "sans-serif", "Helvetica Neue", "Helvetica", "Hiragino Sans GB";
 }

--- a/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
+++ b/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
@@ -159,7 +159,7 @@
             $(".main-left").stop(true).animate({
                 width: "0"
             }, "fast");
-            $(".main-right").css("overflow-y", "auto");
+            $(".main-right").css("overflow-y", "visible");
             showSide = false;
         } else {
             $(".darkMask").stop(true).fadeIn("fast");
@@ -179,7 +179,7 @@
             $(".main-left").stop(true).animate({
                 width: "0"
             }, "fast");
-            $(".main-right").css("overflow-y", "auto");
+            $(".main-right").css("overflow-y", "visible");
         }
     });
 

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -206,7 +206,7 @@
 	<div class="fill">
 		<div class="container">
 			<span class="showSide"></span>
-			<img src="<%=media%>/brand.png"/>
+			<a id="logo" href="<%=url("admin/status/overview")%>"><img src="<%=media%>/brand.png" alt="OpenWrt"></a>
 			<a class="brand" href="#"><%=boardinfo.hostname or "?"%></a>
 			<div class="status">
 				<% render_changes() %>


### PR DESCRIPTION
The material theme is a mess in its current state. This attempts to solve a lot of the problems. A total rewrite would be the proper solution, but I think this is a good compromise.
  
It also reverts the removal of color fill to the buttons since the theme originally seemed to rely on color vibrancy to emphasize button actions. It already barely follows "material design" spec as it is and I don't think heavy use of empty buttons is a good idea without fancy animation that requires heavier js (dynamic ripple) and other significant changes to the button scheme.

Issues #1231, #1795, and #2258 can be closed.