### PR TITLE
luci-mod-network: add master option

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(finestra de %d minuts, interval de %d segons)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s disponibles)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Escolliu, si us plau --"
 msgid "-- custom --"
 msgstr "-- personalitzat --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -208,7 +202,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configuració dels <abbr title=\"Light Emitting Diode\">LED</abbr>s"
 
@@ -257,23 +251,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -287,25 +281,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "Llindar de reintent ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Ponts ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "Identificador de canal virtual (VCI) ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "Identificador de camí virtual (VPI) ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -315,7 +309,7 @@ msgstr ""
 "de xarxa virtual de Linux que es poden utilitzar conjuntament amb DHCP o PPP "
 "per trucar a la xarxa del proveïdor."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Número de dispositiu ATM"
@@ -339,8 +333,7 @@ msgstr "Concentrador d'accés"
 msgid "Access Point"
 msgstr "Punt d'accés"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Accions"
 
@@ -366,7 +359,7 @@ msgstr "Arrendaments DHCP actius"
 msgid "Active DHCPv6 Leases"
 msgstr "Arrendaments DHCPv6 actius"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -376,7 +369,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -387,7 +380,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Afegeix"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -423,7 +416,7 @@ msgstr ""
 "Afegeix el sufix de domini local als noms servits des dels fitxers de hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Afegeix una interfície nova..."
 
@@ -467,19 +460,18 @@ msgid "Address to access local relay bridge"
 msgstr "Adreça per accedir al relay bridge local"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administració"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Paràmetres avançats"
 
@@ -491,7 +483,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -566,7 +558,7 @@ msgstr "Permet respostes del rang 127.0.0.0/8, p.e. per serveis RBL"
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -576,76 +568,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -653,11 +645,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -667,6 +659,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Qualsevol zona"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -696,13 +692,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Estacions associades"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -753,27 +753,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Disponible"
 
@@ -791,11 +791,11 @@ msgstr "Disponible"
 msgid "Average:"
 msgstr "Mitjana:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -819,14 +819,15 @@ msgstr "Enrere al Resum"
 msgid "Back to configuration"
 msgstr "Enrere a la configuració"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Còpia de seguretat"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Còpia de seguretat i microprogramari"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Llista de còpies de seguretat"
@@ -844,6 +845,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -878,17 +880,17 @@ msgstr "Velocitat de bits"
 msgid "Bogus NX Domain Override"
 msgstr "Substitució dels dominis NX falsos"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Pont"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Pont d'interfícies"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Número d'unitat de pont"
 
@@ -897,6 +899,7 @@ msgid "Bring up on boot"
 msgstr "Aixecar a l'engegada"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -924,11 +927,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancel·la"
 
@@ -936,12 +941,8 @@ msgstr "Cancel·la"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -975,28 +976,29 @@ msgstr "Canvia la paraula clau de l'administrador per accedir al dispositiu"
 msgid "Channel"
 msgstr "Canal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Comprovació"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Suma de verificació"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1024,7 +1026,7 @@ msgstr "Xifra"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1032,13 +1034,13 @@ msgstr ""
 "Fes clic a \"Genera l'arxiu\" per obtenir un fitxer .tar.gz amb els fitxers "
 "de configuració actuals."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1073,7 +1075,7 @@ msgstr "Tanca la llista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1088,7 +1090,7 @@ msgstr "Aplegant dades..."
 msgid "Command"
 msgstr "Ordre"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1110,8 +1112,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Configuració"
 
@@ -1120,7 +1121,7 @@ msgstr "Configuració"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1132,7 +1133,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1152,7 +1153,7 @@ msgstr "Connectat"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1161,11 +1162,14 @@ msgid "Connections"
 msgstr "Connexions"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1185,11 +1189,11 @@ msgid "Country Code"
 msgstr "Codi de País"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Crea / Assigna zona de tallafocs"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1218,7 +1222,7 @@ msgstr "Interfície personalitzada"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1253,7 +1257,7 @@ msgstr "Servidor DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP i DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1268,7 +1272,7 @@ msgstr "Opcions DHCP"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1313,7 +1317,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1322,7 +1326,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1364,7 +1368,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Passarel·la per defecte"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1384,9 +1388,9 @@ msgid ""
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1447,10 +1451,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Dispositiu"
 
@@ -1540,7 +1544,7 @@ msgstr "Descarta les respostes RFC1918 des de dalt"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1549,11 +1553,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1597,6 +1602,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1625,19 +1634,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Descarrega còpia de seguretat"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1681,9 +1690,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Mètode EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1785,25 +1794,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Activa/Desactiva"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Habilitat"
 
@@ -1825,8 +1826,8 @@ msgstr "Habilita l'Spanning Tree Protocol a aquest pont"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Mode d'encapsulació"
 
@@ -1854,7 +1855,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Esborrant..."
 
@@ -1876,12 +1877,12 @@ msgstr "Error"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
@@ -1979,9 +1980,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Nom de fitxer de la imatge d'inici que es publica als clients"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Sistema de fitxers"
 
@@ -1998,7 +1998,7 @@ msgstr "Filtra els no útils"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2028,7 +2028,7 @@ msgstr "Ajusts de tallafocs"
 msgid "Firewall Status"
 msgstr "Estat de tallafocs"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2040,25 +2040,27 @@ msgstr "Versió de microprogramari"
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Escriptura del microprogramari a la memòria flaix"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Puja una imatge..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Escriu una imatge nova a la memòria flaix"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Operacions a la memòria flaix"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Escrivint a la memòria flaix..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2084,11 +2086,11 @@ msgstr "Força el TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Força el TKIP i el CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2116,7 +2118,7 @@ msgstr "Reenvia el trànsit difós"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Mode de reenviament"
 
@@ -2163,20 +2165,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Ajusts generals"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2184,7 +2185,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Genera l'arxiu"
 
@@ -2194,11 +2195,11 @@ msgstr ""
 "La contrasenya i la confirmació de contrasenya no es coincideixen. La "
 "contrasenya no s'ha canviat!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2209,7 +2210,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Vés a la configuració de contrasenya"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2260,7 +2261,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "Nom de màquina"
 
@@ -2452,7 +2453,7 @@ msgstr "Veïns IPv6"
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2539,14 +2540,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2585,7 +2586,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2612,7 +2613,7 @@ msgstr "Ignora la interfície"
 msgid "Ignore resolve file"
 msgstr "Ignora el fitxer de resolució"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Fitxer d'imatge"
 
@@ -2672,8 +2673,8 @@ msgstr "Instal·la extensions de protocol"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2757,11 +2758,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2777,7 +2778,7 @@ msgstr "Usuari i/o contrasenya invàlids! Si us plau prova-ho de nou."
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2801,11 +2802,11 @@ msgstr "Uneix-te a la xarxa"
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Mantenir la configuració"
 
@@ -2861,12 +2862,12 @@ msgstr "Llindar de fracàs d'eco LCP"
 msgid "LCP echo interval"
 msgstr "Interval d'eco LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Etiqueta"
 
@@ -3023,7 +3024,7 @@ msgstr "Carregant"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3130,7 +3131,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3163,7 +3164,7 @@ msgstr ""
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3177,7 +3178,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3193,7 +3194,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3252,7 +3254,7 @@ msgstr "Memòria"
 msgid "Memory usage (%)"
 msgstr "Ús de Memòria (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3260,7 +3262,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3319,7 +3321,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Temps d'espera d'inici de mòdem"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3332,30 +3334,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Punt de muntatge"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Punts de muntatge"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3363,23 +3360,27 @@ msgstr ""
 "Els punts de muntatge defineixen en quin punt un dispositiu de memòria "
 "s'adjuntarà amb el sistema de fitxers"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Opcions de muntatge"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Sistemes de fitxers muntats"
 
@@ -3420,15 +3421,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Candidats de servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nom"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Nom de la nova xarxa"
 
@@ -3439,7 +3440,7 @@ msgstr "Navegació"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3464,7 +3465,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "Xarxa sense interfícies."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3489,7 +3490,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3542,7 +3543,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Cap zona assignada"
 
@@ -3600,7 +3601,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3673,6 +3674,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Un o més dels camps requerits no té valor!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Obre una llista..."
@@ -3752,7 +3754,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Opcions"
 
@@ -3915,7 +3916,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3924,7 +3925,7 @@ msgid "Packets"
 msgstr "Paquets"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Part de la zona %q"
 
@@ -4022,11 +4023,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Executa un reinici"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Executa un reinici"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4065,6 +4066,10 @@ msgstr "Paquets"
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Si us plau entra el teu nom d'usuari i contrasenya."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4133,10 +4138,6 @@ msgstr "Evita la comunicació client a client"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Procedeix"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4152,7 +4153,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4235,7 +4236,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Velocitat RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4281,10 +4282,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4317,7 +4314,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reinicia"
@@ -4326,6 +4323,11 @@ msgstr "Reinicia"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Reiniciant..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4379,7 +4381,7 @@ msgstr "Adreça IPv4 remota o FQDN"
 msgid "Remove"
 msgstr "Treu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Reemplaça la configuració sense fil"
 
@@ -4391,7 +4393,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4474,7 +4476,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4486,7 +4488,7 @@ msgstr "Restableix"
 msgid "Reset Counters"
 msgstr "Reinicia els comptadors"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Reestableix els valors per defecte"
 
@@ -4498,7 +4500,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4517,11 +4519,11 @@ msgstr "Reinicia el tallafocs"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Restauració de la configuració"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Restaura còpia de seguretat"
 
@@ -4546,15 +4548,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Arrel"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Directori arrel dels fitxers servits per TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4575,7 +4573,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Contrasenya de l'encaminador"
 
@@ -4597,19 +4595,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4618,7 +4616,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Accés SSH"
 
@@ -4635,7 +4633,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "Claus SSH"
 
@@ -4646,30 +4644,31 @@ msgstr "Claus SSH"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Desa"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Desa i aplica"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4678,7 +4677,7 @@ msgid "Scan"
 msgstr "Escaneja"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Tasques programades"
 
@@ -4690,11 +4689,11 @@ msgstr "Secció afegida"
 msgid "Section removed"
 msgstr "Secció treta"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4735,7 +4734,7 @@ msgstr "Tipus de servei"
 msgid "Services"
 msgstr "Serveis"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4743,10 +4742,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4776,6 +4779,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4797,7 +4801,7 @@ msgstr "Atura aquesta interfície"
 msgid "Signal"
 msgstr "Senyal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4809,7 +4813,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Senyal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Mida"
 
@@ -4834,7 +4838,7 @@ msgstr "Salta al contingut"
 msgid "Skip to navigation"
 msgstr "Salta a la navegació"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4851,7 +4855,7 @@ msgstr "Tristament, l'object que heu sol·licitat no s'ha trobat."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Tristament, el servidor ha encontrat un error inesperat."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4868,7 +4872,7 @@ msgstr "Origen"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Especifica el directori a que el dispositiu està adjuntat"
 
@@ -4907,7 +4911,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Especifiqueu el clau de xifració secret aquí."
 
@@ -4930,7 +4934,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Arrencada"
 
@@ -4950,7 +4954,7 @@ msgstr "Leases estàtics"
 msgid "Static Routes"
 msgstr "Rutes estàtiques"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4989,7 +4993,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Envia"
 
@@ -5004,10 +5008,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Entrada d'intercanvi"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5027,7 +5027,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5120,6 +5120,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Acaba"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5137,17 +5141,13 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Els caràcters permets són: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> i <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5164,8 +5164,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5179,26 +5179,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"El sistema the fitxers que es va fer servir per formatar la memòria (<abbr "
-"title=\"per exemple example\">p.e.</abbr> <samp><abbr title=\"Third Extended "
-"Filesystem\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"S'ha pujat la imatge per a la memòria flaix. A sota hi ha llistades la suma "
-"de verificació i la mida del fitxer per assegurar la integritat de les dades."
-"<br />Fes clic a \"Procedeix\" a continuació per començar el procés "
-"d'escriptura a la memòria flaix."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5218,11 +5208,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5243,7 +5233,7 @@ msgstr "La longitud del prefix IPv6 en bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5257,6 +5247,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5265,7 +5263,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5273,7 +5271,7 @@ msgstr ""
 "El sistema està esborrant la partició de configuració i es reiniciarà quan "
 "termini."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5287,11 +5285,32 @@ msgstr ""
 "connectar-te de nou a l'encaminador, depenent de la configuració que hi "
 "tinguis."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5342,6 +5361,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5431,11 +5451,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Zona horària"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5446,7 +5466,7 @@ msgstr ""
 "inicial, fes clic a \"Restableix la configuració\" (només funciona amb "
 "imatges squashfs)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5486,7 +5506,7 @@ msgstr "Mode d'activació"
 msgid "Tunnel ID"
 msgstr "ID del túnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interfície del túnel"
@@ -5529,8 +5549,8 @@ msgstr "Dispositiu USB"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5560,6 +5580,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5571,6 +5595,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5579,28 +5604,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Sense gestionar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5613,7 +5638,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Canvis sense desar"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5636,7 +5661,11 @@ msgstr "Tipus de protocol no suportat."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5646,7 +5675,9 @@ msgstr ""
 "microprogramari actual. Activa \"Mantenir la configuració\" per retenir la "
 "configuració actual (requereix una imatge de microprogramari compatible)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Puja un arxiu..."
 
@@ -5659,7 +5690,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5717,11 +5754,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5729,7 +5766,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "Utilitza la bandera de difusió"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5792,7 +5829,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Usat"
 
@@ -5820,11 +5857,11 @@ msgstr ""
 msgid "Username"
 msgstr "Nom d'usuari"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5871,9 +5908,9 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Classe de venidor per enviar al sol·licitar DHCP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Verifica"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5893,7 +5930,7 @@ msgstr "Sistema obert WEP"
 msgid "WEP Shared Key"
 msgstr "Clau compartit WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Contrasenya WEP"
 
@@ -5901,7 +5938,7 @@ msgstr "Contrasenya WEP"
 msgid "WMM Mode"
 msgstr "Mode WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Contrasenya WPA"
 
@@ -5965,13 +6002,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Sense fils"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adaptador sense fils"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6022,7 +6059,7 @@ msgstr "Escriure el registre del sistema al fitxer"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6069,9 +6106,9 @@ msgstr ""
 msgid "any"
 msgstr "qualsevol"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6089,7 +6126,7 @@ msgstr "estàtic"
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "pontejat"
 
@@ -6106,7 +6143,7 @@ msgid "create:"
 msgstr "crea:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "crea un pont entre les interfícies especificades"
 
@@ -6242,8 +6279,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "no"
 
@@ -6255,13 +6290,13 @@ msgstr "cap enllaç"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "cap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6291,10 +6326,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6313,7 +6344,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "encaminat"
 
@@ -6327,15 +6358,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6553,14 +6584,58 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "sí"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Enrere"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s disponibles)"
+
+#~ msgid "Check"
+#~ msgstr "Comprovació"
+
+#~ msgid "Checksum"
+#~ msgstr "Suma de verificació"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Escriptura del microprogramari a la memòria flaix"
+
+#~ msgid "Flashing..."
+#~ msgstr "Escrivint a la memòria flaix..."
+
+#~ msgid "Proceed"
+#~ msgstr "Procedeix"
+
+#~ msgid "Root"
+#~ msgstr "Arrel"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Entrada d'intercanvi"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "El sistema the fitxers que es va fer servir per formatar la memòria "
+#~ "(<abbr title=\"per exemple example\">p.e.</abbr> <samp><abbr title="
+#~ "\"Third Extended Filesystem\">ext3</abbr></samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "S'ha pujat la imatge per a la memòria flaix. A sota hi ha llistades la "
+#~ "suma de verificació i la mida del fitxer per assegurar la integritat de "
+#~ "les dades.<br />Fes clic a \"Procedeix\" a continuació per començar el "
+#~ "procés d'escriptura a la memòria flaix."
+
+#~ msgid "Verify"
+#~ msgstr "Verifica"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr ""

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -35,10 +35,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d minutové okno, %d sekundový interval)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s k dispozici)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -79,15 +75,13 @@ msgstr "-- Prosím vyberte --"
 msgid "-- custom --"
 msgstr "-- vlastní --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -205,7 +199,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Konfigurace"
 
@@ -252,23 +246,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -282,25 +276,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "ARP limit opakování"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM mosty"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "Identifikátor virtuálního kanálu ATM (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "Identifikátor virtuální cesty ATM (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -310,7 +304,7 @@ msgstr ""
 "virtuální síťová rozhraní Linuxu, které mohou být použity ve spojení s DHCP "
 "nebo PPP vytáčeného připojení od poskytovatele sítě."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "číslo ATM zařízení"
@@ -334,8 +328,7 @@ msgstr "Přístupový koncentrátor"
 msgid "Access Point"
 msgstr "Přístupový bod"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Akce"
 
@@ -365,7 +358,7 @@ msgstr "Aktivní propůjčené DHCP adresy (leases)"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktivní propůjčené DHCPv6 adresy (leases)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -375,7 +368,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -386,7 +379,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Přidat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -421,7 +414,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "Přidat lokální koncovku k doménovým jménům ze souboru hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Přidat rozhraní..."
 
@@ -465,19 +458,18 @@ msgid "Address to access local relay bridge"
 msgstr "Adresa pro přístup k místnímu relay bridge"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Správa"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Pokročilé nastavení"
 
@@ -489,7 +481,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Upozornění"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -562,7 +554,7 @@ msgstr "Povolit upstream odpovědi na 127.0.0.0/8 rozsah, např. pro RBL služby
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -572,76 +564,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -649,11 +641,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -663,6 +655,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Libovolná zóna"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -692,13 +688,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Připojení klienti"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -749,27 +749,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Dostupné"
 
@@ -787,11 +787,11 @@ msgstr "Dostupné"
 msgid "Average:"
 msgstr "Průměr:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -815,14 +815,15 @@ msgstr "Zpět k přehledu"
 msgid "Back to configuration"
 msgstr "Zpět ke konfiguraci"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Zálohovat"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Zálohovat / nahrát firmware"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Seznam souborů k zálohování"
@@ -840,6 +841,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -874,17 +876,17 @@ msgstr "Přenosová rychlost"
 msgid "Bogus NX Domain Override"
 msgstr "Přepíše falešnou hodnotu NX Domény"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Síťový most"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Síťové mosty"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Číslo síťového mostu"
 
@@ -893,6 +895,7 @@ msgid "Bring up on boot"
 msgstr "Zapnout po startu"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -920,11 +923,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Storno"
 
@@ -932,12 +937,8 @@ msgstr "Storno"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -971,28 +972,29 @@ msgstr "Změní administrátorské heslo pro přístup k zařízení"
 msgid "Channel"
 msgstr "Kanál"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Kontrola"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Kontrolní součet"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1020,20 +1022,20 @@ msgstr "Šifra"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr ""
 "Pro stažení archivu tar s aktuální konfigurací stiskněte \"Vytvořit archiv\"."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1070,7 +1072,7 @@ msgstr "Zavřít seznam..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1085,7 +1087,7 @@ msgstr "Probíhá sběr dat..."
 msgid "Command"
 msgstr "Příkaz"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1107,8 +1109,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Nastavení"
 
@@ -1117,7 +1118,7 @@ msgstr "Nastavení"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1129,7 +1130,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1149,7 +1150,7 @@ msgstr "Připojeno"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1158,11 +1159,14 @@ msgid "Connections"
 msgstr "Připojení"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1182,11 +1186,11 @@ msgid "Country Code"
 msgstr "Kód země"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Vytvořit / přiřadit zónu firewallu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1215,7 +1219,7 @@ msgstr "Vlastní rozhraní"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1250,7 +1254,7 @@ msgstr "DHCP server"
 msgid "DHCP and DNS"
 msgstr "DHCP a DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1265,7 +1269,7 @@ msgstr "Volby DHCP"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1319,7 +1323,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1361,7 +1365,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Výchozí brána"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1383,9 +1387,9 @@ msgstr ""
 "které odkazuje na různé DNS servery pro klienty."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1446,10 +1450,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Zařízení"
 
@@ -1539,7 +1543,7 @@ msgstr "Vyřadit upstream RFC1918 odpovědi"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1548,11 +1552,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1598,6 +1603,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1626,19 +1635,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Stáhnout zálohu"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1684,9 +1693,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Metoda EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1788,25 +1797,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Povolit tento přípojný bod"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Povolit tento swapovací oddíl"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Povolit/Zakázat"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Povoleno"
 
@@ -1828,8 +1829,8 @@ msgstr "Na tomto síťovém mostě povolit Spanning Tree Protocol"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Režim zapouzdření"
 
@@ -1857,7 +1858,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Odstraňování..."
 
@@ -1879,12 +1880,12 @@ msgstr "Chyba"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernetový adaptér"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernetový switch"
@@ -1984,9 +1985,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Název souboru s bootovacím obrazem oznamovaný klientům"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Souborový systém"
 
@@ -2003,7 +2003,7 @@ msgstr "Filtrovat nepotřebné"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2033,7 +2033,7 @@ msgstr "Nastavení firewallu"
 msgid "Firewall Status"
 msgstr "Stav firewallu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2045,25 +2045,27 @@ msgstr "Verze firmwaru"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Pevný zdrojový port pro odchozí DNS dotazy"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Nahrát firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Nahrát obraz..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Nahrát nový obraz s firmwarem"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Operace nad flash pamětí"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Nahrávám..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2089,11 +2091,11 @@ msgstr "Vynutit TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Vynutit TKIP a CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2121,7 +2123,7 @@ msgstr "Přeposílat broadcasty"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Režim přeposílání"
 
@@ -2168,20 +2170,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Obecná nastavení"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Obecné nastavení"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2189,7 +2190,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Vytvorǐt archív"
 
@@ -2197,11 +2198,11 @@ msgstr "Vytvorǐt archív"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Heslo nezměněno z důvodu nesouhlasu nového hesla a ověření hesla!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2212,7 +2213,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Přejít na nastavení hesla..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2262,7 +2263,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2455,7 +2456,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2542,14 +2543,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr "Namísto pevného uzlu zařízení připojovat pomocí UUID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2588,7 +2589,7 @@ msgstr "Pokud není povoleno, není nastaven žádný výchozí směrovací záz
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "Pokud není povoleno, oznámené adresy DNS serverů budou ignorovány"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2615,7 +2616,7 @@ msgstr "Ignorovat rozhraní"
 msgid "Ignore resolve file"
 msgstr "Ignorovat resolv soubor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Obraz"
 
@@ -2675,8 +2676,8 @@ msgstr "Instalovat protokolové rozšíření..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2762,11 +2763,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "Uvedené VLAN ID je neplatné! Každé ID musí být jedinečné"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2782,7 +2783,7 @@ msgstr "Špatné uživatelské jméno a/nebo heslo! Prosím zkuste to znovu."
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2806,11 +2807,11 @@ msgstr "Připojit k síti"
 msgid "Join Network: Wireless Scan"
 msgstr "Připojit k síti: Vyhledání bezdrátových sítí"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Zachovat nastavení"
 
@@ -2866,12 +2867,12 @@ msgstr "LCP echo prahová hodnota selhání"
 msgid "LCP echo interval"
 msgstr "LCP interval upozornění"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Popis"
 
@@ -3029,7 +3030,7 @@ msgstr "Načítání"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3142,7 +3143,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3175,7 +3176,7 @@ msgstr ""
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3189,7 +3190,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3205,7 +3206,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3264,7 +3266,7 @@ msgstr "Paměť"
 msgid "Memory usage (%)"
 msgstr "Využití paměti (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3272,7 +3274,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3331,7 +3333,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Časový limit inicializace modemu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Sledování"
@@ -3344,30 +3346,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Připojit vstup"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Přípojný bod"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Přípojné body"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Přípojné body - vstupy"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Přípojné body - změna vstupu"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3375,23 +3372,27 @@ msgstr ""
 "Přípojný bod určuje místo v souborovém systému, na kterém bude připojeno "
 "paměťové zařízení"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Volby připojení"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Přípojný bod"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Připojené souborové systémy"
 
@@ -3432,15 +3433,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Kandidáti NTP serveru"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Název"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Název nové sítě"
 
@@ -3451,7 +3452,7 @@ msgstr "Navigace"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3476,7 +3477,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "Síť bez rozhraní."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3501,7 +3502,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3554,7 +3555,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Žádná zóna nepřiřazena"
 
@@ -3612,7 +3613,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3685,6 +3686,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Jedno nebo více požadovaných polí neobsahuje hodnotu!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Otevřít seznam..."
@@ -3764,7 +3766,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Možnosti"
 
@@ -3929,7 +3930,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3938,7 +3939,7 @@ msgid "Packets"
 msgstr "Pakety"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Část zóny %q"
 
@@ -4036,11 +4037,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Provést restart"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Provést reset"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4079,6 +4080,10 @@ msgstr "Paketů"
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Prosím vložte vaše uživatelské jméno a heslo."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4149,10 +4154,6 @@ msgstr "Zabraňuje komunikaci klient-klient"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Pokračovat"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4168,7 +4169,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4251,7 +4252,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "RX Rate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4297,10 +4298,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Opravdu resetovat všechny změny?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Opravdu prohodit protokol?"
@@ -4333,7 +4330,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Opětovné nastavení ochrany"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reboot"
@@ -4342,6 +4339,11 @@ msgstr "Reboot"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Rebootuji..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4395,7 +4397,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Odstranit"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Nahradit bezdrátovou konfiguraci"
 
@@ -4407,7 +4409,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4491,7 +4493,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4503,7 +4505,7 @@ msgstr "Reset"
 msgid "Reset Counters"
 msgstr "Resetovat čítače"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Obnovit na výchozí"
 
@@ -4515,7 +4517,7 @@ msgstr "Soubory Resolv a Hosts"
 msgid "Resolve file"
 msgstr "Soubor resolve"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4534,11 +4536,11 @@ msgstr "Restartovat firewall"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Obnovit"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Obnovit zálohu"
 
@@ -4563,15 +4565,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Root"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Kořenový adresář souborů, přístupných přes TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4592,7 +4590,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Heslo routeru"
 
@@ -4613,19 +4611,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Spustit kontrolu souborového systému před připojením zařízení"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Spustit kontrolu souborového systému"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4634,7 +4632,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Přístup přes SSH"
 
@@ -4651,7 +4649,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH klíče"
 
@@ -4662,30 +4660,31 @@ msgstr "SSH klíče"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Uložit"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Uložit & použít"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4694,7 +4693,7 @@ msgid "Scan"
 msgstr "Skenovat"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Naplánované úlohy"
 
@@ -4706,11 +4705,11 @@ msgstr "Přidána sekce"
 msgid "Section removed"
 msgstr "Sekce odebrána"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Podrobnosti viz manuálová stránka příkazu \"mount\""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4753,7 +4752,7 @@ msgstr "Typ služby"
 msgid "Services"
 msgstr "Služby"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4761,10 +4760,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4794,6 +4797,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Ukázat aktuální seznam záložních souborů"
@@ -4815,7 +4819,7 @@ msgstr "Shodit toho rozhraní"
 msgid "Signal"
 msgstr "Signál"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4827,7 +4831,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Signál:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Velikost"
 
@@ -4852,7 +4856,7 @@ msgstr "Skočit na obsah"
 msgid "Skip to navigation"
 msgstr "Skočit na navigaci"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4869,7 +4873,7 @@ msgstr "Omlouváme se, ale požadovaný objekt nebyl nalezen."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Omlouváme se, na serveru došlo k neočekávané vyjímce."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4889,7 +4893,7 @@ msgstr "Zdroj"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4930,7 +4934,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Zde nastavte soukromý šifrovací klíč."
 
@@ -4953,7 +4957,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Po spuštění"
 
@@ -4973,7 +4977,7 @@ msgstr "Statické zápůjčky"
 msgid "Static Routes"
 msgstr "Statické trasy"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5015,7 +5019,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Odeslat"
 
@@ -5030,10 +5034,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Vstupní bod"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5053,7 +5053,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5146,6 +5146,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Ukončit"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5163,17 +5167,13 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr "IPv6 prefix přidělený poskytovatelm většinou končí  <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Povolené znaky jsou: <code>A-Z</code>, <code>a-z</code>, <code>0-9</code> a "
 "<code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5190,8 +5190,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5205,25 +5205,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"Souborový systém, který byl použit pro formátování paměti (<abbr title="
-"\"například\">napři.</abbr> <samp><abbr title=\"Souborový systém\">ext3</"
-"abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Obraz flash byl nahrán. Prosím porovnejte níže uvedený checksum a velikost "
-"souboru s originálním souborem pro zajištění integrity dat.<br /> Kliknutím "
-"na \"Pokračovat\" spustíte proceduru flashování."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5243,11 +5234,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5267,7 +5258,7 @@ msgstr "Délka IPv6 prefixu v bitech"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5287,6 +5278,14 @@ msgstr ""
 "jeden port pro připojení k vyšší síti (Uplink) jako třeba internet a "
 "zbývající porty pro místní síť."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5295,7 +5294,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5303,7 +5302,7 @@ msgstr ""
 "Systém maže konfigurační oddíl, po skončení procesu bude automaticky "
 "restartován."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5316,11 +5315,32 @@ msgstr ""
 "nastavení, bude možná nutné obnovit adresu vašeho počítače, aby jste se "
 "mohli znovu připojit."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5369,6 +5389,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5455,11 +5476,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Časové pásmo"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5469,7 +5490,7 @@ msgstr ""
 "konfigurační soubory. Pro obnovení továrního nastavení stiskněte \"Obnovit "
 "výchozí\" (možné pouze s obrazy squashfs)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5509,7 +5530,7 @@ msgstr "Trigger mód"
 msgid "Tunnel ID"
 msgstr "ID tunelu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Rozhraní tunelu"
@@ -5552,8 +5573,8 @@ msgstr "USB zařízení"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5583,6 +5604,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5594,6 +5619,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5602,28 +5628,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Nespravovaný"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5636,7 +5662,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Neuložené změny"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5659,7 +5685,11 @@ msgstr "Nepodporovaný typ protokolu."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5669,7 +5699,9 @@ msgstr ""
 "Zkontrolujte \"Keep settings\" za účelem udržení aktuální konfigurace "
 "(vyžaduje obraz kompatabilního firmwaru)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Nahrát archiv..."
 
@@ -5682,7 +5714,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5740,11 +5778,11 @@ msgstr "Použít MTU na rozhraní tunelu"
 msgid "Use TTL on tunnel interface"
 msgstr "Použít TTL na rozhraní tunelu"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5752,7 +5790,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "Použít příznak broadcastu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5818,7 +5856,7 @@ msgstr ""
 "adresa</em> identifikuje počítač, <em>IPv4 adresa</em> určuje, jaká pevná "
 "adresa bude použita. <em>Hostname</em> je přiřazeno jako symbolické jméno."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Použit"
 
@@ -5846,11 +5884,11 @@ msgstr ""
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5897,9 +5935,9 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Ověřit"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5919,7 +5957,7 @@ msgstr "WEP Open System"
 msgid "WEP Shared Key"
 msgstr "Sdílený klíč WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP heslo"
 
@@ -5927,7 +5965,7 @@ msgstr "WEP heslo"
 msgid "WMM Mode"
 msgstr "WMM mód"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA heslo"
 
@@ -5991,13 +6029,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Bezdrátová síť"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Bezdrátový adaptér"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6048,7 +6086,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6093,9 +6131,9 @@ msgstr ""
 msgid "any"
 msgstr "libovolný"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6112,7 +6150,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "přemostěný"
 
@@ -6129,7 +6167,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "vytvoří most přes vybraná rozhraní"
 
@@ -6265,8 +6303,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "ne"
 
@@ -6278,13 +6314,13 @@ msgstr "žádné spojení"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "žádný"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6314,10 +6350,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6336,7 +6368,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "směrované"
 
@@ -6350,15 +6382,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6576,14 +6608,69 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "ano"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Zpět"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s k dispozici)"
+
+#~ msgid "Check"
+#~ msgstr "Kontrola"
+
+#~ msgid "Checksum"
+#~ msgstr "Kontrolní součet"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Povolit tento přípojný bod"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Povolit tento swapovací oddíl"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Nahrát firmware"
+
+#~ msgid "Flashing..."
+#~ msgstr "Nahrávám..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Připojit vstup"
+
+#~ msgid "Proceed"
+#~ msgstr "Pokračovat"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Opravdu resetovat všechny změny?"
+
+#~ msgid "Root"
+#~ msgstr "Root"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Vstupní bod"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "Souborový systém, který byl použit pro formátování paměti (<abbr title="
+#~ "\"například\">napři.</abbr> <samp><abbr title=\"Souborový systém\">ext3</"
+#~ "abbr></samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Obraz flash byl nahrán. Prosím porovnejte níže uvedený checksum a "
+#~ "velikost souboru s originálním souborem pro zajištění integrity dat.<br /"
+#~ "> Kliknutím na \"Pokračovat\" spustíte proceduru flashování."
+
+#~ msgid "Verify"
+#~ msgstr "Ověřit"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr ""

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2.1\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr "%s darf nicht ohne VLAN-Tag in mehreren VLAN-Gruppen vorkommen!"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d Minuten Abschnitt, %d Sekunden Intervall)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s verfügbar)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Bitte auswählen --"
 msgid "-- custom --"
 msgstr "-- benutzerdefiniert --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- anhand Gerätedatei selektieren --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- anhand Label selektieren --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- UUID vergleichen --"
 
@@ -207,7 +201,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "IPv6-Suffix (hexadezimal)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "LED Konfiguration"
 
@@ -258,24 +252,24 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr "Es existiert bereits ein Verzeichnis mit dem gleichen Namen."
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 "Ein neuer Login ist erforderlich da die Benutzersitzung abgelaufen ist."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -289,25 +283,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "Grenzwert für ARP-Auflösungsversuche"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr "ATM (Asynchroner Transfer-Modus)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM Brücken"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM Virtual Channel Identifier (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM Virtual Path Identifier (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -317,7 +311,7 @@ msgstr ""
 "Linux Netzwerkschnittstellen welche z.B. in Verbindung mit DHCP oder PPP "
 "genutzt werden können um sich in das Providernetzwerk einzuwählen."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "ATM Geräteindex"
@@ -341,8 +335,7 @@ msgstr "Access Concentrator"
 msgid "Access Point"
 msgstr "Access Point"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -368,7 +361,7 @@ msgstr "Aktive DHCP-Leases"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktive DHCPv6-Leases"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -378,7 +371,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -389,7 +382,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr "ATM-Brücke hinzufügen"
 
@@ -424,7 +417,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "Lokalen Domainsuffx an Namen aus der Hosts-Datei anhängen"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Neue Schnittstelle hinzufügen..."
 
@@ -468,19 +461,18 @@ msgid "Address to access local relay bridge"
 msgstr "Adresse der lokalen Relay-Brücke"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administration"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
@@ -492,7 +484,7 @@ msgstr "Vollständige Sendeleistung (ACTATP)"
 msgid "Alert"
 msgstr "Alarm"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -571,7 +563,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr "Erlaubte IP-Adressen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr "Immer Defaultrouter ankündigen"
 
@@ -584,78 +576,78 @@ msgstr ""
 "benachbarten Funkzellen überlappt. Die Benutzung dieser Option ist eine "
 "Verletzung des IEEE 802.11n-2009 Standards!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr "Annex A, L und M (alle)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr "Annex B (alle Arten)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr "Annex J (alle Arten)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr "Annex M (alle Arten)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 "Kündigt im Netzwerk einen Defaultrouter an, auch wenn kein öffentlicher "
 "Adressbereich verfügbar ist."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr "Angekündigte Suchdomains"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr "Angekündigte DNS Server"
 
@@ -663,11 +655,11 @@ msgstr "Angekündigte DNS Server"
 msgid "Anonymous Identity"
 msgstr "Anonyme Identität"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "Automatische Mountpunkte"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "Automatische Swap-Aktivierung"
 
@@ -677,6 +669,10 @@ msgstr "Automatische Swap-Aktivierung"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Beliebige Zone"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -712,7 +708,7 @@ msgstr ""
 "Der Schnittstelle zugewiesene Partitionen des Adressraums werden anhand "
 "dieser hexadezimalen ID gewählt."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Assoziierte Clients"
@@ -720,6 +716,10 @@ msgstr "Assoziierte Clients"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "Assoziierungen"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -769,27 +769,27 @@ msgstr "Automatisch"
 msgid "Automatic Homenet (HNCP)"
 msgstr "Automatisches Homenet-Protokoll (HNCP)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr "Dateisystem vor dem Einhängen automatisch auf Fehler prüfen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr "Unkonfigurierte Dateisysteme automatisch einhängen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr "Unkonfigurierte SWAP-Partitionen automatisch aktivieren"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "Dateisystem automatisch einhängen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "SWAP automatisch aktivieren"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Verfügbar"
 
@@ -807,11 +807,11 @@ msgstr "Verfügbar"
 msgid "Average:"
 msgstr "Durchschnitt:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -835,14 +835,15 @@ msgstr "Zurück zur Übersicht"
 msgid "Back to configuration"
 msgstr "Zurück zur Konfiguration"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Sichern"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Backup / Firmware Update"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Liste zu sichernder Dateien"
@@ -860,6 +861,7 @@ msgstr "Frequenztyp"
 msgid "Beacon Interval"
 msgstr "Beacon-Intervall"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -897,17 +899,17 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Ungültige \"NX-Domain\" Antworten ignorieren"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bridge"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Netzwerkbrücke"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Geräteindex der Brücke"
 
@@ -916,6 +918,7 @@ msgid "Bring up on boot"
 msgstr "Während des Bootvorgangs starten"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr "Durchsuchen…"
 
@@ -945,11 +948,13 @@ msgstr "Anruf fehlgeschlagen"
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -957,13 +962,9 @@ msgstr "Abbrechen"
 msgid "Category"
 msgstr "Kategorie"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
 msgstr "Achtung: Konfigurationsdateien werden gelöscht"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
-msgstr "Achtung: Systemupgrade wird erzwungen"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
@@ -996,29 +997,30 @@ msgstr "Ändert das Administratorpasswort für den Zugriff auf dieses Gerät"
 msgid "Channel"
 msgstr "Kanal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Prüfen"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "Dateisysteme prüfen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 "Diese Option setzen um existierende Netzwerke auf dem Radio zu löschen."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Prüfsumme"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr "Wähle \"mtdblock\" Datei"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1046,7 +1048,7 @@ msgstr "Verschlüsselungsalgorithmus"
 msgid "Cisco UDP encapsulation"
 msgstr "Cisco UDP-Kapselung"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1054,7 +1056,7 @@ msgstr ""
 "Zum Herunterladen der aktuellen Konfigurationsdateien als gepacktes Archiv "
 "\"Sicherung erstellen\" drücken."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
@@ -1063,7 +1065,7 @@ msgstr ""
 "herunterzuladen. (Hinweis: Diese Funktionalität ist nur für Experten "
 "gedacht!)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1100,7 +1102,7 @@ msgstr "Schließe Liste..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1115,7 +1117,7 @@ msgstr "Sammle Daten..."
 msgid "Command"
 msgstr "Befehl"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr "Kommando OK"
 
@@ -1141,8 +1143,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Konfiguration"
 
@@ -1151,7 +1152,7 @@ msgstr "Konfiguration"
 msgid "Configuration failed"
 msgstr "Konfiguration fehlgeschlagen"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr "Konfigurationsdateien werden beibehalten"
 
@@ -1163,7 +1164,7 @@ msgstr "Die Konfiguration wurde angewendet."
 msgid "Configuration has been rolled back!"
 msgstr "Die Konfiguration wurde zurückgerollt!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr "Verbindungstrennung bestätigen"
 
@@ -1183,7 +1184,7 @@ msgstr "Verbunden"
 msgid "Connection attempt failed"
 msgstr "Verbindungsversuch fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr "Verbindung verloren"
 
@@ -1192,11 +1193,14 @@ msgid "Connections"
 msgstr "Verbindungen"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr "Fortfahren"
 
@@ -1220,11 +1224,11 @@ msgid "Country Code"
 msgstr "Ländercode"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Firewallzone anlegen / zuweisen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr "Schnittstelle anlegen"
 
@@ -1253,7 +1257,7 @@ msgstr "Benutzerdefinierte Schnittstelle"
 msgid "Custom delegated IPv6-prefix"
 msgstr "Delegiertes IPv6-Präfix"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1289,7 +1293,7 @@ msgstr "DHCP-Server"
 msgid "DHCP and DNS"
 msgstr "DHCP und DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1304,7 +1308,7 @@ msgstr "DHCP-Optionen"
 msgid "DHCPv6 client"
 msgstr "DHCPv6 Client"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "DHCPv6-Modus"
 
@@ -1349,7 +1353,7 @@ msgstr "DPD Inaktivitätstimeout"
 msgid "DS-Lite AFTR address"
 msgstr "DS-Lite AFTR-Adresse"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1358,7 +1362,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr "DSL Leitungsmodus"
 
@@ -1400,7 +1404,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Default Gateway"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr "Der Standardwert ist zustandslos und zustandsorientiert"
 
@@ -1422,9 +1426,9 @@ msgstr ""
 "code>\" um einen anderen DNS-Server an Clients zu verteilen."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1485,10 +1489,10 @@ msgstr "Ziel-Zone"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Gerät"
 
@@ -1578,7 +1582,7 @@ msgstr "Eingehende RFC1918-Antworten verwerfen"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr "Trennen"
 
@@ -1587,11 +1591,12 @@ msgstr "Trennen"
 msgid "Disconnection attempt failed"
 msgstr "Verbindungstrennung fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "Schließen"
 
@@ -1641,6 +1646,10 @@ msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 "Soll der untenstehende SSH-Schlüssel wirklich vom System entfernt werden?"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Soll das Verzeichnis \"%s\" wirklich rekursiv gelöscht werden?"
@@ -1667,19 +1676,19 @@ msgstr "Anfragen ohne Domainnamen nicht weiterleiten"
 msgid "Down"
 msgstr "runter"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Backup herunterladen"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr "Mtdblock-Datei herunterladen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr "Downstream SNR-Offset"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr "Ziehen zum Umsortieren"
 
@@ -1724,9 +1733,9 @@ msgstr "EA-Bitlänge"
 msgid "EAP-Method"
 msgstr "EAP-Methode"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1832,25 +1841,17 @@ msgstr "Port-Mirroring für ausgehende Pakete aktivieren"
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr "Das DF-Bit (Nicht fragmentieren) auf gekapselten Paketen setzen."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Diesen Mountpunkt aktivieren"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Dieses Netzwerk aktivieren"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Diesen Auslagerungsspeicher aktivieren"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Aktivieren/Deaktivieren"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Aktiviert"
 
@@ -1874,8 +1875,8 @@ msgstr "Aktiviert das Spanning Tree Protokoll auf dieser Netzwerkbrücke"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Kapselung"
 
@@ -1903,7 +1904,7 @@ msgstr "Eigenen Wert angeben"
 msgid "Enter custom values"
 msgstr "Eigene Werte angeben"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Lösche..."
 
@@ -1925,12 +1926,12 @@ msgstr "Fehler"
 msgid "Errored seconds (ES)"
 msgstr "Fehlersekunden (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Netzwerkschnittstelle"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Netzwerk Switch"
@@ -2033,9 +2034,8 @@ msgstr "Dateiname"
 msgid "Filename of the boot image advertised to clients"
 msgstr "Dateiname des Boot-Images welches den Clients mitgeteilt wird."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Dateisystem"
 
@@ -2052,7 +2052,7 @@ msgstr "Windowsanfragen filtern"
 msgid "Finalizing failed"
 msgstr "Finalisierung fehlgeschlagen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2085,7 +2085,7 @@ msgstr "Firewall Einstellungen"
 msgid "Firewall Status"
 msgstr "Firewall-Status"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr "Firmware-Datei"
 
@@ -2097,25 +2097,27 @@ msgstr "Firmware Version"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Fester Port für ausgehende DNS-Anfragen"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Firmware aktualisieren"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Firmware aktualisieren..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Neues Firmware Image schreiben"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Flash-Operationen"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Firmware wird installiert..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2143,11 +2145,11 @@ msgstr "Erzwinge TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Erzwinge TKIP und CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "Erzwinge Verbindung"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr "Erzwinge Upgrade"
 
@@ -2175,7 +2177,7 @@ msgstr "Broadcasts weiterleiten"
 msgid "Forward mesh peer traffic"
 msgstr "Mesh-Nachbar-Traffic weiterleiten"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Weiterleitungstyp"
 
@@ -2224,20 +2226,19 @@ msgstr "Gateway-Adresse ist ungültig"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Allgemeine Einstellungen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "Konfiguration generieren"
 
@@ -2245,7 +2246,7 @@ msgstr "Konfiguration generieren"
 msgid "Generate PMK locally"
 msgstr "PMK lokal generieren"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Sicherung erstellen"
 
@@ -2255,11 +2256,11 @@ msgstr ""
 "Die angegebenen Passwörter stimmen nicht überein, das Systempasswort wurde "
 "nicht geändert!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "Globale Einstellungen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "Globale Netzwerkeinstellungen"
 
@@ -2270,7 +2271,7 @@ msgstr "Globale Netzwerkeinstellungen"
 msgid "Go to password configuration..."
 msgstr "Zur Passwortkonfiguration..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2320,7 +2321,7 @@ msgstr "Leere Chains ausblenden"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2512,7 +2513,7 @@ msgstr "IPv6 Nachbarn"
 msgid "IPv6 Settings"
 msgstr "IPv6 Einstellungen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr "IPv6 ULA-Präfix"
 
@@ -2599,16 +2600,16 @@ msgstr "Aktiviert die Benutzung von 1DES, wenn ausgewählt"
 msgid "If checked, encryption is disabled"
 msgstr "Deaktiviert die Verschlüsselung, wenn ausgewählt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Wenn angegeben, wird das Gerät anhand seiner UUID statt fester Gerätedatei "
 "gemounted"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2649,7 +2650,7 @@ msgstr "Wenn deaktiviert, wird keine Default-Route gesetzt"
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "Falls deaktiviert werden die zugewiesenen DNS-Server ignoriert"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2674,7 +2675,7 @@ msgstr "Schnittstelle ignorieren"
 msgid "Ignore resolve file"
 msgstr "Resolv-Datei ignorieren"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Image"
 
@@ -2739,8 +2740,8 @@ msgstr "Installiere Protokoll-Erweiterungen"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2825,11 +2826,11 @@ msgstr "Ungültige VLAN ID angegeben! Nur IDs zwischen %d und %d sind erlaubt."
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "Ungültige VLAN ID angegeben! Die ID ist muß eindeutig sein!"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr "Ungültiges Argument"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr "Ungültiges Kommando"
 
@@ -2846,7 +2847,7 @@ msgstr ""
 msgid "Isolate Clients"
 msgstr "Clients isolieren"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2870,11 +2871,11 @@ msgstr "Netzwerk beitreten"
 msgid "Join Network: Wireless Scan"
 msgstr "Netzwerk beitreten: Suche nach Netzwerken"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "Trete Netzwerk %q bei"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Konfiguration behalten"
 
@@ -2930,12 +2931,12 @@ msgstr "LCP Echo Fehler Schwellenwert"
 msgid "LCP echo interval"
 msgstr "LCP Echo Intervall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Label"
 
@@ -3108,7 +3109,7 @@ msgstr "Lade"
 msgid "Loading directory contents…"
 msgstr "Lade Verzeichniseinträge…"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr "Lade Seite…"
@@ -3223,7 +3224,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3256,7 +3257,7 @@ msgstr "MAP-Regel ist ungültig"
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3270,7 +3271,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3286,7 +3287,8 @@ msgstr "Das Root-Dateisystem muss mit folgenden Kommandsos vorbereitet werden:"
 msgid "Manual"
 msgstr "Manuell"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3345,7 +3347,7 @@ msgstr "Hauptspeicher"
 msgid "Memory usage (%)"
 msgstr "Speichernutzung (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3353,7 +3355,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr "Mesh-ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr "Methode nicht gefunden"
 
@@ -3412,7 +3414,7 @@ msgstr "Modem-Informationsabfrage fehlgeschlagen"
 msgid "Modem init timeout"
 msgstr "Wartezeit für Modeminitialisierung"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3425,30 +3427,25 @@ msgstr "Mehr Zeichen"
 msgid "More…"
 msgstr "Mehr…"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Mount-Eintrag"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Einhängepunkt"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Einhängepunkte"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Mountpunkte - Mount-Eintrag"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Mountpunkte - Auslagerungsdatei"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3456,23 +3453,27 @@ msgstr ""
 "Einhängepunkte bestimmen, an welcher Stelle des Dateisystems bestimmte "
 "Laufwerke und Speicher zur Verwendung eingebunden werden."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr "Nicht explizit konfigurierte Dateisysteme einhängen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Mount-Optionen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Mountpunkt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "Unkonfigurierte SWAP-Partitionen aktivieren"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Eingehängte Dateisysteme"
 
@@ -3513,15 +3514,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "NTP Server Kandidaten"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Name"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Name des neuen Netzwerkes"
 
@@ -3532,7 +3533,7 @@ msgstr "Navigation"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3557,7 +3558,7 @@ msgstr "Netzwerkgerät ist nicht vorhanden"
 msgid "Network without interfaces."
 msgstr "Netzwerk ohne Schnittstellen."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr "Name der neuen Schnittstelle…"
 
@@ -3582,7 +3583,7 @@ msgstr "Keine Verschlüsselung"
 msgid "No NAT-T"
 msgstr "Kein NAT-T"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr "Keine Daten empfangen"
 
@@ -3635,7 +3636,7 @@ msgid "No signal"
 msgstr "Kein Signal"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Keine Zone zugewiesen"
 
@@ -3693,7 +3694,7 @@ msgstr "Nicht vorhanden"
 msgid "Not started on boot"
 msgstr "Beim Hochfahren nicht starten"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr "Nicht unterstützt"
 
@@ -3768,6 +3769,7 @@ msgstr "Ein oder mehrere ungültige/benötigte Werte auf Registerkarte"
 msgid "One or more required fields have no value!"
 msgstr "Ein oder mehr benötigte Felder sind nicht ausgefüllt!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Liste öffnen..."
@@ -3861,7 +3863,6 @@ msgstr ""
 "Optional. Benutzte UDP-Port-Nummer für ausgehende und eingehende Pakete."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Optionen"
 
@@ -4026,7 +4027,7 @@ msgstr "PSID-Offset"
 msgid "PSID-bits length"
 msgstr "PSID-Bitlänge"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Paket-Transfer-Modus)"
 
@@ -4035,7 +4036,7 @@ msgid "Packets"
 msgstr "Pakete"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Teil von Zone %q"
 
@@ -4133,11 +4134,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Neustart durchführen"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Reset durchführen"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr "Zugriff verweigert"
 
@@ -4176,6 +4177,10 @@ msgstr "Pkte."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Bitte Benutzernamen und Passwort eingeben."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4246,10 +4251,6 @@ msgstr "Unterbindet Client-Client-Verkehr"
 msgid "Private Key"
 msgstr "Privater Schlüssel"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Fortfahren"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4265,7 +4266,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4357,7 +4358,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "RX-Rate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr "RX-Rate / TX-Rate"
 
@@ -4406,10 +4407,6 @@ msgstr ""
 "gemacht werden! Der Kontakt zum Gerät könnte verloren gehen wenn die "
 "Verbindung über diese Schnittstelle erfolgt."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Sollen wirklich alle Änderungen verworfen werden?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Protokoll wirklich wechseln?"
@@ -4442,7 +4439,7 @@ msgstr "Reassoziierungsfrist"
 msgid "Rebind protection"
 msgstr "DNS-Rebind-Schutz"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Neu Starten"
@@ -4451,6 +4448,11 @@ msgstr "Neu Starten"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Das System wird neu gestartet..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4504,7 +4506,7 @@ msgstr "Entfernte IPv4-Adresse oder Hostname"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Drahtloskonfiguration ersetzen"
 
@@ -4516,7 +4518,7 @@ msgstr "IPv6-Adresse anfordern"
 msgid "Request IPv6-prefix of length"
 msgstr "IPv6-Präfix dieser Länge anfordern"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr "Anfrage-Timeout"
 
@@ -4608,7 +4610,7 @@ msgstr "Benötigt \"wpa-supplicant\" mit OWE-Support"
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "Benötigt \"wpa-supplicant\" mit SAE-Support"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4620,7 +4622,7 @@ msgstr "Zurücksetzen"
 msgid "Reset Counters"
 msgstr "Zähler zurücksetzen"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Auslieferungszustand wiederherstellen"
 
@@ -4632,7 +4634,7 @@ msgstr "Resolv- und Hosts-Dateien"
 msgid "Resolve file"
 msgstr "Resolv-Datei"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr "Resource nicht gefunden"
 
@@ -4651,11 +4653,11 @@ msgstr "Firewall neu starten"
 msgid "Restart radio interface"
 msgstr "W-LAN-Gerät neu starten"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Sicherung wiederherstellen"
 
@@ -4680,15 +4682,11 @@ msgstr "Anforderung zum Verwerfen mit Status <code>%h</code> fehlgeschlagen"
 msgid "Reverting configuration…"
 msgstr "Verwerfe Konfigurationsänderungen..."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Root"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Wurzelverzeichnis für über TFTP ausgelieferte Dateien "
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr "Wurzelverzeichnis erzeugen"
 
@@ -4709,7 +4707,7 @@ msgid "Router Advertisement-Service"
 msgstr "Router-Advertisement-Dienst"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Routerpasswort"
 
@@ -4731,19 +4729,19 @@ msgstr ""
 msgid "Rule"
 msgstr "Regel"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Vor dem Einhängen Dateisystemprüfung starten "
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Dateisystemprüfung durchführen"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr "Laufzeitfehler"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4752,7 +4750,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH-Zugriff"
 
@@ -4769,7 +4767,7 @@ msgid "SSH username"
 msgstr "SSH Benutzername"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH-Schlüssel"
 
@@ -4780,30 +4778,31 @@ msgstr "SSH-Schlüssel"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Speichern"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Speichern & Anwenden"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr "Speichere mtdblock"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr "Inhalte von mtdblock-Partitionen speichern"
 
@@ -4812,7 +4811,7 @@ msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Geplante Aufgaben"
 
@@ -4824,11 +4823,11 @@ msgstr "Sektion hinzugefügt"
 msgid "Section removed"
 msgstr "Sektion entfernt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Siehe \"mount\" Handbuch für Details"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4874,7 +4873,7 @@ msgstr "Service-Typ"
 msgid "Services"
 msgstr "Dienste"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr "Sitzung abgelaufen"
 
@@ -4882,7 +4881,7 @@ msgstr "Sitzung abgelaufen"
 msgid "Set VPN as Default Route"
 msgstr "VPN als Defaultroute benutzen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
@@ -4890,6 +4889,10 @@ msgstr ""
 "Schnittstelleneigenschaften werden unabhängig vom Link gesetzt (ist die "
 "Option ausgewählt, so werden die Hotplug-Skripte bei Änderung nicht "
 "aufgerufen)"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
+msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 #: protocols/luci-proto-qmi/luasrc/model/network/proto_qmi.lua:55
@@ -4918,6 +4921,7 @@ msgstr "kurzes Guardintervall"
 msgid "Short Preamble"
 msgstr "Kurze Präambel"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Zeige aktuelle Liste der gesicherten Dateien"
@@ -4939,7 +4943,7 @@ msgstr "Diese Schnittstelle herunterfahren"
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr "Signal / Rauschen"
 
@@ -4951,7 +4955,7 @@ msgstr "Signaldämpfung (SATN)"
 msgid "Signal:"
 msgstr "Signal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Größe"
 
@@ -4976,7 +4980,7 @@ msgstr "Zum Inhalt springen"
 msgid "Skip to navigation"
 msgstr "Zur Navigation springen"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Software-VLAN"
@@ -4994,7 +4998,7 @@ msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 "Entschuldigung, auf dem Server ist ein unerwarteter Fehler aufgetreten."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -5014,7 +5018,7 @@ msgstr "Quelle"
 msgid "Source Address"
 msgstr "Quelladresse"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Nennt das Verzeichnis, an welches das Gerät angebunden ist"
 
@@ -5064,7 +5068,7 @@ msgstr ""
 "Setzt eine spezifische MTU (Maximum Transmission Unit) abweichend von den "
 "standardmäßigen 1280 Bytes."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Geben Sie hier den geheimen Netzwerkschlüssel an"
 
@@ -5087,7 +5091,7 @@ msgid "Starting wireless scan..."
 msgstr "Starte WLAN Scan..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Systemstart"
 
@@ -5107,7 +5111,7 @@ msgstr "Statische Einträge"
 msgid "Static Routes"
 msgstr "Statische Routen"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5150,7 +5154,7 @@ msgid "Strong"
 msgstr "Stark"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Absenden"
 
@@ -5166,10 +5170,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "Auslagerungsspeicher"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Auslagerungsdatei"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5191,7 +5191,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Switch-Port-Maske"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Switch-VLAN"
@@ -5285,6 +5285,10 @@ msgstr "Zielnetzwerk"
 msgid "Terminate"
 msgstr "Beenden"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5307,17 +5311,13 @@ msgstr ""
 "Vom Provider zugewiesenes IPv6-Präfix, endet normalerweise mit <code>::</"
 "code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Erlaubte Buchstaben sind: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr "Das Backup-Archiv scheint keine valide GZip-Datei zu sein."
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5344,8 +5344,8 @@ msgstr ""
 "Änderungen verwerfen um den aktuell funktionierenden Konfigurationsstand "
 "beizubehalten."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5359,23 +5359,16 @@ msgstr ""
 "Die existierende Drahtlos-Konfiguration muss geändert werden damit LuCI "
 "richtig funktioniert."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
-msgstr "Das Dateisystem mit dem der Speicher formatiert ist (z.B.: ext3)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Das Firmware-Image wurde hochgeladen. Nachfolgend sind die Prüfsumme und "
-"Dateigröße gelistet. Vergleichen Sie diese mit der Originaldatei um die "
-"Integrität sicherzustellen.<br /> Klicken Sie \"Fortfahren\" um die Flash-"
-"Prozedur zu starten."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5397,11 +5390,11 @@ msgstr ""
 "Der angegebene öffentliche SSH Schlüssel ist ungültig, bitte OpenSSH-"
 "kompatible öffentliche RSA oder ECDSA-Schlüssel verwenden."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr "Der Schnittstellenname wird bereits verwendet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr "Der Schnittstellenname ist zu lang"
 
@@ -5423,7 +5416,7 @@ msgstr "Länge des IPv6-Präfix in Bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "Die lokale IPv4-Adresse über die der Tunnel aufgebaut wird (optional)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr "Der Netzwerkname wird bereits verwendet"
 
@@ -5445,6 +5438,14 @@ msgstr ""
 "Schnittstellen bilden ein <abbr title=\"Virtual Local Area Network\">VLAN</"
 "abbr> für das lokale Netzwerk."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5456,7 +5457,7 @@ msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 "Das mitgesendete Sicherheits-Token ist ungültig oder bereits abgelaufen!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5464,7 +5465,7 @@ msgstr ""
 "Die Einstellungen werden nun gelöscht! Anschließend wird ein Neustart des "
 "Systems durchgeführt."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5477,11 +5478,32 @@ msgstr ""
 "Konfiguration ist es notwendig, dass Sie auf Ihrem Computer eine neue IP-"
 "Adresse beziehen müssen um auf das Gerät zugreifen zu können."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "Das Systempasswort wurde erfolgreich geändert."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5537,6 +5559,7 @@ msgstr ""
 "<code>server=1.2.3.4</code> für domainspezifische oder volle Upstream-DNS-"
 "Server beinhalten."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5633,11 +5656,11 @@ msgstr "Zeitintervall für die neubestimmung des Gruppenschlüssels"
 msgid "Timezone"
 msgstr "Zeitzone"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr "Zum Login…"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5648,7 +5671,7 @@ msgstr ""
 "Auslieferungszustand des Systems wieder her (nur möglich bei squashfs-"
 "Images)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr "Ton"
 
@@ -5689,7 +5712,7 @@ msgstr "Auslösmechanismus"
 msgid "Tunnel ID"
 msgstr "Tunnel-ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Tunnelschnittstelle"
@@ -5732,8 +5755,8 @@ msgstr "USB-Gerät"
 msgid "USB Ports"
 msgstr "USB Anschlüsse"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5763,6 +5786,10 @@ msgstr "Kann Anfrage nicht zustellen"
 msgid "Unable to obtain client ID"
 msgstr "Client-ID konnte nicht bezogen werden"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5774,6 +5801,7 @@ msgid "Unable to resolve peer host name"
 msgstr "Der Name des entfernten Hosts konnte nicht aufgelöst werden"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5782,28 +5810,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Nicht verfügbare Sekunden (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Protokollfehler: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr "Unbekannter Fehlercode"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Ignoriert"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "Aushängen"
 
@@ -5816,7 +5844,7 @@ msgstr "Unbenannter Schlüssel"
 msgid "Unsaved Changes"
 msgstr "Ungespeicherte Änderungen"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr "Unbestimmter Fehler"
 
@@ -5839,7 +5867,11 @@ msgstr "Nicht unterstützter Protokolltyp."
 msgid "Up"
 msgstr "Hoch"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5849,7 +5881,9 @@ msgstr ""
 "Image hochgeladen werden. Wenn die vorhandene Konfiguration auch nach dem "
 "Update noch aktiv sein soll, aktivieren Sie \"Konfiguration behalten\"."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Backup wiederherstellen..."
 
@@ -5862,8 +5896,14 @@ msgid "Upload file…"
 msgstr "Datei hochladen…"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
 msgstr "Upload-Anfrage fehlgeschlagen: %s"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
 msgid ""
@@ -5923,11 +5963,11 @@ msgstr "Benutze MTU auf der Tunnelschnittstelle"
 msgid "Use TTL on tunnel interface"
 msgstr "Benutze TTL auf der Tunnelschnittstelle"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr "Als externes Overlay benutzen (/overlay)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "Als Root-Dateisystem benutzen (/)"
 
@@ -5935,7 +5975,7 @@ msgstr "Als Root-Dateisystem benutzen (/)"
 msgid "Use broadcast flag"
 msgstr "Benutze Broadcast-Flag"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "Eingebautes IPv6-Management nutzen"
 
@@ -6002,7 +6042,7 @@ msgstr ""
 "definiert die zu nutzende statische Adresse und der <em>Hostname</em> ist "
 "der symbolische Name der dem Host zugewisen wird."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Belegt"
 
@@ -6032,11 +6072,11 @@ msgstr "PEM-kodierter Benutzerschlüssel"
 msgid "Username"
 msgstr "Benutzername"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -6083,9 +6123,9 @@ msgstr "Hersteller"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Bei DHCP-Anfragen gesendete Vendor-Klasse"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Verifizieren"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -6105,7 +6145,7 @@ msgstr "WEP Open System"
 msgid "WEP Shared Key"
 msgstr "WEP Shared Key"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP Schlüssel"
 
@@ -6113,7 +6153,7 @@ msgstr "WEP Schlüssel"
 msgid "WMM Mode"
 msgstr "WMM Modus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA Schlüssel"
 
@@ -6182,13 +6222,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "WLAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "WLAN-Gerät"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6239,7 +6279,7 @@ msgstr "Systemprotokoll in Datei schreiben"
 msgid "Yes"
 msgstr "Ja"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6288,9 +6328,9 @@ msgstr "ZRAM Größe"
 msgid "any"
 msgstr "beliebig"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6307,7 +6347,7 @@ msgstr "automatisch"
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "bridged"
 
@@ -6324,7 +6364,7 @@ msgid "create:"
 msgstr "erstelle:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "erstellt eine Netzwerkbrücke über die angegebe(n) Schnittstelle(n)"
 
@@ -6458,8 +6498,6 @@ msgstr "Minuten"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "nein"
 
@@ -6471,13 +6509,13 @@ msgstr "nicht verbunden"
 msgid "non-empty value"
 msgstr "nicht-leeren Wert"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "keine"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "nicht vorhanden"
 
@@ -6507,10 +6545,6 @@ msgstr ""
 msgid "output"
 msgstr "ausgehend"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr "Overlay"
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr "positiven Dezimalwert"
@@ -6529,7 +6563,7 @@ msgstr "zufällig"
 msgid "relay mode"
 msgstr "Relay-Modus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "routed"
 
@@ -6543,15 +6577,15 @@ msgstr "Sekunden"
 msgid "server mode"
 msgstr "Server-Modus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr "nur zustandsorientiert"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr "nur zustandlos"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr "zustandslos + zustandsorientiert"
 
@@ -6769,14 +6803,79 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "ja"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Zurück"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s verfügbar)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- anhand Gerätedatei selektieren --"
+
+#~ msgid "Caution: System upgrade will be forced"
+#~ msgstr "Achtung: Systemupgrade wird erzwungen"
+
+#~ msgid "Check"
+#~ msgstr "Prüfen"
+
+#~ msgid "Checksum"
+#~ msgstr "Prüfsumme"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Diesen Mountpunkt aktivieren"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Diesen Auslagerungsspeicher aktivieren"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Firmware aktualisieren"
+
+#~ msgid "Flashing..."
+#~ msgstr "Firmware wird installiert..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Mount-Eintrag"
+
+#~ msgid "Proceed"
+#~ msgstr "Fortfahren"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Sollen wirklich alle Änderungen verworfen werden?"
+
+#~ msgid "Root"
+#~ msgstr "Root"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Auslagerungsdatei"
+
+#~ msgid "The backup archive does not appear to be a valid gzip file."
+#~ msgstr "Das Backup-Archiv scheint keine valide GZip-Datei zu sein."
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr "Das Dateisystem mit dem der Speicher formatiert ist (z.B.: ext3)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Das Firmware-Image wurde hochgeladen. Nachfolgend sind die Prüfsumme und "
+#~ "Dateigröße gelistet. Vergleichen Sie diese mit der Originaldatei um die "
+#~ "Integrität sicherzustellen.<br /> Klicken Sie \"Fortfahren\" um die Flash-"
+#~ "Prozedur zu starten."
+
+#~ msgid "Verify"
+#~ msgstr "Verifizieren"
+
+#~ msgid "overlay"
+#~ msgstr "Overlay"
 
 #~ msgid "Change login password"
 #~ msgstr "Login-Passwort ändern"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.4\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(παράθυρο %d λεπτών, διάστημα %d δευτερολέπτων)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s διαθέσιμα)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Παρακαλώ επιλέξτε --"
 msgid "-- custom --"
 msgstr "-- προσαρμοσμένο --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -208,7 +202,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Παραμετροποίηση <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
@@ -255,23 +249,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -285,25 +279,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "Όριο επαναδοκιμών ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Γέφυρες ΑΤΜ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM Εικονικό Κανάλι Αναγνωριστή (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM Εικονικό μονοπάτι Αναγνωριστή (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -313,7 +307,7 @@ msgstr ""
 "εικονικές διεπαφές δικτύου Linux, οι οποίες μπορούν να χρησιμοποιηθούν σε "
 "συνδυασμό με DHCP ή PPP για την κλήση προς τον παροχέα δικτύου."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Αριθμός συσκευής ATM"
@@ -337,8 +331,7 @@ msgstr "Συγκεντρωτής Πρόσβασης "
 msgid "Access Point"
 msgstr "Σημείο Πρόσβασης"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Ενέργειες"
 
@@ -366,7 +359,7 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -376,7 +369,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -387,7 +380,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Προσθήκη"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -423,7 +416,7 @@ msgstr ""
 "Προσθήκη κατάληξης τοπικού τομέα για ονόματα εξυπηρετούμενα από αρχεία hosts "
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Προσθήκη νέας διεπαφής..."
 
@@ -467,19 +460,18 @@ msgid "Address to access local relay bridge"
 msgstr "Διεύθυνση για πρόσβαση σε την τοπική γέφυρα αναμετάδοσης"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Διαχείριση"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Προχωρημένες Ρυθμίσεις"
 
@@ -491,7 +483,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Ειδοποίηση"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -569,7 +561,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -579,76 +571,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -656,11 +648,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -670,6 +662,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Οιαδήποτε ζώνη"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -699,13 +695,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Συνδεδεμένοι Σταθμοί"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -756,27 +756,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Διαθέσιμο"
 
@@ -794,11 +794,11 @@ msgstr "Διαθέσιμο"
 msgid "Average:"
 msgstr "Μέσος Όρος:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -822,14 +822,15 @@ msgstr "Πίσω προς Επισκόπηση"
 msgid "Back to configuration"
 msgstr "Πίσω προς παραμετροποίηση"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Αποθήκευση"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Αντίγραφο ασφαλείας / Εγγραφή FLASH Υλικολογισμικό"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Λίστα αρχείων για αντίγραφο ασφαλείας"
@@ -848,6 +849,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -883,17 +885,17 @@ msgstr "Ρυθμός δεδομένων"
 msgid "Bogus NX Domain Override"
 msgstr "Παράκαμψη Ψευδούς Τομέα NX"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Γέφυρα"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Γεφύρωμα διεπαφών"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Αριθμός μονάδας γέφυρας"
 
@@ -902,6 +904,7 @@ msgid "Bring up on boot"
 msgstr "Ανέβασμα κατά την εκκίνηση"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -929,11 +932,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Ακύρωση"
 
@@ -941,12 +946,8 @@ msgstr "Ακύρωση"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -980,28 +981,29 @@ msgstr "Αλλάζει τον κωδικό διαχειριστή για πρό�
 msgid "Channel"
 msgstr "Κανάλι"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Έλεγχος"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Άθροισμα Ελέγχου"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1027,7 +1029,7 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1035,13 +1037,13 @@ msgstr ""
 "Κλικ στο \"Δημιουργία αρχείου\" για να κατεβάσετε ένα tar αρχείο με τα "
 "τρέχοντα αρχεία παραμετροποίησης."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1079,7 +1081,7 @@ msgstr "Κλείσιμο λίστας..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1094,7 +1096,7 @@ msgstr "Συλλογή δεδομένων..."
 msgid "Command"
 msgstr "Εντολή"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1116,8 +1118,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Παραμετροποίηση"
 
@@ -1126,7 +1127,7 @@ msgstr "Παραμετροποίηση"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1138,7 +1139,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1158,7 +1159,7 @@ msgstr "Συνδεδεμένος"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1167,11 +1168,14 @@ msgid "Connections"
 msgstr "Συνδέσεις"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1191,11 +1195,11 @@ msgid "Country Code"
 msgstr "Κωδικός Χώρας"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Δημιουργία / Ανάθεση ζώνης τείχους προστασίας"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1224,7 +1228,7 @@ msgstr ""
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1259,7 +1263,7 @@ msgstr "Εξυπηρετητής DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP και DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1274,7 +1278,7 @@ msgstr "Επιλογές DHCP"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1319,7 +1323,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1328,7 +1332,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1370,7 +1374,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Προεπιλεγμένη πύλη"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1392,9 +1396,9 @@ msgstr ""
 "DNS στους πελάτες, για παράδειγμα \"<code>6,192.168.2.1,192.168.2.2</code>\"."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1455,10 +1459,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Συσκευή"
 
@@ -1548,7 +1552,7 @@ msgstr "Αγνόησε τις απαντήσεις ανοδικής ροής RFC
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1557,11 +1561,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1609,6 +1614,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1637,19 +1646,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Κατέβασμα αντιγράφου ασφαλείας"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1696,9 +1705,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Μέθοδος EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1800,25 +1809,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Ενεργοποίηση αυτής της προσάρτησης"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Ενεργοποίηση αυτής της swap"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Ενεργοποίηση/Απενεργοποίηση"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Ενεργοποιημένο"
 
@@ -1840,8 +1841,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Λειτουργία ενθυλάκωσης"
 
@@ -1869,7 +1870,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Διαγράφεται..."
 
@@ -1891,12 +1892,12 @@ msgstr "Σφάλμα"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Προσαρμογέας Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet Switch"
@@ -1997,9 +1998,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Όνομα αρχείου της εικόνας εκκίνησης που διαφημίζετε στους πελάτες"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Σύστημα Αρχείων"
 
@@ -2016,7 +2016,7 @@ msgstr "Φιλτράρισμα άχρηστων"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2046,7 +2046,7 @@ msgstr "Ρυθμίσεις Τείχους Προστασίας"
 msgid "Firewall Status"
 msgstr "Κατάσταση Τείχους Προστασίας"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2058,25 +2058,27 @@ msgstr "Έκδοση Υλικολογισμικού"
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Φλασάρισμα Firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Φλασάρισμα εικόνας..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Φλασάρισμα νέας εικόνας υλικολογισμικού"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Λειτουργίες φλασάρισματος"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Φλασάρεται..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2103,11 +2105,11 @@ msgstr "Επιβολή TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Επιβολή TKIP και CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2135,7 +2137,7 @@ msgstr "Προώθηση κίνησης broadcast"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Μέθοδος προώθησης"
 
@@ -2182,20 +2184,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Γενικές Ρυθμίσεις"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2203,7 +2204,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr ""
 
@@ -2211,11 +2212,11 @@ msgstr ""
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2226,7 +2227,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2276,7 +2277,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2469,7 +2470,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2556,16 +2557,16 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Αν οριστεί, προσάρτησε τη συσκευή με βάση το UUID της αντί για το "
 "καθορισμένο όνομα της"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2606,7 +2607,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2633,7 +2634,7 @@ msgstr "Αγνόησε διεπαφή"
 msgid "Ignore resolve file"
 msgstr "Αγνόησε αρχείο resolve"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr ""
 
@@ -2693,8 +2694,8 @@ msgstr "Εγκατάσταση επεκτάσεων πρωτοκόλλου..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2778,11 +2779,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2798,7 +2799,7 @@ msgstr "Άκυρο όνομα χρήστη και/ή κωδικός πρόσβα
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2822,11 +2823,11 @@ msgstr ""
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Διατήρηση ρυθμίσεων"
 
@@ -2882,12 +2883,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Ετικέτα"
 
@@ -3042,7 +3043,7 @@ msgstr "Φόρτωση"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3149,7 +3150,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3182,7 +3183,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3196,7 +3197,7 @@ msgstr ""
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3212,7 +3213,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3272,7 +3274,7 @@ msgstr "Μνήμη"
 msgid "Memory usage (%)"
 msgstr "Χρήση Μνήμης (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3280,7 +3282,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3339,7 +3341,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Παρακολούθηση"
@@ -3352,31 +3354,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-#, fuzzy
-msgid "Mount Entry"
-msgstr "Προσάρτηση"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Σημείο Προσάρτησης"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Σημεία Προσάρτησης"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Σημεία Προσάρτησης - Είσοδος Προσάρτησης"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3384,23 +3380,27 @@ msgstr ""
 "Τα σημεία προσάρτησης ορίζουν σε ποιο σημείο στο σύστημα αρχείων θα "
 "προσαρτηθεί μία συσκευή μνήμης"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Επιλογές προσάρτησης"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Σημείο προσάρτησης"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Προσαρτημένα συστήματα αρχείων"
 
@@ -3441,15 +3441,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Όνομα"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Όνομα νέου δικτύου"
 
@@ -3460,7 +3460,7 @@ msgstr "Πλοήγηση"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3485,7 +3485,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3510,7 +3510,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3563,7 +3563,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Δεν έχει ανατεθεί ζώνη"
 
@@ -3621,7 +3621,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3694,6 +3694,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Ένα ή περισσότερα πεδία δεν περιέχουν τιμές!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3773,7 +3774,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Επιλογές"
 
@@ -3936,7 +3936,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3945,7 +3945,7 @@ msgid "Packets"
 msgstr "Πακέτα"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Μέρος της ζώνης %q"
 
@@ -4043,11 +4043,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Εκτέλεση επανεκκίνησης"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Διενέργεια αρχικοποίησης"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4086,6 +4086,10 @@ msgstr "Πκτ."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Παρακαλώ εισάγετε όνομα χρήστη και κωδικό πρόσβασης."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4155,10 +4159,6 @@ msgstr "Αποτρέπει την επικοινωνία μεταξύ πελατ
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Συνέχεια"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4174,7 +4174,7 @@ msgstr "Πρωτ."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4257,7 +4257,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4303,10 +4303,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Αρχικοποίηση όλων των αλλαγών;"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Αλλαγή πρωτοκόλλου;"
@@ -4339,7 +4335,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Επανεκκίνηση"
@@ -4348,6 +4344,11 @@ msgstr "Επανεκκίνηση"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Επανεκκίνηση..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4401,7 +4402,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Αντικατάσταση ρυθμίσεων ασύρματης σύνδεσης"
 
@@ -4413,7 +4414,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4496,7 +4497,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4508,7 +4509,7 @@ msgstr "Αρχικοποίηση"
 msgid "Reset Counters"
 msgstr "Αρχικοποίηση Μετρητών"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Αρχικοποίηση στις προεπιλεγμένες τιμές"
 
@@ -4520,7 +4521,7 @@ msgstr "Αρχεία Resolv και Hosts"
 msgid "Resolve file"
 msgstr "Αρχείο Resolve"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4539,11 +4540,11 @@ msgstr "Επανεκκίνηση Τείχους Προστασίας"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Επαναφορά Αντίγραφου Ασφαλείας"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Επαναφορά αντιγράφου ασφαλείας"
 
@@ -4568,15 +4569,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Root"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Κατάλογος Root για αρχεία που σερβίρονται μέσω TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4597,7 +4594,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Κωδικός Πρόσβασης Δρομολογητή"
 
@@ -4620,19 +4617,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Εκτέλεση ελέγχου του συστήματος αρχείων πριν προσαρτηθεί η συσκευή"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Εκτέλεση ελέγχου συστήματος αρχείων"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4641,7 +4638,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Πρόσβαση SSH"
 
@@ -4658,7 +4655,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "Κλειδιά SSH"
 
@@ -4669,30 +4666,31 @@ msgstr "Κλειδιά SSH"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Αποθήκευση & Εφαρμογή"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4701,7 +4699,7 @@ msgid "Scan"
 msgstr "Σάρωση"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Προγραμματισμένες Εργασίες"
 
@@ -4713,11 +4711,11 @@ msgstr ""
 msgid "Section removed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Δείτε το manpage του \"mount\" για λεπτομέρειες"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4758,7 +4756,7 @@ msgstr "Είδος Υπηρεσίας"
 msgid "Services"
 msgstr "Υπηρεσίες"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4766,10 +4764,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4799,6 +4801,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4820,7 +4823,7 @@ msgstr "Απενεργοποίηση αυτής της διεπαφής"
 msgid "Signal"
 msgstr "Σήμα"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4832,7 +4835,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Σήμα:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Μέγεθος"
 
@@ -4857,7 +4860,7 @@ msgstr "Παράκαμψη σε περιεχόμενο"
 msgid "Skip to navigation"
 msgstr "Παράκαμψη σε πλοήγηση"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4874,7 +4877,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4891,7 +4894,7 @@ msgstr "Πηγή"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4930,7 +4933,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Ορίστε το κρυφό κλειδί κρυπτογράφησης."
 
@@ -4953,7 +4956,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Εκκίνηση"
 
@@ -4973,7 +4976,7 @@ msgstr "Στατικά Leases"
 msgid "Static Routes"
 msgstr "Στατικές Διαδρομές"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5012,7 +5015,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Υποβολή"
 
@@ -5026,10 +5029,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -5050,7 +5049,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5143,6 +5142,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Τερματισμός"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5160,17 +5163,13 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Οι επιτρεπόμενοι χαρακτήρες είναι: <code>A-Z</code>, <code>a-z</code>, "
 "<code>0-9</code> και <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5187,8 +5186,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5202,20 +5201,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"Το σύστημα αρχείων που χρησιμοποιήθηκε για διαμόρφωση (<abbr title="
-"\"παραδείγματος χάρην\">π.χ.</abbr> <samp><abbr title=\"Third Extended "
-"Filesystem\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5237,11 +5230,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5261,7 +5254,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5275,6 +5268,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5283,13 +5284,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5302,11 +5303,32 @@ msgstr ""
 "είναι πιθανό να χρειαστεί να ανανεώσετε την διεύθυνση του υπολογιστή σας για "
 "να αποκτήσετε ξανά πρόσβαση στη συσκευή."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5355,6 +5377,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5440,11 +5463,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Ζώνη ώρας"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5455,7 +5478,7 @@ msgstr ""
 "κατάσταση, κάντε κλικ στο \"Εκτέλεσε επαναφορά\" (δυνατό μόνο σε squashfs "
 "εικόνες)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5495,7 +5518,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Διεπαφή Τούνελ"
@@ -5538,8 +5561,8 @@ msgstr "Συσκευή USB"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5569,6 +5592,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5580,6 +5607,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5588,28 +5616,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Άγνωστο"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5622,7 +5650,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Μη-αποθηκευμένες Αλλαγές"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5645,14 +5673,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5665,7 +5699,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5723,11 +5763,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5735,7 +5775,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5798,7 +5838,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Σε χρήση"
 
@@ -5826,11 +5866,11 @@ msgstr ""
 msgid "Username"
 msgstr "Όνομα Χρήστη"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5877,8 +5917,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5899,7 +5939,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr "Μοιραζόμενο κλειδί WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Κωδική φράση WEP"
 
@@ -5907,7 +5947,7 @@ msgstr "Κωδική φράση WEP"
 msgid "WMM Mode"
 msgstr "Υποστήριξη WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Κωδική φράση WPA"
 
@@ -5969,13 +6009,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Ασύρματο"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Ασύρματος Προσαρμογέας"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6026,7 +6066,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6071,9 +6111,9 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6091,7 +6131,7 @@ msgstr "στατικό"
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -6108,7 +6148,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 #, fuzzy
 msgid "creates a bridge over specified interface(s)"
 msgstr "δημιουργεί μία γέφυρα μεταξύ των ορισμένων διεπαφών"
@@ -6245,8 +6285,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "όχι"
 
@@ -6258,13 +6296,13 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "κανένα"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6294,10 +6332,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6316,7 +6350,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6330,15 +6364,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6556,14 +6590,55 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "ναι"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Πίσω"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s διαθέσιμα)"
+
+#~ msgid "Check"
+#~ msgstr "Έλεγχος"
+
+#~ msgid "Checksum"
+#~ msgstr "Άθροισμα Ελέγχου"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Ενεργοποίηση αυτής της προσάρτησης"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Ενεργοποίηση αυτής της swap"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Φλασάρισμα Firmware"
+
+#~ msgid "Flashing..."
+#~ msgstr "Φλασάρεται..."
+
+#, fuzzy
+#~ msgid "Mount Entry"
+#~ msgstr "Προσάρτηση"
+
+#~ msgid "Proceed"
+#~ msgstr "Συνέχεια"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Αρχικοποίηση όλων των αλλαγών;"
+
+#~ msgid "Root"
+#~ msgstr "Root"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "Το σύστημα αρχείων που χρησιμοποιήθηκε για διαμόρφωση (<abbr title="
+#~ "\"παραδείγματος χάρην\">π.χ.</abbr> <samp><abbr title=\"Third Extended "
+#~ "Filesystem\">ext3</abbr></samp>)"
 
 #, fuzzy
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.4\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d minute window, %d second interval)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s available)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Please choose --"
 msgid "-- custom --"
 msgstr "-- custom --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -208,7 +202,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 
@@ -255,23 +249,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -285,25 +279,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "ARP retry threshold"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM Bridges"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM Virtual Channel Identifier (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM Virtual Path Identifier (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -313,7 +307,7 @@ msgstr ""
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "ATM device number"
@@ -337,8 +331,7 @@ msgstr "Access Concentrator"
 msgid "Access Point"
 msgstr "Access Point"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Actions"
 
@@ -364,7 +357,7 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -374,7 +367,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -385,7 +378,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Add"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -420,7 +413,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "Add local domain suffix to names served from hosts files"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Add new interface..."
 
@@ -464,19 +457,18 @@ msgid "Address to access local relay bridge"
 msgstr "Address to access local relay bridge"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administration"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Advanced Settings"
 
@@ -488,7 +480,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Alert"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -560,7 +552,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -570,76 +562,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -647,11 +639,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -661,6 +653,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Any zone"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -690,13 +686,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Associated Stations"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -747,27 +747,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Available"
 
@@ -785,11 +785,11 @@ msgstr "Available"
 msgid "Average:"
 msgstr "Average:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -813,14 +813,15 @@ msgstr "Back to Overview"
 msgid "Back to configuration"
 msgstr "Back to configuration"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Backup / Flash Firmware"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Backup file list"
@@ -838,6 +839,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -872,17 +874,17 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Bogus NX Domain Override"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bridge"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Bridge interfaces"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Bridge unit number"
 
@@ -891,6 +893,7 @@ msgid "Bring up on boot"
 msgstr "Bring up on boot"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -918,11 +921,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -930,12 +935,8 @@ msgstr "Cancel"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -969,28 +970,29 @@ msgstr "Changes the administrator password for accessing the device"
 msgid "Channel"
 msgstr "Channel"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Check"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1016,7 +1018,7 @@ msgstr "Cipher"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1024,13 +1026,13 @@ msgstr ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1067,7 +1069,7 @@ msgstr "Close list..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1082,7 +1084,7 @@ msgstr "Collecting data..."
 msgid "Command"
 msgstr "Command"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1104,8 +1106,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Configuration"
 
@@ -1114,7 +1115,7 @@ msgstr "Configuration"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1126,7 +1127,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1146,7 +1147,7 @@ msgstr "Connected"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1155,11 +1156,14 @@ msgid "Connections"
 msgstr "Connections"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1179,11 +1183,11 @@ msgid "Country Code"
 msgstr "Country Code"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Create / Assign firewall-zone"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1212,7 +1216,7 @@ msgstr "Custom Interface"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1247,7 +1251,7 @@ msgstr "DHCP Server"
 msgid "DHCP and DNS"
 msgstr "DHCP and DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1262,7 +1266,7 @@ msgstr "DHCP-Options"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1316,7 +1320,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1358,7 +1362,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Default gateway"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1381,9 +1385,9 @@ msgstr ""
 "servers to clients."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1444,10 +1448,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Device"
 
@@ -1535,7 +1539,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1544,11 +1548,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1592,6 +1597,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1620,19 +1629,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1676,9 +1685,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-Method"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1780,25 +1789,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Enable/Disable"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Enabled"
 
@@ -1820,8 +1821,8 @@ msgstr "Enables the Spanning Tree Protocol on this bridge"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1849,7 +1850,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr ""
 
@@ -1871,12 +1872,12 @@ msgstr "Error"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet Adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet Switch"
@@ -1974,9 +1975,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Filesystem"
 
@@ -1993,7 +1993,7 @@ msgstr "Filter useless"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2023,7 +2023,7 @@ msgstr "Firewall Settings"
 msgid "Firewall Status"
 msgstr "Firewall Status"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2035,24 +2035,26 @@ msgstr ""
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Flash Firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2079,11 +2081,11 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2111,7 +2113,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2158,20 +2160,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "General Setup"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2179,7 +2180,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr ""
 
@@ -2187,11 +2188,11 @@ msgstr ""
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2202,7 +2203,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2252,7 +2253,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2444,7 +2445,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2531,14 +2532,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2577,7 +2578,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2603,7 +2604,7 @@ msgstr "Ignore interface"
 msgid "Ignore resolve file"
 msgstr "Ignore resolve file"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr ""
 
@@ -2663,8 +2664,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2748,11 +2749,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2768,7 +2769,7 @@ msgstr "Invalid username and/or password! Please try again."
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2792,11 +2793,11 @@ msgstr "Join Network"
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr ""
 
@@ -2852,12 +2853,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr ""
 
@@ -3012,7 +3013,7 @@ msgstr ""
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3119,7 +3120,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3152,7 +3153,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3166,7 +3167,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3182,7 +3183,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3241,7 +3243,7 @@ msgstr "Memory"
 msgid "Memory usage (%)"
 msgstr "Memory usage (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3249,7 +3251,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3308,7 +3310,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3321,30 +3323,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Mount Point"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Mount Points"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3352,23 +3349,27 @@ msgstr ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Mounted file systems"
 
@@ -3409,15 +3410,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Name"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Name of the new network"
 
@@ -3428,7 +3429,7 @@ msgstr "Navigation"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3453,7 +3454,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3478,7 +3479,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3531,7 +3532,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3589,7 +3590,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3662,6 +3663,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3741,7 +3743,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Options"
 
@@ -3904,7 +3905,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3913,7 +3914,7 @@ msgid "Packets"
 msgstr "Packets"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -4011,11 +4012,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Perform reboot"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4054,6 +4055,10 @@ msgstr "Pkts."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Please enter your username and password."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4122,10 +4127,6 @@ msgstr "Prevents client-to-client communication"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Proceed"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4141,7 +4142,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4224,7 +4225,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4270,10 +4271,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4306,7 +4303,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reboot"
@@ -4314,6 +4311,11 @@ msgstr "Reboot"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4368,7 +4370,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Remove"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4380,7 +4382,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4463,7 +4465,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4475,7 +4477,7 @@ msgstr "Reset"
 msgid "Reset Counters"
 msgstr "Reset Counters"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr ""
 
@@ -4487,7 +4489,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4506,11 +4508,11 @@ msgstr "Restart Firewall"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Restore backup"
 
@@ -4535,15 +4537,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4564,7 +4562,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr ""
 
@@ -4586,19 +4584,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4607,7 +4605,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr ""
 
@@ -4624,7 +4622,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4635,30 +4633,31 @@ msgstr ""
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Save"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Save & Apply"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4667,7 +4666,7 @@ msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Scheduled Tasks"
 
@@ -4679,11 +4678,11 @@ msgstr ""
 msgid "Section removed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4724,7 +4723,7 @@ msgstr ""
 msgid "Services"
 msgstr "Services"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4732,10 +4731,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4765,6 +4768,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4786,7 +4790,7 @@ msgstr ""
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4798,7 +4802,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Size"
 
@@ -4823,7 +4827,7 @@ msgstr "Skip to content"
 msgid "Skip to navigation"
 msgstr "Skip to navigation"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4840,7 +4844,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4857,7 +4861,7 @@ msgstr "Source"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4896,7 +4900,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4919,7 +4923,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr ""
 
@@ -4939,7 +4943,7 @@ msgstr "Static Leases"
 msgid "Static Routes"
 msgstr "Static Routes"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4978,7 +4982,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Submit"
 
@@ -4992,10 +4996,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -5016,7 +5016,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5109,6 +5109,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Terminate"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5126,14 +5130,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5151,8 +5151,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5166,20 +5166,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5201,11 +5195,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5225,7 +5219,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5239,6 +5233,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5247,13 +5249,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5266,11 +5268,32 @@ msgstr ""
 "address of your computer to reach the device again, depending on your "
 "settings."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5319,6 +5342,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5401,11 +5425,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Timezone"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5415,7 +5439,7 @@ msgstr ""
 "archive here. To reset the firmware to its initial state, click \"Perform "
 "reset\" (only possible with squashfs images)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5455,7 +5479,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5498,8 +5522,8 @@ msgstr ""
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5529,6 +5553,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5540,6 +5568,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5548,28 +5577,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5582,7 +5611,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Unsaved Changes"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5605,14 +5634,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5625,7 +5660,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5683,11 +5724,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5695,7 +5736,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5758,7 +5799,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Used"
 
@@ -5786,11 +5827,11 @@ msgstr ""
 msgid "Username"
 msgstr "Username"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5837,8 +5878,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5859,7 +5900,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr ""
 
@@ -5867,7 +5908,7 @@ msgstr ""
 msgid "WMM Mode"
 msgstr "WMM Mode"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr ""
 
@@ -5931,13 +5972,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Wireless Adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5988,7 +6029,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6032,9 +6073,9 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6051,7 +6092,7 @@ msgstr "automatic"
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -6068,7 +6109,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "creates a bridge over specified interface(s)"
 
@@ -6204,8 +6245,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr ""
 
@@ -6217,13 +6256,13 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "none"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6253,10 +6292,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6275,7 +6310,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6289,15 +6324,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6515,14 +6550,36 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Back"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s available)"
+
+#~ msgid "Check"
+#~ msgstr "Check"
+
+#~ msgid "Checksum"
+#~ msgstr "Checksum"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Flash Firmware"
+
+#~ msgid "Proceed"
+#~ msgstr "Proceed"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
 
 #~ msgid "Antenna 1"
 #~ msgstr "Antenna 1"

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "X-Generator: Poedit 2.2.3\n"
 "Language-Team: \n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr "%.1f dB"
 
@@ -37,10 +37,6 @@ msgstr "¡%s no está etiquetado en varias VLAN!"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(ventana de %d minutos, intervalo de %d segundos)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s disponible)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Por favor elija --"
 msgid "-- custom --"
 msgstr "-- Personalizado --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- Emparejar por dispositivo --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- Emparejar por etiqueta --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- Emparejar por uuid --"
 
@@ -211,7 +205,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configuración de <abbr title=\"Light Emitting Diode\">LEDs</abbr>"
 
@@ -260,25 +254,25 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr "Ya existe un directorio con el mismo nombre."
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 "Se requiere un nuevo inicio de sesión ya que la sesión de autenticación "
 "expiró."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr "A43C + J43 + A43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr "A43C + J43 + A43 + V43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr "ADSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr "ANSI T1.413"
 
@@ -292,25 +286,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "Umbral de reintento ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr "ATM (Modo de transferencia asíncrono)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Puente ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "Identificador de canal virtual ATM (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "Identificador de camino virtual ATM (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -320,7 +314,7 @@ msgstr ""
 "interfaces de red Linux que se pueden usar junto a DHCP o PPP para conectar "
 "a la red del proveedor."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Número de dispositivo ATM"
@@ -344,8 +338,7 @@ msgstr "Concentrador de acceso"
 msgid "Access Point"
 msgstr "AP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Acciones"
 
@@ -371,7 +364,7 @@ msgstr "Clientes DHCP activos"
 msgid "Active DHCPv6 Leases"
 msgstr "Clientes DHCPv6 activos"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -381,7 +374,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -392,7 +385,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Añadir"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr "Agregar puente ATM"
 
@@ -429,7 +422,7 @@ msgstr ""
 "hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Añadir nueva interfaz..."
 
@@ -473,19 +466,18 @@ msgid "Address to access local relay bridge"
 msgstr "Dirección del puente relé local"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administración"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
@@ -497,7 +489,7 @@ msgstr "Potencia de transmisión agregada (ACTATP)"
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -576,7 +568,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr "IPs permitidas"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr "Siempre anunciar el enrutador predeterminado"
 
@@ -588,78 +580,78 @@ msgstr ""
 "Usará siempre canales de 40MHz incluso si el canal secundario se superpone. "
 "¡El uso de esta opción no cumple con IEEE 802.11n-2009!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr "Anexo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr "Anexo A + L + M (todos)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr "Anexo A G.992.1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr "Anexo A G.992.2"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr "Anexo A G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr "Anexo A G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr "Anexo B (todos)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr "Anexo B G.992.1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr "Anexo B G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr "Anexo B G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr "Anexo J (todos)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr "Anexo L G.992.3 POTS 1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr "Anexo M (todos)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr "Anexo M G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr "Anexo M G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 "Anuncie como enrutador predeterminado incluso si no hay un prefijo público "
 "disponible."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr "Dominios DNS anunciados"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr "Servidores DNS anunciados"
 
@@ -667,11 +659,11 @@ msgstr "Servidores DNS anunciados"
 msgid "Anonymous Identity"
 msgstr "Identidad anónima"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "Monte anónimo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "Swap anónimo"
 
@@ -681,6 +673,10 @@ msgstr "Swap anónimo"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Cualquier zona"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -714,7 +710,7 @@ msgstr ""
 "Asigna partes de prefijo utilizando este ID de subprefijo hexadecimal para "
 "esta interfaz."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Dispositivos conectados"
@@ -722,6 +718,10 @@ msgstr "Dispositivos conectados"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "Dispositivos"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -771,29 +771,29 @@ msgstr "Automático"
 msgid "Automatic Homenet (HNCP)"
 msgstr "Homenet automático (HNCP)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 "Comprobar automáticamente el sistema de archivos para detectar errores antes "
 "del montaje"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr "Montar automáticamente el sistemas de archivos en hotplug"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr "Montar swap automáticamente en hotplug"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "Montar el sistema de archivos automáticamente"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "Montar Swap automáticamente"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Disponible"
 
@@ -811,11 +811,11 @@ msgstr "Disponible"
 msgid "Average:"
 msgstr "Media:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr "B43 + B43C"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr "B43 + B43C + V43"
 
@@ -839,14 +839,15 @@ msgstr "Volver al resumen"
 msgid "Back to configuration"
 msgstr "Volver a la configuración"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Copia de seguridad"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Copia de seguridad / Grabar firmware"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Copia de seguridad de la lista de archivos"
@@ -864,6 +865,7 @@ msgstr "Banda"
 msgid "Beacon Interval"
 msgstr "Intervalo de baliza"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -901,17 +903,17 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Ignorar dominio falso NX"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Puente"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Puentear interfaces"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Número de unidad del puente"
 
@@ -920,6 +922,7 @@ msgid "Bring up on boot"
 msgstr "Iniciar en el arranque"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr "Explorar..."
 
@@ -948,11 +951,13 @@ msgstr "Llamada fallida"
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -960,13 +965,9 @@ msgstr "Cancelar"
 msgid "Category"
 msgstr "Categoría"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
 msgstr "Precaución: los archivos de configuración serán borrados"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
-msgstr "Precaución: la actualización del sistema será forzada"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
@@ -999,28 +1000,29 @@ msgstr "Cambie la contraseña del administrador para acceder al dispositivo"
 msgid "Channel"
 msgstr "Canal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Comprobar"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "Comprobar los sistemas de archivos antes de montar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "Marque esta opción para eliminar las redes existentes de esta radio."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Comprobación"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr "Elegir mtdblock"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1048,7 +1050,7 @@ msgstr "Cifrado"
 msgid "Cisco UDP encapsulation"
 msgstr "Encapsulación UDP de Cisco"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1056,7 +1058,7 @@ msgstr ""
 "Pulse \"Generar archivo\" para descargar un archivo .tar con los archivos de "
 "configuración actuales."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
@@ -1064,7 +1066,7 @@ msgstr ""
 "Haga clic en \"Guardar mtdblock\" para descargar el archivo mtdblock "
 "especificado. (NOTA: ¡ESTA FUNCIÓN ES PARA PROFESIONALES!)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1101,7 +1103,7 @@ msgstr "Cerrar lista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1116,7 +1118,7 @@ msgstr "Recolectando datos..."
 msgid "Command"
 msgstr "Comando"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr "Comando OK"
 
@@ -1143,8 +1145,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Configuración"
 
@@ -1153,7 +1154,7 @@ msgstr "Configuración"
 msgid "Configuration failed"
 msgstr "Configuración fallida"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr "Los archivos de configuración se mantendrán"
 
@@ -1165,7 +1166,7 @@ msgstr "Se ha aplicado la configuración."
 msgid "Configuration has been rolled back!"
 msgstr "¡La configuración ha sido revertida!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr "Confirmar desconexión"
 
@@ -1185,7 +1186,7 @@ msgstr "Conectado"
 msgid "Connection attempt failed"
 msgstr "Intento de conexión fallido"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr "Conexión perdida"
 
@@ -1194,11 +1195,14 @@ msgid "Connections"
 msgstr "Conexiones"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr "Los contenidos han sido guardados."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr "Continuar"
 
@@ -1222,11 +1226,11 @@ msgid "Country Code"
 msgstr "Código de país"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Crear / Asignar zona de firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr "Crear interfaz"
 
@@ -1255,7 +1259,7 @@ msgstr "Interfaz personalizada"
 msgid "Custom delegated IPv6-prefix"
 msgstr "Delegado personalizado IPv6-prefix"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1292,7 +1296,7 @@ msgstr "Servidor DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP y DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1307,7 +1311,7 @@ msgstr "Opciones de DHCP"
 msgid "DHCPv6 client"
 msgstr "Cliente DHCPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "Modo DHCPv6"
 
@@ -1352,7 +1356,7 @@ msgstr "Tiempo de espera de inactividad de DPD"
 msgid "DS-Lite AFTR address"
 msgstr "Dirección DS-Lite AFTR"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr "DSL"
@@ -1361,7 +1365,7 @@ msgstr "DSL"
 msgid "DSL Status"
 msgstr "Estado DSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr "Modo de línea DSL"
 
@@ -1403,7 +1407,7 @@ msgstr "Ruta predeterminada"
 msgid "Default gateway"
 msgstr "Puerta de enlace predeterminada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr "El valor predeterminado es Sin estado + Con estado"
 
@@ -1426,9 +1430,9 @@ msgstr ""
 "DNS a los clientes."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1489,10 +1493,10 @@ msgstr "Zona de destino"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Dispositivo"
 
@@ -1582,7 +1586,7 @@ msgstr "Descartar respuestas RFC1918 salientes"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -1591,11 +1595,12 @@ msgstr "Desconectar"
 msgid "Disconnection attempt failed"
 msgstr "Intento de desconexión fallido"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "Descartar"
 
@@ -1641,6 +1646,10 @@ msgstr "¿Realmente quieres eliminar \"%s\" ?"
 msgid "Do you really want to delete the following SSH key?"
 msgstr "¿Realmente quiere eliminar la siguiente clave SSH?"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "¿Realmente desea eliminar recursivamente el directorio \"%s\" ?"
@@ -1669,19 +1678,19 @@ msgstr ""
 msgid "Down"
 msgstr "Abajo"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Descargar copia de seguridad"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr "Descargar mtdblock"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr "Desplazamiento SNR en sentido descendente"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr "Arrastrar para reordenar"
 
@@ -1727,9 +1736,9 @@ msgstr "Longitud de bits EA"
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1836,25 +1845,17 @@ msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 "Habilita el indicador DF (No fragmentar) de los paquetes de encapsulación."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Habilitar este punto de montaje"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Habilitar esta red"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Habilitar este swap"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Habilitar/Deshabilitar"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Habilitado"
 
@@ -1878,8 +1879,8 @@ msgstr "Habilita el protocolo STP en este puente"
 msgid "Encapsulation limit"
 msgstr "Límite de encapsulación"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Modo de encapsulado"
 
@@ -1907,7 +1908,7 @@ msgstr "Ingrese valor personalizado"
 msgid "Enter custom values"
 msgstr "Ingrese valores personalizados"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Borrando..."
 
@@ -1929,12 +1930,12 @@ msgstr "Error"
 msgid "Errored seconds (ES)"
 msgstr "Segundos errados (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptador ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch ethernet"
@@ -2036,9 +2037,8 @@ msgstr "Nombre de archivo"
 msgid "Filename of the boot image advertised to clients"
 msgstr "Nombre del archivo de imagen de arranque mostrado a los clientes"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Sistema de archivos"
 
@@ -2055,7 +2055,7 @@ msgstr "Filtro inútil"
 msgid "Finalizing failed"
 msgstr "La finalización falló"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2088,7 +2088,7 @@ msgstr "Configuración del Firewall"
 msgid "Firewall Status"
 msgstr "Estado del Firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr "Archivo de firmware"
 
@@ -2100,25 +2100,27 @@ msgstr "Versión del firmware"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Puerto origen fijo para peticiones de DNS salientes"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Grabar firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Grabar imagen..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Grabar nueva imagen de firmware"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Operaciones de grabado"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Grabando..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2144,11 +2146,11 @@ msgstr "Forzar TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forzar TKIP y CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "Forzar enlace"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr "Forzar actualización"
 
@@ -2176,7 +2178,7 @@ msgstr "Reenviar tráfico de difusión"
 msgid "Forward mesh peer traffic"
 msgstr "Reenviar tráfico de pares de malla"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Modo de reenvío"
 
@@ -2225,20 +2227,19 @@ msgstr "La dirección de la puerta de enlace es inválida"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Configuración general"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configuración general"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "Generar Config"
 
@@ -2246,7 +2247,7 @@ msgstr "Generar Config"
 msgid "Generate PMK locally"
 msgstr "Generar PMK localmente"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Generar archivo"
 
@@ -2256,11 +2257,11 @@ msgstr ""
 "La confirmación y la contraseña no coinciden. ¡No se ha cambiado la "
 "contraseña!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "Configuración global"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "Opciones globales de red"
 
@@ -2271,7 +2272,7 @@ msgstr "Opciones globales de red"
 msgid "Go to password configuration..."
 msgstr "Ir a la configuración de la contraseña..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2321,7 +2322,7 @@ msgstr "Ocultar cadenas vacias"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "Host"
 
@@ -2513,7 +2514,7 @@ msgstr "Vecinos de IPv6"
 msgid "IPv6 Settings"
 msgstr "Configuraciones de IPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr "IPv6 ULA-Prefix"
 
@@ -2600,16 +2601,16 @@ msgstr "Si está comprobado, 1DES está habilitado"
 msgid "If checked, encryption is disabled"
 msgstr "Si está marcado, el encriptado estará deshabilitado"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Montar el dispositivo por su UUID en vez de un nodo fijo de dispositivo si "
 "se especifica"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2651,7 +2652,7 @@ msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 "Si está desmarcado, se usarán las direcciones de servidores DNS ingresadas."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2678,7 +2679,7 @@ msgstr "Deshabilitar DHCP"
 msgid "Ignore resolve file"
 msgstr "Ignorar el archivo resolve"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Imagen"
 
@@ -2741,8 +2742,8 @@ msgstr "Instalar extensiones de protocolo..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2826,11 +2827,11 @@ msgstr "¡ID VLAN no válido! Sólo se permiten IDs entre %d y %d."
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "¡ID VLAN no válido! Sólo se permiten IDs únicos"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr "Argumento inválido"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr "Comando inválido"
 
@@ -2846,7 +2847,7 @@ msgstr "¡Nombre de usuario y/o contraseña no válido/s!. Por favor reintente."
 msgid "Isolate Clients"
 msgstr "Aislar clientes"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2869,11 +2870,11 @@ msgstr "Conectar"
 msgid "Join Network: Wireless Scan"
 msgstr "Conectarse a una red: Búsqueda de redes WiFi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "Conectarse a: %q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Conservar la configuración del router"
 
@@ -2929,12 +2930,12 @@ msgstr "Umbral de fracaso en eco LCP"
 msgid "LCP echo interval"
 msgstr "Intervalo de eco LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Etiqueta"
 
@@ -3104,7 +3105,7 @@ msgstr "Cargando"
 msgid "Loading directory contents…"
 msgstr "Cargando el contenido del directorio..."
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr "Cargando vista..."
@@ -3217,7 +3218,7 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3250,7 +3251,7 @@ msgstr "La regla MAP no es válida"
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr "MD5"
 
@@ -3264,7 +3265,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3282,7 +3283,8 @@ msgstr ""
 msgid "Manual"
 msgstr "Manual"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr "AP"
 
@@ -3341,7 +3343,7 @@ msgstr "Memoria"
 msgid "Memory usage (%)"
 msgstr "Uso de RAM (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr "Malla"
 
@@ -3349,7 +3351,7 @@ msgstr "Malla"
 msgid "Mesh Id"
 msgstr "ID de malla"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr "Método no encontrado"
 
@@ -3408,7 +3410,7 @@ msgstr "Error en la consulta de información del módem"
 msgid "Modem init timeout"
 msgstr "Espera de inicialización del modem"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3421,30 +3423,25 @@ msgstr "Más caracteres"
 msgid "More…"
 msgstr "Más…"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Entrada de montaje"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Punto de montaje"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Puntos de montaje"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Puntos de montaje - Entrada de montaje"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Puntos de montaje - Entrada de Swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3452,23 +3449,27 @@ msgstr ""
 "Los puntos de montaje definen el directorio en el que un dispositivo de "
 "memoria se unirá al sistema del archivos"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr "Sistemas de archivos de montaje no configurados específicamente"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Opciones de montaje"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Punto de montaje"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "Montaje de Swap no configurado específicamente"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Sistemas de archivo montados"
 
@@ -3509,15 +3510,15 @@ msgstr "Dominio NT"
 msgid "NTP server candidates"
 msgstr "Servidores NTP a consultar"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nombre"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Nombre de la nueva red"
 
@@ -3528,7 +3529,7 @@ msgstr "Navegación"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3553,7 +3554,7 @@ msgstr "El dispositivo de red no está presente"
 msgid "Network without interfaces."
 msgstr "Red sin interfaces."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr "Nuevo nombre de interfaz..."
 
@@ -3578,7 +3579,7 @@ msgstr "Sin encriptación"
 msgid "No NAT-T"
 msgstr "Sin NAT-T"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr "Sin datos recibidos"
 
@@ -3631,7 +3632,7 @@ msgid "No signal"
 msgstr "Sin señal"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Sin zona asignada"
 
@@ -3689,7 +3690,7 @@ msgstr "No presente"
 msgid "Not started on boot"
 msgstr "No se inició en el arranque"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr "No soportado"
 
@@ -3764,6 +3765,7 @@ msgstr "Uno o más valores inválidos/requeridos en la pestaña"
 msgid "One or more required fields have no value!"
 msgstr "¡Campos vacíos!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Abrir lista..."
@@ -3856,7 +3858,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Opcional. Puerto UDP utilizado para paquetes salientes y entrantes."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Opciones"
 
@@ -4021,7 +4022,7 @@ msgstr "Desplazamiento PSID"
 msgid "PSID-bits length"
 msgstr "Longitud de PSID-bits"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Modo de transferencia de paquetes)"
 
@@ -4030,7 +4031,7 @@ msgid "Packets"
 msgstr "Paquetes"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Parte de zona %q"
 
@@ -4128,11 +4129,11 @@ msgstr "Reenvío secreto perfecto"
 msgid "Perform reboot"
 msgstr "Reiniciar"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Realizar restablecimiento"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr "Permiso denegado"
 
@@ -4171,6 +4172,10 @@ msgstr "Paq."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Por favor, introduzca su nombre de usuario y contraseña."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4241,10 +4246,6 @@ msgstr "Impide la comunicación entre los clientes"
 msgid "Private Key"
 msgstr "Clave privada"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Proceder"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4260,7 +4261,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4352,7 +4353,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Tasa RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr "Tasa RX / Tasa TX"
 
@@ -4403,10 +4404,6 @@ msgstr ""
 "deshacer! Es posible que pierda el acceso a este dispositivo si está "
 "conectado a través de esta interfaz"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "¿Está seguro de restablecer todos los cambios?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "¿Está seguro de querer cambiar el protocolo?"
@@ -4439,7 +4436,7 @@ msgstr "Fecha límite de reasociación"
 msgid "Rebind protection"
 msgstr "Protección contra reasociación"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reiniciar"
@@ -4448,6 +4445,11 @@ msgstr "Reiniciar"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Reiniciando..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4501,7 +4503,7 @@ msgstr "Dirección IPv4 remota o FQDN"
 msgid "Remove"
 msgstr "Remover"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Cambiar la configuración WiFi"
 
@@ -4513,7 +4515,7 @@ msgstr "Solicitar dirección IPv6"
 msgid "Request IPv6-prefix of length"
 msgstr "Solicitud IPv6-prefijo de longitud"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr "Tiempo de espera de solicitud terminada"
 
@@ -4603,7 +4605,7 @@ msgstr "Requiere wpa-supplicant con soporte OWE"
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "Requiere wpa-supplicant con soporte SAE"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4615,7 +4617,7 @@ msgstr "Reiniciar"
 msgid "Reset Counters"
 msgstr "Reiniciar contadores"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Reiniciar a configuraciones predeterminadas"
 
@@ -4627,7 +4629,7 @@ msgstr "Archivos Resolv y Hosts"
 msgid "Resolve file"
 msgstr "Archivo de resolución"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr "Recurso no encontrado"
 
@@ -4646,11 +4648,11 @@ msgstr "Reiniciar Firewall"
 msgid "Restart radio interface"
 msgstr "Reiniciar la interfaz de radio"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Restaurar"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Restaurar copia de seguridad"
 
@@ -4675,15 +4677,11 @@ msgstr "Error al revertir la solicitud con el estado <code>%h</code>"
 msgid "Reverting configuration…"
 msgstr "Revirtiendo configuración..."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Raíz"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Directorio raíz para los archivos servidos por TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr "Preparación de la raíz"
 
@@ -4704,7 +4702,7 @@ msgid "Router Advertisement-Service"
 msgstr "Servicio de anuncio de enrutador"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Contraseña del router"
 
@@ -4726,19 +4724,19 @@ msgstr ""
 msgid "Rule"
 msgstr "Regla"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Comprobar el sistema de archivos antes de montar el dispositivo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Comprobar el sistema de archivos"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr "Error de tiempo de ejecución"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr "SHA256"
 
@@ -4747,7 +4745,7 @@ msgid "SNR"
 msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Acceso SSH"
 
@@ -4764,7 +4762,7 @@ msgid "SSH username"
 msgstr "Nombre de usuario SSH"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "Claves SSH"
 
@@ -4775,30 +4773,31 @@ msgstr "Claves SSH"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Guardar"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Guardar y aplicar"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr "Guardar mtdblock"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr "Guardar contenidos mtdblock"
 
@@ -4807,7 +4806,7 @@ msgid "Scan"
 msgstr "Escanear"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Tareas programadas"
 
@@ -4819,11 +4818,11 @@ msgstr "Sección añadida"
 msgid "Section removed"
 msgstr "Sección removida"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Vea la página del manual de \"mount\" para detalles"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4869,7 +4868,7 @@ msgstr "Tipo de servicio"
 msgid "Services"
 msgstr "Aplicaciones"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr "Sesión expirada"
 
@@ -4877,7 +4876,7 @@ msgstr "Sesión expirada"
 msgid "Set VPN as Default Route"
 msgstr "Establecer VPN como ruta predeterminada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
@@ -4885,6 +4884,10 @@ msgstr ""
 "Configura las propiedades de la interfaz independientemente del operador de "
 "enlace (si está configurado, los eventos de detección de operador no invocan "
 "los controladores de conexión en caliente)."
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
+msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 #: protocols/luci-proto-qmi/luasrc/model/network/proto_qmi.lua:55
@@ -4913,6 +4916,7 @@ msgstr "GI corto"
 msgid "Short Preamble"
 msgstr "Preámbulo corto"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Mostrar lista de archivos a resguardar"
@@ -4934,7 +4938,7 @@ msgstr "Apagar esta interfaz"
 msgid "Signal"
 msgstr "Señal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr "Señal / Ruido"
 
@@ -4946,7 +4950,7 @@ msgstr "Atenuación de señal (SATN)"
 msgid "Signal:"
 msgstr "Señal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Tamaño"
 
@@ -4971,7 +4975,7 @@ msgstr "Saltar al contenido"
 msgid "Skip to navigation"
 msgstr "Saltar a navegación"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Software VLAN"
@@ -4988,7 +4992,7 @@ msgstr "Objeto no encontrado."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "El servidor encontró un error inesperado."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -5008,7 +5012,7 @@ msgstr "Origen"
 msgid "Source Address"
 msgstr "Dirección de la fuente"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Especifica el directorio al que está enlazado el dispositivo"
 
@@ -5058,7 +5062,7 @@ msgstr ""
 "Especifique una MTU (Unidad de transmisión máxima) distinta de la "
 "predeterminada (1280 bytes)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Especifique la clave de encriptación."
 
@@ -5081,7 +5085,7 @@ msgid "Starting wireless scan..."
 msgstr "Iniciando escaneo de WiFi..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Arranque"
 
@@ -5101,7 +5105,7 @@ msgstr "Direcciones estáticas"
 msgid "Static Routes"
 msgstr "Rutas estáticas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5144,7 +5148,7 @@ msgid "Strong"
 msgstr "Fuerte"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Enviar"
 
@@ -5159,10 +5163,6 @@ msgstr "Suprimir el registro de la operación rutinaria de estos protocolos"
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "Swap"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Entrada de Swap"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5184,7 +5184,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Máscara de puerto de Switch"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Switch VLAN"
@@ -5278,6 +5278,10 @@ msgstr "Red de destino"
 msgid "Terminate"
 msgstr "Terminar"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5300,17 +5304,13 @@ msgid ""
 msgstr ""
 "El prefijo IPv6 asignado por el proveedor, suele termina con <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Los caracteres permitidos son: <code>A-Z</code>, <code>a-z</code>, "
 "<code>0-9</code> y <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr "El archivo de copia de seguridad no parece ser un archivo gzip válido."
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5335,8 +5335,8 @@ msgstr ""
 "nuevamente, o revertir todos los cambios pendientes para mantener el estado "
 "de configuración actualmente en funcionamiento."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5352,25 +5352,16 @@ msgstr ""
 "La configuración inalámbrica existente debe cambiarse para que LuCI funcione "
 "correctamente."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"El sistema de archivo que fue utilizado para dar formato a la memoria (<abbr "
-"title=\"por ejemplo\">Ej.</abbr> <samp><abbr title=\"Third Extended "
-"Filesystem\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Imagen recibida. Verifique que la comprobación y tamaño del archivo recibido "
-"coinciden con los del original.<br />Pulse \"Proceder\" para empezar el "
-"grabado."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5392,11 +5383,11 @@ msgstr ""
 "La clave pública SSH dada no es válida. Por favor, suministre las claves "
 "públicas RSA o ECDSA."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr "El nombre de la interfaz ya está en uso."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr "El nombre de la interfaz es demasiado largo."
 
@@ -5417,7 +5408,7 @@ msgstr "Longitud del prefijo IPv6 en bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "La dirección IPv4 local sobre la que se crea el túnel (opcional)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr "El nombre de la red ya está en uso."
 
@@ -5437,6 +5428,14 @@ msgstr ""
 "segmentos de red. Es común que exista un puerto por defecto para subida "
 "hacia una red mayor como internet y el resto se dediquen a la red local."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr "El modo %s seleccionado es incompatible con el cifrado %s"
@@ -5445,7 +5444,7 @@ msgstr "El modo %s seleccionado es incompatible con el cifrado %s"
 msgid "The submitted security token is invalid or already expired!"
 msgstr "¡El token de seguridad enviado no es válido o ya está vencido!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5453,7 +5452,7 @@ msgstr ""
 "El sistema está borrando la partición de configuración y se reiniciará "
 "cuando termine."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5464,11 +5463,32 @@ msgstr ""
 "Espere unos minutos antes de reconectar. Es posible que tenga que renovar la "
 "conexión de su ordenador para poder acceder de nuevo al dispositivo."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "La contraseña del sistema se ha cambiado correctamente."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5522,6 +5542,7 @@ msgstr ""
 "'server=1.2.3.4' para dominios específicos o servidores <abbr title=\"Domain "
 "Name System\">DNS</abbr> full upstream."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5616,11 +5637,11 @@ msgstr "Intervalo de tiempo para reprogramar GTK"
 msgid "Timezone"
 msgstr "Zona horaria"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr "Iniciar sesión…"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5631,7 +5652,7 @@ msgstr ""
 "predeterminadas pulse \"Realizar restablecimiento\" (sólo posible con "
 "imágenes squashfs)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr "Tono"
 
@@ -5671,7 +5692,7 @@ msgstr "Modo de disparador"
 msgid "Tunnel ID"
 msgstr "ID de túnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interfaz de túnel"
@@ -5714,8 +5735,8 @@ msgstr "Dispositivo USB"
 msgid "USB Ports"
 msgstr "Puertos USB"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5745,6 +5766,10 @@ msgstr "Imposible repartir"
 msgid "Unable to obtain client ID"
 msgstr "No se puede obtener la identificación del cliente"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5756,6 +5781,7 @@ msgid "Unable to resolve peer host name"
 msgstr "No se puede resolver el nombre de host del par"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr "No se puede guardar el contenido: %s"
@@ -5764,28 +5790,28 @@ msgstr "No se puede guardar el contenido: %s"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Segundos no disponibles (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Error desconocido (%s)"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr "Código de error desconocido"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "No administrado"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "Desmontar"
 
@@ -5798,7 +5824,7 @@ msgstr "Clave sin nombre"
 msgid "Unsaved Changes"
 msgstr "Cambios sin aplicar"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr "Error no especificado"
 
@@ -5821,7 +5847,11 @@ msgstr "Tipo de protocolo no soportado."
 msgid "Up"
 msgstr "Arriba"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5831,7 +5861,9 @@ msgstr ""
 "actual. Puede marcar \"Conservar la configuración del router\" si lo desea "
 "(es necesario que la imagen sea compatible)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Subir archivo..."
 
@@ -5844,8 +5876,14 @@ msgid "Upload file…"
 msgstr "Subir archivo..."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
 msgstr "Error al cargar la solicitud: %s"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
 msgid ""
@@ -5905,11 +5943,11 @@ msgstr "MTU a usar en el interfaz de túnel"
 msgid "Use TTL on tunnel interface"
 msgstr "TTL a usar en el interfaz de túnel"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr "Utilizar como superposición externa (/overlay)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "Utilizar como sistema de archivos raíz (/)"
 
@@ -5917,7 +5955,7 @@ msgstr "Utilizar como sistema de archivos raíz (/)"
 msgid "Use broadcast flag"
 msgstr "Usar marca de difusión"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "Utilizar la gestión integrada de IPv6"
 
@@ -5984,7 +6022,7 @@ msgstr ""
 "especificará la dirección fija a usar y <em>Nombre del host</em> se asignará "
 "como nombre identificativo."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Usado"
 
@@ -6014,11 +6052,11 @@ msgstr "Clave de usuario (codificada PEM)"
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr "VDSL"
 
@@ -6065,9 +6103,9 @@ msgstr "Proveedor"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Clase de vendedor a enviar cuando solicite DHCP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Verificar"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -6087,7 +6125,7 @@ msgstr "Sistema abierto WEP"
 msgid "WEP Shared Key"
 msgstr "Clave compartida WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Contraseña WEP"
 
@@ -6095,7 +6133,7 @@ msgstr "Contraseña WEP"
 msgid "WMM Mode"
 msgstr "Habilitar WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Contraseña WPA"
 
@@ -6162,13 +6200,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "WiFi"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adaptador WiFi"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6219,7 +6257,7 @@ msgstr "Escribe el registro del sistema al archivo"
 msgid "Yes"
 msgstr "Si"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6267,9 +6305,9 @@ msgstr "Tamaño de ZRam"
 msgid "any"
 msgstr "Cualquiera"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6286,7 +6324,7 @@ msgstr "Automático"
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "Puenteado"
 
@@ -6303,7 +6341,7 @@ msgid "create:"
 msgstr "Crear:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "Crea un puente sobre la interfaz o interfaces asociadas"
 
@@ -6439,8 +6477,6 @@ msgstr "Minutos"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "No"
 
@@ -6452,13 +6488,13 @@ msgstr "Sin enlace"
 msgid "non-empty value"
 msgstr "valor no vacío"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "ninguno"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "No presente"
 
@@ -6488,10 +6524,6 @@ msgstr "red abierta"
 msgid "output"
 msgstr "Salida"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr "Overlay"
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr "valor decimal positivo"
@@ -6510,7 +6542,7 @@ msgstr "Aleatorio"
 msgid "relay mode"
 msgstr "Modo relé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "Enrutado"
 
@@ -6524,15 +6556,15 @@ msgstr "Seg"
 msgid "server mode"
 msgstr "Modo servidor"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr "Con estado solamente"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr "Sin estado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr "Sin estado + Con estado"
 
@@ -6750,14 +6782,82 @@ msgstr "seguridad débil"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "Si"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Volver"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s disponible)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- Emparejar por dispositivo --"
+
+#~ msgid "Caution: System upgrade will be forced"
+#~ msgstr "Precaución: la actualización del sistema será forzada"
+
+#~ msgid "Check"
+#~ msgstr "Comprobar"
+
+#~ msgid "Checksum"
+#~ msgstr "Comprobación"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Habilitar este punto de montaje"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Habilitar este swap"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Grabar firmware"
+
+#~ msgid "Flashing..."
+#~ msgstr "Grabando..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Entrada de montaje"
+
+#~ msgid "Proceed"
+#~ msgstr "Proceder"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "¿Está seguro de restablecer todos los cambios?"
+
+#~ msgid "Root"
+#~ msgstr "Raíz"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Entrada de Swap"
+
+#~ msgid "The backup archive does not appear to be a valid gzip file."
+#~ msgstr ""
+#~ "El archivo de copia de seguridad no parece ser un archivo gzip válido."
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "El sistema de archivo que fue utilizado para dar formato a la memoria "
+#~ "(<abbr title=\"por ejemplo\">Ej.</abbr> <samp><abbr title=\"Third "
+#~ "Extended Filesystem\">ext3</abbr></samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Imagen recibida. Verifique que la comprobación y tamaño del archivo "
+#~ "recibido coinciden con los del original.<br />Pulse \"Proceder\" para "
+#~ "empezar el grabado."
+
+#~ msgid "Verify"
+#~ msgstr "Verificar"
+
+#~ msgid "overlay"
+#~ msgstr "Overlay"
 
 #~ msgid "Change login password"
 #~ msgstr "Cambiar contraseña de inicio de sesión"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(fenêtre de %d minutes, intervalle de %d secondes)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s disponible)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Choisir --"
 msgid "-- custom --"
 msgstr "-- autre --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -208,7 +202,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr ""
 "Configuration des <abbr title=\"Diode Électro-Luminescente\">DEL</abbr>s"
@@ -256,23 +250,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -286,29 +280,29 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "Niveau de ré-essai ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Ponts ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 "Identifiant de canal virtuel (<abbr title=\"Virtual Channel Idendifier"
 "\">VCI</abbr>) ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 "Identifiant de chemin virtuel (<abbr title=\"Virtual Path Idendifier\">VPI</"
 "abbr>) ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -318,7 +312,7 @@ msgstr ""
 "des interfaces réseau virtuelles Linux qui peuvent être utilisées avec DHCP "
 "ou PPP pour se connecter au réseau du fournisseur d'accès."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Numéro de périphérique ATM"
@@ -342,8 +336,7 @@ msgstr "Concentrateur d'accès"
 msgid "Access Point"
 msgstr "Point d'accès"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Actions"
 
@@ -369,7 +362,7 @@ msgstr "Bails DHCP actifs"
 msgid "Active DHCPv6 Leases"
 msgstr "Bails DHCPv6 actifs"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -379,7 +372,7 @@ msgstr "Ad-hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -390,7 +383,7 @@ msgstr "Ad-hoc"
 msgid "Add"
 msgstr "Ajouter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -426,7 +419,7 @@ msgstr ""
 "Ajouter le suffixe du domaine local aux noms résolus d'après le fichier hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Ajout d'une nouvelle interface..."
 
@@ -470,19 +463,18 @@ msgid "Address to access local relay bridge"
 msgstr "Adresse pour accéder au pont-relais local"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administration"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
@@ -494,7 +486,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Alerte"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -572,7 +564,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -582,76 +574,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -659,11 +651,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -673,6 +665,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "N'importe quelle zone"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -702,13 +698,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Équipements associés"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -759,27 +759,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Disponible"
 
@@ -797,11 +797,11 @@ msgstr "Disponible"
 msgid "Average:"
 msgstr "Moyenne :"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -825,14 +825,15 @@ msgstr "Retour à la vue générale"
 msgid "Back to configuration"
 msgstr "Retour à la configuration"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Sauvegarder"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Sauvegarde / Mise à jour du micrologiciel"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Liste des fichiers de sauvegarde"
@@ -850,6 +851,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -884,17 +886,17 @@ msgstr "Débit"
 msgid "Bogus NX Domain Override"
 msgstr "Contourne les «  NX Domain » bogués"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Pont"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Interfaces en pont"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Numéro d'unité du pont"
 
@@ -903,6 +905,7 @@ msgid "Bring up on boot"
 msgstr "L'activer au démarrage"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -930,11 +933,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -942,12 +947,8 @@ msgstr "Annuler"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -981,28 +982,29 @@ msgstr "Change le mot de passe administrateur pour accéder à l'équipement"
 msgid "Channel"
 msgstr "Canal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Vérification"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Somme de contrôle"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1031,7 +1033,7 @@ msgstr "Code de chiffrement"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1039,13 +1041,13 @@ msgstr ""
 "Cliquer sur \"Construire l'archive\" pour télécharger une archive tar des "
 "fichiers de la configuration actuelle."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1082,7 +1084,7 @@ msgstr "Fermer la liste…"
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1097,7 +1099,7 @@ msgstr "Récupération de données..."
 msgid "Command"
 msgstr "Commande"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1119,8 +1121,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Configuration"
 
@@ -1129,7 +1130,7 @@ msgstr "Configuration"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1141,7 +1142,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1161,7 +1162,7 @@ msgstr "Connecté"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1170,11 +1171,14 @@ msgid "Connections"
 msgstr "Connexions"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1194,11 +1198,11 @@ msgid "Country Code"
 msgstr "Code pays"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Créer / Assigner une zone du pare-feu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1227,7 +1231,7 @@ msgstr "Interface spécifique"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1262,7 +1266,7 @@ msgstr "Serveur DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP et DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1277,7 +1281,7 @@ msgstr "Options DHCP"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1322,7 +1326,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1331,7 +1335,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1373,7 +1377,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Passerelle par défaut"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1396,9 +1400,9 @@ msgstr ""
 "DNS à ses clients."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1459,10 +1463,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Équipement"
 
@@ -1552,7 +1556,7 @@ msgstr "Jeter les réponses en RFC1918 amont"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1561,11 +1565,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1614,6 +1619,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1642,19 +1651,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Télécharger la sauvegarde"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1700,9 +1709,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Méthode EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1804,25 +1813,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Activer ce montage"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Activer cette mémoire d'échange (swap)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Activer/Désactiver"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Activé"
 
@@ -1846,8 +1847,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Mode encapsulé"
 
@@ -1875,7 +1876,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Effacement…"
 
@@ -1897,12 +1898,12 @@ msgstr "Erreur"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Module Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Commutateur Ethernet"
@@ -2003,9 +2004,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Nom de fichier d'une image de démarrage publiée aux clients"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Système de fichiers"
 
@@ -2022,7 +2022,7 @@ msgstr "Filtrer les requêtes inutiles"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2052,7 +2052,7 @@ msgstr "Paramètres du pare-feu"
 msgid "Firewall Status"
 msgstr "État du pare-feu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2064,25 +2064,27 @@ msgstr "Version du micrologiciel"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Port source fixe pour les requêtes DNS sortantes"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Mise à jour du micrologiciel"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Écriture de l'image…"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Écrire l'image du nouveau micrologiciel"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Opérations d'écriture"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Écriture…"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2108,11 +2110,11 @@ msgstr "Forcer TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forcer TKIP et CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2140,7 +2142,7 @@ msgstr "Transmettre le trafic de diffusion"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Mode de transmission"
 
@@ -2187,20 +2189,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configuration générale"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2208,7 +2209,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Construire l'archive"
 
@@ -2218,11 +2219,11 @@ msgstr ""
 "La confirmation du nouveau mot de passe ne correspond pas, changement "
 "annulé !"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2233,7 +2234,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Aller à la configuration du mot de passe…"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2283,7 +2284,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2475,7 +2476,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2562,16 +2563,16 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Monte le périphérique identifié par cet UUID au lieu d'un nom de "
 "périphérique fixe"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2612,7 +2613,7 @@ msgstr "Décoché, aucune route par défaut n'est configurée"
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "Décoché, les adresses des serveurs DNS publiés sont ignorées"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2637,7 +2638,7 @@ msgstr "Ignorer l'interface"
 msgid "Ignore resolve file"
 msgstr "Ignorer le fichier de résolution"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Image"
 
@@ -2697,8 +2698,8 @@ msgstr "Installation des extensions de protocole…"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2785,11 +2786,11 @@ msgstr ""
 "Identifiant VLAN donné invalide ! Seuls les identifiants uniques sont "
 "autorisés"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2805,7 +2806,7 @@ msgstr "Nom d'utilisateur et/ou mot de passe invalides ! Réessayez !"
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2830,11 +2831,11 @@ msgstr "Rejoindre un réseau"
 msgid "Join Network: Wireless Scan"
 msgstr "Rejoindre un réseau : recherche des réseaux sans-fil"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Garder le paramètrage"
 
@@ -2890,12 +2891,12 @@ msgstr "Seuil d'erreur des échos LCP"
 msgid "LCP echo interval"
 msgstr "Intervalle entre échos LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Étiquette"
 
@@ -3053,7 +3054,7 @@ msgstr "Chargement"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3169,7 +3170,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3202,7 +3203,7 @@ msgstr ""
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3216,7 +3217,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3232,7 +3233,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3291,7 +3293,7 @@ msgstr "Mémoire"
 msgid "Memory usage (%)"
 msgstr "Utilisation Mémoire (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3299,7 +3301,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3358,7 +3360,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Délai max. d'initialisation du modem"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3371,30 +3373,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Montage"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Point de montage"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Point de montage"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Points de montage - élément à monter"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Points de montage - partition d'échange"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3402,23 +3399,27 @@ msgstr ""
 "Les points de montage définissent l'attachement d'un périphérique au système "
 "de fichier"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Options de montage"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Point de montage"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Systèmes de fichiers montés"
 
@@ -3459,15 +3460,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Serveurs NTP candidats"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nom"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Nom du nouveau réseau"
 
@@ -3478,7 +3479,7 @@ msgstr "Navigation"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3503,7 +3504,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "Réseau sans interfaces."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3528,7 +3529,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3581,7 +3582,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Aucune zone attribuée"
 
@@ -3639,7 +3640,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3712,6 +3713,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Un ou plusieurs champs n'ont pas de valeur !"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Ouvrir la liste…"
@@ -3791,7 +3793,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Options"
 
@@ -3956,7 +3957,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3965,7 +3966,7 @@ msgid "Packets"
 msgstr "Paquets"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Fait partie de la zone %q"
 
@@ -4063,11 +4064,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Redémarrer"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Réinitialiser"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4106,6 +4107,10 @@ msgstr "Pqts."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Saisissez votre nom d'utilisateur et mot de passe."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4176,10 +4181,6 @@ msgstr "Empêche la communication directe entre clients"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Continuer"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4195,7 +4196,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4278,7 +4279,7 @@ msgstr "Reçu"
 msgid "RX Rate"
 msgstr "Débit en réception"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4322,10 +4323,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Voulez-vous vraiment ré-initialiser toutes les modifications ?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Voulez-vous vraiment changer de protocole ?"
@@ -4358,7 +4355,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Protection contre l'attaque « rebind »"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Redémarrage"
@@ -4367,6 +4364,11 @@ msgstr "Redémarrage"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Redémarre…"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4420,7 +4422,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Désinstaller"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Remplacer la configuration sans-fil"
 
@@ -4432,7 +4434,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4515,7 +4517,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4527,7 +4529,7 @@ msgstr "Remise à zéro"
 msgid "Reset Counters"
 msgstr "Remise à zéro des compteurs"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Ré-initialisation"
 
@@ -4539,7 +4541,7 @@ msgstr "Fichiers Resolv et Hosts"
 msgid "Resolve file"
 msgstr "Fichier de résolution des noms"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4558,11 +4560,11 @@ msgstr "Redémarrer le pare-feu"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Restaurer"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Restaurer une sauvegarde"
 
@@ -4587,15 +4589,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Racine"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Répertoire racine des fichiers fournis par TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4616,7 +4614,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Mot de passe du routeur"
 
@@ -4638,20 +4636,20 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 "Faire un vérification du système de fichiers avant de monter le périphérique"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Faire une vérification du système de fichiers"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4660,7 +4658,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Accès SSH"
 
@@ -4677,7 +4675,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "Clés SSH"
 
@@ -4688,30 +4686,31 @@ msgstr "Clés SSH"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Sauvegarder et Appliquer"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4720,7 +4719,7 @@ msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Tâches Régulières"
 
@@ -4732,11 +4731,11 @@ msgstr "Section ajoutée"
 msgid "Section removed"
 msgstr "Section retirée"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Voir le manuel de « mount » pour les détails"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4779,7 +4778,7 @@ msgstr "Type du service"
 msgid "Services"
 msgstr "Services"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4787,10 +4786,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4820,6 +4823,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Afficher la liste des fichiers de la sauvegarde actuelle"
@@ -4841,7 +4845,7 @@ msgstr "Arrêter cet interface"
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4853,7 +4857,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Signal :"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Taille"
 
@@ -4878,7 +4882,7 @@ msgstr "Skip to content"
 msgid "Skip to navigation"
 msgstr "Skip to navigation"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4895,7 +4899,7 @@ msgstr "Désolé, l'objet que vous avez demandé n'as pas été trouvé."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Désolé, le serveur à rencontré une erreur inattendue."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4916,7 +4920,7 @@ msgstr "Source"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Indique le répertoire auquel le périphérique est rattaché"
 
@@ -4957,7 +4961,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Spécifiez ici la clé secrète de chiffrage."
 
@@ -4980,7 +4984,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Démarrage"
 
@@ -5000,7 +5004,7 @@ msgstr "Baux Statiques"
 msgid "Static Routes"
 msgstr "Routes statiques"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5043,7 +5047,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Soumettre"
 
@@ -5058,10 +5062,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Élement de partition d'échange"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5081,7 +5081,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5174,6 +5174,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Terminer"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5193,17 +5197,13 @@ msgstr ""
 "Le préfixe IPv6 attribué par le fournisseur, se termine généralement par "
 "<code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Les caractères autorisés sont : <code>A-Z</code>, <code>a-z</code>, "
 "<code>0-9</code> et <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5220,8 +5220,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5233,25 +5233,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"Le système de fichiers utilisé pour formatter le support de stockage (ex : "
-"ext3)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"L'image du micrologiciel a été chargée. Ci-dessous la taille et la somme de "
-"contrôle de cette image, comparez-les avec le fichier original pour vous "
-"assurer de son intégrité.<br /> Cliquez sur \"Continuer\" pour lancer la "
-"procédure d'écriture."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5271,11 +5262,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5297,7 +5288,7 @@ msgstr "La longueur du préfixe IPv6 en bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5318,6 +5309,14 @@ msgstr ""
 "un port d'uplink pour une connexion vers un réseau plus vaste, comme "
 "internet et les autres ports sont réservés au réseau local."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5326,7 +5325,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5334,7 +5333,7 @@ msgstr ""
 "Le système est en train d'effacer la partition de configuration et "
 "redémarrera tout seul une fois cela fini."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5347,11 +5346,32 @@ msgstr ""
 "address of your computer to reach the device again, depending on your "
 "settings."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5403,6 +5423,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5496,11 +5517,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Fuseau horaire"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5511,7 +5532,7 @@ msgstr ""
 "micrologiciel dans son état initial, cliquer sur \"Réinitialiser\" (possible "
 "seulement avec les images de type squashfs)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5551,7 +5572,7 @@ msgstr "Mode de déclenchement"
 msgid "Tunnel ID"
 msgstr "ID du tunnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interface du tunnel"
@@ -5594,8 +5615,8 @@ msgstr "Périphérique USB"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5625,6 +5646,10 @@ msgstr "Impossible d'envoyer"
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5636,6 +5661,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5644,28 +5670,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "non-géré"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5678,7 +5704,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Changements non appliqués"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5701,7 +5727,11 @@ msgstr "Type de protocole non pris en charge."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5712,7 +5742,9 @@ msgstr ""
 "maintenir la configuration actuelle (nécessite une image de micrologiciel "
 "compatible)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Envoi de l'archive…"
 
@@ -5725,7 +5757,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5783,11 +5821,11 @@ msgstr "Utiliser le MTU sur l'interface du tunnel"
 msgid "Use TTL on tunnel interface"
 msgstr "Utiliser le TTL sur l'interface du tunnel"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5795,7 +5833,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "Utiliser une marque de diffusion"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5862,7 +5900,7 @@ msgstr ""
 "l'adresse fixe à utiliser et le <em>nom d'hôte</em> sera le nom symbolique "
 "attribué à l'hôte qui fait la demande."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Utilisé"
 
@@ -5890,11 +5928,11 @@ msgstr ""
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5941,9 +5979,9 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Classe de fournisseur à envoyer dans les requêtes DHCP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Vérifier"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5963,7 +6001,7 @@ msgstr "Système ouvert WEP"
 msgid "WEP Shared Key"
 msgstr "Clé partagée WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Mot de passe WEP"
 
@@ -5971,7 +6009,7 @@ msgstr "Mot de passe WEP"
 msgid "WMM Mode"
 msgstr "Mode WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Mot de passe WPA"
 
@@ -6035,13 +6073,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Sans-fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Module Wi-Fi"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6092,7 +6130,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6139,9 +6177,9 @@ msgstr ""
 msgid "any"
 msgstr "n'importe lequel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6159,7 +6197,7 @@ msgstr "statique"
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "ponté"
 
@@ -6176,7 +6214,7 @@ msgid "create:"
 msgstr "créer:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "créer un bridge entre plusieurs interfaces"
 
@@ -6310,8 +6348,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "non"
 
@@ -6323,13 +6359,13 @@ msgstr "pas de lien"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "aucun"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6359,10 +6395,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6381,7 +6413,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "routé"
 
@@ -6395,15 +6427,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6621,14 +6653,69 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "oui"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Retour"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s disponible)"
+
+#~ msgid "Check"
+#~ msgstr "Vérification"
+
+#~ msgid "Checksum"
+#~ msgstr "Somme de contrôle"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Activer ce montage"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Activer cette mémoire d'échange (swap)"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Mise à jour du micrologiciel"
+
+#~ msgid "Flashing..."
+#~ msgstr "Écriture…"
+
+#~ msgid "Mount Entry"
+#~ msgstr "Montage"
+
+#~ msgid "Proceed"
+#~ msgstr "Continuer"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Voulez-vous vraiment ré-initialiser toutes les modifications ?"
+
+#~ msgid "Root"
+#~ msgstr "Racine"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Élement de partition d'échange"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "Le système de fichiers utilisé pour formatter le support de stockage "
+#~ "(ex : ext3)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "L'image du micrologiciel a été chargée. Ci-dessous la taille et la somme "
+#~ "de contrôle de cette image, comparez-les avec le fichier original pour "
+#~ "vous assurer de son intégrité.<br /> Cliquez sur \"Continuer\" pour "
+#~ "lancer la procédure d'écriture."
+
+#~ msgid "Verify"
+#~ msgstr "Vérifier"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Indique le port d'écoute de cette instance <em>Dropbear</em>"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -35,10 +35,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s פנוי)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -79,15 +75,13 @@ msgstr "-- נא לבחור --"
 msgid "-- custom --"
 msgstr "-- מותאם אישית --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "הגדרות <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
@@ -246,23 +240,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -277,35 +271,35 @@ msgstr ""
 msgid "ARP retry threshold"
 msgstr "סף נסיונות של ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 #, fuzzy
 msgid "ATM Bridges"
 msgstr "גשרי ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 #, fuzzy
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "מזהה ערוצים ווירטואליים של ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 #, fuzzy
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "מזהה נתיבים ווירטואליים של ATM  (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "מס' התקן של ATM"
@@ -330,8 +324,7 @@ msgstr "מרכז גישות"
 msgid "Access Point"
 msgstr "נקודת גישה"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "פעולות"
 
@@ -358,7 +351,7 @@ msgid "Active DHCPv6 Leases"
 msgstr "הרשאות DHCPv6 פעילות"
 
 # צריך אימות של מישהו שמבין יותר במושגים האלו אם צריך בכלל לתרגם את זה או להשאיר כמו שזה
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 #, fuzzy
@@ -369,7 +362,7 @@ msgstr "אד-הוק"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -380,7 +373,7 @@ msgstr "אד-הוק"
 msgid "Add"
 msgstr "הוסף"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -416,7 +409,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "הוסף דומיין מקומי לשמות המוגשים מהקבצים של המארח"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "הוסף ממשק חדש..."
 
@@ -460,7 +453,7 @@ msgid "Address to access local relay bridge"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 #, fuzzy
 msgid "Administration"
 msgstr "מנהלה"
@@ -468,12 +461,11 @@ msgstr "מנהלה"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "הגדרות מתקדמות"
 
@@ -486,7 +478,7 @@ msgstr ""
 msgid "Alert"
 msgstr "אזעקה"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -559,7 +551,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -569,76 +561,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -646,11 +638,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -662,6 +654,10 @@ msgstr ""
 #, fuzzy
 msgid "Any zone"
 msgstr "כל תחום"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -691,13 +687,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "תחנות קשורות"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -748,27 +748,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "זמין"
 
@@ -786,11 +786,11 @@ msgstr "זמין"
 msgid "Average:"
 msgstr "ממוצע:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -814,14 +814,15 @@ msgstr "חזרה לסקירה"
 msgid "Back to configuration"
 msgstr "חזרה להגדרות"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "גיבוי"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "גיבוי / קושחת פלאש"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "גיבוי רשימת קבצים"
@@ -839,6 +840,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -873,17 +875,17 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "גשר"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "ממשקי גשר"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "מס' יח' גשר"
 
@@ -893,6 +895,7 @@ msgid "Bring up on boot"
 msgstr "הבא באיתחול"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -920,11 +923,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "בטל"
 
@@ -932,12 +937,8 @@ msgstr "בטל"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -971,28 +972,29 @@ msgstr "משנה את סיסמת המנהל לגישה למכשיר"
 msgid "Channel"
 msgstr "ערוץ"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "לבדוק"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1014,19 +1016,19 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1061,7 +1063,7 @@ msgstr "סגור רשימה..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1076,7 +1078,7 @@ msgstr "אוסף מידע..."
 msgid "Command"
 msgstr "פקודה"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1098,8 +1100,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "הגדרות"
 
@@ -1108,7 +1109,7 @@ msgstr "הגדרות"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1120,7 +1121,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1140,7 +1141,7 @@ msgstr "מחובר"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1149,11 +1150,14 @@ msgid "Connections"
 msgstr "חיבורים"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1173,11 +1177,11 @@ msgid "Country Code"
 msgstr "קוד מדינה"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "צור / הקצה תחום-חומת אש"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1206,7 +1210,7 @@ msgstr "ממשק מותאם אישית"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1241,7 +1245,7 @@ msgstr "שרת DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP ו- DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1256,7 +1260,7 @@ msgstr "אפשרויות-DHCP"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1301,7 +1305,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1352,7 +1356,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1374,9 +1378,9 @@ msgstr ""
 "אשר מציגות שרתי DNS שונים ללקוח"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1437,10 +1441,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "מכשיר"
 
@@ -1528,7 +1532,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1537,11 +1541,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1581,6 +1586,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1607,19 +1616,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "הורד גיבוי"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1662,9 +1671,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1766,25 +1775,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "אפשר"
 
@@ -1806,8 +1807,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1835,7 +1836,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "מוחק..."
 
@@ -1857,12 +1858,12 @@ msgstr "שגיאה"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1960,9 +1961,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr ""
 
@@ -1979,7 +1979,7 @@ msgstr ""
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Firewall Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2021,24 +2021,26 @@ msgstr ""
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2065,11 +2067,11 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2097,7 +2099,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2144,20 +2146,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2165,7 +2166,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr ""
 
@@ -2173,11 +2174,11 @@ msgstr ""
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2188,7 +2189,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2236,7 +2237,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2428,7 +2429,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2515,14 +2516,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2561,7 +2562,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2582,7 +2583,7 @@ msgstr ""
 msgid "Ignore resolve file"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr ""
 
@@ -2642,8 +2643,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2727,11 +2728,11 @@ msgstr "מספר VLAN שגוי! רק ערכים בין %d לבין %d הם חו�
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2747,7 +2748,7 @@ msgstr "שם משתמש ו/או סיסמה שגויים! אנא נסה שנית.
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2768,11 +2769,11 @@ msgstr ""
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr ""
 
@@ -2828,12 +2829,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr ""
 
@@ -2988,7 +2989,7 @@ msgstr "טוען"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3095,7 +3096,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3128,7 +3129,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3142,7 +3143,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3158,7 +3159,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3217,7 +3219,7 @@ msgstr ""
 msgid "Memory usage (%)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3225,7 +3227,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3284,7 +3286,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
@@ -3297,52 +3299,51 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr ""
 
@@ -3383,15 +3384,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "שם"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr ""
 
@@ -3402,7 +3403,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3427,7 +3428,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3452,7 +3453,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3505,7 +3506,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3563,7 +3564,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3636,6 +3637,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3715,7 +3717,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr ""
 
@@ -3878,7 +3879,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3887,7 +3888,7 @@ msgid "Packets"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -3985,11 +3986,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4028,6 +4029,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "אנא הזן את שם המשתמש והסיסמה שלך:"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4096,10 +4101,6 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr ""
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4115,7 +4116,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4198,7 +4199,7 @@ msgstr ""
 msgid "RX Rate"
 msgstr "קצב קליטה"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4242,10 +4243,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4278,7 +4275,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr ""
@@ -4286,6 +4283,11 @@ msgstr ""
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4340,7 +4342,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4352,7 +4354,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4435,7 +4437,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4447,7 +4449,7 @@ msgstr ""
 msgid "Reset Counters"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr ""
 
@@ -4459,7 +4461,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4478,11 +4480,11 @@ msgstr ""
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "שחזור"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr ""
 
@@ -4507,15 +4509,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4536,7 +4534,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr ""
 
@@ -4556,19 +4554,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "הרץ בדיקת מערכת קבצים"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4577,7 +4575,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr ""
 
@@ -4594,7 +4592,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4605,30 +4603,31 @@ msgstr ""
 msgid "SSID"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4637,7 +4636,7 @@ msgid "Scan"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr ""
 
@@ -4649,11 +4648,11 @@ msgstr ""
 msgid "Section removed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4694,7 +4693,7 @@ msgstr ""
 msgid "Services"
 msgstr "שירותים"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4702,10 +4701,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4735,6 +4738,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4756,7 +4760,7 @@ msgstr ""
 msgid "Signal"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4768,7 +4772,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr ""
 
@@ -4793,7 +4797,7 @@ msgstr "דלג אל התוכן"
 msgid "Skip to navigation"
 msgstr "דלג אל הניווט"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4810,7 +4814,7 @@ msgstr "סליחה, אך האובייקט שביקשת אינו נמצא."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "סליחה, השרת נתקל בשגיאה לא צפויה."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4829,7 +4833,7 @@ msgstr "מקור"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4868,7 +4872,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4891,7 +4895,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "אתחול"
 
@@ -4911,7 +4915,7 @@ msgstr "הקצאות סטטיות"
 msgid "Static Routes"
 msgstr "ניתובים סטטיים"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4953,7 +4957,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "שלח"
 
@@ -4967,10 +4971,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -4991,7 +4991,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5084,6 +5084,10 @@ msgstr ""
 msgid "Terminate"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5101,14 +5105,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5126,8 +5126,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5139,17 +5139,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5171,11 +5168,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5195,7 +5192,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5209,6 +5206,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5217,13 +5222,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5231,11 +5236,32 @@ msgid ""
 "settings."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5282,6 +5308,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5360,11 +5387,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "אזור זמן"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5372,7 +5399,7 @@ msgid ""
 msgstr ""
 "על מנת לשחזר את קבצי ההגדרות, באפשרותך להעלות ארכיון גיבוי שנוצר לפני כן."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5412,7 +5439,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5455,8 +5482,8 @@ msgstr ""
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5486,6 +5513,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5497,6 +5528,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5505,28 +5537,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5539,7 +5571,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5562,14 +5594,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5582,7 +5620,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5640,11 +5684,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5652,7 +5696,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "השתמש בדגל broadcast"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5715,7 +5759,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr ""
 
@@ -5743,11 +5787,11 @@ msgstr ""
 msgid "Username"
 msgstr "שם משתמש"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5794,8 +5838,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5816,7 +5860,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "סיסמת WEP"
 
@@ -5824,7 +5868,7 @@ msgstr "סיסמת WEP"
 msgid "WMM Mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "סיסמת WPA"
 
@@ -5886,13 +5930,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5943,7 +5987,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -5984,9 +6028,9 @@ msgstr ""
 msgid "any"
 msgstr "כלשהו"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6003,7 +6047,7 @@ msgstr ""
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -6020,7 +6064,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr ""
 
@@ -6154,8 +6198,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "לא"
 
@@ -6167,13 +6209,13 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "ללא"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6203,10 +6245,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6225,7 +6263,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "מנותב"
 
@@ -6239,15 +6277,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6465,14 +6503,18 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "כן"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "<< אחורה"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s פנוי)"
+
+#~ msgid "Check"
+#~ msgstr "לבדוק"
 
 #~ msgid "Antenna 1"
 #~ msgstr "אנטנה 1"

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -35,10 +35,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d perces ablak, %d másodperces intervallum)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s elérhető)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -79,15 +75,13 @@ msgstr "-- Kérem válasszon --"
 msgid "-- custom --"
 msgstr "-- egyéni --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -206,7 +200,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> konfiguráció"
 
@@ -253,23 +247,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -283,25 +277,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "ARP újrapróbálkozási küszöbérték"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM Hidak"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM Virtuális Csatorna Azonosító (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM Virtuális Út Azonosító (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -311,7 +305,7 @@ msgstr ""
 "hálózati interfész mutatják, mely így DHCP-vel vagy PPP-vel összekapcsolva "
 "használható a szolgáltatói hálózatba történő betárcsázáshoz."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "ATM eszközszám"
@@ -335,8 +329,7 @@ msgstr "Elérési központ"
 msgid "Access Point"
 msgstr "Hozzáférési pont"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Műveletek"
 
@@ -364,7 +357,7 @@ msgstr "Aktív DHCP bérletek"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktív DHCPv6 bérletek"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -374,7 +367,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -385,7 +378,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -421,7 +414,7 @@ msgstr ""
 "Helyi tartomány utótag hozzáadása a hosts fájlokból kiszolgált nevekhez"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Új interfész hozzáadása..."
 
@@ -465,19 +458,18 @@ msgid "Address to access local relay bridge"
 msgstr "Helyi közvetítő híd elérési címe"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Adminisztráció"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Haladó beállítások"
 
@@ -489,7 +481,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Riasztás"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -565,7 +557,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -575,76 +567,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -652,11 +644,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -666,6 +658,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Bármelyik zóna"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -695,13 +691,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Kapcsolódó kliensek"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -752,27 +752,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Elérhető"
 
@@ -790,11 +790,11 @@ msgstr "Elérhető"
 msgid "Average:"
 msgstr "Átlag:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -818,14 +818,15 @@ msgstr "Vissza az áttekintéshez"
 msgid "Back to configuration"
 msgstr "Vissza a beállításokhoz"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Mentés"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Mentés / Firmware frissítés"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Mentési fájl lista"
@@ -843,6 +844,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -878,17 +880,17 @@ msgstr "Bitráta"
 msgid "Bogus NX Domain Override"
 msgstr "Hamis NX tartomány felülbírálása"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Híd"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Híd interfészek"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Híd eszközszám"
 
@@ -897,6 +899,7 @@ msgid "Bring up on boot"
 msgstr "Hozza fel a rendszer indításakor"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -924,11 +927,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Mégsem"
 
@@ -936,12 +941,8 @@ msgstr "Mégsem"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -976,28 +977,29 @@ msgstr ""
 msgid "Channel"
 msgstr "Csatorna"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Ellenőrzés"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Ellenőrző összeg"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1026,7 +1028,7 @@ msgstr "Titkosító"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1034,13 +1036,13 @@ msgstr ""
 "Kattintson az \"Archívum készítése\" gombra a jelenlegi konfiguráció tar "
 "archívumként történő letöltéséhez."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1077,7 +1079,7 @@ msgstr "Lista bezárása..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1092,7 +1094,7 @@ msgstr "Adatok összegyűjtése..."
 msgid "Command"
 msgstr "Parancs"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1114,8 +1116,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Beállítás"
 
@@ -1124,7 +1125,7 @@ msgstr "Beállítás"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1136,7 +1137,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1156,7 +1157,7 @@ msgstr "Kapcsolódva"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1165,11 +1166,14 @@ msgid "Connections"
 msgstr "Kapcsolatok"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1189,11 +1193,11 @@ msgid "Country Code"
 msgstr "Országkód"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Tűzfal zóna készítés / hozzárendelés"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1222,7 +1226,7 @@ msgstr "Egyéni interfész"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1257,7 +1261,7 @@ msgstr "DHCP kiszolgáló"
 msgid "DHCP and DNS"
 msgstr "DHCP és DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1272,7 +1276,7 @@ msgstr "DHCP beállítások"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1317,7 +1321,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1326,7 +1330,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1368,7 +1372,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Alapértelmezett átjáró"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1390,9 +1394,9 @@ msgstr ""
 "code>\", mely különböző DNS kiszolgálókat hirdet az ügyfelek részére."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1453,10 +1457,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Eszköz"
 
@@ -1546,7 +1550,7 @@ msgstr "Beérkező RFC1918 DHCP válaszok elvetése. "
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1555,11 +1559,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1605,6 +1610,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1633,19 +1642,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Biztonsági mentés letöltése"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1693,9 +1702,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP metódus"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1797,25 +1806,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "A csatolás engedélyezése"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "A lapozó terület engedélyezése"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Engedélyezés/Letiltás"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Engedélyezve"
 
@@ -1837,8 +1838,8 @@ msgstr "A Spanning Tree prokoll engedélyezése erre a hídra"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Beágyazási mód"
 
@@ -1866,7 +1867,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Törlés..."
 
@@ -1888,12 +1889,12 @@ msgstr "Hiba"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet switch"
@@ -1992,9 +1993,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "A kliensek részére közzétett betöltö kép fájlneve"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Fájlrendszer"
 
@@ -2011,7 +2011,7 @@ msgstr "Használhahatlan kérések szűrése"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2041,7 +2041,7 @@ msgstr "Tűzfal Beállítások"
 msgid "Firewall Status"
 msgstr "Tűzfal Állapot"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2053,25 +2053,27 @@ msgstr "Tűzfal verzió"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Rögzített forrás port a kimenő DNS kérésekhez"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Firmware flash-elés"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Flash image..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Új firmware image flash-elése"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Flash műveletek"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Flash-elés..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2099,11 +2101,11 @@ msgstr "TKIP kényszerítése"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "TKIP és CCMP (AES) kényszerítése"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2131,7 +2133,7 @@ msgstr "Broadcast forgalom továbbítás"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Továbbítás módja"
 
@@ -2178,20 +2180,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Általános beállítások"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Általános beállítások"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2199,7 +2200,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Archívum készítése"
 
@@ -2207,11 +2208,11 @@ msgstr "Archívum készítése"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "A megadott jelszavak nem egyeznek, a jelszó nem lett megváltoztatva!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2222,7 +2223,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Ugrás a jelszó beállításhoz..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2272,7 +2273,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2464,7 +2465,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2551,15 +2552,15 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Megadás esetén az eszköz csomópont helyett UUID alapján történő csatolása"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2601,7 +2602,7 @@ msgstr ""
 "Ha nincs kiválasztva, akkor a hirdetett DNS kiszolgáló címeket nem veszi "
 "figyelembe"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2627,7 +2628,7 @@ msgstr "Interfész figyelmen kívül hagyása"
 msgid "Ignore resolve file"
 msgstr "A resolve fájl figyelmen kívül hagyása"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Image"
 
@@ -2687,8 +2688,8 @@ msgstr "Protokoll kiterjesztések telepítése..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2775,11 +2776,11 @@ msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 "A megadott VLAN azonosító érvénytelen! Minden VLAN-hoz egyedi azonosító kell."
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2795,7 +2796,7 @@ msgstr "Érvénytelen felhasználói név és/vagy jelszó! Kérem próbálja ú
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2819,11 +2820,11 @@ msgstr "Csatlakozás a hálózathoz"
 msgid "Join Network: Wireless Scan"
 msgstr "Csatlakozás a hálózathoz: vezetéknélküli hálózatok keresése"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Beállítások megtartása"
 
@@ -2879,12 +2880,12 @@ msgstr "LCP echo hibaküszöb"
 msgid "LCP echo interval"
 msgstr "LCP Echo időtartam"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Címke"
 
@@ -3043,7 +3044,7 @@ msgstr "Betöltés"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3158,7 +3159,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3191,7 +3192,7 @@ msgstr ""
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3205,7 +3206,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3221,7 +3222,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3280,7 +3282,7 @@ msgstr "Memória"
 msgid "Memory usage (%)"
 msgstr "Memória használat (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3288,7 +3290,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3347,7 +3349,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Modem inicializálás időtúllépés"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Ellenőrzés"
@@ -3360,30 +3362,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Csatolási bejegyzés"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Csatolási pont"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Csatolási pontok"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Csatolási pontok - Csatolási bejegyzés"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Csatolási pontok - Lapozóterület bejegyzés"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3391,23 +3388,27 @@ msgstr ""
 "A csatolási pontok határozzák meg, hogy egy memória eszköz hová lesz "
 "csatlakoztatva a fájlendszeren belül "
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Csatolási beállítások"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Csatolási pont"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Csatolt fájlrendszerek"
 
@@ -3448,15 +3449,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Kijelölt NTP kiszolgálók"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Név"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Az új hálózat neve"
 
@@ -3467,7 +3468,7 @@ msgstr "Navigáció"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3492,7 +3493,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "Interfészhez nem rendelt hálózat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3517,7 +3518,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3570,7 +3571,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Nincs hozzárendelt zóna"
 
@@ -3628,7 +3629,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3701,6 +3702,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Egy vagy több kötelezően kitöltendő mező üres!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Lista megnyitása..."
@@ -3780,7 +3782,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Lehetőségek"
 
@@ -3945,7 +3946,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3954,7 +3955,7 @@ msgid "Packets"
 msgstr "Csomagok"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "A %q zóna része"
 
@@ -4052,11 +4053,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Újraindítás végrehajtása"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Visszaállítás végrehajtása"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4095,6 +4096,10 @@ msgstr "csom."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Adja meg a felhasználónevét és a jelszavát."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4165,10 +4170,6 @@ msgstr "Ügyfél-ügyfél közötti kommunikáció megakadályozása"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Folytatás"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4184,7 +4185,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4267,7 +4268,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "RX sebesség"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4313,10 +4314,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Biztos, hogy visszavonja az összes módosítást?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Biztos, hogy cserélni szeretné a protokollt?"
@@ -4349,7 +4346,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Rebind elleni védelem"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Újraindítás"
@@ -4358,6 +4355,11 @@ msgstr "Újraindítás"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Újraindítás..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4411,7 +4413,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Eltávolítás"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Vezetéknélküli beállítások lecserélése"
 
@@ -4423,7 +4425,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4507,7 +4509,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4519,7 +4521,7 @@ msgstr "Visszaállítás"
 msgid "Reset Counters"
 msgstr "Számlálók nullázása"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Alapértelmezések visszaállítása"
 
@@ -4531,7 +4533,7 @@ msgstr "Resolv és hosts fájlok"
 msgid "Resolve file"
 msgstr "Resolv fájl"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4550,11 +4552,11 @@ msgstr "Tűzfal újraindítása"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Visszaállítás"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Biztonsági mentés visszaállítása"
 
@@ -4579,15 +4581,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Gyökérkönyvtár"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "TFTP-n keresztül megosztott fájlok gyökérkönyvtára"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4608,7 +4606,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Router jelszó"
 
@@ -4630,19 +4628,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Fájlrendszer ellenőrzés futtatása az eszköz csatolása előtt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Fájlrendszer ellenőrzés futtatása"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4651,7 +4649,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH hozzáférés"
 
@@ -4668,7 +4666,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH kulcsok"
 
@@ -4679,30 +4677,31 @@ msgstr "SSH kulcsok"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Mentés"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Mentés & Alkalmazás"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4711,7 +4710,7 @@ msgid "Scan"
 msgstr "Felderítés"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Ütemezett feladatok"
 
@@ -4723,11 +4722,11 @@ msgstr "Szakasz hozzáadva"
 msgid "Section removed"
 msgstr "Szakasz eltávolítva"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Részletekért lásd a 'mount' man oldalát"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4770,7 +4769,7 @@ msgstr "Szolgáltatás típusa"
 msgid "Services"
 msgstr "Szolgáltatások"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4778,10 +4777,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4811,6 +4814,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Mentendő fájlok aktuális listájának megjelenítése"
@@ -4832,7 +4836,7 @@ msgstr "Interfész leállítása"
 msgid "Signal"
 msgstr "Jel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Jel:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Méret"
 
@@ -4869,7 +4873,7 @@ msgstr "Ugrás a tartalomhoz"
 msgid "Skip to navigation"
 msgstr "Ugrás a navigációhoz"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4886,7 +4890,7 @@ msgstr "Sajnálom, a kért objektum nem található."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Sajnálom, a szerver váratlan hibát észlelt."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4906,7 +4910,7 @@ msgstr "Forrás"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Megadja az eszköz csatlakozási könyvtárát."
 
@@ -4948,7 +4952,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Itt adja meg a titkosító kulcsot."
 
@@ -4971,7 +4975,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Rendszerindítás"
 
@@ -4991,7 +4995,7 @@ msgstr "Statikus bérletek"
 msgid "Static Routes"
 msgstr "Statikus útvonalak"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5034,7 +5038,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Elküldés"
 
@@ -5049,10 +5053,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Lapozóterület"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5072,7 +5072,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5165,6 +5165,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Megszakítás"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5183,17 +5187,13 @@ msgid ""
 msgstr ""
 "A szolgáltatóhoz rendelt IPv6 előtag, általában így végződik: <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "A következő karakterek használhatók: <code>A-Z</code>, <code>a-z</code>, "
 "<code>0-9</code> and <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5210,8 +5210,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5225,26 +5225,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"A memória formázásához használt fájlrendszer típusa (<abbr title=\"for "
-"example\">pl.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</"
-"abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Az image feltöltve. Alább található a fájl ellenőrző összege és mérete, "
-"hasonlítsa össze az eredeti fájllal a feltöltött adatok sértetlenségének "
-"ellenőrzéséhez.<br />Kattintson az alábbi \"Folytatás\" gombra a flash-elési "
-"eljárás elindításához."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5264,11 +5254,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5289,7 +5279,7 @@ msgstr "Az IPv6 előtag hossza bitekben"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5310,6 +5300,14 @@ msgstr ""
 "hálózathoz (pl. az internet) való kapcsolódásra és a többi port a helyi "
 "hálózathoz."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5318,13 +5316,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "A rendszer most törli a konfigurációs partíciót majd újraindul."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5337,11 +5335,32 @@ msgstr ""
 "eléréséhez a beállításaitól függően szükséges lehet a számítógépe IP-címének "
 "megújítása."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5393,6 +5412,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5485,11 +5505,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Időzóna"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5500,7 +5520,7 @@ msgstr ""
 "visszaállításához kattintson a \"Visszaállítás végrehajtása\" gombra (csak "
 "squashfs image-ek esetén lehetséges)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5540,7 +5560,7 @@ msgstr "Trigger mód"
 msgid "Tunnel ID"
 msgstr "Tunnel azonosító"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Tunnel interfész"
@@ -5583,8 +5603,8 @@ msgstr "USB eszköz"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5614,6 +5634,10 @@ msgstr "Nem indiítható"
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5625,6 +5649,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5633,28 +5658,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Nem kezelt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5667,7 +5692,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "El nem mentett módosítások"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5690,7 +5715,11 @@ msgstr "Nem támogatott protokoll típus."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5700,7 +5729,9 @@ msgstr ""
 "lecseréléséhez. A jelenlegi beállítások megtartásához jelölje be a "
 "\"Beállítások megtartása\" négyzetet (kompatibilis firmware kép szükséges)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Archívum feltöltése..."
 
@@ -5713,7 +5744,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5771,11 +5808,11 @@ msgstr "MTU használata az alagút interfészen"
 msgid "Use TTL on tunnel interface"
 msgstr "TTL használata az alagút interfészen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5783,7 +5820,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "Broadcast flag használata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5850,7 +5887,7 @@ msgstr ""
 "használandó rögzített IP címet és a <em>Gépnév</em> lesz szimbolikus névként "
 "hozzárendelve az igénylő géphez."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Használt"
 
@@ -5878,11 +5915,11 @@ msgstr ""
 msgid "Username"
 msgstr "Felhasználónév"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5929,9 +5966,9 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "DHCP kérés során küldendő 'Vendor Class'"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Ellenőrzés"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5951,7 +5988,7 @@ msgstr "WEP nyílt rendszer"
 msgid "WEP Shared Key"
 msgstr "WEP megosztott kulcs"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP jelmondat"
 
@@ -5959,7 +5996,7 @@ msgstr "WEP jelmondat"
 msgid "WMM Mode"
 msgstr "WMM mód"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA jelmondat"
 
@@ -6023,13 +6060,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Vezetéknélküli rész"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Vezetéknélküli adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6080,7 +6117,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6127,9 +6164,9 @@ msgstr ""
 msgid "any"
 msgstr "bármelyik"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6146,7 +6183,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "áthidalt"
 
@@ -6163,7 +6200,7 @@ msgid "create:"
 msgstr "új:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "híd létrehozása a megadott interfész(ek) között"
 
@@ -6299,8 +6336,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "nem"
 
@@ -6312,13 +6347,13 @@ msgstr "nincs link"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "nincs"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6348,10 +6383,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6370,7 +6401,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "irányított"
 
@@ -6384,15 +6415,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6610,14 +6641,70 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "igen"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Vissza"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s elérhető)"
+
+#~ msgid "Check"
+#~ msgstr "Ellenőrzés"
+
+#~ msgid "Checksum"
+#~ msgstr "Ellenőrző összeg"
+
+#~ msgid "Enable this mount"
+#~ msgstr "A csatolás engedélyezése"
+
+#~ msgid "Enable this swap"
+#~ msgstr "A lapozó terület engedélyezése"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Firmware flash-elés"
+
+#~ msgid "Flashing..."
+#~ msgstr "Flash-elés..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Csatolási bejegyzés"
+
+#~ msgid "Proceed"
+#~ msgstr "Folytatás"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Biztos, hogy visszavonja az összes módosítást?"
+
+#~ msgid "Root"
+#~ msgstr "Gyökérkönyvtár"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Lapozóterület"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "A memória formázásához használt fájlrendszer típusa (<abbr title=\"for "
+#~ "example\">pl.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Az image feltöltve. Alább található a fájl ellenőrző összege és mérete, "
+#~ "hasonlítsa össze az eredeti fájllal a feltöltött adatok sértetlenségének "
+#~ "ellenőrzéséhez.<br />Kattintson az alábbi \"Folytatás\" gombra a flash-"
+#~ "elési eljárás elindításához."
+
+#~ msgid "Verify"
+#~ msgstr "Ellenőrzés"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Megadja a <em>Dropbear</em> példány portját"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -4781,7 +4781,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Set this interface as master for the dhcpv6 relay."
-msgstr ""
+msgstr "Imposta questa interfaccia come master per il relay dhcpv6"
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 #: protocols/luci-proto-qmi/luasrc/model/network/proto_qmi.lua:55

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.6.10\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d finestra in minuti , %d secondi intervallo)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s disponibile)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Per favore scegli --"
 msgid "-- custom --"
 msgstr "-- personalizzato --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -211,7 +205,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configurazione <abbr title=\"Diodo ad Emissione di Luce\">LED</abbr>"
 
@@ -260,23 +254,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -290,25 +284,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "riprova soglia ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Ponti ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "Identificatore Canale Virtuale ATM (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "Identificatore Percorso Virtuale ATM (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -318,7 +312,7 @@ msgstr ""
 "virtuali si possono interfacciare con le reti virtuali Linux in congiunzione "
 "con la comunicazione DHCP o PPP dell'ISP."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Numero dispositivo ATM "
@@ -342,8 +336,7 @@ msgstr "Accesso Concentratore"
 msgid "Access Point"
 msgstr "Punto di Accesso"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Azioni"
 
@@ -373,7 +366,7 @@ msgstr "Contratti attivi DHCP"
 msgid "Active DHCPv6 Leases"
 msgstr "Contratti attivi DHCPv6"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -383,7 +376,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -394,7 +387,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Aggiungi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -430,7 +423,7 @@ msgstr ""
 "Aggiungere il suffisso di dominio locale ai nomi serviti dal file hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Aggiungi nuova interfaccia..."
 
@@ -474,19 +467,18 @@ msgid "Address to access local relay bridge"
 msgstr "Indirizzo per accedere al ponte locale di trasmissione"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Amministrazione"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Opzioni Avanzate"
 
@@ -498,7 +490,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Allerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -574,7 +566,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -584,76 +576,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -661,11 +653,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -675,6 +667,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Qualsiasi Zona"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -704,13 +700,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Dispositivi Wi-Fi connessi"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -761,27 +761,27 @@ msgstr "Automatico"
 msgid "Automatic Homenet (HNCP)"
 msgstr "Homenet (HNCP) automatico"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr "Controlla automaticamente il filesystem per errori prima di montare"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr "Monta automaticamente i filesystem in hotplug"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr "Monta automaticamente lo swap in hotplug"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "Automonta Filesystem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "Automonta Swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Disponibile"
 
@@ -799,11 +799,11 @@ msgstr "Disponibile"
 msgid "Average:"
 msgstr "Media:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -827,14 +827,15 @@ msgstr "Ritorna alla panoramica"
 msgid "Back to configuration"
 msgstr "Indietro alla configurazione"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Copia di Sicurezza"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Copia di Sicurezza / Flash Firmware"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Elenco dei file di cui effettuare una copia di sicurezza"
@@ -852,6 +853,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -886,17 +888,17 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Ignora Dominio Bogus NX"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Ponte"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Interfacce Ponte"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Numero Unità Ponte"
 
@@ -905,6 +907,7 @@ msgid "Bring up on boot"
 msgstr "Attivare all'avvio"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -932,11 +935,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -944,12 +949,8 @@ msgstr "Annulla"
 msgid "Category"
 msgstr "Categoria"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -983,28 +984,29 @@ msgstr "Cambia la password di amministratore per accedere al dispositivo"
 msgid "Channel"
 msgstr "Canale"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Verifica"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "Controlla i filesystem prima di montare"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "Marca questa opzione per cancellare le reti esistenti da questa radio."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1032,7 +1034,7 @@ msgstr "Cifratura"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1040,13 +1042,13 @@ msgstr ""
 "Premi su \"Genera archivio\" per scaricare un archivio tar di backup dei "
 "file di configurazione attuali."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1083,7 +1085,7 @@ msgstr "Scegliere dall'elenco..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1098,7 +1100,7 @@ msgstr "Raccolgo i dati..."
 msgid "Command"
 msgstr "Comando"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1120,8 +1122,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Configurazione"
 
@@ -1130,7 +1131,7 @@ msgstr "Configurazione"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1142,7 +1143,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1162,7 +1163,7 @@ msgstr "Connesso"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1171,11 +1172,14 @@ msgid "Connections"
 msgstr "Connessioni"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1195,11 +1199,11 @@ msgid "Country Code"
 msgstr "Codice Nazione"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Crea / Assegna zona firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1228,7 +1232,7 @@ msgstr "Interfaccia personalizzata"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1263,7 +1267,7 @@ msgstr "Server DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP e DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1278,7 +1282,7 @@ msgstr "Opzioni DHCP"
 msgid "DHCPv6 client"
 msgstr "Cliente DHCPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1323,7 +1327,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1332,7 +1336,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1374,7 +1378,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Gateway predefinito"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1397,9 +1401,9 @@ msgstr ""
 "client."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1460,10 +1464,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Dispositivo"
 
@@ -1553,7 +1557,7 @@ msgstr "Ignora risposte RFC1918 upstream"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1562,11 +1566,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1611,6 +1616,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1639,19 +1648,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Download backup"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1697,9 +1706,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Metodo EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1801,25 +1810,17 @@ msgstr "Abilita mirroring dei pacchetti in uscita"
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr "Abilita l'opzione DF (non Frammentare) dei pacchetti incapsulati"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Abilita questo mount"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Abilita questo swap"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Abilita/Disabilita"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Abilitato"
 
@@ -1841,8 +1842,8 @@ msgstr "Abilita il protocollo di Spanning Tree su questo bridge"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Modalità di incapsulamento"
 
@@ -1870,7 +1871,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Cancellazione..."
 
@@ -1892,12 +1893,12 @@ msgstr "Errore"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Scheda di Rete"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch di Rete"
@@ -1997,9 +1998,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Nome del file dell'immagine di avvio annunciato ai clienti."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Filesystem"
 
@@ -2016,7 +2016,7 @@ msgstr "Filtra inutili"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2046,7 +2046,7 @@ msgstr "Impostazioni Firewall"
 msgid "Firewall Status"
 msgstr "Stato del Firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2058,25 +2058,27 @@ msgstr "Versione del Firmware"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Porta di origine fissa per le richieste DNS in uscita"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Flash Firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Flash immagine..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Flash immagine nuovo firmware"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Operazioni Flash"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2102,11 +2104,11 @@ msgstr "Forza TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forza TKIP e CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "Forza collegamento"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2134,7 +2136,7 @@ msgstr "Inoltra il traffico broadcast"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Modalità di Inoltro"
 
@@ -2181,20 +2183,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Opzioni Generali"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Impostazioni Generali"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "Genera Configurazione"
 
@@ -2202,7 +2203,7 @@ msgstr "Genera Configurazione"
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Genera Archivio"
 
@@ -2212,11 +2213,11 @@ msgstr ""
 "La conferma della password assegnata non ha prodotto risultati, la password "
 "non è stata cambiata!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "Impostazioni Globali"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "Opzioni rete globale"
 
@@ -2227,7 +2228,7 @@ msgstr "Opzioni rete globale"
 msgid "Go to password configuration..."
 msgstr "Vai alla configurazione della password..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2277,7 +2278,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2470,7 +2471,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr "Impostazioni IPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2557,16 +2558,16 @@ msgstr "Se selezionata, 1DES è abilitata"
 msgid "If checked, encryption is disabled"
 msgstr "Se selezionata, crittografia è disabilitata"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Se specificato, montare il dispositivo dal suo UUID invece che dal nodo di "
 "dispositivo fisso"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2608,7 +2609,7 @@ msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 "Se deselezionata, gli indirizzi ai Server DNS annunciati saranno ignorati"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2635,7 +2636,7 @@ msgstr "Ignora interfaccia"
 msgid "Ignore resolve file"
 msgstr "Ignora file resolv"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Immagine"
 
@@ -2695,8 +2696,8 @@ msgstr "Installa le estensioni del protocollo..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2780,11 +2781,11 @@ msgstr "ID VLAN non valido! Solo gli ID compresi tra %d e %d sono consentiti."
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "ID VLAN non valido! Solo gli ID unici sono consentiti"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2800,7 +2801,7 @@ msgstr "Username o password non validi! Per favore riprova."
 msgid "Isolate Clients"
 msgstr "Isola Clienti"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2824,11 +2825,11 @@ msgstr "Aggiungi Rete"
 msgid "Join Network: Wireless Scan"
 msgstr "Aggiunta Rete: Rilevamento Wireless"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Mantieni le Impostazioni"
 
@@ -2884,12 +2885,12 @@ msgstr "Fallimento soglia echo LCP"
 msgid "LCP echo interval"
 msgstr "Intervallo echo LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Etichetta"
 
@@ -3046,7 +3047,7 @@ msgstr "Caricamento"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3159,7 +3160,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3192,7 +3193,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3206,7 +3207,7 @@ msgstr ""
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3222,7 +3223,8 @@ msgstr ""
 msgid "Manual"
 msgstr "Manuale"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3281,7 +3283,7 @@ msgstr "Memoria"
 msgid "Memory usage (%)"
 msgstr "Uso Memoria (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3289,7 +3291,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3348,7 +3350,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3361,30 +3363,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Voce di Mount"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Punto di Mount"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Punti di Mount"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Punti di Mount - Voce di Mount"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Punti di Mount - Voce Swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3392,23 +3389,27 @@ msgstr ""
 "I punti di mount definiscono in quale punto un dispositivo di memoria verrà "
 "attaccato al tuo filesystem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Opzioni di mount"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Punto di mount"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "Monta swap non configurato specificatamente"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "File system montati"
 
@@ -3449,15 +3450,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Candidati server NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nome"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Nome della nuova rete"
 
@@ -3468,7 +3469,7 @@ msgstr "Navigazione"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3493,7 +3494,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "Rete senza interfaccia"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3518,7 +3519,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3571,7 +3572,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Nessuna zona assegnata"
 
@@ -3629,7 +3630,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3702,6 +3703,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Uno o più campi obbligatori sono vuoti!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Apri lista..."
@@ -3781,7 +3783,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Opzioni"
 
@@ -3946,7 +3947,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3955,7 +3956,7 @@ msgid "Packets"
 msgstr "Pacchetti"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Parte della zona %q"
 
@@ -4053,11 +4054,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Esegui un riavvio"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4096,6 +4097,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Per favore inserisci il tuo username e la password."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4164,10 +4169,6 @@ msgstr "Impedisci la comunicazione fra Client"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Continuare"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4183,7 +4184,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4266,7 +4267,7 @@ msgstr ""
 msgid "RX Rate"
 msgstr "Velocità RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4312,10 +4313,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Azzerare veramente tutte le modifiche?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Cambiare veramente il protocollo?"
@@ -4348,7 +4345,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Riavvia"
@@ -4357,6 +4354,11 @@ msgstr "Riavvia"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Riavviando..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4410,7 +4412,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Sostituisci configurazione wireless"
 
@@ -4422,7 +4424,7 @@ msgstr "Richiede indirizzo-IPv6"
 msgid "Request IPv6-prefix of length"
 msgstr "Richiede prefisso-IPv6 di lunghezza"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4505,7 +4507,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4517,7 +4519,7 @@ msgstr "Reset"
 msgid "Reset Counters"
 msgstr "Azzera Contatori"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Azzera a default"
 
@@ -4529,7 +4531,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr "File Resolve"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4548,11 +4550,11 @@ msgstr "Riavvia Firewall"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Ripristina"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Ripristina backup"
 
@@ -4577,15 +4579,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4606,7 +4604,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr ""
 
@@ -4628,19 +4626,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Esegui un controllo del filesystem prima di montare il dispositivo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Esegui controllo del filesystem"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4649,7 +4647,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr ""
 
@@ -4666,7 +4664,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4677,30 +4675,31 @@ msgstr ""
 msgid "SSID"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Salva"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salva & applica"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4709,7 +4708,7 @@ msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Operazioni programmate"
 
@@ -4721,11 +4720,11 @@ msgstr "Sezione aggiunta"
 msgid "Section removed"
 msgstr "Sezione rimossa"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Vedi \"mount\" manpage per dettagli"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4766,7 +4765,7 @@ msgstr ""
 msgid "Services"
 msgstr "Servizi"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4774,10 +4773,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4807,6 +4810,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4828,7 +4832,7 @@ msgstr ""
 msgid "Signal"
 msgstr "Segnale"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4840,7 +4844,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Dimensione"
 
@@ -4865,7 +4869,7 @@ msgstr "Salta a contenuto"
 msgid "Skip to navigation"
 msgstr "Salta a navigazione"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4882,7 +4886,7 @@ msgstr "Siamo spiacenti, l'oggetto che hai richiesto non è stato trovato."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Spiacente, il server ha rilevato un errore imprevisto."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4903,7 +4907,7 @@ msgstr "Origine"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Specifica la cartella a cui è collegato il dispositivo in"
 
@@ -4946,7 +4950,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Specificare la chiave di cifratura qui."
 
@@ -4969,7 +4973,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Avvio"
 
@@ -4989,7 +4993,7 @@ msgstr "Contratti statici"
 msgid "Static Routes"
 msgstr "Instradamenti Statici"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5032,7 +5036,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Invia"
 
@@ -5047,10 +5051,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Scambia ingresso"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5070,7 +5070,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5163,6 +5163,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Termina"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5182,14 +5186,10 @@ msgstr ""
 "Il prefisso IPv6 assegnati dal provider, si conclude di solito con <code>::</"
 "code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5207,8 +5207,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5222,19 +5222,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"Il filesystem usato per formattare la memoria (<abbr title=\"per esempio\">e."
-"s.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5256,11 +5251,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5280,7 +5275,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5294,6 +5289,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5302,13 +5305,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5321,11 +5324,32 @@ msgstr ""
 "address of your computer to reach the device again, depending on your "
 "settings."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5374,6 +5398,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5458,11 +5483,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Fuso orario"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5472,7 +5497,7 @@ msgstr ""
 "generato precedentemente qui. Per ripristinare il firmware al suo stato "
 "iniziale premi \"Esegui Ripristino\" (solo per firmware basati su squashfs)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5512,7 +5537,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5555,8 +5580,8 @@ msgstr "Periferica USB"
 msgid "USB Ports"
 msgstr "Porte USB"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5586,6 +5611,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5597,6 +5626,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5605,28 +5635,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Non gestito"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "Smonta"
 
@@ -5639,7 +5669,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Modifiche non salvate"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5662,7 +5692,11 @@ msgstr "Tipo protocollo non supportato."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5672,7 +5706,9 @@ msgstr ""
 "esecuzione. Attivare la spunta \"Mantieni Impostazioni\" per mantenere la "
 "configurazione corrente (richiede un immagine del firmware compatibile)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Carica archivio..."
 
@@ -5685,7 +5721,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5743,11 +5785,11 @@ msgstr "Usa MTU nel tunnel dell'interfaccia"
 msgid "Use TTL on tunnel interface"
 msgstr "Usa TTL nel tunnel dell'interfaccia"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5755,7 +5797,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "Usa flag broadcast"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5824,7 +5866,7 @@ msgstr ""
 "<em>tempo di Contratto</em> può essere usato per impostare un tempo di "
 "contratto non-standard a uno specifico host, p.e. 12h, 3d o infinito."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Usato"
 
@@ -5852,11 +5894,11 @@ msgstr ""
 msgid "Username"
 msgstr "Nome Utente"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5903,9 +5945,9 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Classe del Produttore da 'inviare al momento della richiesta DHCP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Verifica"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5925,7 +5967,7 @@ msgstr "Sistema Aperto WEP"
 msgid "WEP Shared Key"
 msgstr "Chiave Condivisa WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "frase di accesso WEP"
 
@@ -5933,7 +5975,7 @@ msgstr "frase di accesso WEP"
 msgid "WMM Mode"
 msgstr "Modalità WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "frase di accesso WPA"
 
@@ -5997,13 +6039,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Dispositivo Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6054,7 +6096,7 @@ msgstr "Scrivi registro di sistema su file"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6102,9 +6144,9 @@ msgstr ""
 msgid "any"
 msgstr "qualsiasi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6121,7 +6163,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "ponte"
 
@@ -6138,7 +6180,7 @@ msgid "create:"
 msgstr "crea:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "Crea un ponte sulle interfacce selezionate"
 
@@ -6274,8 +6316,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "no"
 
@@ -6287,13 +6327,13 @@ msgstr "Nessun collegamento"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "nessuna"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6323,10 +6363,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6345,7 +6381,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "instradato"
 
@@ -6359,15 +6395,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6585,14 +6621,57 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "Sì"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Indietro"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s disponibile)"
+
+#~ msgid "Check"
+#~ msgstr "Verifica"
+
+#~ msgid "Checksum"
+#~ msgstr "Checksum"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Abilita questo mount"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Abilita questo swap"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Flash Firmware"
+
+#~ msgid "Flashing..."
+#~ msgstr "Flashing..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Voce di Mount"
+
+#~ msgid "Proceed"
+#~ msgstr "Continuare"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Azzerare veramente tutte le modifiche?"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Scambia ingresso"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "Il filesystem usato per formattare la memoria (<abbr title=\"per esempio"
+#~ "\">e.s.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</"
+#~ "abbr></samp>)"
+
+#~ msgid "Verify"
+#~ msgstr "Verifica"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Disabilitato (default)"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.2.3\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr "%.1f dB"
 
@@ -37,10 +37,6 @@ msgstr "%s は複数のVLANにUntaggedしています!"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d 分幅, %d 秒間隔)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s 使用可能)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- 選択してください --"
 msgid "-- custom --"
 msgstr "-- 手動設定 --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- デバイスを指定 --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- ラベルを指定 --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- UUID を指定 --"
 
@@ -209,7 +203,7 @@ msgstr ""
 "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-サフィックス (16進数)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 設定"
 
@@ -258,23 +252,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr "同名のディレクトリが既に存在します。"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr "認証セッションの期限切れのため、再ログインが必要です。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr "A43C + J43 + A43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr "A43C + J43 + A43 + V43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr "ADSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr "ANSI T1.413"
 
@@ -288,32 +282,32 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "ARP 再試行しきい値"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATMブリッジ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM仮想チャネル識別子 (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM仮想パス識別子 (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "ATMデバイス番号"
@@ -337,8 +331,7 @@ msgstr "Access Concentrator"
 msgid "Access Point"
 msgstr "アクセスポイント"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "動作"
 
@@ -366,7 +359,7 @@ msgstr "アクティブなDHCPリース"
 msgid "Active DHCPv6 Leases"
 msgstr "アクティブなDHCPv6リース"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -376,7 +369,7 @@ msgstr "アドホック"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -387,7 +380,7 @@ msgstr "アドホック"
 msgid "Add"
 msgstr "追加"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -424,7 +417,7 @@ msgstr ""
 "す。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "インターフェースの新規作成..."
 
@@ -468,19 +461,18 @@ msgid "Address to access local relay bridge"
 msgstr "ローカル リレーブリッジにアクセスするためのIPアドレス"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "管理画面"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "詳細設定"
 
@@ -492,7 +484,7 @@ msgstr ""
 msgid "Alert"
 msgstr "警告"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -567,7 +559,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr "許可されるIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr "常にデフォルト ルーターを通知する"
 
@@ -579,78 +571,78 @@ msgstr ""
 "セカンダリ チャンネルの重複にかかわらず、常に 40MHz チャンネルを使用します。"
 "このオプションの使用は、 IEEE 802.11n-2009 に準拠しません！"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 "利用可能なパブリック プレフィクスが無くても、デフォルトのルーターとして通知し"
 "ます。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -658,11 +650,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "アノニマス マウント"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "アノニマス スワップ"
 
@@ -672,6 +664,10 @@ msgstr "アノニマス スワップ"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "全てのゾーン"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -705,7 +701,7 @@ msgstr ""
 "このサブ プレフィクス ID（16進数）を使用するプレフィクス領域を、このインター"
 "フェースに割り当てます。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "アソシエーション済み端末"
@@ -713,6 +709,10 @@ msgstr "アソシエーション済み端末"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "アソシエーション数"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -762,27 +762,27 @@ msgstr "自動"
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr "マウント実行前にファイルシステムのエラーを自動的にチェックします。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr "ホットプラグによってファイルシステムを自動的にマウントします。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr "ホットプラグによってスワップ パーティションを自動的にマウントします。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "ファイルシステム 自動マウント"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "スワップ 自動マウント"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "使用可"
 
@@ -800,11 +800,11 @@ msgstr "使用可"
 msgid "Average:"
 msgstr "平均値:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -828,14 +828,15 @@ msgstr "概要へ戻る"
 msgid "Back to configuration"
 msgstr "設定へ戻る"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "バックアップ"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "バックアップ / ファームウェア更新"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "バックアップファイル リスト"
@@ -853,6 +854,7 @@ msgstr "バンド"
 msgid "Beacon Interval"
 msgstr "ビーコン間隔"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -889,17 +891,17 @@ msgstr "ビットレート"
 msgid "Bogus NX Domain Override"
 msgstr "偽の NX ドメイン オーバーライド"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "ブリッジ"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "ブリッジ インターフェース"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "ブリッジ ユニット番号"
 
@@ -908,6 +910,7 @@ msgid "Bring up on boot"
 msgstr "デフォルトで起動する"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr "参照..."
 
@@ -935,11 +938,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -947,13 +952,9 @@ msgstr "キャンセル"
 msgid "Category"
 msgstr "カテゴリー"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
 msgstr "注意: 設定ファイルは消去されます"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
-msgstr "注意: システムは強制的にアップグレードされます"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
@@ -986,29 +987,30 @@ msgstr "デバイスの管理者パスワードを変更します"
 msgid "Channel"
 msgstr "チャネル"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "チェック"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "マウント前にファイルシステムをチェックする"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 "この無線から既存のネットワークを削除する場合、このオプションを有効にします。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "チェックサム"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr "mtdblock を選択"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1036,7 +1038,7 @@ msgstr "暗号化方式"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1044,7 +1046,7 @@ msgstr ""
 "\"バックアップ アーカイブを生成\" をクリックすると、現在の設定ファイルをtar形"
 "式のアーカイブファイルとしてダウンロードします。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
@@ -1052,7 +1054,7 @@ msgstr ""
 "指定した mtdblock ファイルをダウンロードするには、 \"mtdblock を保存\" をク"
 "リックしてください。（注: この機能はプロフェッショナル向けです！）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1089,7 +1091,7 @@ msgstr "リストを閉じる"
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1104,7 +1106,7 @@ msgstr "データ収集中です..."
 msgid "Command"
 msgstr "コマンド"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr "コマンド OK"
 
@@ -1130,8 +1132,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "設定"
 
@@ -1140,7 +1141,7 @@ msgstr "設定"
 msgid "Configuration failed"
 msgstr "設定が失敗しました"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr "設定ファイルは保持されます"
 
@@ -1152,7 +1153,7 @@ msgstr "設定が適用されました。"
 msgid "Configuration has been rolled back!"
 msgstr "設定はロールバックされました！"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr "切断の確認"
 
@@ -1172,7 +1173,7 @@ msgstr "接続中"
 msgid "Connection attempt failed"
 msgstr "接続の試行が失敗しました"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr "接続喪失"
 
@@ -1181,11 +1182,14 @@ msgid "Connections"
 msgstr "ネットワーク接続"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr "内容が保存されました。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr "続行"
 
@@ -1208,11 +1212,11 @@ msgid "Country Code"
 msgstr "国コード"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "ファイアウォール ゾーンの作成 / 割り当て"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr "インターフェースを作成"
 
@@ -1241,7 +1245,7 @@ msgstr "新しいインターフェース"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1278,7 +1282,7 @@ msgstr "DHCPサーバー"
 msgid "DHCP and DNS"
 msgstr "DHCP 及び DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1293,7 +1297,7 @@ msgstr "DHCPオプション"
 msgid "DHCPv6 client"
 msgstr "DHCPv6 クライアント"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "DHCPv6-モード"
 
@@ -1338,7 +1342,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr "DS-Lite AFTR アドレス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr "DSL"
@@ -1347,7 +1351,7 @@ msgstr "DSL"
 msgid "DSL Status"
 msgstr "DSL ステータス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1389,7 +1393,7 @@ msgstr "デフォルト ルート"
 msgid "Default gateway"
 msgstr "デフォルト ゲートウェイ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr "デフォルトは ステートレス + ステートフル です。"
 
@@ -1411,9 +1415,9 @@ msgstr ""
 "code>\" と設定することで、クライアントに指定のDNSサーバーを通知します。）"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1474,10 +1478,10 @@ msgstr "宛先ゾーン"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "デバイス"
 
@@ -1567,7 +1571,7 @@ msgstr "RFC1918の応答を破棄します"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr "切断"
 
@@ -1576,11 +1580,12 @@ msgstr "切断"
 msgid "Disconnection attempt failed"
 msgstr "切断の試行が失敗しました"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "閉じる"
 
@@ -1625,6 +1630,10 @@ msgstr "本当に \"%s\" を削除しますか？"
 msgid "Do you really want to delete the following SSH key?"
 msgstr "本当に以下の SSH 公開鍵を削除しますか？"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "本当にディレクトリ \"%s\" を再帰的に削除しますか？"
@@ -1653,19 +1662,19 @@ msgstr ""
 msgid "Down"
 msgstr "下へ"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "バックアップ アーカイブのダウンロード"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr "mtdblock のダウンロード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr "ドラッグして並び替え"
 
@@ -1711,9 +1720,9 @@ msgstr "EA ビット長"
 msgid "EAP-Method"
 msgstr "EAP メソッド"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1819,25 +1828,17 @@ msgstr "送信パケットのミラーリングを有効化"
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr "カプセル化されたパケットの DF (Don't Fragment) フラグを有効にします。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "マウント設定を有効にする"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "このネットワークを有効にします"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "スワップ設定を有効にする"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "有効 / 無効"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "有効"
 
@@ -1861,8 +1862,8 @@ msgstr "スパニングツリー プロトコルを有効にする"
 msgid "Encapsulation limit"
 msgstr "カプセル化制限"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "カプセル化モード"
 
@@ -1890,7 +1891,7 @@ msgstr "カスタム値を入力"
 msgid "Enter custom values"
 msgstr "カスタム値を入力"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "消去中..."
 
@@ -1912,12 +1913,12 @@ msgstr "エラー"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "イーサネットアダプタ"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "イーサネットスイッチ"
@@ -2017,9 +2018,8 @@ msgstr "ファイル名"
 msgid "Filename of the boot image advertised to clients"
 msgstr "クライアントに通知するブートイメージのファイル名"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "ファイルシステム"
 
@@ -2036,7 +2036,7 @@ msgstr ""
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2068,7 +2068,7 @@ msgstr "ファイアウォール設定"
 msgid "Firewall Status"
 msgstr "ファイアウォール ステータス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr "ファームウェア ファイル"
 
@@ -2080,25 +2080,27 @@ msgstr "ファームウェア バージョン"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "DNSクエリを送信する送信元ポートを固定します"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "ファームウェアの更新"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "更新"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "ファームウェアの更新"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "更新機能"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "更新中..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2125,11 +2127,11 @@ msgstr "TKIP を使用"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "TKIP 及びCCMP (AES) を使用"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "強制リンク"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr "強制アップグレード"
 
@@ -2157,7 +2159,7 @@ msgstr "ブロードキャスト トラフィックを転送する"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "転送モード"
 
@@ -2204,20 +2206,19 @@ msgstr "無効なゲートウェイ アドレスです"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "一般設定"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "一般設定"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "コンフィグ生成"
 
@@ -2225,7 +2226,7 @@ msgstr "コンフィグ生成"
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "バックアップ アーカイブを生成"
 
@@ -2233,11 +2234,11 @@ msgstr "バックアップ アーカイブを生成"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "入力されたパスワードが一致しません。パスワードは変更されませんでした!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "全体設定"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "グローバル ネットワークオプション"
 
@@ -2248,7 +2249,7 @@ msgstr "グローバル ネットワークオプション"
 msgid "Go to password configuration..."
 msgstr "パスワード設定へ移動..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2297,7 +2298,7 @@ msgstr "空のチェインを非表示"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "ホスト"
 
@@ -2490,7 +2491,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr "IPv6 設定"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr "IPv6 ULA-プレフィクス"
 
@@ -2577,15 +2578,15 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr "チェックした場合、暗号化は無効になります。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "固定のデバイス ノード名のかわりに、設定されたUUIDを使用してマウントします"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2626,7 +2627,7 @@ msgstr "チェックされていない場合、デフォルト ルートは構�
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "チェックされていない場合、通知されたDNSサーバー アドレスを無視します"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2652,7 +2653,7 @@ msgstr "インターフェースを無視する"
 msgid "Ignore resolve file"
 msgstr "リゾルバ ファイルを無視する"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "イメージ"
 
@@ -2716,8 +2717,8 @@ msgstr "プロトコル拡張機能をインストールします..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2802,11 +2803,11 @@ msgstr "無効なVLAN IDです! IDは%dから%dまでの値のみ入力可能で
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "無効なVLAN IDです! ユニークなIDを入力してください。"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr "無効な引数"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr "無効なコマンド"
 
@@ -2823,7 +2824,7 @@ msgstr ""
 msgid "Isolate Clients"
 msgstr "クライアント間の分離"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2846,11 +2847,11 @@ msgstr "ネットワークに接続する"
 msgid "Join Network: Wireless Scan"
 msgstr "ネットワークに接続する: 無線LANスキャン"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "ネットワークに接続: %q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "設定を保持する"
 
@@ -2906,12 +2907,12 @@ msgstr "LCP echo 失敗数しきい値"
 msgid "LCP echo interval"
 msgstr "LCP echo 送信間隔"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "ラベル"
 
@@ -3072,7 +3073,7 @@ msgstr "ロード中"
 msgid "Loading directory contents…"
 msgstr "ディレクトリ内を読み込み中..."
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr "ビューを読み込み中…"
@@ -3186,7 +3187,7 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3219,7 +3220,7 @@ msgstr "無効な MAP ルールです"
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr "MD5"
 
@@ -3233,7 +3234,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3250,7 +3251,8 @@ msgstr ""
 msgid "Manual"
 msgstr "手動"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr "マスター"
 
@@ -3309,7 +3311,7 @@ msgstr "メモリー"
 msgid "Memory usage (%)"
 msgstr "メモリ使用率 (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr "メッシュ"
 
@@ -3317,7 +3319,7 @@ msgstr "メッシュ"
 msgid "Mesh Id"
 msgstr "メッシュ ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr "メソッドが見つかりません"
 
@@ -3376,7 +3378,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "モデム初期化タイムアウト"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "モニター"
@@ -3389,30 +3391,25 @@ msgstr "文字数不足"
 msgid "More…"
 msgstr "さらに表示…"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "マウント機能"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "マウントポイント"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "マウントポイント"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "マウントポイント - マウント"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "マウントポイント - スワップ"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3420,23 +3417,27 @@ msgstr ""
 "マウントポイントは、記憶デバイスがファイルシステムのどこに接続されているかを"
 "表示しています。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr "明確に設定されていないファイルシステムをマウントします。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "マウントオプション"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "マウントポイント"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "明確に設定されていないスワップ パーティションをマウントします。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "マウント中のファイルシステム"
 
@@ -3477,15 +3478,15 @@ msgstr "NT ドメイン"
 msgid "NTP server candidates"
 msgstr "NTPサーバー候補"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "名前"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "新しいネットワークの名前"
 
@@ -3496,7 +3497,7 @@ msgstr "ナビゲーション"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3521,7 +3522,7 @@ msgstr "ネットワーク デバイスが存在しません"
 msgid "Network without interfaces."
 msgstr "インターフェースの無いネットワークです。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr "新規インターフェース名"
 
@@ -3546,7 +3547,7 @@ msgstr "暗号化無し"
 msgid "No NAT-T"
 msgstr "NAT-Tを使用しない"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr "受信データ無し"
 
@@ -3599,7 +3600,7 @@ msgid "No signal"
 msgstr "無信号"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "ゾーンが設定されていません"
 
@@ -3657,7 +3658,7 @@ msgstr "存在しません"
 msgid "Not started on boot"
 msgstr "システム起動時に開始されません"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr "サポートされていません"
 
@@ -3732,6 +3733,7 @@ msgstr "タブに1つ以上の 無効/必須 の値があります。"
 msgid "One or more required fields have no value!"
 msgstr "1つ以上のフィールドに値が設定されていません！"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "リストを開く..."
@@ -3819,7 +3821,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "発信パケットと受信パケットに使用されるUDPポート（オプション）"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "オプション"
 
@@ -3984,7 +3985,7 @@ msgstr "PSID オフセット"
 msgid "PSID-bits length"
 msgstr "PSID ビット長"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3993,7 +3994,7 @@ msgid "Packets"
 msgstr "パケット"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "ゾーン %q の一部"
 
@@ -4091,11 +4092,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "再起動を実行"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "設定リセットを実行"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr "パーミッション拒否"
 
@@ -4134,6 +4135,10 @@ msgstr "パケット"
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "ユーザー名とパスワードを入力してください。"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4204,10 +4209,6 @@ msgstr "クライアント同士の通信を制限します"
 msgid "Private Key"
 msgstr "秘密鍵"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "続行"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4223,7 +4224,7 @@ msgstr "プロトコル"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4312,7 +4313,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "受信レート"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr "受信レート / 送信レート"
 
@@ -4363,10 +4364,6 @@ msgstr ""
 "ません！もしこのインターフェースを経由して接続している場合、このデバイスにア"
 "クセスできなくなる場合があります"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "本当に全ての変更をリセットしますか?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "本当にプロトコルを切り替えますか?"
@@ -4399,7 +4396,7 @@ msgstr "再アソシエーション制限時間"
 msgid "Rebind protection"
 msgstr "DNSリバインディング・プロテクション"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "再起動"
@@ -4408,6 +4405,11 @@ msgstr "再起動"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "再起動中..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4461,7 +4463,7 @@ msgstr "リモート IPv4アドレス または FQDN"
 msgid "Remove"
 msgstr "削除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "無線設定を置換する"
 
@@ -4473,7 +4475,7 @@ msgstr "IPv6-アドレスのリクエスト"
 msgid "Request IPv6-prefix of length"
 msgstr "リクエストするIPv6-プレフィクス長"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr "リクエスト タイムアウト"
 
@@ -4560,7 +4562,7 @@ msgstr "OWE サポートを含む wpa-supplicant が必要"
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "SAE サポートを含む wpa-supplicant が必要"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4572,7 +4574,7 @@ msgstr "リセット"
 msgid "Reset Counters"
 msgstr "カウンタをリセット"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "標準設定にリセット"
 
@@ -4584,7 +4586,7 @@ msgstr "名前解決およびホストファイル設定"
 msgid "Resolve file"
 msgstr "リゾルバファイル"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr "リソースが見つかりません"
 
@@ -4603,11 +4605,11 @@ msgstr "ファイアウォールを再起動"
 msgid "Restart radio interface"
 msgstr "無線インターフェースを再起動します"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "復元"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "バックアップから復元する"
 
@@ -4632,15 +4634,11 @@ msgstr "取り消しのリクエストはステータス <code>%h</code> で失�
 msgid "Reverting configuration…"
 msgstr "設定を元に戻しています..."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "ルート"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "TFTP経由でファイルを取り扱う際のルートディレクトリ"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr "ルートの準備"
 
@@ -4661,7 +4659,7 @@ msgid "Router Advertisement-Service"
 msgstr "ルーター アドバタイズメント-サービス"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "ルーター パスワード"
 
@@ -4683,19 +4681,19 @@ msgstr ""
 msgid "Rule"
 msgstr "ルール"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "デバイスのマウントを行う前にファイルシステムチェックを行う"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "ファイルシステムチェックを行う"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr "ランタイム エラー"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr "SHA256"
 
@@ -4704,7 +4702,7 @@ msgid "SNR"
 msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH アクセス"
 
@@ -4721,7 +4719,7 @@ msgid "SSH username"
 msgstr "SSH ユーザー名"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH キー"
 
@@ -4732,30 +4730,31 @@ msgstr "SSH キー"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr "スワップ"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "保存"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存 & 適用"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr "mtdblock を保存"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr "mtdblock の保存"
 
@@ -4764,7 +4763,7 @@ msgid "Scan"
 msgstr "スキャン"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "スケジュールタスク"
 
@@ -4776,11 +4775,11 @@ msgstr "追加されるセクション"
 msgid "Section removed"
 msgstr "削除されるセクション"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "詳細情報は \"mount\" のmanページを参照してください"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4826,7 +4825,7 @@ msgstr "サービスタイプ"
 msgid "Services"
 msgstr "サービス"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr "セッションの期限切れ"
 
@@ -4834,10 +4833,14 @@ msgstr "セッションの期限切れ"
 msgid "Set VPN as Default Route"
 msgstr "VPN をデフォルト ルートとして設定します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4867,6 +4870,7 @@ msgstr "Short GI"
 msgid "Short Preamble"
 msgstr "Short Preamble"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "現在のバックアップファイルのリストを表示する"
@@ -4888,7 +4892,7 @@ msgstr "インターフェースを終了します"
 msgid "Signal"
 msgstr "信号強度"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr "信号強度 / ノイズ"
 
@@ -4900,7 +4904,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "信号:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "サイズ"
 
@@ -4925,7 +4929,7 @@ msgstr "コンテンツへ移動"
 msgid "Skip to navigation"
 msgstr "ナビゲーションへ移動"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "ソフトウェア VLAN"
@@ -4942,7 +4946,7 @@ msgstr "申し訳ありません。リクエストされたオブジェクトは
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "申し訳ありません。サーバーに予期せぬエラーが発生しました。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4962,7 +4966,7 @@ msgstr "送信元"
 msgid "Source Address"
 msgstr "アクセス元アドレス"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "デバイスが接続するディレクトリを設定します"
 
@@ -5008,7 +5012,7 @@ msgstr ""
 "デフォルト値 (1280 bytes) 以外の MTU (Maximum Transmission Unit) を指定しま"
 "す。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "暗号鍵を設定します。"
 
@@ -5031,7 +5035,7 @@ msgid "Starting wireless scan..."
 msgstr "無線LANのスキャンを開始しています..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "スタートアップ"
 
@@ -5051,7 +5055,7 @@ msgstr "静的リース"
 msgid "Static Routes"
 msgstr "静的ルーティング"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5093,7 +5097,7 @@ msgid "Strong"
 msgstr "強"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "送信"
 
@@ -5108,10 +5112,6 @@ msgstr "これらのプロトコルの、ルーチン的操作についてのロ
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "スワップ"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "スワップ機能"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5133,7 +5133,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "スイッチポート マスク"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "スイッチ VLAN"
@@ -5226,6 +5226,10 @@ msgstr "対象ネットワーク"
 msgid "Terminate"
 msgstr "停止"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5245,17 +5249,13 @@ msgstr ""
 "プロバイダに割り当てられる IPv6 プレフィクスです。通常、 <code>::</code> で終"
 "わります。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "使用可能な文字は右記の通りです: <code>A-Z</code>, <code>a-z</code>, "
 "<code>0-9</code>, <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5278,8 +5278,8 @@ msgstr ""
 "定内容の編集を行うか、現在動作している設定の状態を維持するために、未適用の変"
 "更を取り消すこともできます。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5293,25 +5293,16 @@ msgid ""
 "properly."
 msgstr "LuCIで正しく機能させるには、既存の無線設定を変更する必要があります。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"記憶領域をフォーマットしているファイルシステムを指定します。(<abbr title="
-"\"for example\">例</abbr> <samp><abbr title=\"Third Extended Filesystem"
-"\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"更新用イメージがアップロードされました。以下はそのチェックサム及びファイルサ"
-"イズです。オリジナルファイルと比較し、整合性を確認してください。<br />\"続行"
-"\"ボタンをクリックすると、更新処理を開始します。"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5333,11 +5324,11 @@ msgstr ""
 "入力された SSH 公開鍵は無効です。正しい RSA または ECDSA 鍵を入力してくださ"
 "い。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr "インターフェース名は既に使用されています"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr "インターフェース名が長すぎます"
 
@@ -5358,7 +5349,7 @@ msgstr "IPv6 プレフィクスの長さ (bit) です。"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr "ネットワーク名は既に使用されています"
 
@@ -5378,6 +5369,14 @@ msgstr ""
 "位のネットワークへの接続に使用するアップリンク ポートと、ローカル ネットワー"
 "ク用のその他のポートが存在します。"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr "選択された %s モードは、 %s 暗号化と非互換です"
@@ -5386,13 +5385,13 @@ msgstr "選択された %s モードは、 %s 暗号化と非互換です"
 msgid "The submitted security token is invalid or already expired!"
 msgstr "送信されたセキュリティ トークンは無効もしくは期限切れです！"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "システムは設定領域を消去中です。完了後、自動的に再起動します。"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5404,11 +5403,32 @@ msgstr ""
 "わる可能性があるため、再接続時にあなたのコンピュータのIPアドレスを変更しなけ"
 "ればならない場合があります。"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "システム パスワードの変更に成功しました。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5463,6 +5483,7 @@ msgstr ""
 "\"Domain Name System\">DNS</abbr> サーバーを指定するための、 'server=/"
 "domain/1.2.3.4' や 'server=1.2.3.4' といった行を含むことができます。"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5554,11 +5575,11 @@ msgstr "Group Temporal Key (GTK) 再生成間隔"
 msgid "Timezone"
 msgstr "タイムゾーン"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr "ログイン…"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5568,7 +5589,7 @@ msgstr ""
 "ださい。設定のリセットを行う場合、\"設定リセット\"をクリックしてください。(た"
 "だし、squashfsをお使いの場合のみ使用可能です)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5608,7 +5629,7 @@ msgstr "トリガーモード"
 msgid "Tunnel ID"
 msgstr "トンネル ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "トンネルインターフェース"
@@ -5651,8 +5672,8 @@ msgstr "USBデバイス"
 msgid "USB Ports"
 msgstr "USB ポート"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5682,6 +5703,10 @@ msgstr "ディスパッチできません"
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5693,6 +5718,7 @@ msgid "Unable to resolve peer host name"
 msgstr "ピアのホスト名を解決できません"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr "内容を保存できません: %s"
@@ -5701,28 +5727,28 @@ msgstr "内容を保存できません: %s"
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "不明"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "不明なエラー (%s)"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr "不明なエラーコード"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Unmanaged"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "アンマウント"
 
@@ -5735,7 +5761,7 @@ msgstr "名称未設定の公開鍵"
 msgid "Unsaved Changes"
 msgstr "保存されていない変更"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr "未指定エラー"
 
@@ -5758,7 +5784,11 @@ msgstr "サポートされていないプロトコルタイプ"
 msgid "Up"
 msgstr "上へ"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5769,7 +5799,9 @@ msgstr ""
 "設定を維持してアップデートを行います（互換性のあるファームウェア イメージが必"
 "要）。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "アーカイブをアップロード..."
 
@@ -5782,8 +5814,14 @@ msgid "Upload file…"
 msgstr "ファイルをアップロード…"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
 msgstr "アップロード リクエスト失敗: %s"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
 msgid ""
@@ -5842,11 +5880,11 @@ msgstr "トンネル インターフェースのMTUを設定"
 msgid "Use TTL on tunnel interface"
 msgstr "トンネル インターフェースのTTLを設定"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr "外部オーバーレイとして使用する (/overlay)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "ルート ファイルシステムとして使用する (/)"
 
@@ -5854,7 +5892,7 @@ msgstr "ルート ファイルシステムとして使用する (/)"
 msgid "Use broadcast flag"
 msgstr "ブロードキャスト フラグを使用する"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "ビルトインのIPv6-マネジメントを使用する"
 
@@ -5921,7 +5959,7 @@ msgstr ""
 "ドレスを設定します。また、<em>ホスト名</em> はそのホストに対して一時的なホス"
 "ト名をアサインします。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "使用"
 
@@ -5949,11 +5987,11 @@ msgstr "ユーザー秘密鍵（PEM エンコード）"
 msgid "Username"
 msgstr "ユーザー名"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr "VDSL"
 
@@ -6000,9 +6038,9 @@ msgstr "ベンダー"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "DHCPリクエスト送信時のベンダークラスを設定"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "確認"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -6022,7 +6060,7 @@ msgstr "WEP オープンシステム"
 msgid "WEP Shared Key"
 msgstr "WEP 共有キー"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP 暗号フレーズ"
 
@@ -6030,7 +6068,7 @@ msgstr "WEP 暗号フレーズ"
 msgid "WMM Mode"
 msgstr "WMM モード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA 暗号フレーズ"
 
@@ -6098,13 +6136,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "無線"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "無線アダプタ"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6155,7 +6193,7 @@ msgstr "システムログをファイルに書き込む"
 msgid "Yes"
 msgstr "はい"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6202,9 +6240,9 @@ msgstr "ZRam サイズ"
 msgid "any"
 msgstr "全て"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6221,7 +6259,7 @@ msgstr "自動"
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "ブリッジ"
 
@@ -6238,7 +6276,7 @@ msgid "create:"
 msgstr "作成:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "指定したインターフェースでブリッジを作成します"
 
@@ -6374,8 +6412,6 @@ msgstr "分"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "いいえ"
 
@@ -6387,13 +6423,13 @@ msgstr "リンクなし"
 msgid "non-empty value"
 msgstr "空ではない値"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "なし"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "存在しません"
 
@@ -6423,10 +6459,6 @@ msgstr "オープン ネットワーク"
 msgid "output"
 msgstr "出力"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr "オーバーレイ"
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr "正の値（10進数）"
@@ -6445,7 +6477,7 @@ msgstr "ランダム"
 msgid "relay mode"
 msgstr "リレー モード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "routed"
 
@@ -6459,15 +6491,15 @@ msgstr "秒"
 msgid "server mode"
 msgstr "サーバー モード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr "ステートフルのみ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr "ステートレス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr "ステートレス + ステートフル"
 
@@ -6685,11 +6717,75 @@ msgstr "セキュリティ: 弱"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "はい"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 戻る"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s 使用可能)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- デバイスを指定 --"
+
+#~ msgid "Caution: System upgrade will be forced"
+#~ msgstr "注意: システムは強制的にアップグレードされます"
+
+#~ msgid "Check"
+#~ msgstr "チェック"
+
+#~ msgid "Checksum"
+#~ msgstr "チェックサム"
+
+#~ msgid "Enable this mount"
+#~ msgstr "マウント設定を有効にする"
+
+#~ msgid "Enable this swap"
+#~ msgstr "スワップ設定を有効にする"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "ファームウェアの更新"
+
+#~ msgid "Flashing..."
+#~ msgstr "更新中..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "マウント機能"
+
+#~ msgid "Proceed"
+#~ msgstr "続行"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "本当に全ての変更をリセットしますか?"
+
+#~ msgid "Root"
+#~ msgstr "ルート"
+
+#~ msgid "Swap Entry"
+#~ msgstr "スワップ機能"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "記憶領域をフォーマットしているファイルシステムを指定します。(<abbr title="
+#~ "\"for example\">例</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "更新用イメージがアップロードされました。以下はそのチェックサム及びファイル"
+#~ "サイズです。オリジナルファイルと比較し、整合性を確認してください。<br />"
+#~ "\"続行\"ボタンをクリックすると、更新処理を開始します。"
+
+#~ msgid "Verify"
+#~ msgstr "確認"
+
+#~ msgid "overlay"
+#~ msgstr "オーバーレイ"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.4\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d 분 window, %d 초 간격)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr ""
 msgid "-- custom --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -204,7 +198,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 설정"
 
@@ -251,23 +245,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -281,32 +275,32 @@ msgstr ""
 msgid "ARP retry threshold"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr ""
@@ -330,8 +324,7 @@ msgstr ""
 msgid "Access Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "관리 도구"
 
@@ -359,7 +352,7 @@ msgstr "Active DHCP 임대 목록"
 msgid "Active DHCPv6 Leases"
 msgstr "Active DHCPv6 임대 목록"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -369,7 +362,7 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -380,7 +373,7 @@ msgstr ""
 msgid "Add"
 msgstr "추가"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -415,7 +408,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "새로운 인터페이스 추가..."
 
@@ -459,19 +452,18 @@ msgid "Address to access local relay bridge"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "관리"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "고급 설정"
 
@@ -483,7 +475,7 @@ msgstr ""
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -554,7 +546,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -564,76 +556,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -641,11 +633,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -654,6 +646,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:181
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
@@ -684,13 +680,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "연결된 station 들"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -741,27 +741,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr ""
 
@@ -779,11 +779,11 @@ msgstr ""
 msgid "Average:"
 msgstr "평균:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -807,14 +807,15 @@ msgstr "개요로 이동"
 msgid "Back to configuration"
 msgstr "설정으로 돌아가기"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "백업"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Firmware 백업 / Flash"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr ""
@@ -832,6 +833,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -866,17 +868,17 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Bridge 인터페이스"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr ""
 
@@ -885,6 +887,7 @@ msgid "Bring up on boot"
 msgstr "부팅시 활성화"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -912,11 +915,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr ""
 
@@ -924,12 +929,8 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -963,28 +964,29 @@ msgstr "장비 접근을 위한 관리자 암호를 변경합니다"
 msgid "Channel"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1012,7 +1014,7 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1020,13 +1022,13 @@ msgstr ""
 "현재 설정 파일에 대한 tar 아카이브 다운로드를 원한다면 \"아카이브 생성\" 버튼"
 "을 클릭하세요."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1061,7 +1063,7 @@ msgstr "목록 닫기..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1076,7 +1078,7 @@ msgstr "Data 를 수집중입니다..."
 msgid "Command"
 msgstr "명령어"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1098,8 +1100,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "설정"
 
@@ -1108,7 +1109,7 @@ msgstr "설정"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1120,7 +1121,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1140,7 +1141,7 @@ msgstr "연결 시간"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1149,11 +1150,14 @@ msgid "Connections"
 msgstr "연결"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1173,11 +1177,11 @@ msgid "Country Code"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Firewall-zone 생성 / 할당"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1206,7 +1210,7 @@ msgstr "임의의 인터페이스"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1241,7 +1245,7 @@ msgstr "DHCP 서버"
 msgid "DHCP and DNS"
 msgstr "DHCP 와 DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1256,7 +1260,7 @@ msgstr "DHCP-옵션들"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1301,7 +1305,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1352,7 +1356,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1375,9 +1379,9 @@ msgstr ""
 "팅하도록 권고할 수 있습니다."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1438,10 +1442,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr ""
 
@@ -1531,7 +1535,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1540,11 +1544,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1587,6 +1592,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1613,19 +1622,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "백업 다운로드"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1670,9 +1679,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1774,25 +1783,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "활성/비활성"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "활성화됨"
 
@@ -1814,8 +1815,8 @@ msgstr "이 bridge 에 Spanning Tree Protocol 활성화합니다"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1843,7 +1844,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr ""
 
@@ -1865,12 +1866,12 @@ msgstr ""
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet 스위치"
@@ -1968,9 +1969,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2017,7 +2017,7 @@ msgstr "방화벽 설정"
 msgid "Firewall Status"
 msgstr "방화벽 상태"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2029,24 +2029,26 @@ msgstr "Firmware 버전"
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "이미지로 Flash..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "새로운 firmware 이미지로 flash"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Flash 작업"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2073,11 +2075,11 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2105,7 +2107,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2152,20 +2154,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "기본 설정"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "기본 설정"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2173,7 +2174,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "아카이브 생성"
 
@@ -2181,11 +2182,11 @@ msgstr "아카이브 생성"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2196,7 +2197,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "암호 설정 하기"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2245,7 +2246,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "호스트"
 
@@ -2437,7 +2438,7 @@ msgstr "IPv6 Neighbour 들"
 msgid "IPv6 Settings"
 msgstr "IPv6 설정"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2524,14 +2525,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2570,7 +2571,7 @@ msgstr "체크하지 않을 경우, 기본 route 가 설정되지 않습니다"
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "체크하지 않을 경우, 사용하도록 권장된 DNS 주소는 무시됩니다"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2591,7 +2592,7 @@ msgstr "인터페이스 무시"
 msgid "Ignore resolve file"
 msgstr "resolve 파일 무시"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "이미지"
 
@@ -2651,8 +2652,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2736,11 +2737,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2756,7 +2757,7 @@ msgstr ""
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2777,11 +2778,11 @@ msgstr "네트워크 연결"
 msgid "Join Network: Wireless Scan"
 msgstr "네트워크 연결: 무선랜 스캔 결과"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "네트워크 연결중: %q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "설정 유지"
 
@@ -2837,12 +2838,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr ""
 
@@ -2999,7 +3000,7 @@ msgstr ""
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3106,7 +3107,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3153,7 +3154,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3169,7 +3170,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3228,7 +3230,7 @@ msgstr "메모리"
 msgid "Memory usage (%)"
 msgstr "메모리 사용량 (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3236,7 +3238,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3295,7 +3297,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
@@ -3308,52 +3310,51 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr ""
 
@@ -3394,15 +3395,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "NTP 서버 목록"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "이름"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr ""
 
@@ -3413,7 +3414,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3438,7 +3439,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3463,7 +3464,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3516,7 +3517,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3574,7 +3575,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3647,6 +3648,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "목록 열람..."
@@ -3726,7 +3728,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr ""
 
@@ -3891,7 +3892,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3900,7 +3901,7 @@ msgid "Packets"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -3998,11 +3999,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "재부팅하기"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Reset 하기"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4041,6 +4042,10 @@ msgstr "Pkts."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "사용자이름과 암호를 입력해 주세요."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4109,10 +4114,6 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr ""
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4128,7 +4129,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4211,7 +4212,7 @@ msgstr ""
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4257,10 +4258,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "정말 프로토콜 변경을 원하세요?"
@@ -4293,7 +4290,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "재부팅"
@@ -4301,6 +4298,11 @@ msgstr "재부팅"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4355,7 +4357,7 @@ msgstr ""
 msgid "Remove"
 msgstr "제거"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4367,7 +4369,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4450,7 +4452,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4462,7 +4464,7 @@ msgstr "초기화"
 msgid "Reset Counters"
 msgstr "Counter 초기화"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "초기값으로 reset"
 
@@ -4474,7 +4476,7 @@ msgstr "Resolv 와 Hosts 파일"
 msgid "Resolve file"
 msgstr "Resolve 파일"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4493,11 +4495,11 @@ msgstr "방화벽 재시작"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "복구"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "백업 복구"
 
@@ -4522,15 +4524,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "TFTP 를 통해 제공되는 파일들의 root 디렉토리"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4551,7 +4549,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "라우터 암호"
 
@@ -4573,19 +4571,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4594,7 +4592,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr ""
 
@@ -4611,7 +4609,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4622,30 +4620,31 @@ msgstr ""
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "저장"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "저장 & 적용"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4654,7 +4653,7 @@ msgid "Scan"
 msgstr "Scan 하기"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "작업 관리"
 
@@ -4666,11 +4665,11 @@ msgstr "추가된 section"
 msgid "Section removed"
 msgstr "삭제된 section"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4711,7 +4710,7 @@ msgstr ""
 msgid "Services"
 msgstr "서비스"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4719,10 +4718,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4752,6 +4755,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "현재 백업 파일 목록 보기"
@@ -4773,7 +4777,7 @@ msgstr "이 인터페이스를 정지합니다"
 msgid "Signal"
 msgstr "신호"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4785,7 +4789,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Size"
 
@@ -4810,7 +4814,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4827,7 +4831,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4883,7 +4887,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4906,7 +4910,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "시작 프로그램"
 
@@ -4926,7 +4930,7 @@ msgstr "Static Lease 들"
 msgid "Static Routes"
 msgstr "Static Route 경로"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4968,7 +4972,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "제출하기"
 
@@ -4982,10 +4986,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -5006,7 +5006,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "스위치 VLAN"
@@ -5099,6 +5099,10 @@ msgstr ""
 msgid "Terminate"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5116,14 +5120,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5141,8 +5141,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5154,17 +5154,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5186,11 +5183,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5210,7 +5207,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5229,6 +5226,14 @@ msgstr ""
 "segment 들을 분리하는데 사용되기도 합니다. 한 개의 uplink 포트가 인터넷에 연"
 "결되어 있고 나머지 포트들은 local 네트워크로 연결되는 구성에 자주 사용됩니다."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5237,13 +5242,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5251,11 +5256,32 @@ msgid ""
 "settings."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5304,6 +5330,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5388,11 +5415,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "시간대"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5402,7 +5429,7 @@ msgstr ""
 "할 수 있습니다.  Firmware 의 초기 설정 reset 을 원한다면 \"Reset 하기\" 를 클"
 "릭하세요. (squashfs 이미지들만 가능)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5442,7 +5469,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5485,8 +5512,8 @@ msgstr ""
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5516,6 +5543,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5527,6 +5558,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5535,28 +5567,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "알수없음"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5569,7 +5601,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "적용 안된 변경 사항"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5592,7 +5624,11 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5602,7 +5638,9 @@ msgstr ""
 "미지를 업로드하세요.  현재의 설정을 유지하고자 한다면 \"설정 유지\" 를 체크하"
 "세요. (이를 지원하는 firmware 이미지 필요)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "아카이브 업로드..."
 
@@ -5615,7 +5653,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5673,11 +5717,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5685,7 +5729,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "Broadcast flag 사용"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "자체 내장 IPv6-관리 기능 사용"
 
@@ -5753,7 +5797,7 @@ msgstr ""
 "택 사항인 <em>임대 시간</em>은 해당 host 에만 해당되는 시각을 설정하는데 사용"
 "될 수 있습니다.  예를 들어 12h, 3d 혹은 infinite 값들이 가능합니다."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr ""
 
@@ -5781,11 +5825,11 @@ msgstr ""
 msgid "Username"
 msgstr "사용자이름"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5832,8 +5876,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "DHCP 요청시 전송할 Vendor Class"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5854,7 +5898,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr ""
 
@@ -5862,7 +5906,7 @@ msgstr ""
 msgid "WMM Mode"
 msgstr "WMM Mode"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr ""
 
@@ -5924,13 +5968,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "무선"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5981,7 +6025,7 @@ msgstr "System log 출력 파일 경로"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6026,9 +6070,9 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6045,7 +6089,7 @@ msgstr ""
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -6062,7 +6106,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "지정한 인터페이스(들)로 구성된 bridge 를 생성합니다"
 
@@ -6198,8 +6242,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr ""
 
@@ -6211,13 +6253,13 @@ msgstr "link 없음"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6247,10 +6289,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6269,7 +6307,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6283,15 +6321,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6509,8 +6547,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr ""
 

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Translate Toolkit 1.1.1\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s sedia)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Sila pilih --"
 msgid "-- custom --"
 msgstr "-- memperibadi --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -205,7 +199,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Konfigurasi lampu LED"
 
@@ -248,23 +242,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -278,32 +272,32 @@ msgstr ""
 msgid "ARP retry threshold"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr ""
@@ -327,8 +321,7 @@ msgstr ""
 msgid "Access Point"
 msgstr "Pusat akses"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Aksi"
 
@@ -354,7 +347,7 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -364,7 +357,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -375,7 +368,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Tambah"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -410,7 +403,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr ""
 
@@ -454,19 +447,18 @@ msgid "Address to access local relay bridge"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Pentadbiran"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Tetapan Lanjutan"
 
@@ -478,7 +470,7 @@ msgstr ""
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -549,7 +541,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -559,76 +551,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -636,11 +628,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -649,6 +641,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:181
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
@@ -679,13 +675,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Associated Stesen"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -736,27 +736,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Boleh didapati"
 
@@ -774,11 +774,11 @@ msgstr "Boleh didapati"
 msgid "Average:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -802,14 +802,15 @@ msgstr ""
 msgid "Back to configuration"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Sandaran"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr ""
@@ -827,6 +828,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -858,17 +860,17 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bridge"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Antara Muka Bridge"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr ""
 
@@ -877,6 +879,7 @@ msgid "Bring up on boot"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -904,11 +907,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Batal"
 
@@ -916,12 +921,8 @@ msgstr "Batal"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -955,28 +956,29 @@ msgstr ""
 msgid "Channel"
 msgstr "Saluran"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Jumlah disemak "
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -998,19 +1000,19 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 #, fuzzy
@@ -1046,7 +1048,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1061,7 +1063,7 @@ msgstr ""
 msgid "Command"
 msgstr "Perintah"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1083,8 +1085,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Konfigurasi"
 
@@ -1093,7 +1094,7 @@ msgstr "Konfigurasi"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1105,7 +1106,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1125,7 +1126,7 @@ msgstr ""
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1134,11 +1135,14 @@ msgid "Connections"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1158,11 +1162,11 @@ msgid "Country Code"
 msgstr "Kod negara"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Buat / Menetapkan dinding api-zon"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1191,7 +1195,7 @@ msgstr ""
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1224,7 +1228,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1239,7 +1243,7 @@ msgstr "DHCP-Pilihan"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1293,7 +1297,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1335,7 +1339,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1355,9 +1359,9 @@ msgid ""
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1418,10 +1422,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Alat"
 
@@ -1509,7 +1513,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1518,11 +1522,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1567,6 +1572,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1593,19 +1602,19 @@ msgstr "Jangan hantar permintaan DNS tanpa nama DNS"
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1647,9 +1656,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-Kaedah"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1751,25 +1760,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr ""
 
@@ -1791,8 +1792,8 @@ msgstr "Aktifkan spanning Tree Protokol di jambatan ini"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1820,7 +1821,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr ""
 
@@ -1842,12 +1843,12 @@ msgstr "Kesalahan"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet Adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet Beralih"
@@ -1945,9 +1946,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Fail Sistem"
 
@@ -1964,7 +1964,7 @@ msgstr "Penapis tak berguna"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -1994,7 +1994,7 @@ msgstr "Tetapan Firewall"
 msgid "Firewall Status"
 msgstr "Status Firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2006,24 +2006,26 @@ msgstr ""
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Firmware Flash"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2050,11 +2052,11 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2082,7 +2084,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2129,20 +2131,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Setup Umum"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2150,7 +2151,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr ""
 
@@ -2158,11 +2159,11 @@ msgstr ""
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2173,7 +2174,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2223,7 +2224,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2415,7 +2416,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2502,14 +2503,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2548,7 +2549,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2574,7 +2575,7 @@ msgstr "Abaikan antara muka"
 msgid "Ignore resolve file"
 msgstr "Abaikan fail yang selesai"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr ""
 
@@ -2634,8 +2635,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2719,11 +2720,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2739,7 +2740,7 @@ msgstr "Username dan / atau password tak sah! Sila cuba lagi."
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2764,11 +2765,11 @@ msgstr "Gabung Rangkaian"
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr ""
 
@@ -2824,12 +2825,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr ""
 
@@ -2984,7 +2985,7 @@ msgstr ""
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3091,7 +3092,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3124,7 +3125,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3138,7 +3139,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3154,7 +3155,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3213,7 +3215,7 @@ msgstr "Memori"
 msgid "Memory usage (%)"
 msgstr "Penggunaan Memori (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3221,7 +3223,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3280,7 +3282,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3293,30 +3295,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Mount Point"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Mount Points"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3324,23 +3321,27 @@ msgstr ""
 "Mount Points menentukan di mana titik peranti memori akan melekat pada fail "
 "sistem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Mounted fail sistems"
 
@@ -3381,15 +3382,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nama"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Nama rangkaian baru"
 
@@ -3400,7 +3401,7 @@ msgstr "Navigation"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3425,7 +3426,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3450,7 +3451,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3503,7 +3504,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3561,7 +3562,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3634,6 +3635,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3713,7 +3715,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Pilihan"
 
@@ -3876,7 +3877,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3885,7 +3886,7 @@ msgid "Packets"
 msgstr "Paket"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -3983,11 +3984,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Lakukan reboot"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4026,6 +4027,10 @@ msgstr "Pkts."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Sila masukkan username dan kata laluan anda."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4094,10 +4099,6 @@ msgstr "Mencegah komunikasi sesama Pelanggan"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Teruskan"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4113,7 +4114,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4197,7 +4198,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4241,10 +4242,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4277,7 +4274,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reboot"
@@ -4285,6 +4282,11 @@ msgstr "Reboot"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4339,7 +4341,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Menghapuskan"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4351,7 +4353,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4434,7 +4436,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4446,7 +4448,7 @@ msgstr "Reset"
 msgid "Reset Counters"
 msgstr "Reset Loket"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr ""
 
@@ -4458,7 +4460,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4477,11 +4479,11 @@ msgstr "Restart Firewall"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Mengembalikan"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Kembalikan sandaran"
 
@@ -4506,15 +4508,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4535,7 +4533,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr ""
 
@@ -4557,19 +4555,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4578,7 +4576,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr ""
 
@@ -4595,7 +4593,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4606,30 +4604,31 @@ msgstr ""
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Simpan"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Simpan & Melaksanakan"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4638,7 +4637,7 @@ msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Tugas Jadual"
 
@@ -4650,11 +4649,11 @@ msgstr ""
 msgid "Section removed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Rujuk \"mount\" laman manual untuk detail"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4695,7 +4694,7 @@ msgstr ""
 msgid "Services"
 msgstr "Perkhidmatan"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4703,10 +4702,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4736,6 +4739,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4757,7 +4761,7 @@ msgstr ""
 msgid "Signal"
 msgstr "Isyarat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4769,7 +4773,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Saiz"
 
@@ -4794,7 +4798,7 @@ msgstr "Skip ke kadar"
 msgid "Skip to navigation"
 msgstr "Skip ke navigation"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4811,7 +4815,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4828,7 +4832,7 @@ msgstr "Sumber"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4867,7 +4871,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4890,7 +4894,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr ""
 
@@ -4910,7 +4914,7 @@ msgstr "Statische Einträge"
 msgid "Static Routes"
 msgstr "Laluan Statik"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4949,7 +4953,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Menyerahkan"
 
@@ -4963,10 +4967,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -4987,7 +4987,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5081,6 +5081,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Menamatkan"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5098,17 +5102,13 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Karakter yang diizinkan adalah: <code>A-Z</code>, <code>a-z</code>, "
 "<code>0-9</code> dan <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5125,8 +5125,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5138,23 +5138,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
-msgstr "Failsistem yang digunakan untuk memformat memori (contohnya: ext3)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Fail gambar flash telah di-upload. Berikut ini adalah checksum dan saiz fail "
-"yang berdaftar, membandingkannya dengan fail gambar asli untuk memastikan "
-"integriti data.<br /> Klik butang terus di bawah untuk memulakan prosedur "
-"flash."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5174,11 +5167,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5198,7 +5191,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5212,6 +5205,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5220,13 +5221,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5239,11 +5240,32 @@ msgstr ""
 "anda perlu mengemas kini alamat komputer anda untuk mencapai peranti lagi, "
 "bergantung pada tetapan anda."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5292,6 +5314,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5376,18 +5399,18 @@ msgstr ""
 msgid "Timezone"
 msgstr "Zon masa"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
 "reset\" (only possible with squashfs images)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5427,7 +5450,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5470,8 +5493,8 @@ msgstr ""
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5501,6 +5524,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5512,6 +5539,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5520,28 +5548,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5554,7 +5582,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Perubahan yang belum disimpan"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5577,14 +5605,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5597,7 +5631,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5655,11 +5695,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5667,7 +5707,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5730,7 +5770,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Diguna"
 
@@ -5758,11 +5798,11 @@ msgstr ""
 msgid "Username"
 msgstr "Username"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5809,8 +5849,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5831,7 +5871,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr ""
 
@@ -5839,7 +5879,7 @@ msgstr ""
 msgid "WMM Mode"
 msgstr "WMM Mod"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr ""
 
@@ -5903,13 +5943,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adapter Wayarles"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5960,7 +6000,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6001,9 +6041,9 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6020,7 +6060,7 @@ msgstr "automatik"
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -6037,7 +6077,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "mencipta jambatan di antara muka tertentu"
 
@@ -6171,8 +6211,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr ""
 
@@ -6184,13 +6222,13 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "tidak ada"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6220,10 +6258,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6242,7 +6276,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6256,15 +6290,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6482,14 +6516,40 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Kembali"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s sedia)"
+
+#~ msgid "Checksum"
+#~ msgstr "Jumlah disemak "
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Firmware Flash"
+
+#~ msgid "Proceed"
+#~ msgstr "Teruskan"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr "Failsistem yang digunakan untuk memformat memori (contohnya: ext3)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Fail gambar flash telah di-upload. Berikut ini adalah checksum dan saiz "
+#~ "fail yang berdaftar, membandingkannya dengan fail gambar asli untuk "
+#~ "memastikan integriti data.<br /> Klik butang terus di bawah untuk "
+#~ "memulakan prosedur flash."
 
 #~ msgid "Antenna 1"
 #~ msgstr "Antena 1"

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -8,7 +8,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -32,10 +32,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d minutters vindu, %d sekunds intervall)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s Tilgjengelig)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -76,15 +72,13 @@ msgstr "-- Vennligst velg --"
 msgid "-- custom --"
 msgstr "-- egendefinert --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Konfigurasjon"
 
@@ -250,23 +244,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -280,29 +274,29 @@ msgstr "<abbr title=\"Aksesspunkt Navn\">APN</abbr>"
 msgid "ARP retry threshold"
 msgstr "APR terskel for nytt forsøk"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "<abbr title=\"Asynchronous Transfer Mode\">ATM</abbr> Broer"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 "<abbr title=\"Asynchronous Transfer Mode\">ATM</abbr> Virtuell kanal "
 "identifikator <abbr title=\"Virtual Channel Identifier\">(VCI)</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 "<abbr title=\"Asynchronous Transfer Mode\">ATM</abbr> Virtuell plasserings "
 "identifikator <abbr title=\"Virtual Path Identifier\">(VPI)</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -312,7 +306,7 @@ msgstr ""
 "nettverk grensesnitt, dette kan brukes sammen med DHCP eller PPP for å koble "
 "seg mot en leverandørs nettverk."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "<abbr title=\"Asynchronous Transfer Mode\">ATM</abbr> enhetsnummer"
@@ -336,8 +330,7 @@ msgstr "Tilgangskonsentrator"
 msgid "Access Point"
 msgstr "Aksesspunkt"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Handlinger"
 
@@ -363,7 +356,7 @@ msgstr "Aktive DHCP Leier"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktive DHCPv6 Leier"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -373,7 +366,7 @@ msgstr "Ad-Hoc (Uavhengig)"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -384,7 +377,7 @@ msgstr "Ad-Hoc (Uavhengig)"
 msgid "Add"
 msgstr "Legg til"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -419,7 +412,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "Legg det lokale domenesuffikset til navn utgitt fra vertsfiler"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Legg til grensesnitt..."
 
@@ -463,19 +456,18 @@ msgid "Address to access local relay bridge"
 msgstr "Adresse for tilgang til lokal relébro"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administrasjon"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Avanserte Innstillinger"
 
@@ -487,7 +479,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Varsle"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -558,7 +550,7 @@ msgstr "Tillat oppstrøms svar i 127.0.0.0/8 nettet, f.eks for RBL tjenester"
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -568,76 +560,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -645,11 +637,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -659,6 +651,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Alle soner"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -688,13 +684,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Tilkoblede Klienter"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -745,27 +745,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Tilgjengelig"
 
@@ -783,11 +783,11 @@ msgstr "Tilgjengelig"
 msgid "Average:"
 msgstr "Gjennomsnitt:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -811,14 +811,15 @@ msgstr "Tilbake til oversikt"
 msgid "Back to configuration"
 msgstr "Tilbake til konfigurasjon"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Sikkerhetskopi"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Sikkerhetskopiering/Firmware oppgradering"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Sikkerhetskopier filliste"
@@ -836,6 +837,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -870,17 +872,17 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Overstyr falske NX Domener"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bro"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Sammenkoble grensesnitt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Bro enhetsnummer"
 
@@ -889,6 +891,7 @@ msgid "Bring up on boot"
 msgstr "Slå på ved oppstart"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -916,11 +919,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -928,12 +933,8 @@ msgstr "Avbryt"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -967,28 +968,29 @@ msgstr "Endrer administrator passordet for tilgang til enheten"
 msgid "Channel"
 msgstr "Kanal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Kontroller"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Kontrollsum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1016,7 +1018,7 @@ msgstr "Krypteringsmetode"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1024,13 +1026,13 @@ msgstr ""
 "Klikk \"Opprett arkiv\" for å laste ned et tar arkiv av de gjeldende "
 "konfigurasjons filer."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1067,7 +1069,7 @@ msgstr "Lukk liste..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1082,7 +1084,7 @@ msgstr "Henter data..."
 msgid "Command"
 msgstr "Kommando"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1104,8 +1106,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Konfigurasjon"
 
@@ -1114,7 +1115,7 @@ msgstr "Konfigurasjon"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1126,7 +1127,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1146,7 +1147,7 @@ msgstr "Tilkoblet"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1155,11 +1156,14 @@ msgid "Connections"
 msgstr "Tilkoblinger"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1179,11 +1183,11 @@ msgid "Country Code"
 msgstr "Landskode"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Opprett/Tildel brannmur sone"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1212,7 +1216,7 @@ msgstr "Egendefinerte Grensesnitt"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1247,7 +1251,7 @@ msgstr "DHCP Server"
 msgid "DHCP and DNS"
 msgstr "DHCP og DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1262,7 +1266,7 @@ msgstr "DHCP-Alternativer"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1316,7 +1320,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1358,7 +1362,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Standard gateway"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1380,9 +1384,9 @@ msgstr ""
 "annonserer forskjellige DNS servere til klientene."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1443,10 +1447,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Enhet"
 
@@ -1536,7 +1540,7 @@ msgstr "Forkast oppstrøms RFC1918 svar"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1545,11 +1549,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1595,6 +1600,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1623,19 +1632,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Last ned sikkerhetskopi"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1681,9 +1690,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-metode"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1785,25 +1794,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Aktiver dette monteringspunktet"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Aktiver denne swapenhet"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Aktiver/Deaktiver"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Aktivert"
 
@@ -1825,8 +1826,8 @@ msgstr "Aktiverer Spanning Tree Protocol på denne broen"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Innkapsling modus"
 
@@ -1854,7 +1855,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Sletter..."
 
@@ -1876,12 +1877,12 @@ msgstr "Feil"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet Tilslutning"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet Svitsj"
@@ -1980,9 +1981,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Filnavn fra boot image annonsert til klienter"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Filsystem"
 
@@ -1999,7 +1999,7 @@ msgstr "Filtrer ubrukelige"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2029,7 +2029,7 @@ msgstr "Brannmur Innstillinger"
 msgid "Firewall Status"
 msgstr "Brannmur Status"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2041,25 +2041,27 @@ msgstr "Firmware Versjon"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Fast kilde port for utgående DNS-spørringer"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Firmware Oppradering"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Flash firmware..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Flash nytt firmware image"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Flash operasjoner"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Flasher..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2086,11 +2088,11 @@ msgstr "Bruk TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Bruk TKIP og CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2118,7 +2120,7 @@ msgstr "Videresend kringkastingstrafikk"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Videresending modus"
 
@@ -2165,20 +2167,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Generelle Innstillinger"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Generelt Oppsett"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2186,7 +2187,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Opprett arkiv"
 
@@ -2194,11 +2195,11 @@ msgstr "Opprett arkiv"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Det oppgitte passordet var ikke korrekt, passord ble ikke endret!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2209,7 +2210,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Gå til passord konfigurasjon..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2259,7 +2260,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2452,7 +2453,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2539,14 +2540,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr "Hvis oppgitt vil denne enhet monteres ut fra dens UUID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2585,7 +2586,7 @@ msgstr "Dersom ikke avmerket blir ingen standard rute konfigurert"
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "Dersom ikke avmerket blir de annonserte DNS server adresser ignorert"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2610,7 +2611,7 @@ msgstr "Ignorer grensesnitt"
 msgid "Ignore resolve file"
 msgstr "Ignorer oppslagsfil"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Firmware"
 
@@ -2670,8 +2671,8 @@ msgstr "Installer protokoll utvidelser..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2755,11 +2756,11 @@ msgstr "Ugyldig VLAN ID gitt! Bare IDer mellom %d og %d er tillatt."
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "Ugyldig VLAN ID gitt! Bare unike ID'er er tillatt"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2775,7 +2776,7 @@ msgstr "Ugyldig brukernavn og/eller passord! Vennligst prøv igjen."
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2799,11 +2800,11 @@ msgstr "Koble til nettverket"
 msgid "Join Network: Wireless Scan"
 msgstr "Koble til nettverk: Trådløs Skanning"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Behold innstillinger"
 
@@ -2859,12 +2860,12 @@ msgstr "LCP ekko feil terskel"
 msgid "LCP echo interval"
 msgstr "LCP ekko intervall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Volumnavn"
 
@@ -3022,7 +3023,7 @@ msgstr "Laster"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3134,7 +3135,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3167,7 +3168,7 @@ msgstr ""
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3181,7 +3182,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3197,7 +3198,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3256,7 +3258,7 @@ msgstr "Minne"
 msgid "Memory usage (%)"
 msgstr "Minne forbruk (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3264,7 +3266,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3323,7 +3325,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Modem initiering tidsavbrudd"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3336,30 +3338,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Monterings Enhet"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Monterings Punkt"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Monterings Punkter"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Monterings Punkter - Monterings Enhet"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Monterings Punkter - Swap Enhet"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3367,23 +3364,27 @@ msgstr ""
 "Monterings punkter definerer hvor lagrings enheter blir tilsluttet "
 "filsystemet"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Monterings alternativer"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Monterings punkt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Monterte Filsystemer"
 
@@ -3424,15 +3425,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "NTP server kandidater"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Navn"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Navnet til det nye nettverket"
 
@@ -3443,7 +3444,7 @@ msgstr "Navigasjon"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3468,7 +3469,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "Nettverk uten grensesnitt."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3493,7 +3494,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3546,7 +3547,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Ingen sone tilknyttet"
 
@@ -3604,7 +3605,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3677,6 +3678,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Ett eller flere obligatoriske felter har ingen verdi!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Åpne liste..."
@@ -3756,7 +3758,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Alternativer"
 
@@ -3921,7 +3922,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3930,7 +3931,7 @@ msgid "Packets"
 msgstr "Pakker"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "En del av sone %q"
 
@@ -4028,11 +4029,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Omstart nå"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Foreta nullstilling"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4071,6 +4072,10 @@ msgstr "Pakker."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Skriv inn ditt brukernavn og passord."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4141,10 +4146,6 @@ msgstr "Hindrer klient-til-klient kommunikasjon"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Fortsett"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4160,7 +4161,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4243,7 +4244,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "RX Rate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4289,10 +4290,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Vil du nullstille alle endringer?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Vil du endre protokoll?"
@@ -4325,7 +4322,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Binde beskyttelse"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Omstart"
@@ -4334,6 +4331,11 @@ msgstr "Omstart"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Starter på nytt..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4387,7 +4389,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Avinstaller"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Erstatt trådløs konfigurasjon"
 
@@ -4399,7 +4401,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4482,7 +4484,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4494,7 +4496,7 @@ msgstr "Nullstill"
 msgid "Reset Counters"
 msgstr "Nullstill Tellere"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Nullstill til standard innstilling"
 
@@ -4506,7 +4508,7 @@ msgstr "Oppslag og Vertsfiler"
 msgid "Resolve file"
 msgstr "<abbr title=\"Resolvefile\">Oppslagsfil</abbr>"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4525,11 +4527,11 @@ msgstr "Omstart Brannmur"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Gjenoppretting"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Gjenopprett sikkerhetskopi"
 
@@ -4554,15 +4556,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Rot"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Rot katalog for filer gitt fra TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4583,7 +4581,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Ruter Passord"
 
@@ -4605,19 +4603,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Kjør filsystem sjekk før montering av enheten"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Kjør filsystem sjekk"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4626,7 +4624,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH Tilgang"
 
@@ -4643,7 +4641,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH-Nøkler"
 
@@ -4654,30 +4652,31 @@ msgstr "SSH-Nøkler"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Lagre"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Lagre & Aktiver"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4686,7 +4685,7 @@ msgid "Scan"
 msgstr "Skann"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Planlagte Oppgaver"
 
@@ -4698,11 +4697,11 @@ msgstr "Seksjon lagt til"
 msgid "Section removed"
 msgstr "Seksjon fjernet"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Se \"mount\" manpage for detaljer"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4745,7 +4744,7 @@ msgstr "Tjeneste type"
 msgid "Services"
 msgstr "Tjenester"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4753,10 +4752,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4786,6 +4789,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Vis gjeldende liste med sikkerhetskopifiler"
@@ -4807,7 +4811,7 @@ msgstr "Slå av dette grensesnittet"
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4819,7 +4823,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Signal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Størrelse"
 
@@ -4844,7 +4848,7 @@ msgstr "Gå til innhold"
 msgid "Skip to navigation"
 msgstr "Gå til navigasjon"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4861,7 +4865,7 @@ msgstr "Beklager, objektet du spurte om ble ikke funnet."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Beklager, det oppstod en uventet feil på serveren."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4881,7 +4885,7 @@ msgstr "Kilde"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Hvor lagrings enheten blir tilsluttet filsystemet (f.eks. /mnt/sda1)"
 
@@ -4921,7 +4925,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Angi krypteringsnøkkelen her."
 
@@ -4944,7 +4948,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Oppstart"
 
@@ -4964,7 +4968,7 @@ msgstr "Statiske Leier"
 msgid "Static Routes"
 msgstr "Statiske Ruter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5006,7 +5010,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Send"
 
@@ -5021,10 +5025,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Swap Enhet"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5044,7 +5044,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5137,6 +5137,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Avslutte"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5155,17 +5159,13 @@ msgid ""
 msgstr ""
 "IPv6 prefikset tilordnet mot leverandør, ender som regel med <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Gyldige tegn er: <code>A-Z</code>, <code>a-z</code>, <code>0-9</code> og "
 "<code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5182,8 +5182,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5197,25 +5197,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"Filsystemet som ble brukt til å formatere partisjonen eller minnet. (<abbr "
-"title=\"for eksempel\">f.eks.</abbr> <samp><abbr title=\"Third Extended "
-"Filesystem\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Firmwaren ble lastet opp. Nedenfor er kontrollsum og filstørrelse oppført, "
-"sammenlign dem med den opprinnelige filen for å sikre dataintegriteten.<br /"
-"> Klikk \"Fortsett\" nedenfor for å starte flash prosedyren."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5235,11 +5226,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5259,7 +5250,7 @@ msgstr "Lengden på IPv6 prefikset i bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5279,6 +5270,14 @@ msgstr ""
 "Uplink port for tilkobling til større nettverk som internett og andre porter "
 "til lokalt nettverk."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5287,7 +5286,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5295,7 +5294,7 @@ msgstr ""
 "Systemet sletter konfigurasjonspartisjonen nå, enheten vil bli startet på "
 "nytt når dette er utført."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5307,11 +5306,32 @@ msgstr ""
 "du prøver å koble til igjen. Det kan være nødvendig å fornye ip-adressen til "
 "datamaskinen din for å nå enheten på nytt. (avhengig av innstillingene dine)"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5362,6 +5382,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5451,11 +5472,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Tidssone"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5466,7 +5487,7 @@ msgstr ""
 "tilstand, klikker du på \"Utfør nullstilling\" (kun mulig på squashfs "
 "firmwarer)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5506,7 +5527,7 @@ msgstr "Utløsende Tilstand"
 msgid "Tunnel ID"
 msgstr "Tunnel ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Tunnel grensesnitt"
@@ -5549,8 +5570,8 @@ msgstr "USB Enhet"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5580,6 +5601,10 @@ msgstr "Kan ikke sende"
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5591,6 +5616,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5599,28 +5625,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Uhåndtert"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5633,7 +5659,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Ulagrede Endringer"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5656,7 +5682,11 @@ msgstr "Protokoll type er ikke støttet."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5666,7 +5696,9 @@ msgstr ""
 "kjørende firmware. Merk av \"Behold innstillinger\" for å beholde gjeldene "
 "konfigurasjon. (en kompatibel firmware er nødvendig)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Last opp arkiv..."
 
@@ -5679,7 +5711,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5737,11 +5775,11 @@ msgstr "Bruk MTU på tunnel grensesnitt"
 msgid "Use TTL on tunnel interface"
 msgstr "Bruk TTL på tunnel grensesnitt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5749,7 +5787,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "Bruk kringkasting flagg"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5816,7 +5854,7 @@ msgstr ""
 "statisk IP adresse som skal brukes og <em>Vertsnavn</em> blir symbolsk "
 "tilknyttet den anmodende verten."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Brukt"
 
@@ -5844,11 +5882,11 @@ msgstr ""
 msgid "Username"
 msgstr "Brukernavn"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5895,9 +5933,9 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Leverandør klasse som sendes ved DHCP spørring"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Bekreft"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5917,7 +5955,7 @@ msgstr "WEP åpent system"
 msgid "WEP Shared Key"
 msgstr "WEP delt nøkkel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP passord"
 
@@ -5925,7 +5963,7 @@ msgstr "WEP passord"
 msgid "WMM Mode"
 msgstr "WMM Modus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA passord"
 
@@ -5989,13 +6027,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Trådløs"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Trådløs Tilslutning"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6046,7 +6084,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6093,9 +6131,9 @@ msgstr ""
 msgid "any"
 msgstr "enhver"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6112,7 +6150,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "brokoblet"
 
@@ -6129,7 +6167,7 @@ msgid "create:"
 msgstr "opprett:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "Oppretter en bro mellom angitte grensesnitt"
 
@@ -6265,8 +6303,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "nei"
 
@@ -6278,13 +6314,13 @@ msgstr "ingen forbindelse"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "ingen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6314,10 +6350,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6336,7 +6368,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "rutet"
 
@@ -6350,15 +6382,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6576,14 +6608,70 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "ja"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Tilbake"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s Tilgjengelig)"
+
+#~ msgid "Check"
+#~ msgstr "Kontroller"
+
+#~ msgid "Checksum"
+#~ msgstr "Kontrollsum"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Aktiver dette monteringspunktet"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Aktiver denne swapenhet"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Firmware Oppradering"
+
+#~ msgid "Flashing..."
+#~ msgstr "Flasher..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Monterings Enhet"
+
+#~ msgid "Proceed"
+#~ msgstr "Fortsett"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Vil du nullstille alle endringer?"
+
+#~ msgid "Root"
+#~ msgstr "Rot"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Swap Enhet"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "Filsystemet som ble brukt til å formatere partisjonen eller minnet. "
+#~ "(<abbr title=\"for eksempel\">f.eks.</abbr> <samp><abbr title=\"Third "
+#~ "Extended Filesystem\">ext3</abbr></samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Firmwaren ble lastet opp. Nedenfor er kontrollsum og filstørrelse "
+#~ "oppført, sammenlign dem med den opprinnelige filen for å sikre "
+#~ "dataintegriteten.<br /> Klikk \"Fortsett\" nedenfor for å starte flash "
+#~ "prosedyren."
+
+#~ msgid "Verify"
+#~ msgstr "Bekreft"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Angir den lyttende porten for denne <em>Dropbear</em> instansen"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -14,7 +14,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -38,10 +38,6 @@ msgstr "%s jest nieotagowany w wielu grupach VLAN!"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(okno %d minut, interwał %d sekund)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(dostępne %s)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -82,15 +78,13 @@ msgstr "-- Proszę wybrać --"
 msgid "-- custom --"
 msgstr "-- własne --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- dopasuj według urządzenia --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- dopasuj po etykiecie --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- dopasuj po uuid --"
 
@@ -208,7 +202,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "Sufiks <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>(hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Konfiguracja diod <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
@@ -257,23 +251,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr "Wymagane jest ponowne zalogowanie ponieważ sesja wygasła."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr "ADSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -287,27 +281,27 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "Próg powtórzeń ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Mosty ATM"
 
 # Nie wiem czy to powinno się tłumaczyć wg. mnie lepiej zostawić po angielsku
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "Identyfikator kanału wirtualnego ATM (VCI)"
 
 # j.w.
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "Identyfikator ścieżki wirtualnej ATM (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -317,7 +311,7 @@ msgstr ""
 "wirtualne interfejsy sieciowe systemu Linux, które mogą być używane w "
 "połączeniu z protokołem DHCP lub PPP w celu polączenia się z siecią dostawcy."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Numer urządzenia ATM"
@@ -342,8 +336,7 @@ msgstr "Koncentrator dostępowy (ATM)"
 msgid "Access Point"
 msgstr "Punkt dostępowy"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Akcje"
 
@@ -373,7 +366,7 @@ msgstr "Aktywne dzierżawy DHCP"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktywne dzierżawy DHCPv6"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -383,7 +376,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -394,7 +387,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Dodaj"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -429,7 +422,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "Dodaj lokalny sufiks domeny do nazw urządzeń z pliku hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Dodaj nowy interfejs..."
 
@@ -474,19 +467,18 @@ msgid "Address to access local relay bridge"
 msgstr "Adres dostępowy do \"relay bridge\""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Zarządzanie"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
 
@@ -498,7 +490,7 @@ msgstr "Agregacja siły transmisji (ACTATP)"
 msgid "Alert"
 msgstr "Alarm"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -572,7 +564,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr "Dozwolone adresy IP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr "Zawsze rozgłaszaj domyślny router"
 
@@ -584,78 +576,78 @@ msgstr ""
 "Zawsze używaj kanału 40 MHz, nawet jeśli kanał dodatkowy nachodzi na inny. "
 "Używanie tej opcji nie jest zgodne z IEEE 802.11n-2009!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 "Rozgłaszaj jako domyślny router nawet jeśli publiczny prefiks nie jest "
 "dostępny."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr "Rozgłaszaj domeny DNS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr "Rozgłaszaj serwery DNS"
 
@@ -663,11 +655,11 @@ msgstr "Rozgłaszaj serwery DNS"
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -677,6 +669,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Dowolna strefa"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -710,7 +706,7 @@ msgstr ""
 "Przypisz cześć prefiksu za pomocą szesnastkowego ID subprefiksu dla tego "
 "interfejsu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Połączone stacje"
@@ -718,6 +714,10 @@ msgstr "Połączone stacje"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "Połączeni"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -767,27 +767,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Dostępne"
 
@@ -805,11 +805,11 @@ msgstr "Dostępne"
 msgid "Average:"
 msgstr "Średnia:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -833,14 +833,15 @@ msgstr "Wróć do przeglądu"
 msgid "Back to configuration"
 msgstr "Wróć do konfiguracji"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Kopia zapasowa"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Kopia zapasowa / aktualizacja firmware"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Kopia zapasowa listy plików"
@@ -858,6 +859,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr "Interwał Beaconu"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -892,17 +894,17 @@ msgstr "Szybkość transmisji"
 msgid "Bogus NX Domain Override"
 msgstr "Podrób statystyki NXDOMAIN"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Most"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Interfejs mostu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Numer Mostu (urządzenia)"
 
@@ -911,6 +913,7 @@ msgid "Bring up on boot"
 msgstr "Podnieś przy stracie"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -938,11 +941,13 @@ msgstr "Połączenie nieudane"
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -950,13 +955,9 @@ msgstr "Anuluj"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
 msgstr "Uwaga: Pliki konfiguracyjne zostaną usunięte"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
-msgstr "Uwaga: Zostanie wymuszone uaktualnienie systemu"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
@@ -989,28 +990,29 @@ msgstr "Zmienia hasło administratora"
 msgid "Channel"
 msgstr "Kanał"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Sprawdź"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Suma kontrolna"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr "Wybierz mtdblock"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1038,7 +1040,7 @@ msgstr "Szyfr"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1046,7 +1048,7 @@ msgstr ""
 "Kliknij \"Twórz archiwum\" aby pobrać archiwum tar zawierające bieżące pliki "
 "konfiguracyjne."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
@@ -1054,7 +1056,7 @@ msgstr ""
 "Kliknij \"Zapisz mtdblock\", aby pobrać określony plik mtdblock. (UWAGA: TA "
 "FUNKCJA JEST DLA PROFESJONALISTÓW! )"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1091,7 +1093,7 @@ msgstr "Zamknij listę..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1106,7 +1108,7 @@ msgstr "Zbieranie danych..."
 msgid "Command"
 msgstr "Polecenie"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1133,8 +1135,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Konfiguracja"
 
@@ -1143,7 +1144,7 @@ msgstr "Konfiguracja"
 msgid "Configuration failed"
 msgstr "Konfiguracja nieudana"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr "Pliki konfiguracyjne zostaną zachowane"
 
@@ -1155,7 +1156,7 @@ msgstr "Konfiguracja została zastosowana."
 msgid "Configuration has been rolled back!"
 msgstr "Konfiguracja została wycofana!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1175,7 +1176,7 @@ msgstr "Połączony"
 msgid "Connection attempt failed"
 msgstr "Próba połączenia nieudana"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1184,11 +1185,14 @@ msgid "Connections"
 msgstr "Połączenia"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1208,11 +1212,11 @@ msgid "Country Code"
 msgstr "Kod kraju"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Utwórz / Przypisz strefę firewalla"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1241,7 +1245,7 @@ msgstr "Interfejs niestandardowy"
 msgid "Custom delegated IPv6-prefix"
 msgstr "Delegowany niestandardowy prefiks IPv6"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1278,7 +1282,7 @@ msgstr "Serwer DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP i DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1293,7 +1297,7 @@ msgstr "Opcje DHCP"
 msgid "DHCPv6 client"
 msgstr "Klient DHCPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "Tryb DHCPv6"
 
@@ -1338,7 +1342,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr "DSL"
@@ -1347,7 +1351,7 @@ msgstr "DSL"
 msgid "DSL Status"
 msgstr "Status DSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1389,7 +1393,7 @@ msgstr "Domyślna ścieżka routingu"
 msgid "Default gateway"
 msgstr "Brama domyślna"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr "Domyślnie jest to stateless + stateful"
 
@@ -1411,9 +1415,9 @@ msgstr ""
 "\" rozgłasza domyślne serwery DNS klientom DHCP."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1474,10 +1478,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Urządzenie"
 
@@ -1567,7 +1571,7 @@ msgstr "Odrzuć wychodzące odpowiedzi RFC1918"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1576,11 +1580,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr "Próba rozłączenia nie powiodła się"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1626,6 +1631,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr "Czy na pewno chcesz usunąć następujący klucz SSH?"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1654,19 +1663,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Pobierz kopię zapasową"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr "Pobierz mtdblock"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1713,9 +1722,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Metoda EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1819,25 +1828,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Włącz ten punkt montowania"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Włącz ten swap"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Wlącz/Wyłącz"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Włączony"
 
@@ -1863,8 +1864,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Sposób enkapsulacji"
 
@@ -1892,7 +1893,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Usuwanie..."
 
@@ -1914,12 +1915,12 @@ msgstr "Błąd"
 msgid "Errored seconds (ES)"
 msgstr "Ilość błędów (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Karta Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
@@ -2019,9 +2020,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Rozgłoszono nazwę pliku obrazu startowego do klientów"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "System plików"
 
@@ -2038,7 +2038,7 @@ msgstr "Filtruj bezużyteczne"
 msgid "Finalizing failed"
 msgstr "Finalizacja nie powiodła się"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2068,7 +2068,7 @@ msgstr "Ustawienia firewalla"
 msgid "Firewall Status"
 msgstr "Stan firewalla"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr "Plik firmware"
 
@@ -2080,25 +2080,27 @@ msgstr "Wersja firmware"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Stały port źródłowy dla wychodzących zapytań DNS"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Aktualizuj firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Wgraj obraz..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Wgraj nowy firmware"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Operacje aktualizacji"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Flashowanie..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2125,11 +2127,11 @@ msgstr "Wymuś TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Wymuś TKIP i CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "Wymuś połączenie"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr "Wymuś uaktualnienie"
 
@@ -2157,7 +2159,7 @@ msgstr "Przekazuj broadcast`y"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Tryb przekazywania"
 
@@ -2204,20 +2206,19 @@ msgstr "Adres bramy jest nieprawidłowy"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Ustawienia podstawowe"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "Wygeneruj konfigurację"
 
@@ -2225,7 +2226,7 @@ msgstr "Wygeneruj konfigurację"
 msgid "Generate PMK locally"
 msgstr "Wygeneruj PMK lokalnie"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Twórz archiwum"
 
@@ -2235,11 +2236,11 @@ msgstr ""
 "Hasło nie zostało zmienione, wpisane poprzednie hasło routera jest "
 "niewłaściwe!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "Globalne opcje sieciowe"
 
@@ -2250,7 +2251,7 @@ msgstr "Globalne opcje sieciowe"
 msgid "Go to password configuration..."
 msgstr "Przejdź do konfiguracji hasła..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2302,7 +2303,7 @@ msgstr "Ukryj puste łańcuchy"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2494,7 +2495,7 @@ msgstr "Sąsiedztwo IPv6"
 msgid "IPv6 Settings"
 msgstr "Ustawienia IPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr "IPv6 Prefiks-ULA"
 
@@ -2582,16 +2583,16 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Jeśli podano, zainstaluj urządzenie poprzez jego UUID zamiast <abbr title="
 "\"fixed device node\">ustalonego węzła urządzenia</abbr>"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2632,7 +2633,7 @@ msgstr "Jeśli odznaczone, nie ma zdefiniowanej domyślnej ścieżki routingu"
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "Jeśli odznaczone, rozgłoszane adresy serwerów DNS są ignorowane"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2658,7 +2659,7 @@ msgstr "Ignoruj interfejs"
 msgid "Ignore resolve file"
 msgstr "Ignoruj pliki resolve"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Obraz"
 
@@ -2719,8 +2720,8 @@ msgstr "Instaluj rozszerzenia protokołów..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2804,11 +2805,11 @@ msgstr "Podano niewłaściwy ID VLAN`u! Dozwolone są tylko ID pomiędzy %d a %d
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "Podano niewłaściwy ID VLAN`u! Dozwolone są tylko unikalne ID."
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2824,7 +2825,7 @@ msgstr "Niewłaściwy login i/lub hasło! Spróbuj ponownie."
 msgid "Isolate Clients"
 msgstr "Izoluj klientów"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2848,11 +2849,11 @@ msgstr "Połącz z siecią"
 msgid "Join Network: Wireless Scan"
 msgstr "Przyłącz do sieci: Skanuj sieci Wi-Fi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "Przyłączanie do sieci: %q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Zachowaj ustawienia"
 
@@ -2908,12 +2909,12 @@ msgstr "Próg błędu echa LCP"
 msgid "LCP echo interval"
 msgstr "Interwał echa LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Oznaczenie"
 
@@ -3072,7 +3073,7 @@ msgstr "Ładowanie"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3185,7 +3186,7 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3218,7 +3219,7 @@ msgstr "Reguła MAP jest nieprawidłowa"
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr "MD5"
 
@@ -3232,7 +3233,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3250,7 +3251,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3309,7 +3311,7 @@ msgstr "Pamięć"
 msgid "Memory usage (%)"
 msgstr "Użycie pamięci (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3317,7 +3319,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3376,7 +3378,7 @@ msgstr "Zapytanie dotyczące modemu nie powiodło się"
 msgid "Modem init timeout"
 msgstr "Limit czasu inicjacji modemu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3389,30 +3391,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Wpis montowania"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Punkt montowania"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Punkty montowania"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Punkty montowania - Wpis montownia"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Punkty montowania - Wpis Swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3420,23 +3417,27 @@ msgstr ""
 "Punkty montowania definiują gdzie urządzenie pamięci zostanie podłączone do "
 "systemu plików"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Opcje montowania"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Punkt montownia"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Zamontowane systemy plików"
 
@@ -3477,15 +3478,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Lista serwerów NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nazwa"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Nazwa nowej sieci"
 
@@ -3496,7 +3497,7 @@ msgstr "Nawigacja"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3521,7 +3522,7 @@ msgstr "Urządzenie sieciowe nie jest obecne"
 msgid "Network without interfaces."
 msgstr "Sieć bez interfejsów"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3546,7 +3547,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3599,7 +3600,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Brak przypisanej strefy"
 
@@ -3657,7 +3658,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3732,6 +3733,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Jedno lub więcej pól nie posiada wpisanych wartości!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Otwórz listę..."
@@ -3815,7 +3817,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Opcje"
 
@@ -3980,7 +3981,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3989,7 +3990,7 @@ msgid "Packets"
 msgstr "Pakiety"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Część strefy %q"
 
@@ -4087,11 +4088,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Wykonaj restart"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Wykonaj reset"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4130,6 +4131,10 @@ msgstr "Pktw."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Proszę wprowadź swój login i hasło."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4200,10 +4205,6 @@ msgstr "Zapobiega komunikacji między klientem a klientem"
 msgid "Private Key"
 msgstr "Klucz prywatny"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Wykonaj"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4219,7 +4220,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4308,7 +4309,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Szybkość RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4356,10 +4357,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Naprawdę usunąć wszelkie zmiany?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Naprawdę zmienić protokół?"
@@ -4392,7 +4389,7 @@ msgstr "Termin reasocjacji"
 msgid "Rebind protection"
 msgstr "Przypisz ochronę"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Restart"
@@ -4401,6 +4398,11 @@ msgstr "Restart"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Ponowne uruchamianie..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4454,7 +4456,7 @@ msgstr "Zdalny adres IPv4 lub FQDN"
 msgid "Remove"
 msgstr "Usuń"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Zamień konfigurację WiFi"
 
@@ -4466,7 +4468,7 @@ msgstr "Zażądaj adresu IPv6"
 msgid "Request IPv6-prefix of length"
 msgstr "Zażądaj długość prefiksu IPv6"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4551,7 +4553,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4563,7 +4565,7 @@ msgstr "Resetuj"
 msgid "Reset Counters"
 msgstr "Wyczyść liczniki"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Resetuj do domyślnych"
 
@@ -4575,7 +4577,7 @@ msgstr "Pliki Resolv i Hosts"
 msgid "Resolve file"
 msgstr "Plik Resolve"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4594,11 +4596,11 @@ msgstr "Uruchom ponownie Firewalla"
 msgid "Restart radio interface"
 msgstr "Uruchom ponownie interfejs radiowy"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Przywróć"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Przywróć kopię zapasową"
 
@@ -4623,15 +4625,11 @@ msgstr "Żądanie powrotu nie powiodło się ze statusem <code>%h</code>"
 msgid "Reverting configuration…"
 msgstr "Przywracanie konfiguracji…"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Root"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Katalog Root`a dla plików udostępnianych przez TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4652,7 +4650,7 @@ msgid "Router Advertisement-Service"
 msgstr "Serwis rozgłoszeniowy routera"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Hasło routera"
 
@@ -4674,20 +4672,20 @@ msgstr ""
 msgid "Rule"
 msgstr "Reguła"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 "Sprawdź czy system plików nie zawiera błędów przed zamontowaniem urządzenia"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Sprawdź czy system plików nie zawiera błędów"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4696,7 +4694,7 @@ msgid "SNR"
 msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Dostęp SSH"
 
@@ -4713,7 +4711,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "Klucze SSH"
 
@@ -4724,30 +4722,31 @@ msgstr "Klucze SSH"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Zapisz"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Zapisz i zastosuj"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr "Zapisz mtdblock"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr "Zapisz zawartość mtdblock"
 
@@ -4756,7 +4755,7 @@ msgid "Scan"
 msgstr "Skanuj"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Zaplanowane Zadania"
 
@@ -4768,11 +4767,11 @@ msgstr "Dodano sekcję"
 msgid "Section removed"
 msgstr "Usunięto sekcję"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Aby poznać szczegóły przeczytaj stronę instrukcji \"mount\""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4818,7 +4817,7 @@ msgstr "Typ serwisu"
 msgid "Services"
 msgstr "Serwisy"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr "Sesja wygasła"
 
@@ -4826,13 +4825,17 @@ msgstr "Sesja wygasła"
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
 msgstr ""
 "Ustaw właściwości interfejsu, niezależnie od operatora łącza (nie wpływa na "
 "programy operatora które ustanawiają połączenie)."
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
+msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 #: protocols/luci-proto-qmi/luasrc/model/network/proto_qmi.lua:55
@@ -4861,6 +4864,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr "Krótki Wstęp"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Pokaż aktualną listę plików do backupu"
@@ -4882,7 +4886,7 @@ msgstr "Wyłącz ten interfejs"
 msgid "Signal"
 msgstr "Sygnał"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4894,7 +4898,7 @@ msgstr "Tłumienie sygnału (SATN)"
 msgid "Signal:"
 msgstr "Sygnał:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Rozmiar"
 
@@ -4919,7 +4923,7 @@ msgstr "Pomiń do zawartości"
 msgid "Skip to navigation"
 msgstr "Pomiń do nawigacji"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Programowy VLAN"
@@ -4936,7 +4940,7 @@ msgstr "Przepraszamy, ale żądany obiekt nie został znaleziony."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Przepraszamy, ale serwer napotkał nieoczekiwany błąd."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4956,7 +4960,7 @@ msgstr "Źródło"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Podaje katalog do którego jest podłączone urządzenie"
 
@@ -4998,7 +5002,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Określ tajny klucz szyfrowania."
 
@@ -5021,7 +5025,7 @@ msgid "Starting wireless scan..."
 msgstr "Rozpoczynanie skanowania..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Autostart"
 
@@ -5041,7 +5045,7 @@ msgstr "Dzierżawy statyczne"
 msgid "Static Routes"
 msgstr "Statyczne ścieżki routingu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5084,7 +5088,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Wyślij"
 
@@ -5099,10 +5103,6 @@ msgstr "Pomiń rejestrowanie rutynowych operacji dla tych protokołów"
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "Swap"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Zamień wpis"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5122,7 +5122,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5216,6 +5216,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Zakończ"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5234,17 +5238,13 @@ msgid ""
 msgstr ""
 "Prefiks IPv6 przypisany do dostawcy, zazwyczaj kończy się <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Dozwolone znaki to: <code>A-Z</code>, <code>a-z</code>, <code>0-9</code> "
 "oraz <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr "Archiwum kopii zapasowej nie wygląda na prawidłowe."
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5261,8 +5261,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5276,26 +5276,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"System plików, który został użyty do sformatowania nośnika (<abbr title=\"na "
-"przykład\">np.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</"
-"abbr></samp>)"
 
-# Przycisk nazywa się "Wykonaj", więc taki sam opis ma być w podpowiedzi.
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Obraz flash został przesłany. Poniżej znajduje się suma kontrolna i rozmiar "
-"pliku, porównaj je z orginałem aby zapewnić integralność danych.<br /> "
-"Wciśnij \"Wykonaj\" aby kontynuować aktualizację."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5317,11 +5307,11 @@ msgstr ""
 "Podany klucz publiczny SSH jest nieprawidłowy. Podaj odpowiedni publiczny "
 "RSA lub klucze ECDSA."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5342,7 +5332,7 @@ msgstr "Długość prefiksu IPv6 w bitach"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "Lokalny adres IPv4, na którym tworzony jest tunel (opcjonalnie)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5363,6 +5353,14 @@ msgstr ""
 "do połączenia z większą siecią, taką jak Internet, a inne porty dla sieci "
 "lokalnej."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5371,14 +5369,14 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr "The submitted security token is invalid or already expired!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 "System usuwa teraz partycję konfiguracji i zrestartuje się po zakończeniu."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5391,11 +5389,32 @@ msgstr ""
 "ustawień może być konieczne odnowienie adresu Twojego komputera, aby dostać "
 "się do urządzenia."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "Hasło systemowe zostało pomyślnie zmienione."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5446,6 +5465,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5539,11 +5559,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Strefa czasowa"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr "Zaloguj się…"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5553,7 +5573,7 @@ msgstr ""
 "utworzoną kopię zapasową. Aby przywrócić ustawienia domyślne wciśnij "
 "\"Wykonaj reset\" (możliwe tylko w przypadku obrazu squashfs)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr "Ton"
 
@@ -5593,7 +5613,7 @@ msgstr "Rodzaj Triggeru"
 msgid "Tunnel ID"
 msgstr "Numer identyfikacyjny tunelu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interfejs tunelu"
@@ -5636,8 +5656,8 @@ msgstr "Urządzenie USB"
 msgid "USB Ports"
 msgstr "Porty USB"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5667,6 +5687,10 @@ msgstr "Nie można wysłać"
 msgid "Unable to obtain client ID"
 msgstr "Nie można uzyskać ID klienta"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5678,6 +5702,7 @@ msgid "Unable to resolve peer host name"
 msgstr "Nie można rozpoznać nazwy peera"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5686,28 +5711,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Czas niedostępnośći (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Nieznany błąd (%s)"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Niezarządzalny"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "Odmontuj"
 
@@ -5720,7 +5745,7 @@ msgstr "Klucz beznazwy"
 msgid "Unsaved Changes"
 msgstr "Niezapisane zmiany"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5743,7 +5768,11 @@ msgstr "Nieobsługiwany typ protokołu."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5754,7 +5783,9 @@ msgstr ""
 "zachować bieżącą konfigurację (wymagany obraz zgodny z bieżącym "
 "opragramowaniem)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Załaduj archiwum..."
 
@@ -5767,7 +5798,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5825,11 +5862,11 @@ msgstr "Użyj MTU na interfejsie tunelu"
 msgid "Use TTL on tunnel interface"
 msgstr "Użyj TTL na interfejsie tunelu"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "Użyj jako systemu plików root (/)"
 
@@ -5837,7 +5874,7 @@ msgstr "Użyj jako systemu plików root (/)"
 msgid "Use broadcast flag"
 msgstr "Użyj flagi rozgłaszania"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "Skorzystaj z wbudowanego zarządzania protokołem IPv6"
 
@@ -5905,7 +5942,7 @@ msgstr ""
 "do określonego hosta."
 
 # Przy liście zamontowanych systemów plików
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Użyte"
 
@@ -5933,11 +5970,11 @@ msgstr "Klucz użytkownika (kodowany PEM)"
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr "VDSL"
 
@@ -5984,9 +6021,9 @@ msgstr "Producent"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Klasa producenta do wysłania podczas żądania DHCP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Zweryfikuj"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -6006,7 +6043,7 @@ msgstr "Otwarty system WEP"
 msgid "WEP Shared Key"
 msgstr "Współdzielony klucz WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Hasło WEP"
 
@@ -6014,7 +6051,7 @@ msgstr "Hasło WEP"
 msgid "WMM Mode"
 msgstr "Tryb WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Hasło WPA"
 
@@ -6080,13 +6117,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "Sieć bezprzewodowa"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adapter bezprzewodowy"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6137,7 +6174,7 @@ msgstr "Zapisz log systemowy do pliku"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6184,9 +6221,9 @@ msgstr "Rozmiar ZRam"
 msgid "any"
 msgstr "dowolny"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6203,7 +6240,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "zmostkowany"
 
@@ -6220,7 +6257,7 @@ msgid "create:"
 msgstr "utwórz:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "utwórz most na określonych interfejsach"
 
@@ -6356,8 +6393,6 @@ msgstr "minuty"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "nie"
 
@@ -6370,13 +6405,13 @@ msgstr "niepowiązane"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "żaden"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "nieobecny"
 
@@ -6406,10 +6441,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6428,7 +6459,7 @@ msgstr "losowy"
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "routowane"
 
@@ -6442,15 +6473,15 @@ msgstr ""
 msgid "server mode"
 msgstr "tryb serwera"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6668,14 +6699,79 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "tak"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Wróć"
+
+#~ msgid "(%s available)"
+#~ msgstr "(dostępne %s)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- dopasuj według urządzenia --"
+
+#~ msgid "Caution: System upgrade will be forced"
+#~ msgstr "Uwaga: Zostanie wymuszone uaktualnienie systemu"
+
+#~ msgid "Check"
+#~ msgstr "Sprawdź"
+
+#~ msgid "Checksum"
+#~ msgstr "Suma kontrolna"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Włącz ten punkt montowania"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Włącz ten swap"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Aktualizuj firmware"
+
+#~ msgid "Flashing..."
+#~ msgstr "Flashowanie..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Wpis montowania"
+
+#~ msgid "Proceed"
+#~ msgstr "Wykonaj"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Naprawdę usunąć wszelkie zmiany?"
+
+#~ msgid "Root"
+#~ msgstr "Root"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Zamień wpis"
+
+#~ msgid "The backup archive does not appear to be a valid gzip file."
+#~ msgstr "Archiwum kopii zapasowej nie wygląda na prawidłowe."
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "System plików, który został użyty do sformatowania nośnika (<abbr title="
+#~ "\"na przykład\">np.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+
+# Przycisk nazywa się "Wykonaj", więc taki sam opis ma być w podpowiedzi.
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Obraz flash został przesłany. Poniżej znajduje się suma kontrolna i "
+#~ "rozmiar pliku, porównaj je z orginałem aby zapewnić integralność danych."
+#~ "<br /> Wciśnij \"Wykonaj\" aby kontynuować aktualizację."
+
+#~ msgid "Verify"
+#~ msgstr "Zweryfikuj"
 
 #~ msgid "Change login password"
 #~ msgstr "Zmień hasło logowania"

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr "%.1f dB"
 
@@ -37,10 +37,6 @@ msgstr "%s está sem etiqueta em múltiplas VLANs!"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(janela de %d minutos, intervalo de %d segundos)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s disponível)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Por favor, escolha --"
 msgid "-- custom --"
 msgstr "-- personalizado --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- casar por dispositivo --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- casar por rótulo --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 "-- casar por <abbr title=\"Universal Unique IDentifier/Identificador Único "
@@ -219,7 +213,7 @@ msgstr ""
 "6\">IPv6</abbr>-Suffix (hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configuração do <abbr title=\"Diodo Emissor de Luz\">LED</abbr>"
 
@@ -268,25 +262,25 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr "A43C + J43 + A43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr "A43C + J43 + A43 + V43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 "<abbr title=\"Assymetrical Digital Subscriber Line/Linha Digital Assimétrica "
 "para Assinante\">ADSL</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr "ANSI T1.413"
 
@@ -302,29 +296,29 @@ msgstr ""
 "Limite de retentativas do <abbr title=\"Address Resolution Protocol\">ARP</"
 "abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr "ATM (Asynchronous Transfer Mode)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Ponte ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 "Identificador de Canal Virtual ATM (<abbr title=\"Virtual Channel Identifier"
 "\">VCI</abbr>)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 "Identificador de Caminho Virtual ATM (<abbr title=\"Virtual Path Identifier"
 "\">VPI</abbr>)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -334,7 +328,7 @@ msgstr ""
 "rede virutais no Linux. Estas podem ser usadas em conjunto com o DHCP ou PPP "
 "para discar em um provedor de rede."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Número do dispositivo ATM"
@@ -358,8 +352,7 @@ msgstr "Concentrador de Acesso"
 msgid "Access Point"
 msgstr "Ponto de Acceso (AP)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Ações"
 
@@ -387,7 +380,7 @@ msgstr "Alocações DHCP ativas"
 msgid "Active DHCPv6 Leases"
 msgstr "Alocações DHCPv6 ativas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -397,7 +390,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -408,7 +401,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Adicionar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -443,7 +436,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "Adiciona um sufixo de domínio local para equipamentos conhecidos"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Adiciona uma nova interface..."
 
@@ -487,19 +480,18 @@ msgid "Address to access local relay bridge"
 msgstr "Endereço para acessar a ponte por retransmissão local"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administração"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Opções Avançadas"
 
@@ -513,7 +505,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -593,7 +585,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr "Endereços IP autorizados"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr "Sempre anuncie o roteador padrão"
 
@@ -605,77 +597,77 @@ msgstr ""
 "Permitir o uso de canais 40Mhz mesmo se o canal secundário estiver "
 "sobreposto. Esta opção não está de acordo com IEEE 802.11n-2009!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr "Anexo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr "Anexos A + L + M (todo)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr "Anexo A G.992.1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr "Anexo A G.992.2"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr "Anexo A G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr "Anexo A G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr "Anexo B (todo)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr "Anexo B G.992.1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr "Anexo B G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr "Anexo B G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr "Anexo J (todo)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr "Anexo L G.992.3 POTS 1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr "Anexo M (todo)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr "Anexo M G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr "Anexo M G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 "Anuncie-se como rotador padrão mesmo se não existir um prefixo público."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr "Domínios DNS anunciados"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr "Servidores DNS anunciados"
 
@@ -683,11 +675,11 @@ msgstr "Servidores DNS anunciados"
 msgid "Anonymous Identity"
 msgstr "Identidade Anônima"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "Montagem Anônima"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "Espaço de Troca (swap) Anônimo"
 
@@ -697,6 +689,10 @@ msgstr "Espaço de Troca (swap) Anônimo"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Qualquer zona"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -730,7 +726,7 @@ msgstr ""
 "Atribua partes do prefixo usando este identificador hexadecimal do "
 "subprefixo para esta interface."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Estações associadas"
@@ -738,6 +734,10 @@ msgstr "Estações associadas"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "Associações"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -789,29 +789,29 @@ msgstr ""
 "Rede Doméstica Automática (<abbr title=\"Homenet Control Protocol\">HNCP</"
 "abbr>)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 "Execute automaticamente a verificação do sistema de arquivos antes da "
 "montagem do dispositivo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr "Monte automaticamente o espaço de troca (swap) ao conectar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr "Monte automaticamente o espaço de troca (swap) ao conectar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "Montagem Automática de Sistema de Arquivo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "Montagem Automática do Espaço de Troca (swap)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Disponível"
 
@@ -829,11 +829,11 @@ msgstr "Disponível"
 msgid "Average:"
 msgstr "Média:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr "B43 + B43C"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr "B43 + B43C + V43"
 
@@ -857,14 +857,15 @@ msgstr "Voltar para Visão Geral"
 msgid "Back to configuration"
 msgstr "Voltar para configuração"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Cópia de Segurança"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Cópia de Segurança / Gravar Firmware"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Lista de arquivos para a cópia de segurança"
@@ -882,6 +883,7 @@ msgstr "Banda"
 msgid "Beacon Interval"
 msgstr "Intervalo do quadro de monitoramento (Beacon)"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -916,17 +918,17 @@ msgstr "Taxa de bits"
 msgid "Bogus NX Domain Override"
 msgstr "Substituir Domínio NX Falsos"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Ponte"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Juntar interfaces em uma ponte"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Número da ponte"
 
@@ -935,6 +937,7 @@ msgid "Bring up on boot"
 msgstr "Levantar na iniciação"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -963,11 +966,13 @@ msgstr "A chamada falhou"
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -975,13 +980,9 @@ msgstr "Cancelar"
 msgid "Category"
 msgstr "Categoria"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
 msgstr "Cuidado: As configurações serão apagadas"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
-msgstr "Cuidado: A atualização do sistema será forçada"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
@@ -1014,29 +1015,30 @@ msgstr "Muda a senha do administrador para acessar este dispositivo"
 msgid "Channel"
 msgstr "Canal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Verificar"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 "Execute a verificação do sistema de arquivos antes da montagem do dispositivo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "Marque esta opção para remover as redes existentes neste rádio."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Soma de verificação"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr "Escolha o bloco mtd"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1064,7 +1066,7 @@ msgstr "Cifra"
 msgid "Cisco UDP encapsulation"
 msgstr "Encapsulamento UDP da Cisco"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1072,7 +1074,7 @@ msgstr ""
 "Clique em \"Gerar arquivo\" para baixar um arquivo tar com os arquivos de "
 "configuração atuais."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
@@ -1080,7 +1082,7 @@ msgstr ""
 "Clique em \"Salvar o bloco mtd\" para baixar o arquivo do bloco mtd "
 "especificado. (NOTA: ESTE RECURSO É PARA PROFISSIONAIS!)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1118,7 +1120,7 @@ msgstr "Fechar a lista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1133,7 +1135,7 @@ msgstr "Coletando dados..."
 msgid "Command"
 msgstr "Comando"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1160,8 +1162,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Configuração"
 
@@ -1170,7 +1171,7 @@ msgstr "Configuração"
 msgid "Configuration failed"
 msgstr "A configuração falhou"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr "Arquivos de configuração que serão mantidos"
 
@@ -1182,7 +1183,7 @@ msgstr "A configuração foi aplicada."
 msgid "Configuration has been rolled back!"
 msgstr "A configuração foi revertida!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1202,7 +1203,7 @@ msgstr "Conectado"
 msgid "Connection attempt failed"
 msgstr "A tentativa de conexão falhou"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1211,11 +1212,14 @@ msgid "Connections"
 msgstr "Conexões"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1239,11 +1243,11 @@ msgid "Country Code"
 msgstr "Código do País"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Criar / Atribuir a uma zona de firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1272,7 +1276,7 @@ msgstr "Interface Personalizada"
 msgid "Custom delegated IPv6-prefix"
 msgstr "Prefixo IPv6 delegado personalizado"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1309,7 +1313,7 @@ msgstr "Servidor DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP e DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1324,7 +1328,7 @@ msgstr "Opções de DHCP"
 msgid "DHCPv6 client"
 msgstr "Cliente DHCPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "Modo DHCPv6"
 
@@ -1369,7 +1373,7 @@ msgstr "Tempo de expiração para ociosidade do DPD"
 msgid "DS-Lite AFTR address"
 msgstr "Endereço DS-Lite AFTR"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr "DSL"
@@ -1378,7 +1382,7 @@ msgstr "DSL"
 msgid "DSL Status"
 msgstr "Estado da DSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr "Modo de linha DSL"
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Roteador Padrão"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr "O padrão é sem estado + com estado"
 
@@ -1445,9 +1449,9 @@ msgstr ""
 "DNS para os clientes."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1508,10 +1512,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Dispositivo"
 
@@ -1603,7 +1607,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1612,11 +1616,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr "A tentativa de desconexão falhou"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "Dispensar"
 
@@ -1664,6 +1669,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1693,21 +1702,21 @@ msgstr ""
 msgid "Down"
 msgstr "Abaixo"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Baixar a cópia de segurança"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr "Baixar o bloco mtd"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 "Deslocamento <abbr title=\"Razão entre Sinal e Ruído/Signal to Noise Ratio"
 "\">SNR</abbr> do sinal recebido"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1755,9 +1764,9 @@ msgstr "Comprimento dos bits EA"
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1865,25 +1874,17 @@ msgstr "Habilitar espelhamento dos pacotes saintes"
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr "Habilita o campo DF (Não Fragmentar) dos pacotes encapsulados."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Ativar esta montagem"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Habilitar esta rede"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Ativar este espaço de troca (swap)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Ativar/Desativar"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -1910,8 +1911,8 @@ msgstr "Ativa o protocolo STP nesta ponte"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Modo de encapsulamento"
 
@@ -1939,7 +1940,7 @@ msgstr "Entre com valor personalizado"
 msgid "Enter custom values"
 msgstr "Entre com valores personalizados"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Apagando..."
 
@@ -1961,12 +1962,12 @@ msgstr "Erro"
 msgid "Errored seconds (ES)"
 msgstr "Segundos com erro (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
@@ -2071,9 +2072,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Nome do arquivo da imagem de boot anunciada para os clientes"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Sistema de Arquivos"
 
@@ -2090,7 +2090,7 @@ msgstr "Filtrar consultas inúteis"
 msgid "Finalizing failed"
 msgstr "A finalização falhou"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2123,7 +2123,7 @@ msgstr "Configurações do Firewall"
 msgid "Firewall Status"
 msgstr "Estado do Firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr "Arquivo da Firmware"
 
@@ -2135,25 +2135,27 @@ msgstr "Versão do Firmware"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Porta de origem fixa para saída de consultas DNS"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Gravar Firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Gravar imagem..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Gravar nova imagem do firmware"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Operações na memória flash"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Gravando na flash..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2179,11 +2181,11 @@ msgstr "Forçar TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forçar TKIP e CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "Forçar o enlace"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr "Forçar a atualização"
 
@@ -2213,7 +2215,7 @@ msgstr "Encaminhar tráfego broadcast"
 msgid "Forward mesh peer traffic"
 msgstr "Encaminhar o tráfego do parceiro da malha"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Modo de encaminhamento"
 
@@ -2260,20 +2262,19 @@ msgstr "O endereço do roteador padrão é inválido"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configurações Gerais"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "Gerar Configuração"
 
@@ -2283,7 +2284,7 @@ msgstr ""
 "Gerar a <abbr title=\"Chave mestre do emparelhamento/Pairwise Master Key"
 "\">PMK</abbr> localmente"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Gerar arquivo"
 
@@ -2291,11 +2292,11 @@ msgstr "Gerar arquivo"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "A senha de confirmação informada não casa. Senha não alterada!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "Configurações Globais"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "Opções de rede globais"
 
@@ -2306,7 +2307,7 @@ msgstr "Opções de rede globais"
 msgid "Go to password configuration..."
 msgstr "Ir para a configuração de senha..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2360,7 +2361,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "Equipamento"
 
@@ -2556,7 +2557,7 @@ msgstr "Vizinhos IPv6"
 msgid "IPv6 Settings"
 msgstr "Configurações IPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 "Prefixo <abbr title=\"Unique Local Address/Endereço Local Único\">ULA</abbr> "
@@ -2645,16 +2646,16 @@ msgstr "Se marcado, a cifragem 1DES será habilitada"
 msgid "If checked, encryption is disabled"
 msgstr "Se marcado, a cifragem estará desabilitada"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Se especificado, monta o dispositivo pelo seu UUID ao invés de um nó de "
 "dispositivo fixo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2696,7 +2697,7 @@ msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 "Se desmarcado, os endereços dos servidores DNS anunciados serão ignorados"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2724,7 +2725,7 @@ msgstr "Ignorar interface"
 msgid "Ignore resolve file"
 msgstr "Ignorar arquivo de resolução de nomes (resolv.conf)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Imagem"
 
@@ -2786,8 +2787,8 @@ msgstr "Instalar extensões de protocolo..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2875,11 +2876,11 @@ msgstr ""
 "O valor informado do ID da VLAN é inválido! Somente valores únicos são "
 "permitidos"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2895,7 +2896,7 @@ msgstr "Usuário e/ou senha inválida! Por favor, tente novamente."
 msgid "Isolate Clients"
 msgstr "Isolar Clientes"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2918,11 +2919,11 @@ msgstr "Conectar à Rede"
 msgid "Join Network: Wireless Scan"
 msgstr "Conectar à Rede: Busca por Rede Sem Fio"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "Juntando-se à rede %q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Manter configurações"
 
@@ -2978,12 +2979,12 @@ msgstr "Limite de falha no eco do LCP"
 msgid "LCP echo interval"
 msgstr "Intervalo do eco do LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Etiqueta"
 
@@ -3157,7 +3158,7 @@ msgstr "Carregando"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3273,7 +3274,7 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3306,7 +3307,7 @@ msgstr "A regra MAC é inválida"
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr "MD5"
 
@@ -3322,7 +3323,7 @@ msgstr ""
 "<abbr title=\"Maximum Transmission Unit/Unidade Máxima de Transmissão\">MTU</"
 "abbr>"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3340,7 +3341,8 @@ msgstr ""
 msgid "Manual"
 msgstr "Manual"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3401,7 +3403,7 @@ msgstr "Memória"
 msgid "Memory usage (%)"
 msgstr "Uso da memória (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3409,7 +3411,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr "Identificador da Malha"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3468,7 +3470,7 @@ msgstr "A consulta das informações do modem falhou"
 msgid "Modem init timeout"
 msgstr "Estouro de tempo da iniciação do modem"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3481,30 +3483,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Entrada de Montagem"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Ponto de Montagem"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Pontos de Montagem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Pontos de Montagem - Entrada de Montagem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Pontos de Montagem - Entrada da Swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3512,23 +3509,27 @@ msgstr ""
 "Pontos de montagem definem em que ponto um dispositivo de armazenamento será "
 "anexado ao sistema de arquivos"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr "Monte sistemas de arquivos não especificamente configurados"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Opções de montagem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Ponto de montagem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "Montar espalho de troca (swap) não especificamente configurado"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Sistemas de arquivos montados"
 
@@ -3569,15 +3570,15 @@ msgstr "Domínio NT"
 msgid "NTP server candidates"
 msgstr "Candidatos a servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nome"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Nome da nova rede"
 
@@ -3588,7 +3589,7 @@ msgstr "Navegação"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3613,7 +3614,7 @@ msgstr "O dispositivo de rede não está presente"
 msgid "Network without interfaces."
 msgstr "Rede sem interfaces."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3638,7 +3639,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr "Sem NAT-T"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3691,7 +3692,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Nenhuma zona definida"
 
@@ -3753,7 +3754,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3827,6 +3828,7 @@ msgstr "Um ou mais valores inválidos/obrigatórios na aba"
 msgid "One or more required fields have no value!"
 msgstr "Um ou mais campos obrigatórios não tem valor!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Abrir lista..."
@@ -3919,7 +3921,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Opcional. Porta UDP usada para pacotes saintes ou entrantes."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Opções"
 
@@ -4087,7 +4088,7 @@ msgstr "Deslocamento PSID"
 msgid "PSID-bits length"
 msgstr "Comprimento dos bits PSID"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Modo de Transferência de Pacotes)"
 
@@ -4096,7 +4097,7 @@ msgid "Packets"
 msgstr "Pacotes"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Parte da zona %q"
 
@@ -4194,11 +4195,11 @@ msgstr "Sigilo Encaminhado Perfeito"
 msgid "Perform reboot"
 msgstr "Reiniciar o sistema"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Restaurar as configuração iniciais"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4237,6 +4238,10 @@ msgstr "Pcts."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Entre com o seu usuário e senha."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4308,10 +4313,6 @@ msgstr "Impede a comunicação de cliente para cliente"
 msgid "Private Key"
 msgstr "Chave Privada"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Proceder"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4327,7 +4328,7 @@ msgstr "Protocolo"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4414,7 +4415,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Taxa de RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4465,10 +4466,6 @@ msgstr ""
 "desfeita! Você pode perder acesso a este dispositivo se você estiver "
 "conectado por meio desta interface"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Realmente limpar todas as mudanças?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Realmente trocar o protocolo?"
@@ -4501,7 +4498,7 @@ msgstr "Limite para Reassociação"
 msgid "Rebind protection"
 msgstr "Proteção contra \"Rebind\""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reiniciar"
@@ -4510,6 +4507,11 @@ msgstr "Reiniciar"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Reiniciando..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4563,7 +4565,7 @@ msgstr "Endereço IPv4 remoto ou FQDN"
 msgid "Remove"
 msgstr "Remover"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Substituir a configuração da rede sem fio"
 
@@ -4575,7 +4577,7 @@ msgstr "Solicita endereço IPv6"
 msgid "Request IPv6-prefix of length"
 msgstr "Solicita prefixo IPv6 de tamanho"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4664,7 +4666,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4676,7 +4678,7 @@ msgstr "Limpar"
 msgid "Reset Counters"
 msgstr "Reiniciar contadores"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Redefinir para os valores padrão"
 
@@ -4688,7 +4690,7 @@ msgstr "Arquivos de Resolv e Hosts"
 msgid "Resolve file"
 msgstr "Arquivo Resolv"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4707,11 +4709,11 @@ msgstr "Reiniciar o firewall"
 msgid "Restart radio interface"
 msgstr "Reinicie a interface do rádio"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Restauração"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Restaurar cópia de segurança"
 
@@ -4737,15 +4739,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr "Revertendo configurações..."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Raiz"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Diretório raiz para arquivos disponibilizados pelo TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr "Prepação da raiz (/)"
 
@@ -4766,7 +4764,7 @@ msgid "Router Advertisement-Service"
 msgstr "Serviço de Anúncio de Roteador"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Senha do Roteador"
 
@@ -4788,20 +4786,20 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 "Execute a verificação do sistema de arquivos antes da montagem do dispositivo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Execute a verificação do sistema de arquivos"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr "SHA256"
 
@@ -4810,7 +4808,7 @@ msgid "SNR"
 msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Acesso SSH"
 
@@ -4827,7 +4825,7 @@ msgid "SSH username"
 msgstr "Usuário do SSH"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "Chaves SSH"
 
@@ -4838,30 +4836,31 @@ msgstr "Chaves SSH"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Salvar"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salvar & Aplicar"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr "Salvar o bloco mtd"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr "Salvar o conteúdo do bloco mtd"
 
@@ -4870,7 +4869,7 @@ msgid "Scan"
 msgstr "Procurar"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Tarefas Agendadas"
 
@@ -4882,11 +4881,11 @@ msgstr "Seção adicionada"
 msgid "Section removed"
 msgstr "Seção removida"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Veja o manual (man) do comando \"mount\" para detalhes"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4932,7 +4931,7 @@ msgstr "Tipo do Serviço"
 msgid "Services"
 msgstr "Serviços"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4940,7 +4939,7 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
@@ -4948,6 +4947,10 @@ msgstr ""
 "Definir as propriedades da interface independentemente da portadora do "
 "enlace (Se definido, eventos de detecção da portadora não irão gerar eventos "
 "do hotplug)."
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
+msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 #: protocols/luci-proto-qmi/luasrc/model/network/proto_qmi.lua:55
@@ -4980,6 +4983,7 @@ msgstr "Intervalo de guarda curto"
 msgid "Short Preamble"
 msgstr "Preâmbulo curto"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Mostra a lista atual de arquivos para a cópia de segurança"
@@ -5001,7 +5005,7 @@ msgstr "Desligar esta interface"
 msgid "Signal"
 msgstr "Sinal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -5013,7 +5017,7 @@ msgstr "Atenuação do Sinal (<abbr title=\"Signal Attenuation\">SATN</abbr>)"
 msgid "Signal:"
 msgstr "Sinal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Tamanho"
 
@@ -5038,7 +5042,7 @@ msgstr "Pular para o conteúdo"
 msgid "Skip to navigation"
 msgstr "Pular para a navegação"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "VLAN em Software"
@@ -5055,7 +5059,7 @@ msgstr "Desculpe o objeto solicitado não foi encontrado."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Desculpe, o servidor encontrou um erro inesperado."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -5075,7 +5079,7 @@ msgstr "Origem"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Especifica o diretório que o dispositivo está conectado"
 
@@ -5122,7 +5126,7 @@ msgstr ""
 "Especifica a unidade máxima de transmissão (<abbr title=\"Maximum "
 "Transmission Unit\">MTU</abbr>) ao invés do valor padrão (1280 bytes)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Especifique a chave de cifragem secreta aqui."
 
@@ -5145,7 +5149,7 @@ msgid "Starting wireless scan..."
 msgstr "Iniciando o escaneamento da rede sem fio..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Iniciação"
 
@@ -5165,7 +5169,7 @@ msgstr "Alocações Estáticas"
 msgid "Static Routes"
 msgstr "Rotas Estáticas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5208,7 +5212,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Enviar"
 
@@ -5223,10 +5227,6 @@ msgstr "Suprimir registros (log) de operações rotineiras destes protocolos"
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "Espaço de Troca (swap)"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Entrada do espaço de troca (Swap)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5248,7 +5248,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Máscara da porta do Switch"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Switch VLAN"
@@ -5341,6 +5341,10 @@ msgstr "Rede de destino"
 msgid "Terminate"
 msgstr "Terminar"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5361,18 +5365,13 @@ msgid ""
 msgstr ""
 "O prefixo IPv6 atribuído pelo provedor, geralmente termina com<code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Os caracteres permitidos são: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> e <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
-"O arquivo de recuperação não parece ser um arquivo válido no formato GZIP."
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5390,8 +5389,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5405,26 +5404,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"O sistema de arquivos que foi usado para formatar a unidade de armazenamento "
-"(<abbr title=\"por exemplo\">ex.</abbr> <samp><abbr title=\"Sistema de "
-"Arquivos ext3\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"A imagem do firmware foi enviada. Abaixo estão a soma de verificação "
-"(checksum) e o tamanho dom arquivo. Compare-os com o arquivo original para "
-"garantir a integridade dos dados. <br /> Clique em \"Proceder\" para iniciar "
-"o procedimetno de gravação."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5444,11 +5433,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5469,7 +5458,7 @@ msgstr "O comprimento do prefixo IPv6 em bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "O endereço IPv4 local sobre o qual o túnel será criado (opcional)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5490,6 +5479,14 @@ msgstr ""
 "uma porta para o enlace superior (uplink) e as demais portas são utilizadas "
 "para a rede local."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5498,7 +5495,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr "A chave eletrônica enviada é inválida ou já expirou!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5506,7 +5503,7 @@ msgstr ""
 "O sistema está apagando agora a partição da configuração e irá reiniciar "
 "quando terminado."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5518,11 +5515,32 @@ msgstr ""
 "da sua configuração, pode ser necessário renovar o endereço do seu "
 "computador para poder conectar novamente ao roteador."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5573,6 +5591,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5668,11 +5687,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Fuso Horário"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5683,7 +5702,7 @@ msgstr ""
 "clique em \"Restaurar as configurações iniciais\" (somente possível para "
 "imagens do tipo squashfs)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr "Tom"
 
@@ -5723,7 +5742,7 @@ msgstr "Modo de disparo"
 msgid "Tunnel ID"
 msgstr "Identificador do Túnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interface de Tunelamento"
@@ -5766,8 +5785,8 @@ msgstr "Dispositivo USB"
 msgid "USB Ports"
 msgstr "Portas USB"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5797,6 +5816,10 @@ msgstr "Não é possível a expedição"
 msgid "Unable to obtain client ID"
 msgstr "Não foi possível obter o identificador do cliente"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5808,6 +5831,7 @@ msgid "Unable to resolve peer host name"
 msgstr "Não foi possível resolver o nome do parceiro"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5818,28 +5842,28 @@ msgstr ""
 "Segundos de indisponibilidade (<abbr title=\"Unavailable Seconds\">UAS</"
 "abbr>)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Erro desconhecido (%s)"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Não gerenciado"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "Desmontar"
 
@@ -5852,7 +5876,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Alterações Não Salvas"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5877,7 +5901,11 @@ msgstr "Tipo de protocolo não suportado."
 msgid "Up"
 msgstr "Acima"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5887,7 +5915,9 @@ msgstr ""
 "execução. Marque \"Manter configurações\" para manter as configurações "
 "atuais (requer uma imagem compatível)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Enviar arquivo..."
 
@@ -5900,7 +5930,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5960,11 +5996,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr "Use TTL na interface do túnel"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr "Use como uma sobreposição externa (/overlay)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "Usar como o sistema de arquivos raiz (/)"
 
@@ -5972,7 +6008,7 @@ msgstr "Usar como o sistema de arquivos raiz (/)"
 msgid "Use broadcast flag"
 msgstr "Use a marcação de broadcast"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "Use o gerenciamento do IPv6 embarcado"
 
@@ -6040,7 +6076,7 @@ msgstr ""
 "equipamento</em> é designado como nome simbólico (DNS) para o equipamento "
 "requisitante."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Usado"
 
@@ -6070,11 +6106,11 @@ msgstr "Chave do usuário (codificada em formato PEM)"
 msgid "Username"
 msgstr "Usuário"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr "VDSL"
 
@@ -6121,9 +6157,9 @@ msgstr "Fabricante"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Classe do fabricante para enviar quando requisitar o DHCP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Verificar"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -6143,7 +6179,7 @@ msgstr "WEP Sistema Aberto"
 msgid "WEP Shared Key"
 msgstr "WEP Chave Compartilhada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP Senha"
 
@@ -6151,7 +6187,7 @@ msgstr "WEP Senha"
 msgid "WMM Mode"
 msgstr "Modo WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA Senha"
 
@@ -6215,13 +6251,13 @@ msgstr "VPN WireGuard"
 msgid "Wireless"
 msgstr "Rede sem fio"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Dispositivo de Rede sem Fio"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6272,7 +6308,7 @@ msgstr "Escrever registro do sistema (log) no arquivo"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6320,9 +6356,9 @@ msgstr ""
 msgid "any"
 msgstr "qualquer"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6339,7 +6375,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "em ponte"
 
@@ -6356,7 +6392,7 @@ msgid "create:"
 msgstr "criar:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "cria uma ponte sobre determinada(s) interface(s)"
 
@@ -6494,8 +6530,6 @@ msgstr "minutos"
 # Is this yes/no or no like in no one?
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "não"
 
@@ -6507,13 +6541,13 @@ msgstr "sem link"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "nenhum"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "não presente"
 
@@ -6543,10 +6577,6 @@ msgstr ""
 msgid "output"
 msgstr "saída"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr "sobreposição"
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6565,7 +6595,7 @@ msgstr "aleatório"
 msgid "relay mode"
 msgstr "modo retransmissor"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "roteado"
 
@@ -6579,15 +6609,15 @@ msgstr ""
 msgid "server mode"
 msgstr "modo servidor"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr "somente com estado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr "sem estado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr "sem estado + com estado"
 
@@ -6805,14 +6835,83 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "sim"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s disponível)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- casar por dispositivo --"
+
+#~ msgid "Caution: System upgrade will be forced"
+#~ msgstr "Cuidado: A atualização do sistema será forçada"
+
+#~ msgid "Check"
+#~ msgstr "Verificar"
+
+#~ msgid "Checksum"
+#~ msgstr "Soma de verificação"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Ativar esta montagem"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Ativar este espaço de troca (swap)"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Gravar Firmware"
+
+#~ msgid "Flashing..."
+#~ msgstr "Gravando na flash..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Entrada de Montagem"
+
+#~ msgid "Proceed"
+#~ msgstr "Proceder"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Realmente limpar todas as mudanças?"
+
+#~ msgid "Root"
+#~ msgstr "Raiz"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Entrada do espaço de troca (Swap)"
+
+#~ msgid "The backup archive does not appear to be a valid gzip file."
+#~ msgstr ""
+#~ "O arquivo de recuperação não parece ser um arquivo válido no formato GZIP."
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "O sistema de arquivos que foi usado para formatar a unidade de "
+#~ "armazenamento (<abbr title=\"por exemplo\">ex.</abbr> <samp><abbr title="
+#~ "\"Sistema de Arquivos ext3\">ext3</abbr></samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "A imagem do firmware foi enviada. Abaixo estão a soma de verificação "
+#~ "(checksum) e o tamanho dom arquivo. Compare-os com o arquivo original "
+#~ "para garantir a integridade dos dados. <br /> Clique em \"Proceder\" para "
+#~ "iniciar o procedimetno de gravação."
+
+#~ msgid "Verify"
+#~ msgstr "Verificar"
+
+#~ msgid "overlay"
+#~ msgstr "sobreposição"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Desabilitado (padrão)"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -37,10 +37,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(janela de %d minutos, intervalo de %d segundos)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s disponível)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- Por favor escolha --"
 msgid "-- custom --"
 msgstr "-- personalizado --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -213,7 +207,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configuração do <abbr title=\"Diodo Emissor de Luz\">LED</abbr>"
 
@@ -260,23 +254,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -290,25 +284,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "Limiar de tentativas ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Bridges ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "Identificador Canais Virtuais ATM (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "Identificador de Caminho Virtual ATM (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -318,7 +312,7 @@ msgstr ""
 "interface de Rede Virtual Linux que pode ser usada em conjugação com o DHCP "
 "ou PPP para marcar para a rede ISP."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Número de Dispositivo ATM"
@@ -342,8 +336,7 @@ msgstr "Concentrador de Acesso"
 msgid "Access Point"
 msgstr "Access Point (AP)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Acções"
 
@@ -371,7 +364,7 @@ msgstr "Concessões DHCP Ativas"
 msgid "Active DHCPv6 Leases"
 msgstr "Concessões DHCPv6 Ativas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -381,7 +374,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -392,7 +385,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Adicionar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -429,7 +422,7 @@ msgstr ""
 "hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Adicionar uma nova interface..."
 
@@ -473,19 +466,18 @@ msgid "Address to access local relay bridge"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administração"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Definições Avançadas"
 
@@ -497,7 +489,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -571,7 +563,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -581,76 +573,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -658,11 +650,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -672,6 +664,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Qualquer zona"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -701,13 +697,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Estações Associadas"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -758,27 +758,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Disponível"
 
@@ -796,11 +796,11 @@ msgstr "Disponível"
 msgid "Average:"
 msgstr "Média:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -824,14 +824,15 @@ msgstr "Voltar à Visão Global"
 msgid "Back to configuration"
 msgstr "Voltar à configuração"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Backup"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Backup / Flashar Firmware"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Lista de ficheiros para backup"
@@ -849,6 +850,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -883,17 +885,17 @@ msgstr "Taxa de bits"
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bridge"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Ativar brigde nas interfaces"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Número de unidade da bridge"
 
@@ -902,6 +904,7 @@ msgid "Bring up on boot"
 msgstr "Levantar no arranque"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -929,11 +932,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -941,12 +946,8 @@ msgstr "Cancelar"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -980,28 +981,29 @@ msgstr "Altera a password de administrador para acesso ao dispositivo"
 msgid "Channel"
 msgstr "Canal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Verificar"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1029,7 +1031,7 @@ msgstr "Cifra"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1037,13 +1039,13 @@ msgstr ""
 "Clique em \"Gerar arquivo\" para descarregar o ficheiro tar com os actuais "
 "ficheiros de configuração."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1080,7 +1082,7 @@ msgstr "Fechar lista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1095,7 +1097,7 @@ msgstr "A obter dados..."
 msgid "Command"
 msgstr "Comando"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1117,8 +1119,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Configuração"
 
@@ -1127,7 +1128,7 @@ msgstr "Configuração"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1139,7 +1140,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1159,7 +1160,7 @@ msgstr "Ligado"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1168,11 +1169,14 @@ msgid "Connections"
 msgstr "Ligações"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1192,11 +1196,11 @@ msgid "Country Code"
 msgstr "Código do País"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Criar / Atribuir a uma zona de firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1225,7 +1229,7 @@ msgstr "Interface Personalizada"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1260,7 +1264,7 @@ msgstr "Servidor DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP e DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1275,7 +1279,7 @@ msgstr "Opções DHCP"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1329,7 +1333,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1371,7 +1375,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Gateway predefinido"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1394,9 +1398,9 @@ msgstr ""
 "servidores DNS."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1457,10 +1461,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Dispositivo"
 
@@ -1550,7 +1554,7 @@ msgstr "Descartar respostas RFC1918 a montante"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1559,11 +1563,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1610,6 +1615,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1638,19 +1647,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Descarregar backup"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1697,9 +1706,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "Metodo-EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1801,25 +1810,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Ativar este mount"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Ativar esta swap"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Ativar/Desativar"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -1841,8 +1842,8 @@ msgstr "Ativa o Spanning Tree nesta bridge"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Modo de encapsulamento"
 
@@ -1870,7 +1871,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "A apagar..."
 
@@ -1892,12 +1893,12 @@ msgstr "Erro"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
@@ -1998,9 +1999,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "Nome de ficheiro da imagem de boot a anunciar aos clientes"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Sistema de ficheiros"
 
@@ -2017,7 +2017,7 @@ msgstr "Filtro inútil"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2047,7 +2047,7 @@ msgstr "Definições da Firewall"
 msgid "Firewall Status"
 msgstr "Estado da Firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2059,25 +2059,27 @@ msgstr "Versão do Firmware"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Porta fixa de origem para saída das consultas DNS"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Gravar Firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Flashar imagem..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Flashar nova imagem do firmware"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "A programar...."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2103,11 +2105,11 @@ msgstr "Forçar TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forçar TKIP e CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2135,7 +2137,7 @@ msgstr "Encaminhar trafego de broadcast"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Modo de encaminhamento"
 
@@ -2182,20 +2184,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Definições Gerais"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configuração Geral"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2203,7 +2204,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Gerar arquivo"
 
@@ -2212,11 +2213,11 @@ msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 "A confirmação de password não corresponde, a password não foi alterada!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2227,7 +2228,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Ir para a configuração da password"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2279,7 +2280,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2472,7 +2473,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2559,14 +2560,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2605,7 +2606,7 @@ msgstr "Se desmarcado, não é configurada uma rota pré-definida"
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "Se desmarcado, os endereços servidor DNS anunciados são ignorados "
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2632,7 +2633,7 @@ msgstr "Ignorar interface"
 msgid "Ignore resolve file"
 msgstr "Ignorar ficheiro resolv.conf"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Imagem"
 
@@ -2692,8 +2693,8 @@ msgstr "Instalar extensões do protocolo..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2778,11 +2779,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "O ID de VLAN fornecido é inválido! Só os IDs únicos são permitidos."
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2798,7 +2799,7 @@ msgstr "Username inválido e/ou a password! Por favor, tente novamente."
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2822,11 +2823,11 @@ msgstr "Associar Rede"
 msgid "Join Network: Wireless Scan"
 msgstr "Associar Rede: Procurar Redes Wireless"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Manter definições"
 
@@ -2882,12 +2883,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr "Intervalo de echo LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Etiqueta"
 
@@ -3045,7 +3046,7 @@ msgstr "A carregar"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3157,7 +3158,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3190,7 +3191,7 @@ msgstr ""
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3204,7 +3205,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3220,7 +3221,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3279,7 +3281,7 @@ msgstr "Memória"
 msgid "Memory usage (%)"
 msgstr "Uso de memória (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3287,7 +3289,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3346,7 +3348,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3359,30 +3361,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Montar Entrada"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Ponto de Montagem"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Pontos de Montagem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3390,23 +3387,27 @@ msgstr ""
 "Pontos de montagem definem em que ponto um dispositivo de memória será "
 "anexado ao sistema de arquivos"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Ponto de montagem"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Sistemas de arquivos montados"
 
@@ -3447,15 +3448,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "Candidatos a servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nome"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Nome da nova rede"
 
@@ -3466,7 +3467,7 @@ msgstr "Navegação"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3491,7 +3492,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "Rede sem interfaces."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3516,7 +3517,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3569,7 +3570,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Sem zona atribuída"
 
@@ -3627,7 +3628,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3700,6 +3701,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Um ou mais campos obrigatórios não têm valores!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Abrir lista..."
@@ -3779,7 +3781,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Opções"
 
@@ -3942,7 +3943,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3951,7 +3952,7 @@ msgid "Packets"
 msgstr "Pacotes"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Parte da zona %q"
 
@@ -4049,11 +4050,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Executar reinicialização"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Executar reset"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4092,6 +4093,10 @@ msgstr "Pkts."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Insira o seu username e password."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4160,10 +4165,6 @@ msgstr "Impede a comunicação cliente-a-cliente"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Proceder"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4179,7 +4180,7 @@ msgstr "Protocolo"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4262,7 +4263,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Taxa RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4308,10 +4309,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Deseja mesmo limpar todas as alterações?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Deseja mesmo trocar o protocolo?"
@@ -4344,7 +4341,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Religar protecção"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reiniciar"
@@ -4353,6 +4350,11 @@ msgstr "Reiniciar"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "A reiniciar..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4406,7 +4408,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Remover"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Substituir configuração wireless"
 
@@ -4418,7 +4420,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4501,7 +4503,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4513,7 +4515,7 @@ msgstr "Reset"
 msgid "Reset Counters"
 msgstr "Limpar contadores"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr ""
 
@@ -4525,7 +4527,7 @@ msgstr "Ficheiros Resolv e Hosts"
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4544,11 +4546,11 @@ msgstr "Reiniciar Firewall"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Restauração"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Restaurar backup"
 
@@ -4573,15 +4575,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4602,7 +4600,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Password do Router"
 
@@ -4624,20 +4622,20 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 "Correr uma verificação do sistema de ficheiros antes de montar um dispositivo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Correr uma verificação do sistema de ficheiros"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4646,7 +4644,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Acesso SSH"
 
@@ -4663,7 +4661,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "Chaves-SSH"
 
@@ -4674,30 +4672,31 @@ msgstr "Chaves-SSH"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Salvar"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salvar & Aplicar"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4706,7 +4705,7 @@ msgid "Scan"
 msgstr "Procurar"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Tarefas Agendadas"
 
@@ -4718,11 +4717,11 @@ msgstr "Secção adicionada"
 msgid "Section removed"
 msgstr "Secção removida"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4763,7 +4762,7 @@ msgstr "Tipo de Serviço"
 msgid "Services"
 msgstr "Serviços"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4771,10 +4770,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4804,6 +4807,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Mostrar lista ficheiros para backup"
@@ -4825,7 +4829,7 @@ msgstr "Desligar esta interface"
 msgid "Signal"
 msgstr "Sinal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4837,7 +4841,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Sinal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Tamanho"
 
@@ -4862,7 +4866,7 @@ msgstr "Ir para o conteúdo"
 msgid "Skip to navigation"
 msgstr "Ir para a navegação"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgstr "Lamento, o objecto que pediu não foi encontrado."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Lamento, o servidor encontrou um erro inesperado."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4896,7 +4900,7 @@ msgstr "Origem"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4935,7 +4939,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4958,7 +4962,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr ""
 
@@ -4978,7 +4982,7 @@ msgstr "Atribuições Estáticas"
 msgid "Static Routes"
 msgstr "Rotas Estáticas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5017,7 +5021,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Enviar"
 
@@ -5031,10 +5035,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -5055,7 +5055,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5148,6 +5148,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Terminar"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5167,17 +5171,13 @@ msgstr ""
 "O prefixo IPv6 atribuído ao provider, habitualmente termina com <code>::</"
 "code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Os caracteres permitidos são: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> e <code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5194,8 +5194,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5209,25 +5209,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"O sistema que foi usado para formatar a memória (<abbr title=\"por exemplo"
-"\">ex.</abbr> <samp><abbr title=\"Sistema de Arquivos ext3\">ext3</abbr></"
-"samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"A imagem foi carregada. Abaixo está o checksum e o tamanho dos ficheiros, "
-"compare com o ficheiro original para assegurar a integração de dados.<br /> "
-"Click em \"Proceder\" para iniciar o procedimento."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5247,11 +5238,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5272,7 +5263,7 @@ msgstr "O comprimento do prefixo IPv6 em bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5292,6 +5283,14 @@ msgstr ""
 "diferentes. Muitas vezes existe por defeito uma porta de Uplink  para uma "
 "ligação para a rede acima como a internet ou outras portas de uma rede local."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5300,7 +5299,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5308,7 +5307,7 @@ msgstr ""
 "O sistema está agora a limpar a partição de configuração e irá reiniciar-se "
 "quando terminar."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5321,11 +5320,32 @@ msgstr ""
 "da sua configuração, ode ser necessário renovar o endereço do seu computador "
 "para poder ligar novamente ao router."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5376,6 +5396,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5459,11 +5480,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Fuso Horário"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5473,7 +5494,7 @@ msgstr ""
 "de backup gerado anteriormente. Para voltar as definições originais do "
 "firmware, clique \" Fazer reset\" (só possível com imagens squashfs)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5513,7 +5534,7 @@ msgstr "Modo de Trigger"
 msgid "Tunnel ID"
 msgstr "ID do Túnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interface de Túnel"
@@ -5556,8 +5577,8 @@ msgstr "Dispositivo USB"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5587,6 +5608,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5598,6 +5623,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5606,28 +5632,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Não gerido"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5640,7 +5666,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Alterações não Guardadas"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5663,14 +5689,20 @@ msgstr "Tipo de protocolo não suportado."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Carregar arquivo..."
 
@@ -5683,7 +5715,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5741,11 +5779,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5753,7 +5791,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5816,7 +5854,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Usado"
 
@@ -5844,11 +5882,11 @@ msgstr ""
 msgid "Username"
 msgstr "Utilizador"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5895,9 +5933,9 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Verificar"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5917,7 +5955,7 @@ msgstr "Sistema Aberto WEP"
 msgid "WEP Shared Key"
 msgstr "Chave partilhada WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Palavra-Passe WEP"
 
@@ -5925,7 +5963,7 @@ msgstr "Palavra-Passe WEP"
 msgid "WMM Mode"
 msgstr "Modo WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Palavra-Passe WPA"
 
@@ -5989,13 +6027,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Rede Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adaptador Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6046,7 +6084,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6094,9 +6132,9 @@ msgstr ""
 msgid "any"
 msgstr "qualquer"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6114,7 +6152,7 @@ msgstr "estático"
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -6131,7 +6169,7 @@ msgid "create:"
 msgstr "criar:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "cria uma bridge sobre determinada(s) interface(s)"
 
@@ -6268,8 +6306,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "não"
 
@@ -6281,13 +6317,13 @@ msgstr "sem link"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "nenhum"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6317,10 +6353,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6339,7 +6371,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6353,15 +6385,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6579,14 +6611,63 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "sim"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s disponível)"
+
+#~ msgid "Check"
+#~ msgstr "Verificar"
+
+#~ msgid "Checksum"
+#~ msgstr "Checksum"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Ativar este mount"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Ativar esta swap"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Gravar Firmware"
+
+#~ msgid "Flashing..."
+#~ msgstr "A programar...."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Montar Entrada"
+
+#~ msgid "Proceed"
+#~ msgstr "Proceder"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Deseja mesmo limpar todas as alterações?"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "O sistema que foi usado para formatar a memória (<abbr title=\"por exemplo"
+#~ "\">ex.</abbr> <samp><abbr title=\"Sistema de Arquivos ext3\">ext3</abbr></"
+#~ "samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "A imagem foi carregada. Abaixo está o checksum e o tamanho dos ficheiros, "
+#~ "compare com o ficheiro original para assegurar a integração de dados.<br /"
+#~ "> Click em \"Proceder\" para iniciar o procedimento."
+
+#~ msgid "Verify"
+#~ msgstr "Verificar"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Especifica as portas de escuta desta instância <em>Dropbear</em>"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -12,7 +12,7 @@ msgstr ""
 "20)) ? 1 : 2);;\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -36,10 +36,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d fereastra minute, %d interval secunde)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s disponibil)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -80,15 +76,13 @@ msgstr "-- Te rog sa alegi --"
 msgid "-- custom --"
 msgstr "-- particularizat --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -206,7 +200,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Configurare"
 
@@ -251,23 +245,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -281,25 +275,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "ARP prag reincercare"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "Punti ATM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM Indentificator Canal Virtual (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM Indentificator Cale Virtual(VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -309,7 +303,7 @@ msgstr ""
 "virtuale de rețea Linux care pot fi utilizate în asociere cu DHCP sau PPP "
 "pentru a forma în rețeaua furnizorului."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "ATM numar echipament"
@@ -333,8 +327,7 @@ msgstr "Concentrator de Access "
 msgid "Access Point"
 msgstr "Punct de Acces"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Actiune"
 
@@ -360,7 +353,7 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -370,7 +363,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -381,7 +374,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Adauga"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -416,7 +409,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "Adauga un sufix local numelor servite din fisierele de tip hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Adauga interfata noua.."
 
@@ -460,19 +453,18 @@ msgid "Address to access local relay bridge"
 msgstr "Adresa de acces punte locala repetor"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administrare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Setari avansate"
 
@@ -484,7 +476,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -557,7 +549,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -567,76 +559,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -644,11 +636,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -658,6 +650,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Orice Zona"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -687,13 +683,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Statiile asociate"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -744,27 +744,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Disponibil"
 
@@ -782,11 +782,11 @@ msgstr "Disponibil"
 msgid "Average:"
 msgstr "Medie:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -810,14 +810,15 @@ msgstr "Inapoi la sumar"
 msgid "Back to configuration"
 msgstr "Inapoi la Configurare"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Salveaza"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Salveaza / Scrie Firmware"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Salveaza lista fisiere"
@@ -835,6 +836,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -866,17 +868,17 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Bogus NX Domain Override"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Punte"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Leaga interfetele"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Numarul unitatii in punte"
 
@@ -885,6 +887,7 @@ msgid "Bring up on boot"
 msgstr "Activeaza la pornire"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -912,11 +915,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Anuleaza"
 
@@ -924,12 +929,8 @@ msgstr "Anuleaza"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -963,28 +964,29 @@ msgstr "Schimba parola administratorului pentru accesarea dispozitivului"
 msgid "Channel"
 msgstr "Canal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Verificare"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Suma de verificare"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1009,19 +1011,19 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1056,7 +1058,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1071,7 +1073,7 @@ msgstr "Colectez datele.."
 msgid "Command"
 msgstr "Comanda"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1093,8 +1095,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Configurare"
 
@@ -1103,7 +1104,7 @@ msgstr "Configurare"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1115,7 +1116,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1135,7 +1136,7 @@ msgstr "Conectat"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1144,11 +1145,14 @@ msgid "Connections"
 msgstr "Conexiuni"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1168,11 +1172,11 @@ msgid "Country Code"
 msgstr "Codul de tara"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1201,7 +1205,7 @@ msgstr ""
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1234,7 +1238,7 @@ msgstr "Server DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP si DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1249,7 +1253,7 @@ msgstr "Optiuni DHCP"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1294,7 +1298,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1303,7 +1307,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1345,7 +1349,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1365,9 +1369,9 @@ msgid ""
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1428,10 +1432,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Dispozitiv"
 
@@ -1521,7 +1525,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1530,11 +1534,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1574,6 +1579,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1600,19 +1609,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Descarca backup"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1653,9 +1662,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1757,25 +1766,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Activeaza/Dezactiveaza"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Activat"
 
@@ -1797,8 +1798,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Modul de incapsulare"
 
@@ -1826,7 +1827,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Stergere..."
 
@@ -1848,12 +1849,12 @@ msgstr "Eroare"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptor de retea ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch-ul ethernet"
@@ -1951,9 +1952,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Sistem de fisiere"
 
@@ -1970,7 +1970,7 @@ msgstr "Filtreaza nefolositele"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2000,7 +2000,7 @@ msgstr "Setarile firewall-ului"
 msgid "Firewall Status"
 msgstr "Status la firewall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2012,24 +2012,26 @@ msgstr "Versiunea de firmware"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Portul sursa pentru intrebarile DNS catre exterior"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Rescrie firmware"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2057,11 +2059,11 @@ msgstr "Forteaza TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forteaza TKIP si CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2089,7 +2091,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2136,20 +2138,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Setari principale"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configurare generala"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2157,7 +2158,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr ""
 
@@ -2165,11 +2166,11 @@ msgstr ""
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Confirmarea parolei nu se potriveste cu prima, parola neschimbata !"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2180,7 +2181,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2230,7 +2231,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2422,7 +2423,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2509,14 +2510,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2555,7 +2556,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2576,7 +2577,7 @@ msgstr ""
 msgid "Ignore resolve file"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Imagine"
 
@@ -2636,8 +2637,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2721,11 +2722,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2741,7 +2742,7 @@ msgstr "Utilizator si/sau parola invalide! Incearcati din nou."
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2765,11 +2766,11 @@ msgstr ""
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Pastrati setarile"
 
@@ -2825,12 +2826,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Eticheta"
 
@@ -2985,7 +2986,7 @@ msgstr "Incarcare"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3092,7 +3093,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3125,7 +3126,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3139,7 +3140,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3155,7 +3156,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3214,7 +3216,7 @@ msgstr "Memorie"
 msgid "Memory usage (%)"
 msgstr "Utilizarea memoriei (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3222,7 +3224,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3281,7 +3283,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
@@ -3294,52 +3296,51 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr ""
 
@@ -3380,15 +3381,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Nume"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Numele interfetei noi"
 
@@ -3399,7 +3400,7 @@ msgstr "Navigare"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3424,7 +3425,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3449,7 +3450,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3502,7 +3503,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3560,7 +3561,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3633,6 +3634,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "Unul sau mai multe campuri nu contin valori !"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3712,7 +3714,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Optiuni"
 
@@ -3875,7 +3876,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3884,7 +3885,7 @@ msgid "Packets"
 msgstr "Pachete"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -3982,11 +3983,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Restarteaza"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Reseteaza"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4025,6 +4026,10 @@ msgstr "Packete."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Introdu utilizatorul si parola."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4093,10 +4098,6 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Continua"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4112,7 +4113,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4195,7 +4196,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4241,10 +4242,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4277,7 +4274,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Rebooteaza"
@@ -4285,6 +4282,11 @@ msgstr "Rebooteaza"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4339,7 +4341,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Elimina"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Inlocuieste configuratia wireless"
 
@@ -4351,7 +4353,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4434,7 +4436,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4446,7 +4448,7 @@ msgstr "Reset"
 msgid "Reset Counters"
 msgstr "Reseteaza counterii"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr ""
 
@@ -4458,7 +4460,7 @@ msgstr "Fisierele de rezolvare si hosturi DNS"
 msgid "Resolve file"
 msgstr "Fisierul de rezolvare"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4477,11 +4479,11 @@ msgstr "Restarteaza firewallul"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Restaureaza"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Reface backup-ul"
 
@@ -4506,15 +4508,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4535,7 +4533,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Parola routerului"
 
@@ -4555,19 +4553,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4576,7 +4574,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Acces SSH"
 
@@ -4593,7 +4591,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "Cheile SSH"
 
@@ -4604,30 +4602,31 @@ msgstr "Cheile SSH"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Salveaza"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salveaza si aplica"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4636,7 +4635,7 @@ msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Operatiuni programate"
 
@@ -4648,11 +4647,11 @@ msgstr "Sectiune adaugata"
 msgid "Section removed"
 msgstr "Sectiune eliminata"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4693,7 +4692,7 @@ msgstr "Tip de serviciu"
 msgid "Services"
 msgstr "Servicii"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4701,10 +4700,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4734,6 +4737,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4755,7 +4759,7 @@ msgstr "Opreste aceasta interfata"
 msgid "Signal"
 msgstr "Semnal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4767,7 +4771,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Semnal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Marime"
 
@@ -4792,7 +4796,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4809,7 +4813,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4826,7 +4830,7 @@ msgstr "Sursa"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4865,7 +4869,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4888,7 +4892,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Pornire"
 
@@ -4908,7 +4912,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr "Rute statice"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4947,7 +4951,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Trimite"
 
@@ -4961,10 +4965,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -4985,7 +4985,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5078,6 +5078,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Termina"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5095,14 +5099,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5120,8 +5120,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5133,17 +5133,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5165,11 +5162,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5189,7 +5186,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5203,6 +5200,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5211,13 +5216,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5225,11 +5230,32 @@ msgid ""
 "settings."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5278,6 +5304,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5356,18 +5383,18 @@ msgstr ""
 msgid "Timezone"
 msgstr "Fusul orar"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
 "reset\" (only possible with squashfs images)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5407,7 +5434,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interfata de tunel"
@@ -5450,8 +5477,8 @@ msgstr "Dispozitiv USB"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5481,6 +5508,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5492,6 +5523,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5500,28 +5532,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Necunoscut"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Neadministrate"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5534,7 +5566,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Modificari nesalvate"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5557,14 +5589,20 @@ msgstr "Tipul de protocol neacceptat."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5577,7 +5615,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5635,11 +5679,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5647,7 +5691,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5710,7 +5754,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Folosit"
 
@@ -5738,11 +5782,11 @@ msgstr ""
 msgid "Username"
 msgstr "Utilizator"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5789,8 +5833,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5811,7 +5855,7 @@ msgstr "Sistem deschis WEP"
 msgid "WEP Shared Key"
 msgstr "Sistem de cheie impartasita WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Parola WEP"
 
@@ -5819,7 +5863,7 @@ msgstr "Parola WEP"
 msgid "WMM Mode"
 msgstr "Mod WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Parola WPA"
 
@@ -5883,13 +5927,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adaptorul wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5940,7 +5984,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -5981,9 +6025,9 @@ msgstr ""
 msgid "any"
 msgstr "oricare"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6000,7 +6044,7 @@ msgstr ""
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -6017,7 +6061,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr ""
 
@@ -6151,8 +6195,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "nu"
 
@@ -6164,13 +6206,13 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6200,10 +6242,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6222,7 +6260,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "rutat"
 
@@ -6236,15 +6274,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6462,14 +6500,27 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "da"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Inapoi"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s disponibil)"
+
+#~ msgid "Check"
+#~ msgstr "Verificare"
+
+#~ msgid "Checksum"
+#~ msgstr "Suma de verificare"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Rescrie firmware"
+
+#~ msgid "Proceed"
+#~ msgstr "Continua"
 
 #~ msgid "Antenna 1"
 #~ msgstr "Antena 1"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -15,7 +15,7 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr "%.1f дБ"
 
@@ -39,10 +39,6 @@ msgstr "%s не тегирован в множестве VLAN!"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d минутное окно, %d секундный интервал)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s доступно)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -83,15 +79,13 @@ msgstr "-- Сделайте выбор --"
 msgid "-- custom --"
 msgstr "-- пользовательский --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- проверка по устройству --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- проверка по метке --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- проверка по uuid --"
 
@@ -211,7 +205,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-суффикс (hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Настройка <abbr title=\"Светодиод\">LED</abbr> индикации"
 
@@ -261,23 +255,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr "Директория с таким же именем уже существует."
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr "Время сессии истекло, требуется повторная аутентификация."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr "A43C + J43 + A43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr "A43C + J43 + A43 + V43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr "ADSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr "ANSI T1.413"
 
@@ -291,25 +285,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "Порог повтора ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr "ATM (режим асинхронной передачи)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM мосты"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM идентификатор виртуального канала (VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM идентификатор виртуального пути (VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -319,7 +313,7 @@ msgstr ""
 "как виртуальные сетевые интерфейсы Linux, которые могут использоваться "
 "совместно с DHCP или PPP для набора номера в сети провайдера."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "ATM номер устройства"
@@ -343,8 +337,7 @@ msgstr "Концентратор доступа"
 msgid "Access Point"
 msgstr "Точка доступа"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Действия"
 
@@ -372,7 +365,7 @@ msgstr "Активные DHCP аренды"
 msgid "Active DHCPv6 Leases"
 msgstr "Активные DHCPv6 аренды"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -382,7 +375,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -393,7 +386,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Добавить"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr "Добавить ATM мост"
 
@@ -429,7 +422,7 @@ msgstr ""
 "Добавить локальный суффикс домена для имен из файла хостов (/etc/hosts)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Добавить новый интерфейс..."
 
@@ -473,19 +466,18 @@ msgid "Address to access local relay bridge"
 msgstr "Адрес для доступа к локальному мосту-ретранслятору"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Управление"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Дополнительные настройки"
 
@@ -497,7 +489,7 @@ msgstr "Aggregate Transmit Power (ACTATP)"
 msgid "Alert"
 msgstr "Тревога"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -578,7 +570,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr "Разрешенные IP-адреса"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr "Объявлять всегда, как маршрутизатор по умолчанию"
 
@@ -590,78 +582,78 @@ msgstr ""
 "Всегда использовать каналы 40 МГц, даже если вторичный канал перекрывается. "
 "Использование этой опции не соответствует стандарту IEEE 802.11n-2009!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr "Annex"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr "Annex A + L + M (all)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr "Annex A G.992.1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr "Annex A G.992.2"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr "Annex A G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr "Annex A G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr "Annex B (all)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr "Annex B G.992.1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr "Annex B G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr "Annex B G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr "Annex J (all)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr "Annex L G.992.3 POTS 1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr "Annex M (all)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr "Annex M G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr "Annex M G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 "Объявить маршрутизатором по умолчанию, даже если общедоступный префикс "
 "недоступен."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr "Объявить DNS домены"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr "Объявить DNS сервера"
 
@@ -669,11 +661,11 @@ msgstr "Объявить DNS сервера"
 msgid "Anonymous Identity"
 msgstr "Анонимная идентификация"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "Неизвестный раздел"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "Неизвестный swap"
 
@@ -683,6 +675,10 @@ msgstr "Неизвестный swap"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Любая зона"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -715,7 +711,7 @@ msgstr ""
 "Назначьте префикс части, используя этот шестнадцатеричный ID вложенного "
 "исправления для этого интерфейса."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Подключенные клиенты"
@@ -723,6 +719,10 @@ msgstr "Подключенные клиенты"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "Ассоциации"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -772,33 +772,33 @@ msgstr "Автоматически"
 msgid "Automatic Homenet (HNCP)"
 msgstr "Автоматическая Homenet (HNCP)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 "Автоматическая проверка файловой системы раздела на ошибки, перед "
 "монтированием"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 "Автоматическое монтирование раздела, при подключении к системе во время её "
 "работы, без выключения питания и остановки системы (hotplug)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 "Автоматическое монтирование раздела подкачки при подключении к системе во "
 "время её работы без выключения питания и остановки системы (hotplug)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "Hotplug раздела"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "Hotplug раздела подкачки"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Доступно"
 
@@ -816,11 +816,11 @@ msgstr "Доступно"
 msgid "Average:"
 msgstr "Средняя:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr "B43 + B43C"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr "B43 + B43C + V43"
 
@@ -844,14 +844,15 @@ msgstr "Назад к обзору"
 msgid "Back to configuration"
 msgstr "Назад к настройкам"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Резервное копирование"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Резервное копирование / Перепрошивка"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Список файлов для резервного копирования"
@@ -869,6 +870,7 @@ msgstr "Диапазон"
 msgid "Beacon Interval"
 msgstr "Интервал рассылки пакетов Beacon"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -905,17 +907,17 @@ msgstr "Скорость"
 msgid "Bogus NX Domain Override"
 msgstr "Переопределение поддельного NX-домена"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Мост"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Объединить в мост"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Номер моста"
 
@@ -924,6 +926,7 @@ msgid "Bring up on boot"
 msgstr "Запустить при загрузке"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr "Обзор..."
 
@@ -952,11 +955,13 @@ msgstr "Ошибка вызова"
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Отменить"
 
@@ -964,13 +969,9 @@ msgstr "Отменить"
 msgid "Category"
 msgstr "Категория"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
 msgstr "Внимание: файлы конфигурации будут удалены"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
-msgstr "Внимание: выбрано принудительное обновление системы"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
@@ -1003,30 +1004,31 @@ msgstr "Изменить пароль администратора для дос
 msgid "Channel"
 msgstr "Канал"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Проверить"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "Проверка файловых систем перед монтированием"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 "Проверьте эту опцию, чтобы удалить существующие сети беспроводного "
 "устройства."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Контрольная сумма"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr "Выберите MTD раздел"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1055,7 +1057,7 @@ msgstr "Алгоритм шифрования"
 msgid "Cisco UDP encapsulation"
 msgstr "Формирование пакетов данных Cisco UDP "
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1063,7 +1065,7 @@ msgstr ""
 "Нажмите 'Создать архив', чтобы загрузить tar-архив текущих config файлов "
 "прошивки устройства, таким образом вы сохраните его настройки."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
@@ -1071,7 +1073,7 @@ msgstr ""
 "Нажмите \"Сохранить MTD раздел\" для скачивания образа указанного MTD "
 "раздела (ВНИМАНИЕ: ДАННЫЙ ФУНКЦИОНАЛ ТОЛЬКО ДЛЯ ОПЫТНЫХ ПОЛЬЗОВАТЕЛЕЙ)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1108,7 +1110,7 @@ msgstr "Закрыть список..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1123,7 +1125,7 @@ msgstr "Сбор данных..."
 msgid "Command"
 msgstr "Команда"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr "Успешное выполнение"
 
@@ -1149,8 +1151,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Настройка config файла"
 
@@ -1159,7 +1160,7 @@ msgstr "Настройка config файла"
 msgid "Configuration failed"
 msgstr "Ошибка конфигурации"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr "Конфигурационные файлы будут сохранены"
 
@@ -1171,7 +1172,7 @@ msgstr "Конфигурация применена"
 msgid "Configuration has been rolled back!"
 msgstr "Конфигурация возвращена назад!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr "Подтверждение отключения"
 
@@ -1191,7 +1192,7 @@ msgstr "Подключен"
 msgid "Connection attempt failed"
 msgstr "Ошибка попытки соединения"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr "Подключение потеряно"
 
@@ -1200,11 +1201,14 @@ msgid "Connections"
 msgstr "Соединения"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr "Продолжить"
 
@@ -1227,11 +1231,11 @@ msgid "Country Code"
 msgstr "Код страны"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Создать / назначить зону сетевого экрана"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr "Создать интерфейс"
 
@@ -1260,7 +1264,7 @@ msgstr "Пользовательский интерфейс"
 msgid "Custom delegated IPv6-prefix"
 msgstr "Установленный пользователем IPv6-prefix"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1297,7 +1301,7 @@ msgstr "DHCP-сервер"
 msgid "DHCP and DNS"
 msgstr "DHCP и DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1312,7 +1316,7 @@ msgstr "DHCP настройки"
 msgid "DHCPv6 client"
 msgstr "DHCPv6 клиент"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "DHCPv6 режим"
 
@@ -1357,7 +1361,7 @@ msgstr "DPD время простоя"
 msgid "DS-Lite AFTR address"
 msgstr "DS-Lite AFTR-адрес"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr "DSL"
@@ -1366,7 +1370,7 @@ msgstr "DSL"
 msgid "DSL Status"
 msgstr "Состояние DSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr "DSL линейный режим"
 
@@ -1408,7 +1412,7 @@ msgstr "Маршрут по умолчанию"
 msgid "Default gateway"
 msgstr "Шлюз по умолчанию"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr "Значение по умолчанию — 'stateless + stateful'"
 
@@ -1431,9 +1435,9 @@ msgstr ""
 "серверах."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1494,10 +1498,10 @@ msgstr "Зона назначения"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Устройство"
 
@@ -1587,7 +1591,7 @@ msgstr "Отбрасывать ответы внешней сети RFC1918"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr "Отключить"
 
@@ -1596,11 +1600,12 @@ msgstr "Отключить"
 msgid "Disconnection attempt failed"
 msgstr "Ошибка попытки отключения"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "Отклонить"
 
@@ -1646,6 +1651,10 @@ msgstr "Вы действительно хотите удалить «%s»?"
 msgid "Do you really want to delete the following SSH key?"
 msgstr "Вы действительно хотите удалить следующий SSH ключ?"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Вы действительно хотите рекурсивно удалить директорию «%s»?"
@@ -1674,19 +1683,19 @@ msgstr ""
 msgid "Down"
 msgstr "Вниз"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Загрузить резервную копию"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr "Скачать MTD раздел"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr "SNR offset внутренней сети"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr "Перетащите, чтобы изменить порядок"
 
@@ -1732,9 +1741,9 @@ msgstr "EA-bits длина"
 msgid "EAP-Method"
 msgstr "Метод EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1840,25 +1849,17 @@ msgstr "Включить отражение исходящих пакетов"
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr "Включите флаг DF (не Фрагментировать) инкапсулирующих пакетов."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Включить эту точку монтирования"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Включить данную сеть"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Включить этот раздел подкачки"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Включить/выключить"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Включено"
 
@@ -1882,8 +1883,8 @@ msgstr "Включает Spanning Tree Protocol на этом мосту"
 msgid "Encapsulation limit"
 msgstr "Предел инкапсуляции"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Режим инкапсуляции"
 
@@ -1911,7 +1912,7 @@ msgstr "Введите пользовательское значение"
 msgid "Enter custom values"
 msgstr "Введите пользовательские значения"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Стирание..."
 
@@ -1933,12 +1934,12 @@ msgstr "Ошибка"
 msgid "Errored seconds (ES)"
 msgstr "Ошибочные секунды (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet-адаптер"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet-коммутатор"
@@ -2039,9 +2040,8 @@ msgstr "Имя файла"
 msgid "Filename of the boot image advertised to clients"
 msgstr "Имя загрузочного образа, извещаемого клиентам"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Файловая система"
 
@@ -2058,7 +2058,7 @@ msgstr "Фильтровать бесполезные"
 msgid "Finalizing failed"
 msgstr "Ошибка финализации"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2091,7 +2091,7 @@ msgstr "Настройки межсетевого экрана"
 msgid "Firewall Status"
 msgstr "Состояние межсетевого экрана"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr "Файл прошивки"
 
@@ -2103,25 +2103,27 @@ msgstr "Версия прошивки"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Фиксированный порт для исходящих DNS-запросов"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Установить прошивку"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Установить..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Установить новый образ прошивки"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Операции с прошивкой"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Прошивка..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2147,11 +2149,11 @@ msgstr "Назначить TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Назначить TKIP и CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "Активировать соединение"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr "Принудительная прошивка"
 
@@ -2179,7 +2181,7 @@ msgstr "Перенаправлять широковещательный траф
 msgid "Forward mesh peer traffic"
 msgstr "Перенаправлять запросы трафика Mesh"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Режим перенаправления"
 
@@ -2228,20 +2230,19 @@ msgstr "Неверный адрес шлюза"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Основные настройки"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Основные настройки"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "Создать config"
 
@@ -2249,7 +2250,7 @@ msgstr "Создать config"
 msgid "Generate PMK locally"
 msgstr "Создать PMK локально"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Создать архив"
 
@@ -2257,11 +2258,11 @@ msgstr "Создать архив"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Введённые пароли не совпадают, пароль не изменён!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "Основные настройки"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "Основные настройки сети"
 
@@ -2272,7 +2273,7 @@ msgstr "Основные настройки сети"
 msgid "Go to password configuration..."
 msgstr "Перейти к настройке пароля..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2322,7 +2323,7 @@ msgstr "Скрыть пустые цепочки"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "Хост"
 
@@ -2514,7 +2515,7 @@ msgstr "IPv6 соседи (neighbours)"
 msgid "IPv6 Settings"
 msgstr "Настройки IPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr "IPv6 ULA-префикс"
 
@@ -2601,16 +2602,16 @@ msgstr "Если выбрано, то 1DES включено"
 msgid "If checked, encryption is disabled"
 msgstr "Если выбрано, то шифрование выключено"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Если выбрано, монтировать устройство используя его UUID, а не фиксированный "
 "файл устройства"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2651,7 +2652,7 @@ msgstr "Если не выбрано, то маршрут по умолчани�
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "Если не выбрано, то извещаемые адреса DNS серверов игнорируются"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2678,7 +2679,7 @@ msgstr "Игнорировать интерфейс"
 msgid "Ignore resolve file"
 msgstr "Игнорировать файл resolv"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Образ"
 
@@ -2741,8 +2742,8 @@ msgstr "Установить расширения протокола..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2828,11 +2829,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "Указан неверный VLAN ID! Доступны только уникальные ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr "Неверный аргумент"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr "Неверная команда"
 
@@ -2848,7 +2849,7 @@ msgstr "Неверный логин и/или пароль! Попробуйте
 msgid "Isolate Clients"
 msgstr "Изолировать клиентов"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2871,11 +2872,11 @@ msgstr "Подключение к сети"
 msgid "Join Network: Wireless Scan"
 msgstr "Найденные точки доступа Wi-Fi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "Подключение к сети: %q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Сохранить настройки"
 
@@ -2931,12 +2932,12 @@ msgstr "Порог ошибок эхо-запросов LCP"
 msgid "LCP echo interval"
 msgstr "Интервал эхо-запросов LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Метка"
 
@@ -3105,7 +3106,7 @@ msgstr "Загрузка"
 msgid "Loading directory contents…"
 msgstr "Загрузка содержимого директории..."
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr "Загрузка страницы..."
@@ -3219,7 +3220,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3252,7 +3253,7 @@ msgstr "Неверное MAP правило"
 msgid "MB/s"
 msgstr "МБ/с"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr "MD5"
 
@@ -3266,7 +3267,7 @@ msgstr "МГц"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3284,7 +3285,8 @@ msgstr ""
 msgid "Manual"
 msgstr "Вручную"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr "Мастер"
 
@@ -3343,7 +3345,7 @@ msgstr "Оперативная память (RAM)"
 msgid "Memory usage (%)"
 msgstr "Использование памяти (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3351,7 +3353,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr "Mesh ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr "Метод не найден"
 
@@ -3410,7 +3412,7 @@ msgstr "Ошибка запроса информации о модеме"
 msgid "Modem init timeout"
 msgstr "Время ожидания инициализации модема"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Монитор"
@@ -3423,30 +3425,25 @@ msgstr "Слишком мало символов"
 msgid "More…"
 msgstr "Больше..."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Настройка config файла fstab (/etc/config/fstab)"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Точка монтирования"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Монтирование разделов"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Точки монтирования — Настройка раздела"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Точки монтирования — Настройка раздела подкачки"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3454,23 +3451,27 @@ msgstr ""
 "Точки монтирования определяют, куда в файловой системе будут смонтированы "
 "разделы запоминающего устройства"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr "Монтирование не сконфигурированного раздела"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Опции монтирования"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Точка монтирования"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "Монтирование не сконфигурированного раздела подкачки"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Смонтированные разделы"
 
@@ -3511,15 +3512,15 @@ msgstr "NT домен"
 msgid "NTP server candidates"
 msgstr "Список NTP-серверов"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Имя"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Имя новой сети"
 
@@ -3530,7 +3531,7 @@ msgstr "Навигация"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3555,7 +3556,7 @@ msgstr "Нет сетевого устройства"
 msgid "Network without interfaces."
 msgstr "Сеть без интерфейсов."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr "Новое имя интерфейса..."
 
@@ -3580,7 +3581,7 @@ msgstr "Без шифрования"
 msgid "No NAT-T"
 msgstr "Без NAT-T"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr "Данные не получены"
 
@@ -3633,7 +3634,7 @@ msgid "No signal"
 msgstr "Нет сигнала"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Зона не присвоена"
 
@@ -3691,7 +3692,7 @@ msgstr "Не существует"
 msgid "Not started on boot"
 msgstr "Не запускается при загрузке"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr "Не поддерживается"
 
@@ -3766,6 +3767,7 @@ msgstr "Одно или несколько недопустимых / обяза
 msgid "One or more required fields have no value!"
 msgstr "Одно или несколько обязательных полей не заполнены!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Открыть список..."
@@ -3859,7 +3861,6 @@ msgstr ""
 "Необязательно. Udp-порт, используемый для исходящих и входящих пакетов."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Опции"
 
@@ -4024,7 +4025,7 @@ msgstr "PSID смещение"
 msgid "PSID-bits length"
 msgstr "PSID длина в битах"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM (Packet Transfer Mode)"
 
@@ -4033,7 +4034,7 @@ msgid "Packets"
 msgstr "Пакеты"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Часть зоны %q"
 
@@ -4131,11 +4132,11 @@ msgstr "Perfect Forward Secrecy"
 msgid "Perform reboot"
 msgstr "Выполнить перезагрузку"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Выполнить сброс"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr "Доступ запрещён"
 
@@ -4174,6 +4175,10 @@ msgstr "Пакетов"
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Введите логин и пароль."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4244,10 +4249,6 @@ msgstr "Не позволяет клиентам обмениваться дру
 msgid "Private Key"
 msgstr "Приватный ключ"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Продолжить"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4263,7 +4264,7 @@ msgstr "Прот."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4354,7 +4355,7 @@ msgstr "Получение (RX)"
 msgid "RX Rate"
 msgstr "Скорость получения"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr "Скорость получения / Скорость отправки"
 
@@ -4405,10 +4406,6 @@ msgstr ""
 "можете потерять доступ к этому устройству, если вы подключены через данный "
 "интерфейс"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Действительно сбросить все изменения?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Вы действительно хотите изменить протокол?"
@@ -4441,7 +4438,7 @@ msgstr "Срок реассоциации"
 msgid "Rebind protection"
 msgstr "Защита от DNS Rebinding"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Перезагрузка"
@@ -4450,6 +4447,11 @@ msgstr "Перезагрузка"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Перезагрузка..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4504,7 +4506,7 @@ msgstr "Удалённый IPv4-адрес или FQDN"
 msgid "Remove"
 msgstr "Удалить"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Заменить настройку беспроводного соединения"
 
@@ -4516,7 +4518,7 @@ msgstr "Запрос IPv6 адреса"
 msgid "Request IPv6-prefix of length"
 msgstr "Запрос IPv6 префикс длины"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr "Таймаут запроса"
 
@@ -4606,7 +4608,7 @@ msgstr "Требуется wpa-supplicant с поддержкой OWE"
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "Требуется wpa-supplicant с поддержкой SAE"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4618,7 +4620,7 @@ msgstr "Сбросить"
 msgid "Reset Counters"
 msgstr "Сбросить счётчики"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Сбросить на значения по умолчанию"
 
@@ -4630,7 +4632,7 @@ msgstr "Файлы resolv и hosts"
 msgid "Resolve file"
 msgstr "Файл resolv"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr "Ресурс не найден"
 
@@ -4649,11 +4651,11 @@ msgstr "Перезапустить межсетевой экран"
 msgid "Restart radio interface"
 msgstr "Перезапустить радио-интерфейс"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Восстановление"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Восстановить резервную копию"
 
@@ -4678,15 +4680,11 @@ msgstr "Ошибка <code>%h</code> отмены конфигурации"
 msgid "Reverting configuration…"
 msgstr "Отмена конфигурации..."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Корень"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Корневая директория для файлов сервера, вроде TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr "Подготовка корневой директории"
 
@@ -4707,7 +4705,7 @@ msgid "Router Advertisement-Service"
 msgstr "Доступные режимы работы"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Пароль маршрутизатора"
 
@@ -4729,19 +4727,19 @@ msgstr ""
 msgid "Rule"
 msgstr "Правило"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Проверять файловую систему перед монтированием раздела"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Проверить"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr "Ошибка исполнения"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr "SHA256"
 
@@ -4750,7 +4748,7 @@ msgid "SNR"
 msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "Доступ по SSH"
 
@@ -4767,7 +4765,7 @@ msgid "SSH username"
 msgstr "SSH логин"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH ключи"
 
@@ -4778,30 +4776,31 @@ msgstr "SSH ключи"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr "Разделы подкачки (swap)"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Сохранить"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Сохранить и применить"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr "Сохранить MTD раздел"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr "Сохранить содержимое MTD раздела"
 
@@ -4810,7 +4809,7 @@ msgid "Scan"
 msgstr "Поиск"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Запланированные задания"
 
@@ -4822,11 +4821,11 @@ msgstr "Строки добавлены"
 msgid "Section removed"
 msgstr "Строки удалены"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Для подробной информации обратитесь к справке по 'mount' (man mount)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4872,7 +4871,7 @@ msgstr "Тип службы"
 msgid "Services"
 msgstr "Сервисы"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr "Сессия истекла"
 
@@ -4880,12 +4879,16 @@ msgstr "Сессия истекла"
 msgid "Set VPN as Default Route"
 msgstr "Установить VPN в качестве маршрута по умолчанию"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
 msgstr ""
 "Автоматически активировать соединение, при подключении в разъем кабеля."
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
+msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 #: protocols/luci-proto-qmi/luasrc/model/network/proto_qmi.lua:55
@@ -4914,6 +4917,7 @@ msgstr "Short GI"
 msgid "Short Preamble"
 msgstr "Короткая преамбула"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Показать текущий список файлов резервной копии"
@@ -4935,7 +4939,7 @@ msgstr "Выключить этот интерфейс"
 msgid "Signal"
 msgstr "Сигнал"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr "Сигнал / шум"
 
@@ -4947,7 +4951,7 @@ msgstr "Затухание сигнала (SATN)"
 msgid "Signal:"
 msgstr "Сигнал:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Размер"
 
@@ -4972,7 +4976,7 @@ msgstr "Перейти к содержимому"
 msgid "Skip to navigation"
 msgstr "Перейти к навигации"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Программное обеспечение VLAN"
@@ -4989,7 +4993,7 @@ msgstr "Извините, запрошенный объект не был най
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Извините, сервер столкнулся с неожиданной ошибкой."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -5009,7 +5013,7 @@ msgstr "Источник"
 msgid "Source Address"
 msgstr "Адрес источника"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Папка, к которой монтируется раздел устройства"
 
@@ -5059,7 +5063,7 @@ msgstr ""
 "Укажите MTU (Максимальный Объем Данных), отличный от стандартного (1280 "
 "байт)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Укажите закрытый ключ."
 
@@ -5082,7 +5086,7 @@ msgid "Starting wireless scan..."
 msgstr "Начато сканирование беспроводных сетей..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Загрузка"
 
@@ -5102,7 +5106,7 @@ msgstr "Постоянные аренды"
 msgid "Static Routes"
 msgstr "Статические маршруты"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5144,7 +5148,7 @@ msgid "Strong"
 msgstr "Сильная"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Применить"
 
@@ -5159,10 +5163,6 @@ msgstr "Подавить логирование стандартной рабо�
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "Раздел подкачки (swap)"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Настройка config файла fstab (/etc/config/fstab)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5184,7 +5184,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Изменить маску порта"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Изменить VLAN"
@@ -5277,6 +5277,10 @@ msgstr "Сеть назначения"
 msgid "Terminate"
 msgstr "Завершить"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5297,17 +5301,13 @@ msgid ""
 msgstr ""
 "Назначенный провайдеру префикс IPv6, обычно заканчивается на <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Допустимые символы: <code>A-Z</code>, <code>a-z</code>, <code>0-9</code> и "
 "<code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr "Архив резервной копии не является правильным gzip файлом."
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5330,8 +5330,8 @@ msgstr ""
 "попыткой применить конфигурацию снова или откатить все изменения, чтобы "
 "сохранить рабочее состояние конфигурации."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5347,24 +5347,16 @@ msgstr ""
 "Для правильной работы LuCI необходимо изменить существующую конфигурацию "
 "беспроводной связи."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"Файловая система (<abbr title=\"например\">напр.</abbr> <samp><abbr title="
-"\"Third Extended Filesystem\">ext3</abbr></samp>)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Образ загружен. Сравните размер файла и контрольную сумму, чтобы "
-"удостовериться в целостности данных.<br /> Нажмите 'Продолжить', чтобы "
-"начать процедуру обновления прошивки."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5385,11 +5377,11 @@ msgid ""
 msgstr ""
 "Указанный публичный SSH ключ неверный. Укажите правильный RSA или ECDSA ключ."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr "Имя интерфейса уже используется"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr "Имя интерфейса слишком длинное"
 
@@ -5410,7 +5402,7 @@ msgstr "Длина префикса IPv6 в битах"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "Локальный адрес IPv4, по которому создается туннель (необязательно)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr "Имя сети уже используется"
 
@@ -5431,6 +5423,14 @@ msgstr ""
 "внешней сети, например к Интернету и другие порты предназначенные для "
 "внутренней — локальной сети."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr "Выбранный режим %s несовместим с шифрованием %s"
@@ -5439,13 +5439,13 @@ msgstr "Выбранный режим %s несовместим с шифров�
 msgid "The submitted security token is invalid or already expired!"
 msgstr "Представленный маркер безопасности недействителен или уже истек!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "Идёт удаление настроек раздела с последующей перезагрузкой системы."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5457,11 +5457,32 @@ msgstr ""
 "потребуется обновить адрес компьютера, чтобы снова подключиться к "
 "устройству, в зависимости от настроек."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "Пароль администратора успешно изменен."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5515,6 +5536,7 @@ msgstr ""
 "code> или <code>server=1.2.3.4</code> для каждого отдельного домена или "
 "общий <abbr title=\"англ. Domain Name System\">DNS</abbr> сервер."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5609,11 +5631,11 @@ msgstr "Интервал регенерации ключей GTK"
 msgid "Timezone"
 msgstr "Часовой пояс"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr "Аутентификация..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5624,7 +5646,7 @@ msgstr ""
 "прошивки к исходному состоянию нажмите 'Выполнить сброс' (возможно только "
 "для squashfs-образов)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr "Тон"
 
@@ -5664,7 +5686,7 @@ msgstr "Режим работы"
 msgid "Tunnel ID"
 msgstr "Идентификатор туннеля"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Интерфейс туннеля"
@@ -5707,8 +5729,8 @@ msgstr "USB устройство"
 msgid "USB Ports"
 msgstr "USB порты"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5738,6 +5760,10 @@ msgstr "Невозможно обработать запрос для"
 msgid "Unable to obtain client ID"
 msgstr "Невозможно получить идентификатор клиента"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5749,6 +5775,7 @@ msgid "Unable to resolve peer host name"
 msgstr "Не удалось разрешить имя хоста пира"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5757,28 +5784,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Секунды неготовности (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Неизвестная ошибка (%s)"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr "Неизвестный код ошибки"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Неуправляемый"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "Отмонтировать"
 
@@ -5791,7 +5818,7 @@ msgstr "Ключ без имени"
 msgid "Unsaved Changes"
 msgstr "Не принятые изменения"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr "Неопознанная ошибка"
 
@@ -5814,7 +5841,11 @@ msgstr "Не поддерживаемый тип протокола."
 msgid "Up"
 msgstr "Вверх"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5825,7 +5856,9 @@ msgstr ""
 "config файлы — ваши настройки устройства (требуется совместимый образ "
 "прошивки)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Загрузка архива..."
 
@@ -5838,8 +5871,14 @@ msgid "Upload file…"
 msgstr "Загрузка файла..."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
 msgstr "Ошибка запроса на загрузку: %d %s"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
 msgid ""
@@ -5899,11 +5938,11 @@ msgstr "Использовать MTU на интерфейсе туннеля"
 msgid "Use TTL on tunnel interface"
 msgstr "Использовать TTL на интерфейсе туннеля"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr "Использовать как внешний overlay (/overlay)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "Использовать как корень (/)"
 
@@ -5911,7 +5950,7 @@ msgstr "Использовать как корень (/)"
 msgid "Use broadcast flag"
 msgstr "Использовать широковещательный флаг"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "Использовать встроенный IPv6-менеджмент"
 
@@ -5980,7 +6019,7 @@ msgstr ""
 "адреса'</em> может быть использовано для того, чтобы установить "
 "индивидуальное время аренды, например 12h, 3d или бесконечное."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Использовано"
 
@@ -6010,11 +6049,11 @@ msgstr "Ключ пользователя (PEM encoded)"
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr "VDSL"
 
@@ -6062,9 +6101,9 @@ msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 "Класс производителя (Vendor class), который отправлять при DHCP-запросах"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Проверить"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -6084,7 +6123,7 @@ msgstr "Открытая система WEP"
 msgid "WEP Shared Key"
 msgstr "Общий ключ WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Пароль WEP"
 
@@ -6092,7 +6131,7 @@ msgstr "Пароль WEP"
 msgid "WMM Mode"
 msgstr "Режим WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Пароль WPA"
 
@@ -6161,13 +6200,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "Wi-Fi"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Беспроводной адаптер"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6218,7 +6257,7 @@ msgstr "Записывать системные события в файл"
 msgid "Yes"
 msgstr "Да"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6267,9 +6306,9 @@ msgstr "Размер ZRam"
 msgid "any"
 msgstr "любой"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6286,7 +6325,7 @@ msgstr "автоматически"
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "соед. мостом"
 
@@ -6303,7 +6342,7 @@ msgid "create:"
 msgstr "создать:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "Создаёт мост для выбранных сетевых интерфейсов"
 
@@ -6439,8 +6478,6 @@ msgstr "минут(ы)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "нет"
 
@@ -6452,13 +6489,13 @@ msgstr "нет соединения"
 msgid "non-empty value"
 msgstr "не пустое значение"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "нет"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "не существует"
 
@@ -6488,10 +6525,6 @@ msgstr ""
 msgid "output"
 msgstr "вывод"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr "overlay"
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr "положительное десятичное число"
@@ -6510,7 +6543,7 @@ msgstr "случайно"
 msgid "relay mode"
 msgstr "режим передачи"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "маршрутизируемый"
 
@@ -6524,15 +6557,15 @@ msgstr "секунды"
 msgid "server mode"
 msgstr "режим сервера"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr "stateful-only"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr "stateless"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr "stateless + stateful"
 
@@ -6750,14 +6783,80 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "да"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s доступно)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- проверка по устройству --"
+
+#~ msgid "Caution: System upgrade will be forced"
+#~ msgstr "Внимание: выбрано принудительное обновление системы"
+
+#~ msgid "Check"
+#~ msgstr "Проверить"
+
+#~ msgid "Checksum"
+#~ msgstr "Контрольная сумма"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Включить эту точку монтирования"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Включить этот раздел подкачки"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Установить прошивку"
+
+#~ msgid "Flashing..."
+#~ msgstr "Прошивка..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Настройка config файла fstab (/etc/config/fstab)"
+
+#~ msgid "Proceed"
+#~ msgstr "Продолжить"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Действительно сбросить все изменения?"
+
+#~ msgid "Root"
+#~ msgstr "Корень"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Настройка config файла fstab (/etc/config/fstab)"
+
+#~ msgid "The backup archive does not appear to be a valid gzip file."
+#~ msgstr "Архив резервной копии не является правильным gzip файлом."
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "Файловая система (<abbr title=\"например\">напр.</abbr> <samp><abbr title="
+#~ "\"Third Extended Filesystem\">ext3</abbr></samp>)."
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Образ загружен. Сравните размер файла и контрольную сумму, чтобы "
+#~ "удостовериться в целостности данных.<br /> Нажмите 'Продолжить', чтобы "
+#~ "начать процедуру обновления прошивки."
+
+#~ msgid "Verify"
+#~ msgstr "Проверить"
+
+#~ msgid "overlay"
+#~ msgstr "overlay"
 
 #~ msgid "Change login password"
 #~ msgstr "Изменить пароль"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -32,10 +32,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:168
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
@@ -77,15 +73,13 @@ msgstr ""
 msgid "-- custom --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -200,7 +194,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr ""
 
@@ -243,23 +237,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -273,32 +267,32 @@ msgstr ""
 msgid "ARP retry threshold"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr ""
@@ -322,8 +316,7 @@ msgstr ""
 msgid "Access Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr ""
 
@@ -349,7 +342,7 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -359,7 +352,7 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -370,7 +363,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -405,7 +398,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr ""
 
@@ -449,19 +442,18 @@ msgid "Address to access local relay bridge"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr ""
 
@@ -473,7 +465,7 @@ msgstr ""
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -544,7 +536,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -554,76 +546,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -631,11 +623,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -644,6 +636,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:181
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
@@ -674,13 +670,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -731,27 +731,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr ""
 
@@ -769,11 +769,11 @@ msgstr ""
 msgid "Average:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -797,14 +797,15 @@ msgstr ""
 msgid "Back to configuration"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr ""
@@ -822,6 +823,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -853,17 +855,17 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr ""
 
@@ -872,6 +874,7 @@ msgid "Bring up on boot"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -899,11 +902,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr ""
 
@@ -911,12 +916,8 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -950,28 +951,29 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -993,19 +995,19 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1040,7 +1042,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1055,7 +1057,7 @@ msgstr ""
 msgid "Command"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1077,8 +1079,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr ""
 
@@ -1087,7 +1088,7 @@ msgstr ""
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1099,7 +1100,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1119,7 +1120,7 @@ msgstr ""
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1128,11 +1129,14 @@ msgid "Connections"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1152,11 +1156,11 @@ msgid "Country Code"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1185,7 +1189,7 @@ msgstr ""
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1218,7 +1222,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1233,7 +1237,7 @@ msgstr ""
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1278,7 +1282,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1287,7 +1291,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1329,7 +1333,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1349,9 +1353,9 @@ msgid ""
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1412,10 +1416,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr ""
 
@@ -1503,7 +1507,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1512,11 +1516,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1556,6 +1561,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1582,19 +1591,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1635,9 +1644,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1739,25 +1748,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr ""
 
@@ -1779,8 +1780,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1808,7 +1809,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr ""
 
@@ -1830,12 +1831,12 @@ msgstr ""
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1933,9 +1934,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -1982,7 +1982,7 @@ msgstr ""
 msgid "Firewall Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -1994,24 +1994,26 @@ msgstr ""
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2038,11 +2040,11 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2070,7 +2072,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2117,20 +2119,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2138,7 +2139,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr ""
 
@@ -2146,11 +2147,11 @@ msgstr ""
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2161,7 +2162,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2209,7 +2210,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2401,7 +2402,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2488,14 +2489,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2534,7 +2535,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2555,7 +2556,7 @@ msgstr ""
 msgid "Ignore resolve file"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr ""
 
@@ -2615,8 +2616,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2700,11 +2701,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2720,7 +2721,7 @@ msgstr ""
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2741,11 +2742,11 @@ msgstr ""
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr ""
 
@@ -2801,12 +2802,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr ""
 
@@ -2961,7 +2962,7 @@ msgstr ""
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3068,7 +3069,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3101,7 +3102,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3131,7 +3132,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3190,7 +3192,7 @@ msgstr ""
 msgid "Memory usage (%)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3198,7 +3200,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3257,7 +3259,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
@@ -3270,52 +3272,51 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr ""
 
@@ -3356,15 +3357,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr ""
 
@@ -3375,7 +3376,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3400,7 +3401,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3425,7 +3426,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3478,7 +3479,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3536,7 +3537,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3609,6 +3610,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3688,7 +3690,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr ""
 
@@ -3851,7 +3852,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3860,7 +3861,7 @@ msgid "Packets"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -3958,11 +3959,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4000,6 +4001,10 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -4069,10 +4074,6 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr ""
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4088,7 +4089,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4171,7 +4172,7 @@ msgstr ""
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4215,10 +4216,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4251,7 +4248,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr ""
@@ -4259,6 +4256,11 @@ msgstr ""
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4313,7 +4315,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4325,7 +4327,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4408,7 +4410,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4420,7 +4422,7 @@ msgstr ""
 msgid "Reset Counters"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr ""
 
@@ -4432,7 +4434,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4451,11 +4453,11 @@ msgstr ""
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr ""
 
@@ -4480,15 +4482,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4509,7 +4507,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr ""
 
@@ -4529,19 +4527,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4550,7 +4548,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr ""
 
@@ -4567,7 +4565,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4578,30 +4576,31 @@ msgstr ""
 msgid "SSID"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4610,7 +4609,7 @@ msgid "Scan"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr ""
 
@@ -4622,11 +4621,11 @@ msgstr ""
 msgid "Section removed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4667,7 +4666,7 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4675,10 +4674,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4708,6 +4711,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4729,7 +4733,7 @@ msgstr ""
 msgid "Signal"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4741,7 +4745,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr ""
 
@@ -4766,7 +4770,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4783,7 +4787,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4800,7 +4804,7 @@ msgstr ""
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4839,7 +4843,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4862,7 +4866,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr ""
 
@@ -4882,7 +4886,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4921,7 +4925,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr ""
 
@@ -4935,10 +4939,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -4959,7 +4959,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5052,6 +5052,10 @@ msgstr ""
 msgid "Terminate"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5069,14 +5073,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5094,8 +5094,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5107,17 +5107,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5139,11 +5136,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5163,7 +5160,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5177,6 +5174,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5185,13 +5190,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5199,11 +5204,32 @@ msgid ""
 "settings."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5250,6 +5276,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5328,18 +5355,18 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
 "reset\" (only possible with squashfs images)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5379,7 +5406,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5422,8 +5449,8 @@ msgstr ""
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5453,6 +5480,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5464,6 +5495,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5472,28 +5504,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5506,7 +5538,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5529,14 +5561,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5549,7 +5587,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5607,11 +5651,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5619,7 +5663,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5682,7 +5726,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr ""
 
@@ -5710,11 +5754,11 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5761,8 +5805,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5783,7 +5827,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr ""
 
@@ -5791,7 +5835,7 @@ msgstr ""
 msgid "WMM Mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr ""
 
@@ -5853,13 +5897,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5910,7 +5954,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -5951,9 +5995,9 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -5970,7 +6014,7 @@ msgstr ""
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -5987,7 +6031,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr ""
 
@@ -6121,8 +6165,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr ""
 
@@ -6134,13 +6176,13 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6170,10 +6212,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6192,7 +6230,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6206,15 +6244,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6432,8 +6470,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr ""
 

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -35,10 +35,6 @@ msgstr "%s är inte taggad i flera VLAN!"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d minut-fönster, %d sekundintervall)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s tillgängligt)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -79,15 +75,13 @@ msgstr "-- Vänligen välj --"
 msgid "-- custom --"
 msgstr "-- anpassad --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- matcha enligt enhet --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- matcha enligt märke --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- matcha enligt uuid --"
 
@@ -205,7 +199,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Lysdiod\">LED</abbr>-konfiguration"
 
@@ -250,23 +244,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr "A43C + J43 + A43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr "A43C + J43 + A43 + V43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr "ADSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr "ANSI T1.413"
 
@@ -280,32 +274,32 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM-bryggor"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr ""
@@ -329,8 +323,7 @@ msgstr ""
 msgid "Access Point"
 msgstr "Accesspunkt"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Åtgärder"
 
@@ -356,7 +349,7 @@ msgstr "Aktiva DHCP-kontrakt"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktiva DHCPv6-kontrakt"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -366,7 +359,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -377,7 +370,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Lägg till"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -412,7 +405,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Lägg till ett nytt gränssnitt"
 
@@ -456,19 +449,18 @@ msgid "Address to access local relay bridge"
 msgstr "Adress för att komma åt lokal reläbrygga"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Administration"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Avancerade inställningar"
 
@@ -480,7 +472,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Varning"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -554,7 +546,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr "Tillåtna IP-adresser"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -564,76 +556,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr "Aviserade DNS-domäner"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr "Aviserade DNS-servrar"
 
@@ -641,11 +633,11 @@ msgstr "Aviserade DNS-servrar"
 msgid "Anonymous Identity"
 msgstr "Anonym identitet"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "Anonym montering"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "Anonym Swap"
 
@@ -655,6 +647,10 @@ msgstr "Anonym Swap"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Någon zon"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -684,13 +680,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Associerade stationer"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -741,27 +741,27 @@ msgstr "Automatisk"
 msgid "Automatic Homenet (HNCP)"
 msgstr "Automatiskt hemnet (HNCP)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr "Kolla efter fel i filsystemet automatiskt innan det monteras"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "Monstera filsystem automatiskt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "Montera Swap automatiskt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Tillgänglig"
 
@@ -779,11 +779,11 @@ msgstr "Tillgänglig"
 msgid "Average:"
 msgstr "Snitt:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr "B43 + B43C"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr "B43 + B43C + V43"
 
@@ -807,14 +807,15 @@ msgstr "Backa till Överblick"
 msgid "Back to configuration"
 msgstr "Backa till konfiguration"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Säkerhetskopiera"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Säkerhetskopiera / Flasha inre mjukvara"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Säkerhetskopiera fillista"
@@ -832,6 +833,7 @@ msgstr "Band"
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -863,17 +865,17 @@ msgstr "Bithastighet"
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Brygga"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Brygga gränssnitt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr ""
 
@@ -882,6 +884,7 @@ msgid "Bring up on boot"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -910,11 +913,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -922,12 +927,8 @@ msgstr "Avbryt"
 msgid "Category"
 msgstr "Kategori"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -961,30 +962,31 @@ msgstr "Ändrar administratörens lösenord för att få tillgång till enheten"
 msgid "Channel"
 msgstr "Kanal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Kontrollera"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "Kontrollera filsystemen innan de monteras"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 "Bocka för det här alternativet för att ta bort befintliga nätverk från den "
 "här radion."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Checksumma"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1006,19 +1008,19 @@ msgstr "Chiffer"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1053,7 +1055,7 @@ msgstr "Stäng ner lista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1068,7 +1070,7 @@ msgstr "Samlar in data..."
 msgid "Command"
 msgstr "Kommando"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1090,8 +1092,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Konfiguration"
 
@@ -1100,7 +1101,7 @@ msgstr "Konfiguration"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1112,7 +1113,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1132,7 +1133,7 @@ msgstr "Ansluten"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1141,11 +1142,14 @@ msgid "Connections"
 msgstr "Anslutningar"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1165,11 +1169,11 @@ msgid "Country Code"
 msgstr "Landskod"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1198,7 +1202,7 @@ msgstr "Anpassat gränssnitt"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1231,7 +1235,7 @@ msgstr "DHCP-server"
 msgid "DHCP and DNS"
 msgstr "DHCP och DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1246,7 +1250,7 @@ msgstr "DHCP-alternativ"
 msgid "DHCPv6 client"
 msgstr "DHCPv6-klient"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "DHCPv6-läge"
 
@@ -1291,7 +1295,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr "DSL"
@@ -1300,7 +1304,7 @@ msgstr "DSL"
 msgid "DSL Status"
 msgstr "DSL-status"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1342,7 +1346,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Standard gateway"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1362,9 +1366,9 @@ msgid ""
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1425,10 +1429,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Enhet"
 
@@ -1518,7 +1522,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1527,11 +1531,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1573,6 +1578,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1601,19 +1610,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Ladda ner säkerhetskopia"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1654,9 +1663,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-metod"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1758,25 +1767,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Aktivera den här monteringen"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Aktivera den här swap"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Aktivera/Inaktivera"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Aktiverad"
 
@@ -1798,8 +1799,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1827,7 +1828,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Raderar..."
 
@@ -1849,12 +1850,12 @@ msgstr "Fel"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet-adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1952,9 +1953,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Filsystem"
 
@@ -1971,7 +1971,7 @@ msgstr "Filtrera icke-användbara"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2001,7 +2001,7 @@ msgstr "Inställningar för brandvägg"
 msgid "Firewall Status"
 msgstr "Status för brandvägg"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2013,25 +2013,27 @@ msgstr "Version för inre mjukvara"
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Skriver..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2057,11 +2059,11 @@ msgstr "Tvinga TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Tvinga TKIP och CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "Tvinga länk"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2089,7 +2091,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Vidarebefordringsläge"
 
@@ -2136,20 +2138,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Generella inställningar"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "Generera konfig"
 
@@ -2157,7 +2158,7 @@ msgstr "Generera konfig"
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Generera arkiv"
 
@@ -2165,11 +2166,11 @@ msgstr "Generera arkiv"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Angiven lösenordsbekräftelse matchade inte, lösenordet ändrades inte!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "Globala inställningar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "Globala nätverksalternativ"
 
@@ -2180,7 +2181,7 @@ msgstr "Globala nätverksalternativ"
 msgid "Go to password configuration..."
 msgstr "Gå till lösenordskonfiguration..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2228,7 +2229,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "Värd"
 
@@ -2420,7 +2421,7 @@ msgstr "IPV6-grannar"
 msgid "IPv6 Settings"
 msgstr "IPv6-inställningar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2507,14 +2508,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2553,7 +2554,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2574,7 +2575,7 @@ msgstr "Ignorera gränssnitt"
 msgid "Ignore resolve file"
 msgstr "Ignorera resolv-fil"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Bild"
 
@@ -2634,8 +2635,8 @@ msgstr "Installera protokoll-förlängningar..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2719,11 +2720,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2739,7 +2740,7 @@ msgstr "Ogiltigt användarnamn och/eller lösenord! Vänligen försök igen."
 msgid "Isolate Clients"
 msgstr "Isolera klienter"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2760,11 +2761,11 @@ msgstr "Anslut till nätverk"
 msgid "Join Network: Wireless Scan"
 msgstr "Anslut till nätverk: Trådlös skanning"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "Ansluter till nätverk: %q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Behåll inställningar"
 
@@ -2820,12 +2821,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Märke"
 
@@ -2981,7 +2982,7 @@ msgstr "Laddar"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3088,7 +3089,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3121,7 +3122,7 @@ msgstr ""
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr "MD5"
 
@@ -3135,7 +3136,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3151,7 +3152,8 @@ msgstr ""
 msgid "Manual"
 msgstr "Manuell"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3210,7 +3212,7 @@ msgstr "Minne"
 msgid "Memory usage (%)"
 msgstr "Minnesanvändning (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3218,7 +3220,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3277,7 +3279,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Övervaka"
@@ -3290,52 +3292,51 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Monteringspunkt"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Monteringspunkter"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Monteringsalternativ"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Monteringspunkt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Monterade filsystem"
 
@@ -3376,15 +3377,15 @@ msgstr "NT-domän"
 msgid "NTP server candidates"
 msgstr "NTP-serverkandidater"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Namn"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Namnet på det nya nätverket"
 
@@ -3395,7 +3396,7 @@ msgstr "Navigering"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3420,7 +3421,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "Nätverk utan gränssnitt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3445,7 +3446,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr "Ingen NAT-T"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3498,7 +3499,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3556,7 +3557,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3629,6 +3630,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "En eller fler fält som krävs har inget värde!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Öppna lista..."
@@ -3708,7 +3710,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Alternativ"
 
@@ -3871,7 +3872,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3880,7 +3881,7 @@ msgid "Packets"
 msgstr "Paket"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Del av zon %q"
 
@@ -3978,11 +3979,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Utför omstart"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Utför återställning"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4021,6 +4022,10 @@ msgstr "Pkt."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Vänligen ange ditt användarnamn och lösenord."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4089,10 +4094,6 @@ msgstr "Förhindrar kommunikation klient-till-klient"
 msgid "Private Key"
 msgstr "Privat nyckel"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Fortsätt"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4108,7 +4109,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4191,7 +4192,7 @@ msgstr "RT"
 msgid "RX Rate"
 msgstr "RX-hastighet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4237,10 +4238,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Verkligen återställa alla ändringar?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Verkligen byta protokoll?"
@@ -4273,7 +4270,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Starta om"
@@ -4282,6 +4279,11 @@ msgstr "Starta om"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Startar om..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4335,7 +4337,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Ta bort"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Ersätt trådlös konfiguration"
 
@@ -4347,7 +4349,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4430,7 +4432,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4442,7 +4444,7 @@ msgstr "Återställ"
 msgid "Reset Counters"
 msgstr "Återställ räknare"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Återställ till standard"
 
@@ -4454,7 +4456,7 @@ msgstr "Resolv och Värd-filer"
 msgid "Resolve file"
 msgstr "Resolv-fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4473,11 +4475,11 @@ msgstr "Starta om brandvägg"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Återställ"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Återställ säkerhetskopian"
 
@@ -4502,15 +4504,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Root"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Root-mappen för filer som skickas via TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr "Root-förberedelse"
 
@@ -4531,7 +4529,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Router-lösenord"
 
@@ -4551,19 +4549,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Kör en filsystemskontroll innan enheten monteras"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Kör filsystemskontrollen"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr "SHA256"
 
@@ -4572,7 +4570,7 @@ msgid "SNR"
 msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH-åtkomst"
 
@@ -4589,7 +4587,7 @@ msgid "SSH username"
 msgstr "Användarnamn för SSH"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH-nycklar"
 
@@ -4600,30 +4598,31 @@ msgstr "SSH-nycklar"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Spara"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Spara och Verkställ"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4632,7 +4631,7 @@ msgid "Scan"
 msgstr "Skanna"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Schemalagda uppgifter"
 
@@ -4644,11 +4643,11 @@ msgstr "Sektionen lades till"
 msgid "Section removed"
 msgstr "Sektionen togs bort"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4689,7 +4688,7 @@ msgstr "Typ av tjänst"
 msgid "Services"
 msgstr "Tjänster"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4697,10 +4696,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4730,6 +4733,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4751,7 +4755,7 @@ msgstr "Stäng ner det här gränssnittet"
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4763,7 +4767,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "Signal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Storlek"
 
@@ -4788,7 +4792,7 @@ msgstr "Hoppa över till innehåll"
 msgid "Skip to navigation"
 msgstr "Hoppa över till navigering"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4805,7 +4809,7 @@ msgstr "Tyvärr, objektet som du frågade efter kunde inte hittas."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "Tyvärr, servern stötte på ett oväntat fel."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4822,7 +4826,7 @@ msgstr "Källa"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Ange den hemliga krypteringsnyckeln här."
 
@@ -4884,7 +4888,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr ""
 
@@ -4904,7 +4908,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr "Statiska rutter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4943,7 +4947,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Skicka in"
 
@@ -4958,10 +4962,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "Swap"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -4981,7 +4981,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Byt VLAN"
@@ -5074,6 +5074,10 @@ msgstr "Målnätverk"
 msgid "Terminate"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5091,14 +5095,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5116,8 +5116,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5129,17 +5129,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5161,11 +5158,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5185,7 +5182,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5199,6 +5196,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5207,13 +5212,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5221,11 +5226,32 @@ msgid ""
 "settings."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5274,6 +5300,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5352,11 +5379,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "Tidszon"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5365,7 +5392,7 @@ msgstr ""
 "För att återställa konfigurationsfiler så kan du ladda upp ett tidigare "
 "genererat säkerhetskopierings arkiv här."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr "Ton"
 
@@ -5405,7 +5432,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr "Tunnel-ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Tunnelgränssnitt"
@@ -5448,8 +5475,8 @@ msgstr "USB-enhet"
 msgid "USB Ports"
 msgstr "USB-portar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5479,6 +5506,10 @@ msgstr "Det går inte att skicka"
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5490,6 +5521,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5498,28 +5530,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Otillgängliga Sekunder (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Okänd"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "Avmontera"
 
@@ -5532,7 +5564,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Osparade ändringar"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5555,14 +5587,20 @@ msgstr "Protokolltypen stöds inte."
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Ladda upp arkiv..."
 
@@ -5575,7 +5613,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5633,11 +5677,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "Använd som root-filsystem (/)"
 
@@ -5645,7 +5689,7 @@ msgstr "Använd som root-filsystem (/)"
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5708,7 +5752,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr ""
 
@@ -5736,11 +5780,11 @@ msgstr "Användarnyckel (PEM-krypterad)"
 msgid "Username"
 msgstr "Användarnamn"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr "VDSL"
 
@@ -5787,9 +5831,9 @@ msgstr "Tillverkare"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Verkställ"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5809,7 +5853,7 @@ msgstr "Öppet System WEP"
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP-lösenordsfras"
 
@@ -5817,7 +5861,7 @@ msgstr "WEP-lösenordsfras"
 msgid "WMM Mode"
 msgstr "WMM-läge"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA-lösenordsfras"
 
@@ -5880,13 +5924,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Trådlöst"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Trådlös adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5937,7 +5981,7 @@ msgstr "Skriv systemlogg till fil"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -5980,9 +6024,9 @@ msgstr ""
 msgid "any"
 msgstr "något"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -5999,7 +6043,7 @@ msgstr ""
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "bryggad"
 
@@ -6016,7 +6060,7 @@ msgid "create:"
 msgstr "skapa:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "skapar en brygga över angivna gränssnitt(en)"
 
@@ -6150,8 +6194,6 @@ msgstr "minuter"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "nej"
 
@@ -6163,13 +6205,13 @@ msgstr "ingen länk"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "inte tillgängligt"
 
@@ -6199,10 +6241,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6221,7 +6259,7 @@ msgstr ""
 msgid "relay mode"
 msgstr "relä-läge"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6235,15 +6273,15 @@ msgstr ""
 msgid "server mode"
 msgstr "server-läge"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6461,14 +6499,45 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "ja"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Bakåt"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s tillgängligt)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- matcha enligt enhet --"
+
+#~ msgid "Check"
+#~ msgstr "Kontrollera"
+
+#~ msgid "Checksum"
+#~ msgstr "Checksumma"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Aktivera den här monteringen"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Aktivera den här swap"
+
+#~ msgid "Flashing..."
+#~ msgstr "Skriver..."
+
+#~ msgid "Proceed"
+#~ msgstr "Fortsätt"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Verkligen återställa alla ändringar?"
+
+#~ msgid "Root"
+#~ msgstr "Root"
+
+#~ msgid "Verify"
+#~ msgstr "Verkställ"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Inaktiverad (standard)"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -24,10 +24,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:168
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
@@ -69,15 +65,13 @@ msgstr ""
 msgid "-- custom --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -192,7 +186,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr ""
 
@@ -235,23 +229,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -265,32 +259,32 @@ msgstr ""
 msgid "ARP retry threshold"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr ""
@@ -314,8 +308,7 @@ msgstr ""
 msgid "Access Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr ""
 
@@ -341,7 +334,7 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -351,7 +344,7 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -362,7 +355,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -397,7 +390,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr ""
 
@@ -441,19 +434,18 @@ msgid "Address to access local relay bridge"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr ""
 
@@ -465,7 +457,7 @@ msgstr ""
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -536,7 +528,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -546,76 +538,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -623,11 +615,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -636,6 +628,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:181
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
@@ -666,13 +662,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -723,27 +723,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr ""
 
@@ -761,11 +761,11 @@ msgstr ""
 msgid "Average:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -789,14 +789,15 @@ msgstr ""
 msgid "Back to configuration"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr ""
@@ -814,6 +815,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -845,17 +847,17 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr ""
 
@@ -864,6 +866,7 @@ msgid "Bring up on boot"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -891,11 +894,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr ""
 
@@ -903,12 +908,8 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -942,28 +943,29 @@ msgstr ""
 msgid "Channel"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -985,19 +987,19 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1032,7 +1034,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1047,7 +1049,7 @@ msgstr ""
 msgid "Command"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1069,8 +1071,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr ""
 
@@ -1079,7 +1080,7 @@ msgstr ""
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1091,7 +1092,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1111,7 +1112,7 @@ msgstr ""
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1120,11 +1121,14 @@ msgid "Connections"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1144,11 +1148,11 @@ msgid "Country Code"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1177,7 +1181,7 @@ msgstr ""
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1210,7 +1214,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1225,7 +1229,7 @@ msgstr ""
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1279,7 +1283,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1321,7 +1325,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1341,9 +1345,9 @@ msgid ""
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1404,10 +1408,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr ""
 
@@ -1495,7 +1499,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1504,11 +1508,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1548,6 +1553,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1574,19 +1583,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1627,9 +1636,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1731,25 +1740,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr ""
 
@@ -1771,8 +1772,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1800,7 +1801,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr ""
 
@@ -1822,12 +1823,12 @@ msgstr ""
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1925,9 +1926,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr ""
 
@@ -1944,7 +1944,7 @@ msgstr ""
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -1974,7 +1974,7 @@ msgstr ""
 msgid "Firewall Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -1986,24 +1986,26 @@ msgstr ""
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2030,11 +2032,11 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2062,7 +2064,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2109,20 +2111,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2130,7 +2131,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr ""
 
@@ -2138,11 +2139,11 @@ msgstr ""
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2153,7 +2154,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2201,7 +2202,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2393,7 +2394,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2480,14 +2481,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2526,7 +2527,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2547,7 +2548,7 @@ msgstr ""
 msgid "Ignore resolve file"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr ""
 
@@ -2607,8 +2608,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2692,11 +2693,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2712,7 +2713,7 @@ msgstr ""
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2733,11 +2734,11 @@ msgstr ""
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr ""
 
@@ -2793,12 +2794,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr ""
 
@@ -2953,7 +2954,7 @@ msgstr ""
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3060,7 +3061,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3093,7 +3094,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3107,7 +3108,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3123,7 +3124,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3182,7 +3184,7 @@ msgstr ""
 msgid "Memory usage (%)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3190,7 +3192,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3249,7 +3251,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
@@ -3262,52 +3264,51 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr ""
 
@@ -3348,15 +3349,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr ""
 
@@ -3367,7 +3368,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3392,7 +3393,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3417,7 +3418,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3470,7 +3471,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3528,7 +3529,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3601,6 +3602,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3680,7 +3682,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr ""
 
@@ -3843,7 +3844,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3852,7 +3853,7 @@ msgid "Packets"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -3950,11 +3951,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -3992,6 +3993,10 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -4061,10 +4066,6 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr ""
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4080,7 +4081,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4163,7 +4164,7 @@ msgstr ""
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4207,10 +4208,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4243,7 +4240,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr ""
@@ -4251,6 +4248,11 @@ msgstr ""
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4305,7 +4307,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4317,7 +4319,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4400,7 +4402,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4412,7 +4414,7 @@ msgstr ""
 msgid "Reset Counters"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr ""
 
@@ -4424,7 +4426,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4443,11 +4445,11 @@ msgstr ""
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr ""
 
@@ -4472,15 +4474,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4501,7 +4499,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr ""
 
@@ -4521,19 +4519,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4542,7 +4540,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr ""
 
@@ -4559,7 +4557,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4570,30 +4568,31 @@ msgstr ""
 msgid "SSID"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4602,7 +4601,7 @@ msgid "Scan"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr ""
 
@@ -4614,11 +4613,11 @@ msgstr ""
 msgid "Section removed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4659,7 +4658,7 @@ msgstr ""
 msgid "Services"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4667,10 +4666,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4700,6 +4703,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4721,7 +4725,7 @@ msgstr ""
 msgid "Signal"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4733,7 +4737,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr ""
 
@@ -4758,7 +4762,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4775,7 +4779,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4792,7 +4796,7 @@ msgstr ""
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4831,7 +4835,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4854,7 +4858,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr ""
 
@@ -4874,7 +4878,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4913,7 +4917,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr ""
 
@@ -4927,10 +4931,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5044,6 +5044,10 @@ msgstr ""
 msgid "Terminate"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5061,14 +5065,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5086,8 +5086,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5099,17 +5099,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5131,11 +5128,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5155,7 +5152,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5169,6 +5166,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5177,13 +5182,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5191,11 +5196,32 @@ msgid ""
 "settings."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5242,6 +5268,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5320,18 +5347,18 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
 "reset\" (only possible with squashfs images)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5371,7 +5398,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5414,8 +5441,8 @@ msgstr ""
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5445,6 +5472,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5456,6 +5487,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5464,28 +5496,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5498,7 +5530,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5521,14 +5553,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5541,7 +5579,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5599,11 +5643,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5611,7 +5655,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5674,7 +5718,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr ""
 
@@ -5702,11 +5746,11 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5753,8 +5797,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5775,7 +5819,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr ""
 
@@ -5783,7 +5827,7 @@ msgstr ""
 msgid "WMM Mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr ""
 
@@ -5845,13 +5889,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5902,7 +5946,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -5943,9 +5987,9 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -5962,7 +6006,7 @@ msgstr ""
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -5979,7 +6023,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr ""
 
@@ -6113,8 +6157,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr ""
 
@@ -6126,13 +6168,13 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6162,10 +6204,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6184,7 +6222,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6198,15 +6236,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6424,8 +6462,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr ""
 

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -36,10 +36,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d dakika gösteriliyor, %d saniye aralıklı)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s uygun)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -80,15 +76,13 @@ msgstr "-- Lütfen seçiniz --"
 msgid "-- custom --"
 msgstr "-- özel --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- cihaza göre eşleştir --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- etikete göre eşleştir --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- uuid'e göre eşleştir --"
 
@@ -205,7 +199,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Ayarları"
 
@@ -252,23 +246,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -282,32 +276,32 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "ARP yenileme aralığı"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM Köprüleri"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr ""
@@ -331,8 +325,7 @@ msgstr ""
 msgid "Access Point"
 msgstr "Erişim Noktası"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Eylemler"
 
@@ -360,7 +353,7 @@ msgstr "Aktif DHCP Kiraları"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktif DHCPv6 Kiraları"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -370,7 +363,7 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -381,7 +374,7 @@ msgstr ""
 msgid "Add"
 msgstr "Ekle"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -416,7 +409,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Yeni arabirim ekle..."
 
@@ -460,19 +453,18 @@ msgid "Address to access local relay bridge"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Gelişmiş Ayarlar"
 
@@ -484,7 +476,7 @@ msgstr ""
 msgid "Alert"
 msgstr "Uyarı"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -557,7 +549,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -567,76 +559,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -644,11 +636,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -657,6 +649,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:181
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
@@ -687,13 +683,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "İlişkili istasyonlar"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -744,27 +744,27 @@ msgstr "Otomatik"
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Kullanılabilir"
 
@@ -782,11 +782,11 @@ msgstr "Kullanılabilir"
 msgid "Average:"
 msgstr "Ortalama:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -810,14 +810,15 @@ msgstr "Genel Bakışa dön"
 msgid "Back to configuration"
 msgstr "Yapılandırmaya dön"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Yedekleme"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Yedek/Firmware Yazma"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr ""
@@ -835,6 +836,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -866,17 +868,17 @@ msgstr "Bit hızı"
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Köprü"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Köprü arabirimleri"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr ""
 
@@ -885,6 +887,7 @@ msgid "Bring up on boot"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -912,11 +915,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Vazgeç"
 
@@ -924,12 +929,8 @@ msgstr "Vazgeç"
 msgid "Category"
 msgstr "Kategori"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -963,28 +964,29 @@ msgstr ""
 msgid "Channel"
 msgstr "Kanal"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1006,7 +1008,7 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1014,13 +1016,13 @@ msgstr ""
 "Mevcut yapılandırma dosyalarının yeni bir arşivini indirmek için \"Arşiv "
 "Oluştur\"'u tıklayın."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1055,7 +1057,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1070,7 +1072,7 @@ msgstr ""
 msgid "Command"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1092,8 +1094,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr ""
 
@@ -1102,7 +1103,7 @@ msgstr ""
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1114,7 +1115,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1134,7 +1135,7 @@ msgstr "Bağlandı"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1143,11 +1144,14 @@ msgid "Connections"
 msgstr "Bağlantılar"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1167,11 +1171,11 @@ msgid "Country Code"
 msgstr "Ülke Kodu"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1200,7 +1204,7 @@ msgstr "Özel Arabirim"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1233,7 +1237,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1248,7 +1252,7 @@ msgstr ""
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1293,7 +1297,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1344,7 +1348,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "Default ağ geçidi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1364,9 +1368,9 @@ msgid ""
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1427,10 +1431,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Cihaz"
 
@@ -1520,7 +1524,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1529,11 +1533,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr "Bağlantı kesme girişimi başarısız oldu"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "Reddet"
 
@@ -1573,6 +1578,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1599,19 +1608,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1652,9 +1661,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1756,25 +1765,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr ""
 
@@ -1796,8 +1797,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1825,7 +1826,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr ""
 
@@ -1847,12 +1848,12 @@ msgstr ""
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1950,9 +1951,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr ""
 
@@ -1969,7 +1969,7 @@ msgstr ""
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -1999,7 +1999,7 @@ msgstr ""
 msgid "Firewall Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2011,24 +2011,26 @@ msgstr "Firmware Versiyon"
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Firmware Güncelle"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Dosyayı yaz..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Yeni firmware dosyasını yaz"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2055,11 +2057,11 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2087,7 +2089,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2134,20 +2136,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2155,7 +2156,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Arşiv oluştur"
 
@@ -2163,11 +2164,11 @@ msgstr "Arşiv oluştur"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2178,7 +2179,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2226,7 +2227,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2418,7 +2419,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2505,14 +2506,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2551,7 +2552,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2572,7 +2573,7 @@ msgstr ""
 msgid "Ignore resolve file"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr ""
 
@@ -2632,8 +2633,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2717,11 +2718,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2737,7 +2738,7 @@ msgstr ""
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2758,11 +2759,11 @@ msgstr ""
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr ""
 
@@ -2818,12 +2819,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr ""
 
@@ -2978,7 +2979,7 @@ msgstr ""
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3085,7 +3086,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3118,7 +3119,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3132,7 +3133,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3148,7 +3149,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3207,7 +3209,7 @@ msgstr "Bellek"
 msgid "Memory usage (%)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3215,7 +3217,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3274,7 +3276,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
@@ -3287,52 +3289,51 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr ""
 
@@ -3373,15 +3374,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr ""
 
@@ -3392,7 +3393,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3417,7 +3418,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3442,7 +3443,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3495,7 +3496,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3553,7 +3554,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3626,6 +3627,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3705,7 +3707,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr ""
 
@@ -3868,7 +3869,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3877,7 +3878,7 @@ msgid "Packets"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -3975,11 +3976,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4017,6 +4018,10 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -4086,10 +4091,6 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr ""
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4105,7 +4106,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4188,7 +4189,7 @@ msgstr ""
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4232,10 +4233,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4268,7 +4265,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr ""
@@ -4276,6 +4273,11 @@ msgstr ""
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4330,7 +4332,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4342,7 +4344,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4425,7 +4427,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4437,7 +4439,7 @@ msgstr "Sıfırla"
 msgid "Reset Counters"
 msgstr "Sayaçları Sıfırla"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Varsayılanlara dön"
 
@@ -4449,7 +4451,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4468,11 +4470,11 @@ msgstr ""
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Geri Yükleme"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Yedeklemeyi geri yükle"
 
@@ -4497,15 +4499,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Kök"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4526,7 +4524,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Yönlendirici Parolası"
 
@@ -4546,19 +4544,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Cihazı bağlamadan önce bir dosya sistemi kontrolü yapın"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Dosya sistemi kontrolünü çalıştır"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr "SHA256"
 
@@ -4567,7 +4565,7 @@ msgid "SNR"
 msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH Erişimi"
 
@@ -4584,7 +4582,7 @@ msgid "SSH username"
 msgstr "SSH kullanıcı adı"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4595,30 +4593,31 @@ msgstr ""
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Kaydet"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Kaydet & Uygula"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4627,7 +4626,7 @@ msgid "Scan"
 msgstr "Tara"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Zamanlanmış Görevler"
 
@@ -4639,11 +4638,11 @@ msgstr "Bölüm eklendi"
 msgid "Section removed"
 msgstr "Bölüm kaldırıldı"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4684,7 +4683,7 @@ msgstr ""
 msgid "Services"
 msgstr "Servisler"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4692,10 +4691,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4725,6 +4728,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4746,7 +4750,7 @@ msgstr ""
 msgid "Signal"
 msgstr "Sinyal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4758,7 +4762,7 @@ msgstr "Sinyal Zayıflama (SATN)"
 msgid "Signal:"
 msgstr "Sinyal:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Boyut"
 
@@ -4783,7 +4787,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4800,7 +4804,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4817,7 +4821,7 @@ msgstr "Kaynak"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4856,7 +4860,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4879,7 +4883,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr ""
 
@@ -4899,7 +4903,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4938,7 +4942,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Gönder"
 
@@ -4952,10 +4956,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -4976,7 +4976,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5069,6 +5069,10 @@ msgstr ""
 msgid "Terminate"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5086,14 +5090,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5111,8 +5111,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5124,17 +5124,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5156,11 +5153,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5180,7 +5177,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5194,6 +5191,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5202,13 +5207,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5216,11 +5221,32 @@ msgid ""
 "settings."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5267,6 +5293,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5345,18 +5372,18 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
 "reset\" (only possible with squashfs images)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5396,7 +5423,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5439,8 +5466,8 @@ msgstr ""
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5470,6 +5497,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5481,6 +5512,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5489,28 +5521,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5523,7 +5555,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5546,14 +5578,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5566,7 +5604,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5624,11 +5668,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5636,7 +5680,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5699,7 +5743,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Kullanılmış"
 
@@ -5727,11 +5771,11 @@ msgstr ""
 msgid "Username"
 msgstr "Kullanıcı adı"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5778,9 +5822,9 @@ msgstr "Satıcı"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Kontrol"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5800,7 +5844,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr ""
 
@@ -5808,7 +5852,7 @@ msgstr ""
 msgid "WMM Mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr ""
 
@@ -5870,13 +5914,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Kablosuz"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5927,7 +5971,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -5970,9 +6014,9 @@ msgstr ""
 msgid "any"
 msgstr "herhangi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -5989,7 +6033,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "köprülü"
 
@@ -6006,7 +6050,7 @@ msgid "create:"
 msgstr "oluşturma:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr ""
 
@@ -6140,8 +6184,6 @@ msgstr "dakika"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "hayır"
 
@@ -6153,13 +6195,13 @@ msgstr "bağlantı yok"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "hiçbiri"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "mevcut değil"
 
@@ -6189,10 +6231,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr "bindirilmiş"
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6211,7 +6249,7 @@ msgstr "rastgele"
 msgid "relay mode"
 msgstr "anahtarlama modu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "yönlendirildi"
 
@@ -6225,15 +6263,15 @@ msgstr ""
 msgid "server mode"
 msgstr "sunucu modu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr "durumsuz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr "durumsuz + durumlu"
 
@@ -6451,14 +6489,30 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "evet"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Geri"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s uygun)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- cihaza göre eşleştir --"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Firmware Güncelle"
+
+#~ msgid "Root"
+#~ msgstr "Kök"
+
+#~ msgid "Verify"
+#~ msgstr "Kontrol"
+
+#~ msgid "overlay"
+#~ msgstr "bindirilmiş"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Devre dışı (varsayılan)"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr "%.1f дБ"
 
@@ -33,10 +33,6 @@ msgstr "%s є непозначеним у декількох VLAN!"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(вікно - %d хв, інтервал - %d с)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr " (доступно %s)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -77,15 +73,13 @@ msgstr "-- Оберіть --"
 msgid "-- custom --"
 msgstr "-- нетипово --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- відповідно пристрою --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- відповідно мітці --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- відповідно UUID --"
 
@@ -214,7 +208,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "<abbr title=\"Інтернет-протокол версії 6\">IPv6</abbr>-суфікс (hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr ""
 "Налаштування <abbr title=\"Light Emitting Diode — світлодіод\">LED</abbr>"
@@ -267,24 +261,24 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr "Каталог з такою ж назвою вже існує."
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 "Оскільки сеанс автентифікації закінчився, потрібен новий вхід у систему."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -299,31 +293,31 @@ msgstr ""
 msgid "ARP retry threshold"
 msgstr "Поріг повторювання ARP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 "<abbr title=\"Asynchronous Transfer Mode — асинхронний режим передавання"
 "\">ATM</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM-мости"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 "Ідентифікатор віртуального каналу ATM (<abbr title=\"Virtual Channel "
 "Identifier\">VCI</abbr>)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 "Ідентифікатор віртуального шляху ATM (<abbr title=\"Virtual Path Identifier"
 "\">VPI</abbr>)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -333,7 +327,7 @@ msgstr ""
 "віртуальні мережеві інтерфейси Linux, котрі можуть використовуватися в "
 "поєднанні з DHCP або PPP для підключення до мережі провайдера."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "Номер ATM-пристрою"
@@ -357,8 +351,7 @@ msgstr "Концентратор доступу"
 msgid "Access Point"
 msgstr "Точка доступу"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Дії"
 
@@ -384,7 +377,7 @@ msgstr "Активні оренди DHCP"
 msgid "Active DHCPv6 Leases"
 msgstr "Активні оренди DHCPv6"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -394,7 +387,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -405,7 +398,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Додати"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr "Додати ATM-міст"
 
@@ -440,7 +433,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "Додавати суфікс локального домену до імен, отриманих із файлів hosts"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "Додати новий інтерфейс..."
 
@@ -484,19 +477,18 @@ msgid "Address to access local relay bridge"
 msgstr "Адреса для доступу до мосту локального ретранслятора"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Адміністрування"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "Додаткові параметри"
 
@@ -508,7 +500,7 @@ msgstr "Сукупна потужність передавача"
 msgid "Alert"
 msgstr "Тривога"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -588,7 +580,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr "Дозволено IP-адреси"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr "Завжди оголошувати типовим маршрутизатором"
 
@@ -601,78 +593,78 @@ msgstr ""
 "перекривається. Використання цієї опції не відповідає стандарту IEEE "
 "802.11n-2009!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 "Оголошувати типовим маршрутизатором, навіть якщо немає доступного публічного "
 "префікса."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr "Оголошено DNS-домени"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr "Оголошено DNS-сервери"
 
@@ -680,11 +672,11 @@ msgstr "Оголошено DNS-сервери"
 msgid "Anonymous Identity"
 msgstr "Анонімне посвідчення"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "Анонімне монтування"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "Анонімний своп"
 
@@ -694,6 +686,10 @@ msgstr "Анонімний своп"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "Будь-яка зона"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -727,7 +723,7 @@ msgstr ""
 "Призначати для цього інтерфейсу частину префікса, використовуючи цей "
 "шістнадцятковий ID субпрефікса."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Приєднано станції"
@@ -735,6 +731,10 @@ msgstr "Приєднано станції"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "З'єднань"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -784,28 +784,28 @@ msgstr "Автоматично"
 msgid "Automatic Homenet (HNCP)"
 msgstr "Автоматично Homenet (HNCP)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 "Автоматично перевіряти файлову систему на наявність помилок перед монтуванням"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr "Автоматично монтувати файлові системи при оперативниму підключенні"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr "Автоматично монтувати своп при оперативниму підключенні"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "Автомонтування ФС"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "Автомонтування своп"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Доступно"
 
@@ -823,11 +823,11 @@ msgstr "Доступно"
 msgid "Average:"
 msgstr "Середнє значення:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -851,14 +851,15 @@ msgstr "Повернутися до переліку"
 msgid "Back to configuration"
 msgstr "Повернутися до конфігурації"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "Резервне копіювання"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "Рез. копіювання / Перепрош."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "Список файлів резервних копій"
@@ -876,6 +877,7 @@ msgstr "Діапазон"
 msgid "Beacon Interval"
 msgstr "Інтервал маяка"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -912,17 +914,17 @@ msgstr "Швидкість потоку"
 msgid "Bogus NX Domain Override"
 msgstr "Відкидати підробки NX-домену"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Міст"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Об'єднати інтерфейси в міст"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "Номер моста"
 
@@ -931,6 +933,7 @@ msgid "Bring up on boot"
 msgstr "Піднімати при завантаженні"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr "Огляд…"
 
@@ -959,11 +962,13 @@ msgstr "Не вдалося здійснити виклик"
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -971,13 +976,9 @@ msgstr "Скасувати"
 msgid "Category"
 msgstr "Категорія"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
 msgstr "Увага: файли конфігурації буде видалено."
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
-msgstr "Увага: систему буде оновлено примусово"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
@@ -1010,28 +1011,29 @@ msgstr "Зміна пароля адміністратора для доступ
 msgid "Channel"
 msgstr "Канал"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "Перевірити"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "Перевірити файлову систему перед монтуванням"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "Позначте цей параметр, щоб видалити існуючі мережі з цього радіо."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Контрольна сума"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr "Виберіть mtdblock"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1059,7 +1061,7 @@ msgstr "Шифр"
 msgid "Cisco UDP encapsulation"
 msgstr "Інкапсуляція UDP Cisco"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
@@ -1067,7 +1069,7 @@ msgstr ""
 "Натисніть кнопку \"Створити архів\", щоб завантажити tar-архів поточних "
 "файлів конфігурації."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
@@ -1075,7 +1077,7 @@ msgstr ""
 "Натисніть \"Зберегти mtdblock\", щоб завантажити вказаний файл mtdblock. "
 "(ПРИМІТКА: ЦЕ ФУНКЦІЯ ДЛЯ ПРОФЕСІОНАЛІВ!)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1112,7 +1114,7 @@ msgstr "Згорнути список..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1127,7 +1129,7 @@ msgstr "Збирання даних..."
 msgid "Command"
 msgstr "Команда"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr "Команду виконано успішно"
 
@@ -1153,8 +1155,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Конфігурація"
 
@@ -1163,7 +1164,7 @@ msgstr "Конфігурація"
 msgid "Configuration failed"
 msgstr "Помилка налаштування"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr "Конфігураційні файли буде збережено"
 
@@ -1175,7 +1176,7 @@ msgstr "Конфігурацію застосовано."
 msgid "Configuration has been rolled back!"
 msgstr "Конфігурацію було відкочено!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr "Підтвердіть від'єднання"
 
@@ -1195,7 +1196,7 @@ msgstr "Підключено"
 msgid "Connection attempt failed"
 msgstr "Невдала спроба підключення"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr "З'єднання втрачено"
 
@@ -1204,11 +1205,14 @@ msgid "Connections"
 msgstr "Підключення"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr "Вміст збережено."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr "Продовжити"
 
@@ -1232,11 +1236,11 @@ msgid "Country Code"
 msgstr "Код країни"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Створити / Визначити зону брандмауера"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr "Створити інтерфейс"
 
@@ -1265,7 +1269,7 @@ msgstr "Інтерфейс користувача"
 msgid "Custom delegated IPv6-prefix"
 msgstr "Користувацький делегований префікс IPv6"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1303,7 +1307,7 @@ msgstr "Сервер DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP та DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1318,7 +1322,7 @@ msgstr "Параметри DHCP"
 msgid "DHCPv6 client"
 msgstr "Клієнт DHCPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "Режим DHCPv6"
 
@@ -1363,7 +1367,7 @@ msgstr "Тайм-аут простою DPD"
 msgid "DS-Lite AFTR address"
 msgstr "AFTR-адреса DS-Lite"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr "DSL"
@@ -1372,7 +1376,7 @@ msgstr "DSL"
 msgid "DSL Status"
 msgstr "Стан DSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr "Режим лінії DSL"
 
@@ -1416,7 +1420,7 @@ msgstr "Типовий маршрут"
 msgid "Default gateway"
 msgstr "Типовий шлюз"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr "Типовим є БЕЗ та ЗІ збереженням стану"
 
@@ -1439,9 +1443,9 @@ msgstr ""
 "сервери для клієнтів."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1502,10 +1506,10 @@ msgstr "Зона призначення"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Пристрій"
 
@@ -1595,7 +1599,7 @@ msgstr "Відкидати висхідні RFC1918-відповіді"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr "Від’єднати"
 
@@ -1604,11 +1608,12 @@ msgstr "Від’єднати"
 msgid "Disconnection attempt failed"
 msgstr "Спроба від'єднання не вдалася"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "Відхилити"
 
@@ -1657,6 +1662,10 @@ msgstr "Справді видалити \"%s\"?"
 msgid "Do you really want to delete the following SSH key?"
 msgstr "Справді видалити такий SSH ключ?"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Справді рекурсивно видалити каталог \"%s\"?"
@@ -1686,19 +1695,19 @@ msgstr ""
 msgid "Down"
 msgstr "Вниз"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "Завантажити резервну копію"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr "Завантажити mtdblock"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr "Низхідний зсув SNR"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr "Перетягніть, щоб змінити порядок"
 
@@ -1745,9 +1754,9 @@ msgstr "Довжина EA-бітів"
 msgid "EAP-Method"
 msgstr "EAP-Метод"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1853,25 +1862,17 @@ msgstr "Увімкнути віддзеркалення вихідних пак�
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr "Увімкнути прапорець DF (Don't Fragment) для інкапсульованих пакетів."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "Увімкнути це монтування"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Увімкнути цю мережу"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "Увімкнути цей своп"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Увімкнено/Вимкнено"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "Увімкнено"
 
@@ -1896,8 +1897,8 @@ msgstr ""
 msgid "Encapsulation limit"
 msgstr "Межа інкапсуляції"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "Режим інкапсуляції"
 
@@ -1925,7 +1926,7 @@ msgstr "Введіть власне значення"
 msgid "Enter custom values"
 msgstr "Введіть власні значення"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "Видалення..."
 
@@ -1947,12 +1948,12 @@ msgstr "Помилка"
 msgid "Errored seconds (ES)"
 msgstr "Секунд з помилками (<abbr title=\"Errored seconds\">ES</abbr>)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet-адаптер"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet-комутатор"
@@ -2050,9 +2051,8 @@ msgstr "Ім'я файлу"
 msgid "Filename of the boot image advertised to clients"
 msgstr "І'мя завантажувального образу, що оголошується клієнтам"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Файлова система"
 
@@ -2069,7 +2069,7 @@ msgstr "Фільтрувати непридатні"
 msgid "Finalizing failed"
 msgstr "Завершення не вдалося"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2101,7 +2101,7 @@ msgstr "Налаштування брандмауера"
 msgid "Firewall Status"
 msgstr "Стан брандмауера"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr "Файл мікропрограми"
 
@@ -2113,25 +2113,27 @@ msgstr "Версія мікропрограми"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "Фіксований порт для вихідних DNS-запитів"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Прошиваємо мікропрограму"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "Прошити образ..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "Прошити новий образ мікропрограми"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "Операції прошивання"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "Перепрошиваємо..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2157,11 +2159,11 @@ msgstr "Примусово TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Примусово TKIP та CCMP (AES)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "Примусове з'єднання"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr "Примусове оновлення"
 
@@ -2189,7 +2191,7 @@ msgstr "Переспрямовувати широкомовний трафік"
 msgid "Forward mesh peer traffic"
 msgstr "Переспрямовувати одноранговий трафік"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "Режим переспрямовування"
 
@@ -2238,20 +2240,19 @@ msgstr "Неприпустима адреса шлюзу"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "Загальні параметри"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Загальні налаштування"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "Cтворити конфігурацію"
 
@@ -2259,7 +2260,7 @@ msgstr "Cтворити конфігурацію"
 msgid "Generate PMK locally"
 msgstr "Генерувати PMK локально"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "Cтворити архів"
 
@@ -2267,11 +2268,11 @@ msgstr "Cтворити архів"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Оскільки пароль і підтвердження не співпадають, то пароль не змінено!"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "Загальні параметри"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "Глобальні параметри мережі"
 
@@ -2282,7 +2283,7 @@ msgstr "Глобальні параметри мережі"
 msgid "Go to password configuration..."
 msgstr "Перейти до конфігурації пароля..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2336,7 +2337,7 @@ msgstr "Приховати порожні ланцюжки"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "Вузол"
 
@@ -2528,7 +2529,7 @@ msgstr "Сусіди IPv6"
 msgid "IPv6 Settings"
 msgstr "Налаштування IPv6"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 "<abbr title=\"Unique Local Address — унікальна локальна адреса\">ULA</abbr>-"
@@ -2617,16 +2618,16 @@ msgstr "Якщо позначено, 1DES увімкнено"
 msgid "If checked, encryption is disabled"
 msgstr "Якщо позначено, шифрування вимкнено"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 "Якщо обрано, монтувати пристрій за його UUID замість фіксованого вузла "
 "пристрою"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2667,7 +2668,7 @@ msgstr "Якщо не позначено, типовий маршрут не н�
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "Якщо не позначено, оголошувані адреси DNS-серверів ігноруються"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2694,7 +2695,7 @@ msgstr "Ігнорувати интерфейс"
 msgid "Ignore resolve file"
 msgstr "Ігнорувати файли resolv"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "Образ"
 
@@ -2757,8 +2758,8 @@ msgstr "Інсталяція розширень протоколу..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2845,11 +2846,11 @@ msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 "Задано неприпустимий VLAN ID! Доступні тільки унікальні ідентифікатори."
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr "Неприпустимий аргумент"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr "Неприпустима команда"
 
@@ -2865,7 +2866,7 @@ msgstr "Неприпустиме ім'я користувача та/або па
 msgid "Isolate Clients"
 msgstr "Ізолювати клієнтів"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2888,11 +2889,11 @@ msgstr "Підключення до мережі"
 msgid "Join Network: Wireless Scan"
 msgstr "Підключення до мережі: Сканування бездротових мереж"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "Приєднання до мережі: %q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "Зберегти налаштування"
 
@@ -2948,12 +2949,12 @@ msgstr "Поріг помилок ехо-запитів LCP"
 msgid "LCP echo interval"
 msgstr "Інтервал ехо-запитів LCP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "Мітка"
 
@@ -3130,7 +3131,7 @@ msgstr "Завантаження"
 msgid "Loading directory contents…"
 msgstr "Завантаження вмісту каталогу…"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr "Завантаження подання…"
@@ -3246,7 +3247,7 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3279,7 +3280,7 @@ msgstr "Неприпустиме правило MAP"
 msgid "MB/s"
 msgstr "MБ/с"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3293,7 +3294,7 @@ msgstr " МГц"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3311,7 +3312,8 @@ msgstr ""
 msgid "Manual"
 msgstr "Вручну"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr "Основний"
 
@@ -3370,7 +3372,7 @@ msgstr "Пам'ять"
 msgid "Memory usage (%)"
 msgstr "Використання пам'яті, %"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr "Mesh"
 
@@ -3378,7 +3380,7 @@ msgstr "Mesh"
 msgid "Mesh Id"
 msgstr "Mesh Id"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr "Метод не знайдено"
 
@@ -3437,7 +3439,7 @@ msgstr "Помилка запиту інформації про модем"
 msgid "Modem init timeout"
 msgstr "Тайм-аут ініціалізації модему"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Диспетчер"
@@ -3450,30 +3452,25 @@ msgstr "Більше символів"
 msgid "More…"
 msgstr "Докладніше…"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "Вхід монтування"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Точка монтування"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Точки монтування"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "Точки монтування – Записи монтування"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "Точки монтування – Вхід свопу"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3481,23 +3478,27 @@ msgstr ""
 "Точки монтування визначають, до якої точки пристрою пам'яті буде прикріплено "
 "файлову систему"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr "Монтувати не конкретно налаштовані файлові системи"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "Опції монтування"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "Точка монтування"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "Монтувати не конкретно налаштований своп"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Змонтовано файлові системи"
 
@@ -3538,15 +3539,15 @@ msgstr "Домен NT"
 msgid "NTP server candidates"
 msgstr "Кандидати для синхронізації сервера NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Ім'я"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "Назва нової мережі"
 
@@ -3557,7 +3558,7 @@ msgstr "Навігація"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3582,7 +3583,7 @@ msgstr "Мережевий пристрій відсутній"
 msgid "Network without interfaces."
 msgstr "Мережа без інтерфейсів."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr "Нова назва інтерфейсу…"
 
@@ -3607,7 +3608,7 @@ msgstr "Без шифрування"
 msgid "No NAT-T"
 msgstr "Немає NAT-T"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr "Жодних даних не отримано"
 
@@ -3660,7 +3661,7 @@ msgid "No signal"
 msgstr "Немає сигналу"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "Зону не призначено"
 
@@ -3718,7 +3719,7 @@ msgstr "Не існує"
 msgid "Not started on boot"
 msgstr "Не запущено під час завантаження"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr "Не підтримується"
 
@@ -3791,6 +3792,7 @@ msgstr "Одне або декілька неприпустимих/обов'я�
 msgid "One or more required fields have no value!"
 msgstr "Одне або декілька обов'язкових полів не мають значень!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "Відкрити список..."
@@ -3885,7 +3887,6 @@ msgstr ""
 "пакетів."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Опції"
 
@@ -4053,7 +4054,7 @@ msgstr "Зсув PSID"
 msgid "PSID-bits length"
 msgstr "Довжина PSID у бітах"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -4062,7 +4063,7 @@ msgid "Packets"
 msgstr "Пакети"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "Частина зони %q"
 
@@ -4160,11 +4161,11 @@ msgstr "Perfect Forward Secrecy"
 msgid "Perform reboot"
 msgstr "Виконати перезавантаження"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "Виконати відновлення"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr "Дозволу не надано"
 
@@ -4203,6 +4204,10 @@ msgstr "пакетів"
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Введіть ім'я користувача і пароль."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4273,10 +4278,6 @@ msgstr "Перешкоджати спілкуванню клієнт-клієн�
 msgid "Private Key"
 msgstr "Приватний ключ"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Продовжити"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4292,7 +4293,7 @@ msgstr "Прот."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4381,7 +4382,7 @@ msgstr "Одержано"
 msgid "RX Rate"
 msgstr "Швидкість приймання"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr "Швидкість прийм./перед."
 
@@ -4432,10 +4433,6 @@ msgstr ""
 "Дійсно видалити цей інтерфейс? Скасувати видалення неможливо! Ви можете "
 "втратити доступ до цього пристрою, якщо вас підключено через цей інтерфейс."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "Дійсно скинути всі зміни?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "Дійсно змінити протокол?"
@@ -4468,7 +4465,7 @@ msgstr "Кінцевий термін реассоціації"
 msgid "Rebind protection"
 msgstr "Захист від переприв'язки"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Перезавантаження"
@@ -4477,6 +4474,11 @@ msgstr "Перезавантаження"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "Перезавантаження..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4530,7 +4532,7 @@ msgstr "Віддалена адреса IPv4 або FQDN"
 msgid "Remove"
 msgstr "Видалити"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "Замінити конфігурацію бездротової мережі"
 
@@ -4542,7 +4544,7 @@ msgstr "Запит IPv6-адреси"
 msgid "Request IPv6-prefix of length"
 msgstr "Запит довжини IPv6-префіксу"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr "Час очікування запиту минув"
 
@@ -4632,7 +4634,7 @@ msgstr "Потребує wpa-суплікатора з підтримкою OWE"
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "Потребує wpa-суплікатора з підтримкою SAE"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4644,7 +4646,7 @@ msgstr "Скинути"
 msgid "Reset Counters"
 msgstr "Скинути лічильники"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "Відновити початковий стан"
 
@@ -4656,7 +4658,7 @@ msgstr "Файли resolv і hosts"
 msgid "Resolve file"
 msgstr "Файл resolv"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr "Ресурс не знайдено"
 
@@ -4675,11 +4677,11 @@ msgstr "Перезавантажити брандмауер"
 msgid "Restart radio interface"
 msgstr "Перезавантажити радіоінтерфейс"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "Відновлення"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Відновити з резервної копії"
 
@@ -4704,15 +4706,11 @@ msgstr "Помилка запиту на скасування зі статус�
 msgid "Reverting configuration…"
 msgstr "Відкат конфігурації…"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Корінь"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "Кореневий каталог для файлів TFTP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr "Підготовка Root"
 
@@ -4733,7 +4731,7 @@ msgid "Router Advertisement-Service"
 msgstr "Служба оголошень маршрутизатора"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "Пароль маршрутизатора"
 
@@ -4755,19 +4753,19 @@ msgstr ""
 msgid "Rule"
 msgstr "Правило"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "Виконати перевірку файлової системи перед монтуванням пристрою"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "Виконати перевірку файлової системи"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr "Помилка виконання"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4776,7 +4774,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH-доступ"
 
@@ -4793,7 +4791,7 @@ msgid "SSH username"
 msgstr "Ім'я користувача SSH"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH-ключі"
 
@@ -4804,30 +4802,31 @@ msgstr "SSH-ключі"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Зберегти"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Зберегти і застосувати"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr "Зберегти mtdblock"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr "Зберегти вміст mtdblock"
 
@@ -4836,7 +4835,7 @@ msgid "Scan"
 msgstr "Сканувати"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Заплановані завдання"
 
@@ -4848,11 +4847,11 @@ msgstr "Секцію додано"
 msgid "Section removed"
 msgstr "Секцію видалено"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "Подробиці дивись на сторінці керівництва \"mount\"."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4898,7 +4897,7 @@ msgstr "Тип сервісу"
 msgid "Services"
 msgstr "Сервіси"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr "Час сеансу минув"
 
@@ -4906,13 +4905,17 @@ msgstr "Час сеансу минув"
 msgid "Set VPN as Default Route"
 msgstr "Встановити VPN типовим маршрутом"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
 msgstr ""
 "Властивості інтерфейсу встановлюються незалежно від каналу зв'язку (якщо "
 "позначено, обробник автовизначення не викликається при змінах)."
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
+msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 #: protocols/luci-proto-qmi/luasrc/model/network/proto_qmi.lua:55
@@ -4943,6 +4946,7 @@ msgstr "Short GI"
 msgid "Short Preamble"
 msgstr "Коротка преамбула"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "Показати поточний список файлів резервного копіювання"
@@ -4964,7 +4968,7 @@ msgstr "Вимкнути цей інтерфейс"
 msgid "Signal"
 msgstr "Сигнал"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr "Сигнал / шум"
 
@@ -4976,7 +4980,7 @@ msgstr "Затухання сигналу (SATN)"
 msgid "Signal:"
 msgstr "Сигнал:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Розмір"
 
@@ -5001,7 +5005,7 @@ msgstr "Перейти до вмісту"
 msgid "Skip to navigation"
 msgstr "Перейти до навігації"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Програмово реалізований VLAN"
@@ -5018,7 +5022,7 @@ msgstr "На жаль, об'єкт, який ви просили, не знай�
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "На жаль, на сервері сталася неочікувана помилка."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -5038,7 +5042,7 @@ msgstr "Джерело"
 msgid "Source Address"
 msgstr "Адреса джерела"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "Визначає каталог, до якого приєднаний пристрій"
 
@@ -5088,7 +5092,7 @@ msgstr ""
 "Вкажіть MTU (Maximum Transmission Unit — максимальний блок передавання), "
 "відмінний від типового (1280 байт)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "Вкажіть тут секретний ключ шифрування."
 
@@ -5111,7 +5115,7 @@ msgid "Starting wireless scan..."
 msgstr "Розпочато сканування бездротових мереж..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "Запуск"
 
@@ -5131,7 +5135,7 @@ msgstr "Статичні оренди"
 msgid "Static Routes"
 msgstr "Статичні маршрути"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5174,7 +5178,7 @@ msgid "Strong"
 msgstr "Висока"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Надіслати"
 
@@ -5189,10 +5193,6 @@ msgstr "Блокувати ведення журналу звичайної ро
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "Своп"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Вхід своп"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5214,7 +5214,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Маска портів комутатора"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "VLAN комутатора"
@@ -5307,6 +5307,10 @@ msgstr "Цільова мережа"
 msgid "Terminate"
 msgstr "Завершити"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5328,17 +5332,13 @@ msgstr ""
 "Призначений провайдером IPv6-префікс, зазвичай закінчується на <code>::</"
 "code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "Дозволено символи: <code>A-Z</code>, <code>a-z</code>, <code>0-9</code> та "
 "<code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr "Архів резервної копії не є правильним файлом gzip."
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5361,8 +5361,8 @@ msgstr ""
 "та відредагувати зміни, перш ніж намагатись застосувати їх знову, або ж "
 "скасувати всі очікуючі зміни, щоб зберегти поточну робочу конфігурацію."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5376,25 +5376,16 @@ msgstr ""
 "Для правильного функціонування LuCI, потрібно змінити існуючу конфігурацію "
 "бездротового зв'язку."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"Файлова система, яка використовуватиметься для форматування пам'яті "
-"(наприклад, <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"Образ завантажено. Нижче наведено контрольну суму та розмір файлу. "
-"Порівняйте їх з вихідним файлом, щоб переконатися в цілісності даних.<br /> "
-"Натисніть \"Продовжити\", щоб розпочати процедуру прошивання."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5416,11 +5407,11 @@ msgstr ""
 "Наданий відкритий SSH-ключ є недійсним. Надавайте належні відкриті ключі RSA "
 "або ECDSA."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr "Назва інтерфейсу вже використовується"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr "Назва інтерфейсу занадто довга"
 
@@ -5440,7 +5431,7 @@ msgstr "Довжина IPv6-префікса в бітах"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "Локальна адреса IPv4, за якою створюється тунель (необов'язково)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr "Назва мережі вже використовується"
 
@@ -5462,6 +5453,14 @@ msgstr ""
 "більшою мережею, такою наприклад, як Інтернет, а інші порти — для локальної "
 "мережі."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr "Обраний режим %s несумісний із шифруванням %s"
@@ -5470,7 +5469,7 @@ msgstr "Обраний режим %s несумісний із шифруван�
 msgid "The submitted security token is invalid or already expired!"
 msgstr "Поданий маркер безпеки недійсний або вже збіг!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5478,7 +5477,7 @@ msgstr ""
 "Зараз система видаляє розділ конфігурації і коли закінчить, "
 "перезавантажиться."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5490,11 +5489,32 @@ msgstr ""
 "під'єднатися. Залежно від налаштувань, можливо, треба буде оновити адресу "
 "вашого комп'ютера, щоб знову отримати доступ до пристрою."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "Системний пароль успішно змінено."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5548,6 +5568,7 @@ msgstr ""
 "'server=1.2.3.4' для домен-орієнтованих або повних висхідних <abbr title="
 "\"Domain Name System\">DNS</abbr>-серверів."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5643,11 +5664,11 @@ msgstr "Інтервал часу для зміни ключа GTK"
 msgid "Timezone"
 msgstr "Часовий пояс"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr "До входу…"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5658,7 +5679,7 @@ msgstr ""
 "натисніть кнопку \"Виконати відновлення\" (можливо тільки з образами "
 "SquashFS)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr "Тоновий"
 
@@ -5698,7 +5719,7 @@ msgstr "Режим запуску"
 msgid "Tunnel ID"
 msgstr "Ідентифікатор тунелю"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Інтерфейс тунелю"
@@ -5741,8 +5762,8 @@ msgstr "USB-пристрій"
 msgid "USB Ports"
 msgstr "USB-порт"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5772,6 +5793,10 @@ msgstr "Не вдається опрацювати запит"
 msgid "Unable to obtain client ID"
 msgstr "Не вдається отримати ідентифікатор клієнта"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5783,6 +5808,7 @@ msgid "Unable to resolve peer host name"
 msgstr "Не вдається розрізнити ім'я хоста вузла"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr "Не вдалося зберегти вміст: %s"
@@ -5791,28 +5817,28 @@ msgstr "Не вдалося зберегти вміст: %s"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Недоступні секунди (<abbr title=\"Unavailable Seconds\">UAS</abbr>)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Невідома помилка (%s)"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr "Невідомий код помилки"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "Некерований"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "Демонтувати"
 
@@ -5825,7 +5851,7 @@ msgstr "Безіменний ключ"
 msgid "Unsaved Changes"
 msgstr "Незбережені зміни"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr "Невизначена помилка"
 
@@ -5848,7 +5874,11 @@ msgstr "Непідтримуваний тип протоколу."
 msgid "Up"
 msgstr "Вгору"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5858,7 +5888,9 @@ msgstr ""
 "Для збереження поточної конфігурації встановіть прапорець \"Зберегти "
 "налаштування\" (потрібен сумісний образ мікропрограми)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "Відвантажити архів..."
 
@@ -5871,8 +5903,14 @@ msgid "Upload file…"
 msgstr "Відвантажити файл…"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
 msgstr "Не вдалося виконати запит на відвантаження: %s"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
 msgid ""
@@ -5932,11 +5970,11 @@ msgstr "Використовувати на тунельному інтерфе�
 msgid "Use TTL on tunnel interface"
 msgstr "Використовувати на тунельному інтерфейсі TTL"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr "Використовувати як зовнішній оверлей (/overlay)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "Використовувати як кореневу файлову систему (/)"
 
@@ -5944,7 +5982,7 @@ msgstr "Використовувати як кореневу файлову си
 msgid "Use broadcast flag"
 msgstr "Використовувати прапорець широкомовності"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "Використовувати вбудоване керування IPv6"
 
@@ -6014,7 +6052,7 @@ msgstr ""
 "часу оренди, наприклад 12h, 3d чи <abbr title=\"необмежений\">infinite</"
 "abbr>."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Використано"
 
@@ -6045,11 +6083,11 @@ msgstr "Ключ користувача (PEM-кодований)"
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr "VDSL"
 
@@ -6096,9 +6134,9 @@ msgstr "Постачальник"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "Клас постачальника для відправки при запиті DHCP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "Перевірте"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -6118,7 +6156,7 @@ msgstr "Відкрита система WEP"
 msgid "WEP Shared Key"
 msgstr "Спільний ключ WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "Парольна фраза WEP"
 
@@ -6126,7 +6164,7 @@ msgstr "Парольна фраза WEP"
 msgid "WMM Mode"
 msgstr "Режим <abbr title=\"Wi-Fi Multimedia\">WMM</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "Парольна фраза WPA"
 
@@ -6194,13 +6232,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "Бездротові мережі"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Бездротовий адаптер"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6251,7 +6289,7 @@ msgstr "Записувати cистемний журнал до файлу"
 msgid "Yes"
 msgstr "Так"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6300,9 +6338,9 @@ msgstr "Розмір ZRam"
 msgid "any"
 msgstr "будь-який"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6319,7 +6357,7 @@ msgstr "автоматично"
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "з'єд. мостом"
 
@@ -6336,7 +6374,7 @@ msgid "create:"
 msgstr "створити:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "Створює мережевий міст через зазначені інтерфейси"
 
@@ -6474,8 +6512,6 @@ msgstr "хв."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "ні"
 
@@ -6487,13 +6523,13 @@ msgstr "нема з'єднання"
 msgid "non-empty value"
 msgstr "непусте значення"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "нема нічого"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "не присутній"
 
@@ -6523,10 +6559,6 @@ msgstr "відкрита мережа"
 msgid "output"
 msgstr "вихід"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr "оверлей"
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr "додатне десяткове значення"
@@ -6545,7 +6577,7 @@ msgstr "випадковий"
 msgid "relay mode"
 msgstr "режим реле"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "спрямовано"
 
@@ -6559,15 +6591,15 @@ msgstr "с"
 msgid "server mode"
 msgstr "режим сервера"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr "тільки ЗІ збереженням стану"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr "БЕЗ збереження стану"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr "БЕЗ та ЗІ збереженням стану"
 
@@ -6785,11 +6817,78 @@ msgstr "слабкий рівень безпеки"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "так"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "(%s available)"
+#~ msgstr " (доступно %s)"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- відповідно пристрою --"
+
+#~ msgid "Caution: System upgrade will be forced"
+#~ msgstr "Увага: систему буде оновлено примусово"
+
+#~ msgid "Check"
+#~ msgstr "Перевірити"
+
+#~ msgid "Checksum"
+#~ msgstr "Контрольна сума"
+
+#~ msgid "Enable this mount"
+#~ msgstr "Увімкнути це монтування"
+
+#~ msgid "Enable this swap"
+#~ msgstr "Увімкнути цей своп"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Прошиваємо мікропрограму"
+
+#~ msgid "Flashing..."
+#~ msgstr "Перепрошиваємо..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "Вхід монтування"
+
+#~ msgid "Proceed"
+#~ msgstr "Продовжити"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "Дійсно скинути всі зміни?"
+
+#~ msgid "Root"
+#~ msgstr "Корінь"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Вхід своп"
+
+#~ msgid "The backup archive does not appear to be a valid gzip file."
+#~ msgstr "Архів резервної копії не є правильним файлом gzip."
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "Файлова система, яка використовуватиметься для форматування пам'яті "
+#~ "(наприклад, <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
+#~ "samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "Образ завантажено. Нижче наведено контрольну суму та розмір файлу. "
+#~ "Порівняйте їх з вихідним файлом, щоб переконатися в цілісності даних.<br /"
+#~ "> Натисніть \"Продовжити\", щоб розпочати процедуру прошивання."
+
+#~ msgid "Verify"
+#~ msgstr "Перевірте"
+
+#~ msgid "overlay"
+#~ msgstr "оверлей"

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Pootle 1.1.0\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -36,11 +36,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-#, fuzzy
-msgid "(%s available)"
-msgstr "(%s available)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +76,13 @@ msgstr "--Hãy chọn--"
 msgid "-- custom --"
 msgstr "--tùy chỉnh--"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -206,7 +199,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 
@@ -249,23 +242,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -279,32 +272,32 @@ msgstr ""
 msgid "ARP retry threshold"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr ""
@@ -328,8 +321,7 @@ msgstr ""
 msgid "Access Point"
 msgstr "Điểm truy cập"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "Hành động"
 
@@ -355,7 +347,7 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -365,7 +357,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -376,7 +368,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "Thêm vào"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -411,7 +403,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr ""
 
@@ -455,19 +447,18 @@ msgid "Address to access local relay bridge"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "Quản trị"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr ""
 
@@ -479,7 +470,7 @@ msgstr ""
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -550,7 +541,7 @@ msgstr ""
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -560,76 +551,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -637,11 +628,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr ""
 
@@ -650,6 +641,10 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:181
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
@@ -680,13 +675,17 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
@@ -737,27 +736,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "Sẵn có"
 
@@ -775,11 +774,11 @@ msgstr "Sẵn có"
 msgid "Average:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -803,14 +802,15 @@ msgstr ""
 msgid "Back to configuration"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr ""
@@ -828,6 +828,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -859,17 +860,17 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "Giao diện cầu nối"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr ""
 
@@ -878,6 +879,7 @@ msgid "Bring up on boot"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -905,11 +907,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Bỏ qua"
 
@@ -917,12 +921,8 @@ msgstr "Bỏ qua"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -956,28 +956,29 @@ msgstr ""
 msgid "Channel"
 msgstr "Kênh"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "Checksum"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -999,19 +1000,19 @@ msgstr ""
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1046,7 +1047,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1061,7 +1062,7 @@ msgstr ""
 msgid "Command"
 msgstr "Lệnh"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1083,8 +1084,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "Cấu hình"
 
@@ -1093,7 +1093,7 @@ msgstr "Cấu hình"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Configuration has been rolled back!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1134,11 +1134,14 @@ msgid "Connections"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1158,11 +1161,11 @@ msgid "Country Code"
 msgstr "Mã quốc gia"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "Tạo/ gán firewall-zone"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1191,7 +1194,7 @@ msgstr ""
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1226,7 +1229,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1241,7 +1244,7 @@ msgstr "Tùy chọn DHCP"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1286,7 +1289,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1295,7 +1298,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1337,7 +1340,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1357,9 +1360,9 @@ msgid ""
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1420,10 +1423,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "Công cụ"
 
@@ -1511,7 +1514,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1520,11 +1523,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr ""
 
@@ -1568,6 +1572,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1596,19 +1604,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1652,9 +1660,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP-Method"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1756,25 +1764,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "Cho kích hoạt/ Vô hiệu hóa"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr ""
 
@@ -1796,8 +1796,8 @@ msgstr "Kích hoạt Spanning Tree Protocol trên cầu nối này"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr ""
 
@@ -1825,7 +1825,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr ""
 
@@ -1847,12 +1847,12 @@ msgstr "Lỗi"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Bộ tương hợp ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Bộ chuyển đảo ethernet"
@@ -1950,9 +1950,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "Tập tin hệ thống"
 
@@ -1969,7 +1968,7 @@ msgstr "Lọc không hữu dụng"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -1999,7 +1998,7 @@ msgstr ""
 msgid "Firewall Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2011,24 +2010,26 @@ msgstr ""
 msgid "Fixed source port for outbound DNS queries"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "Phần cứng flash"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
@@ -2055,11 +2056,11 @@ msgstr ""
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2087,7 +2088,7 @@ msgstr ""
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2134,20 +2135,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr ""
 
@@ -2163,11 +2163,11 @@ msgstr ""
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr ""
 
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2228,7 +2228,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2420,7 +2420,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2507,14 +2507,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2553,7 +2553,7 @@ msgstr ""
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2579,7 +2579,7 @@ msgstr "Lờ đi giao diện"
 msgid "Ignore resolve file"
 msgstr "Lờ đi tập tin resolve"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr ""
 
@@ -2639,8 +2639,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2724,11 +2724,11 @@ msgstr ""
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2744,7 +2744,7 @@ msgstr "Tên và mật mã không đúng. Xin thử lại "
 msgid "Isolate Clients"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2768,11 +2768,11 @@ msgstr ""
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr ""
 
@@ -2828,12 +2828,12 @@ msgstr ""
 msgid "LCP echo interval"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr ""
 
@@ -2988,7 +2988,7 @@ msgstr ""
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3128,7 +3128,7 @@ msgstr ""
 msgid "MB/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3142,7 +3142,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3158,7 +3158,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3217,7 +3218,7 @@ msgstr "Bộ nhớ"
 msgid "Memory usage (%)"
 msgstr "Memory usage (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3225,7 +3226,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3284,7 +3285,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
@@ -3297,30 +3298,25 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "Lắp điểm"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "Lắp điểm"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
@@ -3328,23 +3324,27 @@ msgstr ""
 "Số điểm lắp xác định tại một điểm mà ở đó bộ nhớ sẽ được gắn vào hệ thống "
 "tập tin"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "Lắp tập tin hệ thống"
 
@@ -3385,15 +3385,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "Tên"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr ""
 
@@ -3404,7 +3404,7 @@ msgstr "Sự điều hướng"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3429,7 +3429,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3454,7 +3454,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3507,7 +3507,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr ""
 
@@ -3565,7 +3565,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3638,6 +3638,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr ""
@@ -3717,7 +3718,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "Lựa chọn "
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3889,7 +3889,7 @@ msgid "Packets"
 msgstr "Gói tin"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr ""
 
@@ -3987,11 +3987,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "Tiến hành reboot"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4030,6 +4030,10 @@ msgstr ""
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "Nhập tên và mật mã"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4098,10 +4102,6 @@ msgstr "Ngăn chặn giao tiếp giữa client-và-client"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "Proceed"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4117,7 +4117,7 @@ msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4200,7 +4200,7 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4246,10 +4246,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr ""
@@ -4282,7 +4278,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reboot"
@@ -4290,6 +4286,11 @@ msgstr "Reboot"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
@@ -4344,7 +4345,7 @@ msgstr ""
 msgid "Remove"
 msgstr "Loại bỏ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4356,7 +4357,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4439,7 +4440,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4451,7 +4452,7 @@ msgstr "Reset"
 msgid "Reset Counters"
 msgstr "Reset bộ đếm"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr ""
 
@@ -4463,7 +4464,7 @@ msgstr ""
 msgid "Resolve file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4482,11 +4483,11 @@ msgstr "Khởi động lại Firewall"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "Phục hồi backup"
 
@@ -4511,15 +4512,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4540,7 +4537,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr ""
 
@@ -4562,19 +4559,19 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4583,7 +4580,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr ""
 
@@ -4600,7 +4597,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr ""
 
@@ -4611,30 +4608,31 @@ msgstr ""
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "Lưu"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Lưu & áp dụng "
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4643,7 +4641,7 @@ msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "Scheduled Tasks"
 
@@ -4655,11 +4653,11 @@ msgstr ""
 msgid "Section removed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4700,7 +4698,7 @@ msgstr ""
 msgid "Services"
 msgstr "Dịch vụ "
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4708,10 +4706,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4741,6 +4743,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr ""
@@ -4762,7 +4765,7 @@ msgstr ""
 msgid "Signal"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4774,7 +4777,7 @@ msgstr ""
 msgid "Signal:"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "Dung lượng "
 
@@ -4799,7 +4802,7 @@ msgstr "Nhảy tới nội dung"
 msgid "Skip to navigation"
 msgstr "Chuyển đến mục định hướng"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4816,7 +4819,7 @@ msgstr ""
 msgid "Sorry, the server encountered an unexpected error."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4833,7 +4836,7 @@ msgstr "Nguồn"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
@@ -4872,7 +4875,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4895,7 +4898,7 @@ msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr ""
 
@@ -4915,7 +4918,7 @@ msgstr "Thống kê leases"
 msgid "Static Routes"
 msgstr "Static Routes"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4954,7 +4957,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "Trình "
 
@@ -4968,10 +4971,6 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
@@ -4992,7 +4991,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5085,6 +5084,10 @@ msgstr ""
 msgid "Terminate"
 msgstr "Terminate"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5102,14 +5105,10 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
@@ -5127,8 +5126,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5142,19 +5141,14 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"Filesystem mà được dùng để format memory (<abbr title=\"for example\">e.g.</"
-"abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
 
@@ -5176,11 +5170,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5200,7 +5194,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5214,6 +5208,14 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5222,13 +5224,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5240,11 +5242,32 @@ msgstr ""
 "một vài phút cho tới khi kết nối lại. Có thể cần phải làm mới địa chỉ của "
 "máy tính để tiếp cận thiết bị một lần nữa, phụ thuộc vào cài đặt của bạn. "
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5293,6 +5316,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5376,18 +5400,18 @@ msgstr ""
 msgid "Timezone"
 msgstr "Múi giờ "
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
 "reset\" (only possible with squashfs images)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5427,7 +5451,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5470,8 +5494,8 @@ msgstr ""
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr ""
 
@@ -5501,6 +5525,10 @@ msgstr ""
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5512,6 +5540,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5520,28 +5549,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5554,7 +5583,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "Thay đổi không lưu"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5577,14 +5606,20 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
 "compatible firmware image)."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr ""
 
@@ -5597,7 +5632,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5655,11 +5696,11 @@ msgstr ""
 msgid "Use TTL on tunnel interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5667,7 +5708,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr ""
 
@@ -5730,7 +5771,7 @@ msgid ""
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "Đã sử dụng"
 
@@ -5758,11 +5799,11 @@ msgstr ""
 msgid "Username"
 msgstr "Tên người dùng "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5809,8 +5850,8 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
@@ -5831,7 +5872,7 @@ msgstr ""
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr ""
 
@@ -5839,7 +5880,7 @@ msgstr ""
 msgid "WMM Mode"
 msgstr "WMM Mode"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr ""
 
@@ -5901,13 +5942,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Bộ tương hợp không dây"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5958,7 +5999,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6003,9 +6044,9 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6023,7 +6064,7 @@ msgstr "thống kê"
 msgid "baseT"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr ""
 
@@ -6040,7 +6081,7 @@ msgid "create:"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "tạo một cầu nối trên một giao diện được chỉ định"
 
@@ -6176,8 +6217,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr ""
 
@@ -6189,13 +6228,13 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "không "
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6225,10 +6264,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6247,7 +6282,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr ""
 
@@ -6261,15 +6296,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6487,14 +6522,34 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr ""
+
+#, fuzzy
+#~ msgid "(%s available)"
+#~ msgstr "(%s available)"
+
+#~ msgid "Checksum"
+#~ msgstr "Checksum"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "Phần cứng flash"
+
+#~ msgid "Proceed"
+#~ msgstr "Proceed"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "Filesystem mà được dùng để format memory (<abbr title=\"for example\">e.g."
+#~ "</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
+#~ "samp>)"
 
 #~ msgid "Connection Limit"
 #~ msgstr "Giới hạn kết nối"

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr "%.1f dB"
 
@@ -37,10 +37,6 @@ msgstr "%s 在多个 VLAN 中均未标记！"
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "（最近 %d 分钟信息，每 %d 秒刷新）"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "（%s 可用）"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -81,15 +77,13 @@ msgstr "-- 请选择 --"
 msgid "-- custom --"
 msgstr "-- 自定义 --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr "-- 根据设备匹配 --"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr "-- 根据标签匹配 --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr "-- 根据 UUID 匹配 --"
 
@@ -208,7 +202,7 @@ msgstr ""
 "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr> 后缀（十六进制）"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 配置"
 
@@ -255,23 +249,23 @@ msgstr ""
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr "由于身份验证会话已过期，需要重新登录。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr "A43C + J43 + A43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr "A43C + J43 + A43 + V43"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr "ADSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr "ANSI T1.413"
 
@@ -285,25 +279,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "ARP 重试阈值"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr "ATM（异步传输模式）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM 桥接"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM 虚拟通道标识（VCI）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM 虚拟路径标识（VPI）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -312,7 +306,7 @@ msgstr ""
 "ATM 桥是以 AAL5 协议封装以太网的虚拟 Linux 网桥，用于协同 DHCP 或 PPP 来拨号"
 "连接到网络运营商。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "ATM 设备号码"
@@ -336,8 +330,7 @@ msgstr "接入集中器"
 msgid "Access Point"
 msgstr "接入点 AP"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "动作"
 
@@ -363,7 +356,7 @@ msgstr "已分配的 DHCP 租约"
 msgid "Active DHCPv6 Leases"
 msgstr "已分配的 DHCPv6 租约"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -373,7 +366,7 @@ msgstr "点对点 Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -384,7 +377,7 @@ msgstr "点对点 Ad-Hoc"
 msgid "Add"
 msgstr "添加"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -419,7 +412,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "添加本地域名后缀到 HOSTS 文件中的域名"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "添加新接口…"
 
@@ -463,19 +456,18 @@ msgid "Address to access local relay bridge"
 msgstr "接入本地中继桥的地址"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "管理权"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "高级设置"
 
@@ -487,7 +479,7 @@ msgstr "总发射功率（ACTATP）"
 msgid "Alert"
 msgstr "警戒"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -558,7 +550,7 @@ msgstr "允许 127.0.0.0/8 回环范围内的上行响应，例如：RBL 服务"
 msgid "Allowed IPs"
 msgstr "允许的 IP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr "总是通告默认路由"
 
@@ -569,76 +561,76 @@ msgid ""
 msgstr ""
 "即使辅助信道重叠，也始终使用 40MHz 信道。使用此选项不符合 IEEE 802.11n-2009！"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr "Annex"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr "Annex A + L + M（全部）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr "Annex A G.992.1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr "Annex A G.992.2"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr "Annex A G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr "Annex A G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr "Annex B（全部）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr "Annex B G.992.1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr "Annex B G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr "Annex B G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr "Annex J（全部）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr "Annex L G.992.3 POTS 1"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr "Annex M（全部）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr "Annex M G.992.3"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr "Annex M G.992.5"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr "即使没有可用的公网前缀，也仍通告自己为默认路由。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr "通告的 DNS 域名"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr "通告的 DNS 服务器"
 
@@ -646,11 +638,11 @@ msgstr "通告的 DNS 服务器"
 msgid "Anonymous Identity"
 msgstr "匿名身份"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "自动挂载未配置的磁盘分区"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "自动挂载未配置的 Swap 分区"
 
@@ -660,6 +652,10 @@ msgstr "自动挂载未配置的 Swap 分区"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "任意区域"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -689,7 +685,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr "将此十六进制子 ID 前缀分配给此接口"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "已连接站点"
@@ -697,6 +693,10 @@ msgstr "已连接站点"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "关联数"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -746,27 +746,27 @@ msgstr "自动"
 msgid "Automatic Homenet (HNCP)"
 msgstr "自动家庭网络（HNCP）"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr "在挂载前自动检查文件系统错误"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr "通过 hotplug 自动挂载磁盘"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr "通过 hotplug 自动挂载 swap 分区"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "自动挂载磁盘"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "自动挂载 Swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "可用"
 
@@ -784,11 +784,11 @@ msgstr "可用"
 msgid "Average:"
 msgstr "平均："
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr "B43 + B43C"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr "B43 + B43C + V43"
 
@@ -812,14 +812,15 @@ msgstr "返回至概况"
 msgid "Back to configuration"
 msgstr "返回至配置"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "备份"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "备份/升级"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "文件备份列表"
@@ -837,6 +838,7 @@ msgstr "频宽"
 msgid "Beacon Interval"
 msgstr "Beacon 间隔"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -870,17 +872,17 @@ msgstr "传输速率"
 msgid "Bogus NX Domain Override"
 msgstr "忽略虚假空域名解析"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "桥接"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "桥接接口"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "桥接号"
 
@@ -889,6 +891,7 @@ msgid "Bring up on boot"
 msgstr "开机自动运行"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -916,11 +919,13 @@ msgstr "调用失败"
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "取消"
 
@@ -928,13 +933,9 @@ msgstr "取消"
 msgid "Category"
 msgstr "分类"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
 msgstr "注意：配置文件将被删除"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
-msgstr "注意：将强制进行系统升级"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:48
@@ -967,28 +968,29 @@ msgstr "更改访问设备的管理员密码"
 msgid "Channel"
 msgstr "信道"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "检查"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "在挂载前检查文件系统"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "选中此选项以从无线中删除现有网络。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "校验值"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr "选择 mtdblock"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1012,13 +1014,13 @@ msgstr "算法"
 msgid "Cisco UDP encapsulation"
 msgstr "Cisco UDP 封装"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr "点击“生成备份”下载当前配置文件的 tar 存档。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
@@ -1026,7 +1028,7 @@ msgstr ""
 "单击“保存 mtdblock”以下载指定的 mtdblock 文件。（注意：此功能适用于专业人"
 "士！）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1061,7 +1063,7 @@ msgstr "关闭列表…"
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1076,7 +1078,7 @@ msgstr "正在收集数据…"
 msgid "Command"
 msgstr "命令"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1101,8 +1103,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "配置"
 
@@ -1111,7 +1112,7 @@ msgstr "配置"
 msgid "Configuration failed"
 msgstr "配置失败"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr "将保留配置文件"
 
@@ -1123,7 +1124,7 @@ msgstr "配置已应用。"
 msgid "Configuration has been rolled back!"
 msgstr "配置已回滚！"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1143,7 +1144,7 @@ msgstr "已连接"
 msgid "Connection attempt failed"
 msgstr "尝试连接失败"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1152,11 +1153,14 @@ msgid "Connections"
 msgstr "连接"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1178,11 +1182,11 @@ msgid "Country Code"
 msgstr "国家代码"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "创建/分配防火墙区域"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1211,7 +1215,7 @@ msgstr "自定义接口"
 msgid "Custom delegated IPv6-prefix"
 msgstr "自定义分配的 IPv6 前缀"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1245,7 +1249,7 @@ msgstr "DHCP 服务器"
 msgid "DHCP and DNS"
 msgstr "DHCP/DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1260,7 +1264,7 @@ msgstr "DHCP 选项"
 msgid "DHCPv6 client"
 msgstr "DHCPv6 客户端"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr "DHCPv6 模式"
 
@@ -1305,7 +1309,7 @@ msgstr "DPD 空闲超时"
 msgid "DS-Lite AFTR address"
 msgstr "DS-Lite AFTR 地址"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr "DSL"
@@ -1314,7 +1318,7 @@ msgstr "DSL"
 msgid "DSL Status"
 msgstr "DSL 状态"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr "DSL 线路模式"
 
@@ -1356,7 +1360,7 @@ msgstr "默认路由"
 msgid "Default gateway"
 msgstr "默认网关"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr "默认是无状态的 + 有状态的"
 
@@ -1378,9 +1382,9 @@ msgstr ""
 "示通告不同的 DNS 服务器给客户端。"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1441,10 +1445,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "设备"
 
@@ -1534,7 +1538,7 @@ msgstr "丢弃 RFC1918 上行响应数据"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr "断开连接"
 
@@ -1543,11 +1547,12 @@ msgstr "断开连接"
 msgid "Disconnection attempt failed"
 msgstr "尝试断开连接失败"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "解除"
 
@@ -1590,6 +1595,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr "您真的要删除以下 SSH 密钥吗？"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1617,19 +1626,19 @@ msgstr ""
 msgid "Down"
 msgstr "下移"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "下载备份"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr "下载 mtdblock"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr "下游 SNR 偏移"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1673,9 +1682,9 @@ msgstr "EA-位长"
 msgid "EAP-Method"
 msgstr "EAP 类型"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1778,25 +1787,17 @@ msgstr "启用流出数据包镜像"
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr "启用后报文的 DF（禁止分片）标志。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "启用此挂载点"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "启用此网络"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "启用此 swap 分区"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "启用/禁用"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "已启用"
 
@@ -1818,8 +1819,8 @@ msgstr "在此桥接上启用生成树协议"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "封装模式"
 
@@ -1847,7 +1848,7 @@ msgstr "输入自定义值"
 msgid "Enter custom values"
 msgstr "输入自定义值"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "擦除中…"
 
@@ -1869,12 +1870,12 @@ msgstr "错误"
 msgid "Errored seconds (ES)"
 msgstr "错误秒数（ES）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "以太网适配器"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "以太网交换机"
@@ -1972,9 +1973,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "向客户端通告的启动镜像文件名"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "文件系统"
 
@@ -1991,7 +1991,7 @@ msgstr "过滤无用包"
 msgid "Finalizing failed"
 msgstr "最终确认失败"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2021,7 +2021,7 @@ msgstr "防火墙设置"
 msgid "Firewall Status"
 msgstr "防火墙状态"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr "固件文件"
 
@@ -2033,25 +2033,27 @@ msgstr "固件版本"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "指定的 DNS 查询源端口"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "刷新固件"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "刷写固件…"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "刷写新的固件"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "刷新操作"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "正在刷写…"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2077,11 +2079,11 @@ msgstr "强制 TKIP"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "强制 TKIP 和 CCMP（AES）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr "强制链路"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr "强制升级"
 
@@ -2109,7 +2111,7 @@ msgstr "转发广播数据包"
 msgid "Forward mesh peer traffic"
 msgstr "转发 mesh 节点数据包"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "转发模式"
 
@@ -2156,20 +2158,19 @@ msgstr "网关地址无效"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "基本设置"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "基本设置"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "生成配置"
 
@@ -2177,7 +2178,7 @@ msgstr "生成配置"
 msgid "Generate PMK locally"
 msgstr "本地生成 PMK"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "生成备份"
 
@@ -2185,11 +2186,11 @@ msgstr "生成备份"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "由于密码验证不匹配，密码没有更改！"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr "全局设置"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "全局网络选项"
 
@@ -2200,7 +2201,7 @@ msgstr "全局网络选项"
 msgid "Go to password configuration..."
 msgstr "跳转到密码配置页…"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2248,7 +2249,7 @@ msgstr "隐藏空链"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr "主机"
 
@@ -2440,7 +2441,7 @@ msgstr "IPv6 网上邻居"
 msgid "IPv6 Settings"
 msgstr "IPv6 设置"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr "IPv6 ULA 前缀"
 
@@ -2527,14 +2528,14 @@ msgstr "如果选中，则启用1DES。"
 msgid "If checked, encryption is disabled"
 msgstr "如果选中，则禁用加密"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr "如果指定，则通过 UUID 而不是固定的设备文件来挂载设备"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2573,7 +2574,7 @@ msgstr "留空则不配置默认路由"
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "留空则忽略所通告的 DNS 服务器地址"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2598,7 +2599,7 @@ msgstr "忽略此接口"
 msgid "Ignore resolve file"
 msgstr "忽略解析文件"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "固件文件"
 
@@ -2660,8 +2661,8 @@ msgstr "安装扩展协议…"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2745,11 +2746,11 @@ msgstr "无效的 VLAN ID！只有 %d 和 %d 之间的 ID 有效。"
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "无效的 VLAN ID！只允许唯一的 ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2765,7 +2766,7 @@ msgstr "无效的用户名和/或密码！请重试。"
 msgid "Isolate Clients"
 msgstr "隔离客户端"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
 "flash memory, please verify the image file!"
@@ -2786,11 +2787,11 @@ msgstr "加入网络"
 msgid "Join Network: Wireless Scan"
 msgstr "加入网络：搜索无线"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr "加入网络：%q"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "保留配置"
 
@@ -2846,12 +2847,12 @@ msgstr "LCP 响应故障阈值"
 msgid "LCP echo interval"
 msgstr "LCP 响应间隔"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "卷标"
 
@@ -3014,7 +3015,7 @@ msgstr "加载中"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3121,7 +3122,7 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3154,7 +3155,7 @@ msgstr "MAP 规则无效"
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr "MD5"
 
@@ -3168,7 +3169,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3184,7 +3185,8 @@ msgstr "确保使用以下命令来复制根文件系统："
 msgid "Manual"
 msgstr "手动"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3243,7 +3245,7 @@ msgstr "内存"
 msgid "Memory usage (%)"
 msgstr "内存使用率（%）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3251,7 +3253,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr "Mesh ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3310,7 +3312,7 @@ msgstr "调制解调器信息查询失败"
 msgid "Modem init timeout"
 msgstr "调制解调器初始化超时"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "监听"
@@ -3323,52 +3325,51 @@ msgstr "需要更多字符"
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "挂载项目"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "挂载点"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "挂载点"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "挂载点 - 存储区"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "挂载点 - 交换区"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr "配置存储设备挂载到文件系统中的位置和参数"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr "自动挂载未专门配置挂载点的分区"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "挂载选项"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "挂载点"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "自动挂载未专门配置的 swap 分区"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "已挂载的文件系统"
 
@@ -3409,15 +3410,15 @@ msgstr "NT 域"
 msgid "NTP server candidates"
 msgstr "候选 NTP 服务器"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "名称"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "新网络的名称"
 
@@ -3428,7 +3429,7 @@ msgstr "导航"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3453,7 +3454,7 @@ msgstr "网络设备不存在"
 msgid "Network without interfaces."
 msgstr "无接口的网络。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3478,7 +3479,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr "无 NAT-T"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3531,7 +3532,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "未指定区域"
 
@@ -3589,7 +3590,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr "开机时不启动"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3662,6 +3663,7 @@ msgstr "选项卡上存在一个或多个无效/必需值"
 msgid "One or more required fields have no value!"
 msgstr "一个或多个必选项值为空！"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "打开列表…"
@@ -3747,7 +3749,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "可选，用于传出和传入数据包的 UDP 端口。"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "选项"
 
@@ -3910,7 +3911,7 @@ msgstr "PSID 偏移"
 msgid "PSID-bits length"
 msgstr "PSID-位长"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr "PTM/EFM（分组传输模式）"
 
@@ -3919,7 +3920,7 @@ msgid "Packets"
 msgstr "数据包"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "区域 %q"
 
@@ -4017,11 +4018,11 @@ msgstr "完全正向保密"
 msgid "Perform reboot"
 msgstr "执行重启"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "执行重置"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4060,6 +4061,10 @@ msgstr "数据包"
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "请输入用户名和密码。"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4128,10 +4133,6 @@ msgstr "禁止客户端间通信"
 msgid "Private Key"
 msgstr "私钥"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "执行"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4147,7 +4148,7 @@ msgstr "协议"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4233,7 +4234,7 @@ msgstr "接收"
 msgid "RX Rate"
 msgstr "接收速率"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4280,10 +4281,6 @@ msgid ""
 msgstr ""
 "确定要删除此接口？删除操作无法撤消！若您删除此接口，可能导致无法再访问此设备"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "确定要放弃所有更改？"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "确定要切换协议？"
@@ -4316,7 +4313,7 @@ msgstr "重关联截止时间"
 msgid "Rebind protection"
 msgstr "重绑定保护"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "重启"
@@ -4325,6 +4322,11 @@ msgstr "重启"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "正在重启…"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4378,7 +4380,7 @@ msgstr "远程 IPv4 地址或 FQDN"
 msgid "Remove"
 msgstr "移除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "重置无线配置"
 
@@ -4390,7 +4392,7 @@ msgstr "请求 IPv6 地址"
 msgid "Request IPv6-prefix of length"
 msgstr "请求指定长度的 IPv6 前缀"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4477,7 +4479,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4489,7 +4491,7 @@ msgstr "复位"
 msgid "Reset Counters"
 msgstr "复位计数器"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "恢复到出厂设置"
 
@@ -4501,7 +4503,7 @@ msgstr "HOSTS 和解析文件"
 msgid "Resolve file"
 msgstr "解析文件"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4520,11 +4522,11 @@ msgstr "重启防火墙"
 msgid "Restart radio interface"
 msgstr "重启无线接口"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "恢复"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "恢复配置"
 
@@ -4549,15 +4551,11 @@ msgstr "恢复请求失败，状态 <code>%h</code>"
 msgid "Reverting configuration…"
 msgstr "正在恢复配置…"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "Root"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "TFTP 服务器的根目录"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr "根目录准备"
 
@@ -4578,7 +4576,7 @@ msgid "Router Advertisement-Service"
 msgstr "路由通告服务"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "主机密码"
 
@@ -4598,19 +4596,19 @@ msgstr "路由表描述了数据包的可达路径。"
 msgid "Rule"
 msgstr "规则"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "挂载设备前运行文件系统检查"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "文件系统检查"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr "SHA256"
 
@@ -4619,7 +4617,7 @@ msgid "SNR"
 msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH 访问"
 
@@ -4636,7 +4634,7 @@ msgid "SSH username"
 msgstr "SSH 用户名"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH 密钥"
 
@@ -4647,30 +4645,31 @@ msgstr "SSH 密钥"
 msgid "SSID"
 msgstr "SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr "交换分区"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "保存"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存并应用"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr "保存 mtdblock"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr "保存 mtdblock 内容"
 
@@ -4679,7 +4678,7 @@ msgid "Scan"
 msgstr "扫描"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "计划任务"
 
@@ -4691,11 +4690,11 @@ msgstr "添加的节点"
 msgid "Section removed"
 msgstr "移除的节点"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "详参“mount”联机帮助"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4738,7 +4737,7 @@ msgstr "服务类型"
 msgid "Services"
 msgstr "服务"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr "会话已过期"
 
@@ -4746,13 +4745,17 @@ msgstr "会话已过期"
 msgid "Set VPN as Default Route"
 msgstr "将 VPN 设置为默认路由"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
 msgstr ""
 "不管接口的链路状态如何，总是用应用设置（如果勾选，链路状态变更将不再触发 "
 "hotplug 事件处理）。"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
+msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 #: protocols/luci-proto-qmi/luasrc/model/network/proto_qmi.lua:55
@@ -4781,6 +4784,7 @@ msgstr "Short GI"
 msgid "Short Preamble"
 msgstr "Short Preamble"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "显示当前备份文件列表"
@@ -4802,7 +4806,7 @@ msgstr "关闭此接口"
 msgid "Signal"
 msgstr "信号"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4814,7 +4818,7 @@ msgstr "信号衰减（SATN）"
 msgid "Signal:"
 msgstr "信号："
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "大小"
 
@@ -4839,7 +4843,7 @@ msgstr "跳到内容"
 msgid "Skip to navigation"
 msgstr "跳转到导航"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "软件 VLAN"
@@ -4856,7 +4860,7 @@ msgstr "对不起，请求的目标未找到。"
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "对不起，服务器遇到未知错误。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4875,7 +4879,7 @@ msgstr "源地址"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "指定设备的挂载目录"
 
@@ -4914,7 +4918,7 @@ msgid ""
 "bytes)."
 msgstr "设置 MTU（最大传输单位），缺省值：1280 bytes"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "在此指定密钥。"
 
@@ -4937,7 +4941,7 @@ msgid "Starting wireless scan..."
 msgstr "正在启动无线扫描…"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "启动项"
 
@@ -4957,7 +4961,7 @@ msgstr "静态地址分配"
 msgid "Static Routes"
 msgstr "静态路由"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4998,7 +5002,7 @@ msgid "Strong"
 msgstr "强"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "提交"
 
@@ -5013,10 +5017,6 @@ msgstr "不记录这些协议的常规操作日志。"
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr "Swap"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Swap 节点"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5036,7 +5036,7 @@ msgstr "交换机 %q 具有未知的拓扑结构，VLAN 设置可能不正确。
 msgid "Switch Port Mask"
 msgstr "交换机端口掩码"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "交换机 VLAN"
@@ -5129,6 +5129,10 @@ msgstr "目标网络"
 msgid "Terminate"
 msgstr "关闭"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5146,17 +5150,13 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr "运营商特定的 IPv6 前缀，通常以 <code>::</code> 为结尾"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "合法字符：<code>A-Z</code>, <code>a-z</code>, <code>0-9</code> 和 <code>_</"
 "code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr "备份存档似乎不是有效的 gzip 文件。"
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5173,8 +5173,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5186,23 +5186,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"用于格式化存储器的文件系统（例如：<samp><abbr title=\"Third Extended "
-"Filesystem\">ext3</abbr></samp>）"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"固件已上传，请注意核对文件大小和校验值！<br />点击下面的“继续”开始刷写，刷新"
-"过程中切勿断电！"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5222,11 +5215,11 @@ msgid ""
 "ECDSA keys."
 msgstr "给定的 SSH 公钥无效。请提供适当的公共 RSA 或 ECDSA 密钥。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5246,7 +5239,7 @@ msgstr "IPv6 前缀长度（位）"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "所创建隧道的本地 IPv4 地址（可选）。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5264,6 +5257,14 @@ msgstr ""
 "abbr> 也常用于分割不同网段。默认通常是一条上行端口连接 ISP，其余端口为本地子"
 "网。"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5272,13 +5273,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr "提交的安全令牌无效或已过期！"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "系统正在擦除配置分区，完成后会自动重启。"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5288,11 +5289,32 @@ msgstr ""
 "正在刷写系统…<br />切勿关闭电源！ DO NOT POWER OFF THE DEVICE!<br />等待数分"
 "钟后即可尝试重新连接到路由。您可能需要更改计算机的 IP 地址以重新连接。"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "系统密码已更改成功。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5339,6 +5361,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5422,11 +5445,11 @@ msgstr "重新加密 GTK 的时间间隔"
 msgid "Timezone"
 msgstr "时区"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr "去登录…"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5435,7 +5458,7 @@ msgstr ""
 "上传备份存档以恢复配置。要将固件恢复到初始状态，请单击“执行重置”（仅 "
 "squashfs 格式的固件有效）。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr "Tone"
 
@@ -5475,7 +5498,7 @@ msgstr "触发模式"
 msgid "Tunnel ID"
 msgstr "隧道 ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "隧道接口"
@@ -5518,8 +5541,8 @@ msgstr "USB 设备"
 msgid "USB Ports"
 msgstr "USB 接口"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "UUID"
 
@@ -5549,6 +5572,10 @@ msgstr "无法调度"
 msgid "Unable to obtain client ID"
 msgstr "无法获取客户端 ID"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5560,6 +5587,7 @@ msgid "Unable to resolve peer host name"
 msgstr "无法解析 Pear 主机名"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5568,28 +5596,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "不可用秒数（UAS）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "未知"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "未知错误（%s）"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "不配置协议"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr "卸载分区"
 
@@ -5602,7 +5630,7 @@ msgstr "未命名的密钥"
 msgid "Unsaved Changes"
 msgstr "未保存的配置"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5625,7 +5653,11 @@ msgstr "不支持的协议类型"
 msgid "Up"
 msgstr "上移"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5634,7 +5666,9 @@ msgstr ""
 "上传一个 sysupgrade 格式的固件映像文件以替换当前运行的固件。勾选“保留配置”以"
 "使更新后的系统仍然使用当前的系统配置（新的固件需要和当前固件兼容）。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "上传备份…"
 
@@ -5647,7 +5681,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5705,11 +5745,11 @@ msgstr "隧道接口的 MTU"
 msgid "Use TTL on tunnel interface"
 msgstr "隧道接口的 TTL"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr "作为外部 overlay 使用（/overlay）"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr "作为根文件系统使用（/）"
 
@@ -5717,7 +5757,7 @@ msgstr "作为根文件系统使用（/）"
 msgid "Use broadcast flag"
 msgstr "使用广播标签"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "使用内置的 IPv6 管理"
 
@@ -5783,7 +5823,7 @@ msgstr ""
 "给“MAC 地址”字段标识的主机，“租期”是一个可选字段，可为每个主机单独设定 DHCP "
 "租期的时长，例如：12h、3d、infinite，分别表示 12 小时、3 天、永久。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "已用"
 
@@ -5813,11 +5853,11 @@ msgstr "用户密钥（PEM）"
 msgid "Username"
 msgstr "用户名"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr "VDSL"
 
@@ -5864,9 +5904,9 @@ msgstr "Vendor"
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "请求 DHCP 时发送的 Vendor Class 选项"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "验证"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5886,7 +5926,7 @@ msgstr "WEP 开放式系统"
 msgid "WEP Shared Key"
 msgstr "WEP 共享密钥"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP 密钥"
 
@@ -5894,7 +5934,7 @@ msgstr "WEP 密钥"
 msgid "WMM Mode"
 msgstr "WMM 模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA 密钥"
 
@@ -5960,13 +6000,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "无线"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "无线适配器"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6017,7 +6057,7 @@ msgstr "将系统日志写入文件"
 msgid "Yes"
 msgstr "是"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6060,9 +6100,9 @@ msgstr "ZRam 大小"
 msgid "any"
 msgstr "任意"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6079,7 +6119,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "桥接的"
 
@@ -6096,7 +6136,7 @@ msgid "create:"
 msgstr "创建："
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "为指定接口创建桥接"
 
@@ -6232,8 +6272,6 @@ msgstr "分钟"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "否"
 
@@ -6245,13 +6283,13 @@ msgstr "未连接"
 msgid "non-empty value"
 msgstr "非空值"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "无"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr "不存在"
 
@@ -6281,10 +6319,6 @@ msgstr ""
 msgid "output"
 msgstr "输出"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr "覆盖"
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr "正十进制值"
@@ -6303,7 +6337,7 @@ msgstr "随机"
 msgid "relay mode"
 msgstr "中继模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "已路由"
 
@@ -6317,15 +6351,15 @@ msgstr "秒"
 msgid "server mode"
 msgstr "服务器模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr "有状态"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr "无状态"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr "无状态 + 有状态"
 
@@ -6543,14 +6577,79 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "是"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 后退"
+
+#~ msgid "(%s available)"
+#~ msgstr "（%s 可用）"
+
+#~ msgid "-- match by device --"
+#~ msgstr "-- 根据设备匹配 --"
+
+#~ msgid "Caution: System upgrade will be forced"
+#~ msgstr "注意：将强制进行系统升级"
+
+#~ msgid "Check"
+#~ msgstr "检查"
+
+#~ msgid "Checksum"
+#~ msgstr "校验值"
+
+#~ msgid "Enable this mount"
+#~ msgstr "启用此挂载点"
+
+#~ msgid "Enable this swap"
+#~ msgstr "启用此 swap 分区"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "刷新固件"
+
+#~ msgid "Flashing..."
+#~ msgstr "正在刷写…"
+
+#~ msgid "Mount Entry"
+#~ msgstr "挂载项目"
+
+#~ msgid "Proceed"
+#~ msgstr "执行"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "确定要放弃所有更改？"
+
+#~ msgid "Root"
+#~ msgstr "Root"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Swap 节点"
+
+#~ msgid "The backup archive does not appear to be a valid gzip file."
+#~ msgstr "备份存档似乎不是有效的 gzip 文件。"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "用于格式化存储器的文件系统（例如：<samp><abbr title=\"Third Extended "
+#~ "Filesystem\">ext3</abbr></samp>）"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "固件已上传，请注意核对文件大小和校验值！<br />点击下面的“继续”开始刷写，刷"
+#~ "新过程中切勿断电！"
+
+#~ msgid "Verify"
+#~ msgstr "验证"
+
+#~ msgid "overlay"
+#~ msgstr "覆盖"
 
 #~ msgid "Change login password"
 #~ msgstr "更改登录密码"

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Pootle 2.0.6\n"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:867
 msgid "%.1f dB"
 msgstr ""
 
@@ -35,10 +35,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/wireless.htm:169
 msgid "(%d minute window, %d second interval)"
 msgstr "(%d 分鐘資訊,每 %d 秒更新)"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:35
-msgid "(%s available)"
-msgstr "(%s 可用)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:105
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:111
@@ -79,15 +75,13 @@ msgstr "-- 請選擇 --"
 msgid "-- custom --"
 msgstr "-- 自訂 --"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:89
-msgid "-- match by device --"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:73
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:402
 msgid "-- match by label --"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:59
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:279
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:385
 msgid "-- match by uuid --"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:29
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 設定"
 
@@ -250,23 +244,23 @@ msgstr "注意: 如果這個檔案在編輯之前是空的,您將需要重新啟
 msgid "A directory with the same name already exists."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:863
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:875
 msgid "A new login is required since the authentication session expired."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:847
 msgid "A43C + J43 + A43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
 msgid "A43C + J43 + A43 + V43"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
 msgid "ADSL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:826
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 msgid "ANSI T1.413"
 msgstr ""
 
@@ -280,25 +274,25 @@ msgstr "APN"
 msgid "ARP retry threshold"
 msgstr "ARP重試門檻"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:855
 msgid "ATM (Asynchronous Transfer Mode)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid "ATM Bridges"
 msgstr "ATM橋接"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:898
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:66
 msgid "ATM Virtual Channel Identifier (VCI)"
 msgstr "ATM虛擬通道識別(VCI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:70
 msgid "ATM Virtual Path Identifier (VPI)"
 msgstr "ATM虛擬路徑識別(VPI)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:866
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:876
 msgid ""
 "ATM bridges expose encapsulated ethernet in AAL5 connections as virtual "
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
@@ -307,7 +301,7 @@ msgstr ""
 "ATM橋接是以AAL5協定封裝乙太網路如同虛擬Linux網路界面卡，用於連接DHCP或PPP來撥"
 "號連接到網際網路。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:915
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
 msgid "ATM device number"
 msgstr "ATM裝置號碼"
@@ -331,8 +325,7 @@ msgstr "接入集線器"
 msgid "Access Point"
 msgstr "存取點 (AP)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:8
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:12
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:481
 msgid "Actions"
 msgstr "動作"
 
@@ -358,7 +351,7 @@ msgstr "已分配的DHCP租用"
 msgid "Active DHCPv6 Leases"
 msgstr "已分配的DHCPv6租用"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2193
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
@@ -368,7 +361,7 @@ msgstr "Ad-Hoc"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:904
 #: modules/luci-base/htdocs/luci-static/resources/form.js:917
 #: modules/luci-base/htdocs/luci-static/resources/form.js:918
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1538
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -379,7 +372,7 @@ msgstr "Ad-Hoc"
 msgid "Add"
 msgstr "增加"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:880
 msgid "Add ATM Bridge"
 msgstr ""
 
@@ -414,7 +407,7 @@ msgid "Add local domain suffix to names served from hosts files"
 msgstr "添加本地網域微碼到HOSTS檔案"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:705
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:709
 msgid "Add new interface..."
 msgstr "增加新界面"
 
@@ -458,19 +451,18 @@ msgid "Address to access local relay bridge"
 msgstr "存取本地中繼橋接位置"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:29
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:14
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:12
 msgid "Administration"
 msgstr "管理"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:70
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:276
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:264
 msgid "Advanced Settings"
 msgstr "進階設定"
 
@@ -482,7 +474,7 @@ msgstr ""
 msgid "Alert"
 msgstr "警示"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -553,7 +545,7 @@ msgstr "允許127.0.0.0/8範圍內的上游回應，例如：RBL服務"
 msgid "Allowed IPs"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Always announce default router"
 msgstr ""
 
@@ -563,76 +555,76 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:119
 msgid "Annex"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
 msgid "Annex A + L + M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:827
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:837
 msgid "Annex A G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:828
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:838
 msgid "Annex A G.992.2"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
 msgid "Annex A G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
 msgid "Annex A G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:830
 msgid "Annex B (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
 msgid "Annex B G.992.1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:824
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:834
 msgid "Annex B G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
 msgid "Annex B G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:821
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
 msgid "Annex J (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:831
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:841
 msgid "Annex L G.992.3 POTS 1"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:822
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid "Annex M (all)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:842
 msgid "Annex M G.992.3"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
 msgid "Annex M G.992.5"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:602
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
 msgid "Announce as default router even if no public prefix is available."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:607
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:611
 msgid "Announced DNS domains"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:610
 msgid "Announced DNS servers"
 msgstr ""
 
@@ -640,11 +632,11 @@ msgstr ""
 msgid "Anonymous Identity"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Anonymous Mount"
 msgstr "自動掛載檔案系統"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Anonymous Swap"
 msgstr "自動掛載swap分區"
 
@@ -654,6 +646,10 @@ msgstr "自動掛載swap分區"
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:60
 msgid "Any zone"
 msgstr "任意區域"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:268
+msgid "Apply backup?"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
@@ -683,7 +679,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1972
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "已連接裝置"
@@ -691,6 +687,10 @@ msgstr "已連接裝置"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:178
 msgid "Associations"
 msgstr "已連接裝置"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Attempt to enable configured mount points for attached devices"
+msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:101
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:64
@@ -740,27 +740,27 @@ msgstr ""
 msgid "Automatic Homenet (HNCP)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Automatically check filesystem for errors before mounting"
 msgstr "在掛載前先檢查檔案系統中是否含有錯誤"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automatically mount filesystems on hotplug"
 msgstr "在連接裝置後自動掛載檔案系統"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automatically mount swap on hotplug"
 msgstr "在連接裝置後自動掛載swap分區"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:61
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
 msgid "Automount Filesystem"
 msgstr "自動掛載檔案系統"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:57
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:190
 msgid "Automount Swap"
 msgstr "自動掛載swap分區"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Available"
 msgstr "可用"
 
@@ -778,11 +778,11 @@ msgstr "可用"
 msgid "Average:"
 msgstr "平均:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
 msgid "B43 + B43C"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:840
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:850
 msgid "B43 + B43C + V43"
 msgstr ""
 
@@ -806,14 +806,15 @@ msgstr "返回至總覽"
 msgid "Back to configuration"
 msgstr "返回至設定"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid "Backup"
 msgstr "備份"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:32
 msgid "Backup / Flash Firmware"
 msgstr "備份/升級韌體"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:446
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:12
 msgid "Backup file list"
 msgstr "備份檔列表"
@@ -831,6 +832,7 @@ msgstr ""
 msgid "Beacon Interval"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:46
 msgid ""
 "Below is the determined list of files to backup. It consists of changed "
@@ -864,17 +866,17 @@ msgstr "傳輸速率"
 msgid "Bogus NX Domain Override"
 msgstr "忽略NX網域解析"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "橋接"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "Bridge interfaces"
 msgstr "橋接介面"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Bridge unit number"
 msgstr "橋接單位號碼"
 
@@ -883,6 +885,7 @@ msgid "Bring up on boot"
 msgstr "開機自動執行"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:96
 msgid "Browse…"
 msgstr ""
 
@@ -910,11 +913,13 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1844
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:399
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "取消"
 
@@ -922,12 +927,8 @@ msgstr "取消"
 msgid "Category"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:44
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Caution: Configuration files will be erased"
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:48
-msgid "Caution: System upgrade will be forced"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
@@ -961,28 +962,29 @@ msgstr "修改管理員密碼"
 msgid "Channel"
 msgstr "頻道"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:229
-msgid "Check"
-msgstr "檢查"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:198
 msgid "Check filesystems before mount"
 msgstr "在掛載前先檢查檔案系統"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:27
-msgid "Checksum"
-msgstr "效驗碼"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:259
+msgid "Checking archive…"
+msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:70
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:340
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:342
+msgid "Checking image…"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:512
 msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1008,19 +1010,19 @@ msgstr "加密方式"
 msgid "Cisco UDP encapsulation"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:484
 msgid ""
 "Click \"Generate archive\" to download a tar archive of the current "
 "configuration files."
 msgstr "按下\"壓縮檔製作\"就能下載目前設定檔的tar格式的壓縮."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:65
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid ""
 "Click \"Save mtdblock\" to download specified mtdblock file. (NOTE: THIS "
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
@@ -1055,7 +1057,7 @@ msgstr "關閉清單"
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1970
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1070,7 +1072,7 @@ msgstr "收集資料中..."
 msgid "Command"
 msgstr "指令"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:193
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
 msgid "Command OK"
 msgstr ""
 
@@ -1092,8 +1094,7 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
-#: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 msgid "Configuration"
 msgstr "設定"
 
@@ -1102,7 +1103,7 @@ msgstr "設定"
 msgid "Configuration failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:42
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:361
 msgid "Configuration files will be kept"
 msgstr ""
 
@@ -1114,7 +1115,7 @@ msgstr "設定值已套用"
 msgid "Configuration has been rolled back!"
 msgstr "設定值已復原"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:942
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:952
 msgid "Confirm disconnect"
 msgstr ""
 
@@ -1134,7 +1135,7 @@ msgstr "已連線"
 msgid "Connection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
 msgid "Connection lost"
 msgstr ""
 
@@ -1143,11 +1144,14 @@ msgid "Connections"
 msgstr "連線數"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:463
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:281
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:391
 msgid "Continue"
 msgstr ""
 
@@ -1167,11 +1171,11 @@ msgid "Country Code"
 msgstr "國別碼"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1834
 msgid "Create / Assign firewall-zone"
 msgstr "建立/指定防火牆作用區"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:735
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:739
 msgid "Create interface"
 msgstr ""
 
@@ -1200,7 +1204,7 @@ msgstr "自訂介面"
 msgid "Custom delegated IPv6-prefix"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
@@ -1237,7 +1241,7 @@ msgstr "DHCP伺服器"
 msgid "DHCP and DNS"
 msgstr "DHCP 和 DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1388
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1252,7 +1256,7 @@ msgstr "DHCP選項"
 msgid "DHCPv6 client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "DHCPv6-Mode"
 msgstr ""
 
@@ -1297,7 +1301,7 @@ msgstr ""
 msgid "DS-Lite AFTR address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:815
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:14
 msgid "DSL"
 msgstr ""
@@ -1306,7 +1310,7 @@ msgstr ""
 msgid "DSL Status"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:848
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:858
 msgid "DSL line mode"
 msgstr ""
 
@@ -1348,7 +1352,7 @@ msgstr ""
 msgid "Default gateway"
 msgstr "預設閘道"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
 msgid "Default is stateless + stateful"
 msgstr ""
 
@@ -1370,9 +1374,9 @@ msgstr ""
 "的DNS伺服器到客戶端."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:966
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1212
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1215
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1523
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
@@ -1433,10 +1437,10 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:52
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:85
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:72
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:154
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:253
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:86
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:270
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:379
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid "Device"
 msgstr "設備"
 
@@ -1525,7 +1529,7 @@ msgstr "丟棄上游RFC1918 虛擬IP網路的回應"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:114
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:956
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "Disconnect"
 msgstr ""
 
@@ -1534,11 +1538,12 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1374
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:453
 msgid "Dismiss"
 msgstr "忽略"
 
@@ -1581,6 +1586,10 @@ msgstr ""
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:241
+msgid "Do you really want to erase all settings?"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
@@ -1609,19 +1618,19 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:487
 msgid "Download backup"
 msgstr "下載備份檔"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:87
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:519
 msgid "Download mtdblock"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:863
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1171
 msgid "Drag to reorder"
 msgstr ""
 
@@ -1664,9 +1673,9 @@ msgstr ""
 msgid "EAP-Method"
 msgstr "EAP協定驗證方式"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1190
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1193
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1449
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
@@ -1768,25 +1777,17 @@ msgstr ""
 msgid "Enable the DF (Don't Fragment) flag of the encapsulating packets."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:53
-msgid "Enable this mount"
-msgstr "啟用掛載點"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:37
-msgid "Enable this swap"
-msgstr "啟用swap功能"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:88
 msgid "Enable/Disable"
 msgstr "啟用/關閉"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:266
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:375
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
 msgid "Enabled"
 msgstr "啟用"
 
@@ -1808,8 +1809,8 @@ msgstr "在橋接器上啟用802.1d Spanning Tree協定"
 msgid "Encapsulation limit"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:843
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:901
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "Encapsulation mode"
 msgstr "封裝模式"
 
@@ -1837,7 +1838,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:248
 msgid "Erasing..."
 msgstr "刪除中..."
 
@@ -1859,12 +1860,12 @@ msgstr "錯誤"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1855
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "乙太網路卡"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "乙太交換器"
@@ -1963,9 +1964,8 @@ msgstr ""
 msgid "Filename of the boot image advertised to clients"
 msgstr "開機影像檔通知給用戶端"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:98
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:199
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:126
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:215
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:337
 msgid "Filesystem"
 msgstr "檔案系統"
 
@@ -1982,7 +1982,7 @@ msgstr "無用過濾器"
 msgid "Finalizing failed"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
@@ -2012,7 +2012,7 @@ msgstr "防火牆設定"
 msgid "Firewall Status"
 msgstr "防火牆狀況"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:860
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:870
 msgid "Firmware File"
 msgstr ""
 
@@ -2024,25 +2024,27 @@ msgstr "防火牆版本"
 msgid "Fixed source port for outbound DNS queries"
 msgstr "外發DNS請求的固定埠號"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Flash Firmware"
-msgstr "韌體更新"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:409
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:538
 msgid "Flash image..."
 msgstr "更新映像檔中..."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:406
+msgid "Flash image?"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:525
 msgid "Flash new firmware image"
 msgstr "更新新版韌體映像檔"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:478
 msgid "Flash operations"
 msgstr "執行更新"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
-msgid "Flashing..."
-msgstr "更新中..."
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:414
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:416
+msgid "Flashing…"
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:550
 msgid "Force"
@@ -2068,11 +2070,11 @@ msgstr "強制使用TKIP加密"
 msgid "Force TKIP and CCMP (AES)"
 msgstr "強制使用TKIP+CCMP (AES)加密"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid "Force link"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:382
 msgid "Force upgrade"
 msgstr ""
 
@@ -2100,7 +2102,7 @@ msgstr "轉發廣播流量"
 msgid "Forward mesh peer traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:908
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:918
 msgid "Forwarding mode"
 msgstr "轉發模式"
 
@@ -2147,20 +2149,19 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:263
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
 msgstr "一般設定"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:905
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "一般設置"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 msgid "Generate Config"
 msgstr "生成設定檔"
 
@@ -2168,7 +2169,7 @@ msgstr "生成設定檔"
 msgid "Generate PMK locally"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:25
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:489
 msgid "Generate archive"
 msgstr "製作壓縮檔"
 
@@ -2176,11 +2177,11 @@ msgstr "製作壓縮檔"
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "鍵入的密碼不吻合,密碼將不變更"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:170
 msgid "Global Settings"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:816
 msgid "Global network options"
 msgstr "全域網路設定"
 
@@ -2191,7 +2192,7 @@ msgstr "全域網路設定"
 msgid "Go to password configuration..."
 msgstr "前往密碼設定頁"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1114
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
@@ -2239,7 +2240,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1964
 msgid "Host"
 msgstr ""
 
@@ -2431,7 +2432,7 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr "IPv6 設定"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:810
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:820
 msgid "IPv6 ULA-Prefix"
 msgstr ""
 
@@ -2518,14 +2519,14 @@ msgstr ""
 msgid "If checked, encryption is disabled"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:57
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:48
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr "假若指定的話, 掛載設備的UUID獨立設備識別碼取代固定的設備節點"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:71
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
@@ -2564,7 +2565,7 @@ msgstr "如果沒打勾點選, 將不會設置預設路由"
 msgid "If unchecked, the advertised DNS server addresses are ignored"
 msgstr "如果沒打勾點選, 公告的DNS伺服器位址將被忽視"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid ""
 "If your physical memory is insufficient unused data can be temporarily "
 "swapped to a swap-device resulting in a higher amount of usable <abbr title="
@@ -2589,7 +2590,7 @@ msgstr "被忽視的介面"
 msgid "Ignore resolve file"
 msgstr "不使用解析檔"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:536
 msgid "Image"
 msgstr "映像檔"
 
@@ -2649,8 +2650,8 @@ msgstr "安裝延伸協定中..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:423
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:687
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:691
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
@@ -2734,11 +2735,11 @@ msgstr "輸入的VLAN ID無效僅有介於 %d 和 %d的被允許"
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
 msgstr "輸入的是不正確的VLAN ID!僅允許獨一無二的IDs"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
 msgid "Invalid argument"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:194
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:195
 msgid "Invalid command"
 msgstr ""
 
@@ -2754,7 +2755,7 @@ msgstr "不正確的用戶名稱和/或者密碼!請再試一次."
 msgid "Isolate Clients"
 msgstr "隔離用戶端"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:369
 #, fuzzy
 msgid ""
 "It appears that you are trying to flash an image that does not fit into the "
@@ -2776,11 +2777,11 @@ msgstr "加入網路"
 msgid "Join Network: Wireless Scan"
 msgstr "加入網路:無線網路掃描"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1838
 msgid "Joining Network: %q"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:533
 msgid "Keep settings"
 msgstr "保留設定值"
 
@@ -2836,12 +2837,12 @@ msgstr "LCP協定呼叫失敗次數門檻"
 msgid "LCP echo interval"
 msgstr "LCP協定呼叫間隔"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:902
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid "LLC"
 msgstr "LLC邏輯鏈結控制層"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:70
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:50
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:290
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:399
 msgid "Label"
 msgstr "標籤"
 
@@ -2996,7 +2997,7 @@ msgstr "讀取中"
 msgid "Loading directory contents…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1296
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1308
 #: modules/luci-base/luasrc/view/view.htm:4
 msgid "Loading view…"
 msgstr ""
@@ -3104,7 +3105,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1963
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
@@ -3137,7 +3138,7 @@ msgstr ""
 msgid "MB/s"
 msgstr "MB/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:359
 msgid "MD5"
 msgstr ""
 
@@ -3151,7 +3152,7 @@ msgstr "MHz"
 msgid "MTU"
 msgstr "最大傳輸單位MTU"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:121
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:325
 msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
@@ -3167,7 +3168,8 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
 msgid "Master"
 msgstr ""
 
@@ -3226,7 +3228,7 @@ msgstr "記憶體"
 msgid "Memory usage (%)"
 msgstr "記憶體使用 (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2194
 msgid "Mesh"
 msgstr ""
 
@@ -3234,7 +3236,7 @@ msgstr ""
 msgid "Mesh Id"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:196
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
 msgid "Method not found"
 msgstr ""
 
@@ -3293,7 +3295,7 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "數據機初始化終結時間"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2195
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "監視"
@@ -3306,52 +3308,51 @@ msgstr ""
 msgid "More…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:45
-msgid "Mount Entry"
-msgstr "掛載項目"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:100
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:216
 msgid "Mount Point"
 msgstr "掛載點"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:168
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
 msgid "Mount Points"
 msgstr "掛載設定"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:35
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:252
 msgid "Mount Points - Mount Entry"
 msgstr "掛載各點 - 掛載項目"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:363
 msgid "Mount Points - Swap Entry"
 msgstr "掛載各點 - 交換項目"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:251
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr "掛載各點定義所指定到記憶體設備將會被附載到檔案系統上"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:53
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:178
+msgid "Mount attached devices"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:186
 msgid "Mount filesystems not specifically configured"
 msgstr "自動掛載沒有預先設定的檔案系統"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:147
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "Mount options"
 msgstr "掛載選項"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Mount point"
 msgstr "掛載點"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:49
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:182
 msgid "Mount swap not specifically configured"
 msgstr "自動掛載沒有預先設定的swap分區"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:96
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:246
 msgid "Mounted file systems"
 msgstr "已掛載檔案系統"
 
@@ -3392,15 +3393,15 @@ msgstr ""
 msgid "NTP server candidates"
 msgstr "NTP伺服器備選"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1094
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:49
 msgid "Name"
 msgstr "名稱"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid "Name of the new network"
 msgstr "新網路的名稱"
 
@@ -3411,7 +3412,7 @@ msgstr "導覽"
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1962
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3436,7 +3437,7 @@ msgstr ""
 msgid "Network without interfaces."
 msgstr "尚無任何介面的網路."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:661
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:665
 msgid "New interface name…"
 msgstr ""
 
@@ -3461,7 +3462,7 @@ msgstr ""
 msgid "No NAT-T"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
 msgid "No data received"
 msgstr ""
 
@@ -3514,7 +3515,7 @@ msgid "No signal"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "No zone assigned"
 msgstr "尚未指定區碼"
 
@@ -3572,7 +3573,7 @@ msgstr ""
 msgid "Not started on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
 msgid "Not supported"
 msgstr ""
 
@@ -3645,6 +3646,7 @@ msgstr ""
 msgid "One or more required fields have no value!"
 msgstr "有一個以上的欄位缺乏任何數值!"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:560
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
 msgid "Open list..."
 msgstr "開啟清單"
@@ -3724,7 +3726,6 @@ msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:63
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:212
 msgid "Options"
 msgstr "選項"
 
@@ -3887,7 +3888,7 @@ msgstr ""
 msgid "PSID-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:856
 msgid "PTM/EFM (Packet Transfer Mode)"
 msgstr ""
 
@@ -3896,7 +3897,7 @@ msgid "Packets"
 msgstr "封包"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:145
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:766
 msgid "Part of zone %q"
 msgstr "區域 %q 的部分 "
 
@@ -3994,11 +3995,11 @@ msgstr ""
 msgid "Perform reboot"
 msgstr "重新開機"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:499
 msgid "Perform reset"
 msgstr "執行重置"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:199
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
 msgid "Permission denied"
 msgstr ""
 
@@ -4037,6 +4038,10 @@ msgstr "封包數."
 #: modules/luci-base/luasrc/view/sysauth.htm:19
 msgid "Please enter your username and password."
 msgstr "請輸入您的用戶名稱和密碼"
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:81
+msgid "Please select the file to upload."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:45
 msgid "Policy"
@@ -4105,10 +4110,6 @@ msgstr "防止用戶端對用戶端的通訊"
 msgid "Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:61
-msgid "Proceed"
-msgstr "前進"
-
 #: modules/luci-mod-status/luasrc/controller/admin/status.lua:17
 #: modules/luci-mod-status/luasrc/model/cbi/admin_status/processes.lua:5
 msgid "Processes"
@@ -4124,7 +4125,7 @@ msgstr "協定."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:72
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:349
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:675
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:679
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:84
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:87
@@ -4207,7 +4208,7 @@ msgstr "接收"
 msgid "RX Rate"
 msgstr "接收速率"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1966
 msgid "RX Rate / TX Rate"
 msgstr ""
 
@@ -4253,10 +4254,6 @@ msgid ""
 "access to this device if you are connected via this interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:40
-msgid "Really reset all changes?"
-msgstr "確定要回復原廠設定?"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:354
 msgid "Really switch protocol?"
 msgstr "確定要更換協定?"
@@ -4289,7 +4286,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "重新綁護"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:34
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "重開機"
@@ -4298,6 +4295,11 @@ msgstr "重開機"
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "Rebooting..."
 msgstr "重新啟動中..."
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:301
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:310
+msgid "Rebooting…"
+msgstr ""
 
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:11
 msgid "Reboots the operating system of your device"
@@ -4351,7 +4353,7 @@ msgstr ""
 msgid "Remove"
 msgstr "移除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1811
 msgid "Replace wireless configuration"
 msgstr "替代性無線設定"
 
@@ -4363,7 +4365,7 @@ msgstr ""
 msgid "Request IPv6-prefix of length"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:200
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:201
 msgid "Request timeout"
 msgstr ""
 
@@ -4446,7 +4448,7 @@ msgstr ""
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1367
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4458,7 +4460,7 @@ msgstr "重置"
 msgid "Reset Counters"
 msgstr "重置計數器"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:497
 msgid "Reset to defaults"
 msgstr "回復預設值"
 
@@ -4470,7 +4472,7 @@ msgstr "解析和Hosts檔案"
 msgid "Resolve file"
 msgstr "解析檔"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:197
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:198
 msgid "Resource not found"
 msgstr ""
 
@@ -4489,11 +4491,11 @@ msgstr "重啟防火牆"
 msgid "Restart radio interface"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:31
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid "Restore"
 msgstr "還原"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:503
 msgid "Restore backup"
 msgstr "還原之前備份設定"
 
@@ -4518,15 +4520,11 @@ msgstr ""
 msgid "Reverting configuration…"
 msgstr "正在還原設定值..."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:217
-msgid "Root"
-msgstr "根"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:271
 msgid "Root directory for files served via TFTP"
 msgstr "透過TFTP存取根目錄檔案"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:320
 msgid "Root preparation"
 msgstr ""
 
@@ -4547,7 +4545,7 @@ msgid "Router Advertisement-Service"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:13
 msgid "Router Password"
 msgstr "路由器密碼"
 
@@ -4567,19 +4565,19 @@ msgstr "路由器指定介面導出到特定主機或者能夠到達的網路."
 msgid "Rule"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run a filesystem check before mounting the device"
 msgstr "掛載這個設備前先跑系統檢查"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:358
 msgid "Run filesystem check"
 msgstr "執行系統檢查"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:669
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:673
 msgid "Runtime error"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:360
 msgid "SHA256"
 msgstr ""
 
@@ -4588,7 +4586,7 @@ msgid "SNR"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:16
 msgid "SSH Access"
 msgstr "SSH存取"
 
@@ -4605,7 +4603,7 @@ msgid "SSH username"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:17
 msgid "SSH-Keys"
 msgstr "SSH-金鑰"
 
@@ -4616,30 +4614,31 @@ msgstr "SSH-金鑰"
 msgid "SSID"
 msgstr "基地台服務設定識別碼SSID"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:236
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:362
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1378
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1363
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:551
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
 msgid "Save"
 msgstr "保存"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1359
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存並啟用"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:89
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:521
 msgid "Save mtdblock"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:64
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:509
 msgid "Save mtdblock contents"
 msgstr ""
 
@@ -4648,7 +4647,7 @@ msgid "Scan"
 msgstr "掃描"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:21
 msgid "Scheduled Tasks"
 msgstr "排程任務"
 
@@ -4660,11 +4659,11 @@ msgstr "新增的區段"
 msgid "Section removed"
 msgstr "區段移除"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:148
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:354
 msgid "See \"mount\" manpage for details"
 msgstr "查看\"mount\"主頁獲取進階資訊"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:119
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:384
 msgid ""
 "Select 'Force upgrade' to flash the image even if the image format check "
 "fails. Use only if you are sure that the firmware is correct and meant for "
@@ -4705,7 +4704,7 @@ msgstr "服務型態"
 msgid "Services"
 msgstr "各服務"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:861
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:873
 msgid "Session expired"
 msgstr ""
 
@@ -4713,10 +4712,14 @@ msgstr ""
 msgid "Set VPN as Default Route"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:805
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:594
+msgid "Set this interface as master for the dhcpv6 relay."
 msgstr ""
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
@@ -4746,6 +4749,7 @@ msgstr ""
 msgid "Short Preamble"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:558
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
 msgstr "顯示現今的備份檔清單"
@@ -4767,7 +4771,7 @@ msgstr "關閉這個介面"
 msgid "Signal"
 msgstr "信號"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4779,7 +4783,7 @@ msgstr ""
 msgid "Signal:"
 msgstr "信號:"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:358
 msgid "Size"
 msgstr "大小"
 
@@ -4804,7 +4808,7 @@ msgstr "跳到內容"
 msgid "Skip to navigation"
 msgstr "跳到導覽"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4821,7 +4825,7 @@ msgstr "抱歉, 您請求的這物件尚無發現."
 msgid "Sorry, the server encountered an unexpected error."
 msgstr "抱歉, 伺服器遭遇非預期的錯誤."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:133
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:528
 msgid ""
 "Sorry, there is no sysupgrade support present; a new firmware image must be "
 "flashed manually. Please refer to the wiki for device specific install "
@@ -4840,7 +4844,7 @@ msgstr "來源"
 msgid "Source Address"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:315
 msgid "Specifies the directory the device is attached to"
 msgstr "指定這個設備被附掛到那個目錄"
 
@@ -4879,7 +4883,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "Specify the secret encryption key here."
 msgstr "指定加密金鑰在此."
 
@@ -4902,7 +4906,7 @@ msgid "Starting wireless scan..."
 msgstr "開始無線掃描..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
 msgid "Startup"
 msgstr "開機自動執行"
 
@@ -4922,7 +4926,7 @@ msgstr "靜態租約"
 msgid "Static Routes"
 msgstr "靜態路由"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1387
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4963,7 +4967,7 @@ msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1848
 msgid "Submit"
 msgstr "提交"
 
@@ -4978,10 +4982,6 @@ msgstr ""
 #: modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm:24
 msgid "Swap"
 msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:29
-msgid "Swap Entry"
-msgstr "Swap交換頁項目"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:135
 #: modules/luci-mod-network/luasrc/controller/admin/network.lua:21
@@ -5001,7 +5001,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5094,6 +5094,10 @@ msgstr ""
 msgid "Terminate"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:120
+msgid "The <em>block mount</em> command failed with code %d"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
@@ -5111,17 +5115,13 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr "指定到這供應商的IPv6字首, 通常用 <code>::</code>結尾"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
 msgstr ""
 "所允許的字元是: <code>A-Z</code>, <code>a-z</code>, <code>0-9</code> and "
 "<code>_</code>"
-
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:59
-msgid "The backup archive does not appear to be a valid gzip file."
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/error.htm:6
 msgid "The configuration file could not be loaded due to the following error:"
@@ -5138,8 +5138,8 @@ msgid ""
 "state."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:87
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:41
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:303
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:415
 msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
@@ -5153,23 +5153,16 @@ msgid ""
 "properly."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:127
-msgid ""
-"The filesystem that was used to format the memory (<abbr title=\"for example"
-"\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></"
-"samp>)"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:246
+msgid "The firstboot command failed with code %d"
 msgstr ""
-"這檔案系統適用來格式化記憶體(<abbr title=\"for example\">例.如.</abbr> "
-"<samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></samp>)"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:11
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:356
 msgid ""
 "The flash image was uploaded. Below is the checksum and file size listed, "
-"compare them with the original file to ensure data integrity.<br /> Click "
+"compare them with the original file to ensure data integrity. <br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"即將刷入的映像檔已上傳.下面是這個校驗碼和檔案大小詳細資訊, 用原始檔比對他們以"
-"確保資料完整性.<br />按下面的\"繼續\"便可以開始更新程序."
 
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:38
 msgid "The following rules are currently active on this system."
@@ -5189,11 +5182,11 @@ msgid ""
 "ECDSA keys."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:664
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:668
 msgid "The interface name is already used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:670
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "The interface name is too long"
 msgstr ""
 
@@ -5213,7 +5206,7 @@ msgstr "這IPv6開頭以位元計的長度"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
 msgid "The network name is already used"
 msgstr ""
 
@@ -5231,6 +5224,14 @@ msgstr ""
 "Local Area Network\">VLAN</abbr>群經常用來分割網路區段. 預設經常會有一個上傳"
 "埠來連接到下一個大型網路類似Intenet而其它埠則用來本地區網使用."
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:306
+msgid "The reboot command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:295
+msgid "The restore command failed with code %d"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
@@ -5239,13 +5240,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:249
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "系統正在刪除設定分割並且當完成時將自行重開."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:417
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5256,11 +5257,32 @@ msgstr ""
 "系統正在刷機中.<br /> 請勿關閉設備!<br />  請等待數分鐘直到您重新連線. 可能需"
 "要更新您電腦的位址以便再次連接設備, 端看您的設定. "
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:311
+msgid ""
+"The system is rebooting now. If the restored configuration changed the "
+"current LAN IP address, you might need to reconnect manually."
+msgstr ""
+
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:118
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:440
+msgid "The sysupgrade command failed with code %d"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:269
+msgid ""
+"The uploaded backup archive appears to be valid and contains the files "
+"listed below. Press \"Continue\" to restore the backup and reboot, or "
+"\"Cancel\" to abort the operation."
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:264
+msgid "The uploaded backup archive is not readable"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:377
 msgid ""
 "The uploaded image file does not contain a supported format. Make sure that "
 "you choose the generic image format for your platform."
@@ -5308,6 +5330,7 @@ msgid ""
 "Name System\">DNS</abbr> servers."
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:543
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
 msgid ""
 "This is a list of shell glob patterns for matching files and directories to "
@@ -5392,11 +5415,11 @@ msgstr ""
 msgid "Timezone"
 msgstr "時區"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:871
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:883
 msgid "To login…"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:493
 msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
@@ -5405,7 +5428,7 @@ msgstr ""
 "要復原設定檔, 可以上傳之前製作的備份壓縮檔放這. 要重置回復出廠值,按下\"執行還"
 "原\"(可能只對squashfs影像檔有效)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:835
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:845
 msgid "Tone"
 msgstr ""
 
@@ -5445,7 +5468,7 @@ msgstr "觸發模式"
 msgid "Tunnel ID"
 msgstr "通道ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "通道介面"
@@ -5488,8 +5511,8 @@ msgstr "USB設備"
 msgid "USB Ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:56
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:277
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:383
 msgid "UUID"
 msgstr "設備通用唯一識別碼UUID"
 
@@ -5519,6 +5542,10 @@ msgstr "無法發送"
 msgid "Unable to obtain client ID"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:244
+msgid "Unable to obtain mount information"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua:61
 msgid "Unable to resolve AFTR host name"
@@ -5530,6 +5557,7 @@ msgid "Unable to resolve peer host name"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:465
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
 msgstr ""
@@ -5538,28 +5566,28 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1389
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "未知"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1542
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:204
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:205
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
 msgstr "未託管"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:119
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:125
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:219
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:240
 msgid "Unmount"
 msgstr ""
 
@@ -5572,7 +5600,7 @@ msgstr ""
 msgid "Unsaved Changes"
 msgstr "尚未存檔的修改"
 
-#: modules/luci-base/htdocs/luci-static/resources/rpc.js:202
+#: modules/luci-base/htdocs/luci-static/resources/rpc.js:203
 msgid "Unspecified error"
 msgstr ""
 
@@ -5595,7 +5623,11 @@ msgstr "不支援的協定型態"
 msgid "Up"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:153
+msgid "Upload"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:527
 msgid ""
 "Upload a sysupgrade-compatible image here to replace the running firmware. "
 "Check \"Keep settings\" to retain the current configuration (requires a "
@@ -5604,7 +5636,9 @@ msgstr ""
 "上傳一個sysupgrade-相容的映像檔在這以便替代正執行中的韌體. 勾選\"保持設定\"以"
 "保留目前設定值(必須要是OpenWrt相容性韌體映像檔)."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:51
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:286
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:316
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:505
 msgid "Upload archive..."
 msgstr "上傳壓縮檔..."
 
@@ -5617,7 +5651,13 @@ msgid "Upload file…"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:142
 msgid "Upload request failed: %s"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:80
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:118
+msgid "Uploading file…"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:613
@@ -5675,11 +5715,11 @@ msgstr "在通道介面上使用的MTU數值"
 msgid "Use TTL on tunnel interface"
 msgstr "在通道介面上使用的TTL存活時間"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:106
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:317
 msgid "Use as external overlay (/overlay)"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:105
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:316
 msgid "Use as root filesystem (/)"
 msgstr ""
 
@@ -5687,7 +5727,7 @@ msgstr ""
 msgid "Use broadcast flag"
 msgstr "當作廣播旗標"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:801
 msgid "Use builtin IPv6-management"
 msgstr "使用內建的IPv6管理功能"
 
@@ -5753,7 +5793,7 @@ msgstr ""
 "個主機, the <em>IPv4-Address</em> 指定固定位址以便使用,<em>Hostname</em> 備指"
 "定當作象徵名稱到請求的主機上."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:218
 msgid "Used"
 msgstr "已使用"
 
@@ -5781,11 +5821,11 @@ msgstr ""
 msgid "Username"
 msgstr "用戶名稱"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:903
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:913
 msgid "VC-Mux"
 msgstr "虛擬電路多工器VC-Mux"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:861
 msgid "VDSL"
 msgstr ""
 
@@ -5832,9 +5872,9 @@ msgstr ""
 msgid "Vendor Class to send when requesting DHCP"
 msgstr "當請求DHCP封包時要傳送的製造商類別碼"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:9
-msgid "Verify"
-msgstr "確認"
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:343
+msgid "Verifying the uploaded image file."
+msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:76
@@ -5854,7 +5894,7 @@ msgstr "WEP 開放系統"
 msgid "WEP Shared Key"
 msgstr "WEP 共享金鑰"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WEP passphrase"
 msgstr "WEP通關密碼"
 
@@ -5862,7 +5902,7 @@ msgstr "WEP通關密碼"
 msgid "WMM Mode"
 msgstr "無線多媒體機制"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1828
 msgid "WPA passphrase"
 msgstr "WPA 密碼"
 
@@ -5926,13 +5966,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "無線網路"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "無線網卡"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1826
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2291
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5983,7 +6023,7 @@ msgstr "將系統日誌寫入檔案"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:943
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:953
 msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
@@ -6026,9 +6066,9 @@ msgstr ""
 msgid "any"
 msgstr "任意"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:846
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:854
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:859
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
@@ -6045,7 +6085,7 @@ msgstr ""
 msgid "baseT"
 msgstr "baseT"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:909
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:919
 msgid "bridged"
 msgstr "已橋接"
 
@@ -6062,7 +6102,7 @@ msgid "create:"
 msgstr "建立:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:368
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:678
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:682
 msgid "creates a bridge over specified interface(s)"
 msgstr "在指定的介面群上建立橋接"
 
@@ -6198,8 +6238,6 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:225
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "no"
 msgstr "無"
 
@@ -6211,13 +6249,13 @@ msgstr "無連線"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1445
 msgid "none"
 msgstr "無"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:166
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:176
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:186
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:91
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:105
 msgid "not present"
 msgstr ""
 
@@ -6247,10 +6285,6 @@ msgstr ""
 msgid "output"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:223
-msgid "overlay"
-msgstr ""
-
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:236
 msgid "positive decimal value"
 msgstr ""
@@ -6269,7 +6303,7 @@ msgstr ""
 msgid "relay mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:910
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:920
 msgid "routed"
 msgstr "路由"
 
@@ -6283,15 +6317,15 @@ msgstr ""
 msgid "server mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:601
 msgid "stateful-only"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:595
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:599
 msgid "stateless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:600
 msgid "stateless + stateful"
 msgstr ""
 
@@ -6509,14 +6543,67 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:232
 msgid "yes"
 msgstr "是的"
 
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 倒退"
+
+#~ msgid "(%s available)"
+#~ msgstr "(%s 可用)"
+
+#~ msgid "Check"
+#~ msgstr "檢查"
+
+#~ msgid "Checksum"
+#~ msgstr "效驗碼"
+
+#~ msgid "Enable this mount"
+#~ msgstr "啟用掛載點"
+
+#~ msgid "Enable this swap"
+#~ msgstr "啟用swap功能"
+
+#~ msgid "Flash Firmware"
+#~ msgstr "韌體更新"
+
+#~ msgid "Flashing..."
+#~ msgstr "更新中..."
+
+#~ msgid "Mount Entry"
+#~ msgstr "掛載項目"
+
+#~ msgid "Proceed"
+#~ msgstr "前進"
+
+#~ msgid "Really reset all changes?"
+#~ msgstr "確定要回復原廠設定?"
+
+#~ msgid "Root"
+#~ msgstr "根"
+
+#~ msgid "Swap Entry"
+#~ msgstr "Swap交換頁項目"
+
+#~ msgid ""
+#~ "The filesystem that was used to format the memory (<abbr title=\"for "
+#~ "example\">e.g.</abbr> <samp><abbr title=\"Third Extended Filesystem"
+#~ "\">ext3</abbr></samp>)"
+#~ msgstr ""
+#~ "這檔案系統適用來格式化記憶體(<abbr title=\"for example\">例.如.</abbr> "
+#~ "<samp><abbr title=\"Third Extended Filesystem\">ext3</abbr></samp>)"
+
+#~ msgid ""
+#~ "The flash image was uploaded. Below is the checksum and file size listed, "
+#~ "compare them with the original file to ensure data integrity.<br /> Click "
+#~ "\"Proceed\" below to start the flash procedure."
+#~ msgstr ""
+#~ "即將刷入的映像檔已上傳.下面是這個校驗碼和檔案大小詳細資訊, 用原始檔比對他"
+#~ "們以確保資料完整性.<br />按下面的\"繼續\"便可以開始更新程序."
+
+#~ msgid "Verify"
+#~ msgstr "確認"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "指定這個 <em>Dropbear</em>的監聽埠"

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -591,6 +591,10 @@ return L.view.extend({
 					so.value('relay', _('relay mode'));
 					so.value('hybrid', _('hybrid mode'));
 
+					so = ss.taboption('ipv6', form.Flag , 'master', _('Master'), _('Set this interface as master for the dhcpv6 relay.'));
+					so.depends('dhcpv6', 'relay');
+					so.depends('dhcpv6', 'hybrid');
+
 					so = ss.taboption('ipv6', form.ListValue, 'ra_management', _('DHCPv6-Mode'), _('Default is stateless + stateful'));
 					so.value('0', _('stateless'));
 					so.value('1', _('stateless + stateful'));


### PR DESCRIPTION
This option is usefull if someone needs to route ipv6 dhcp from wan to lan.
@jow- 
Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>