### PR TITLE
luci-app-aria2: fix http/https protocol when opening aria2 webUI

### DIFF
--- a/applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm
+++ b/applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm
@@ -67,7 +67,7 @@ function openWebUI(path) {
 	var pathName = window.document.location.pathname;
 	var pos = curWwwPath.indexOf(pathName);
 	var localhostPath = curWwwPath.substring(0, pos);
-	var url = "http:" + localhostPath.substring(window.location.protocol.length) + "/" + path;
+	var url = localhostPath + "/" + path;
 	window.open(url)
 };
 //]]>


### PR DESCRIPTION
In the openWebUI function, the url is assumed as http protocol,
this will cause problem when we login luci-admin with https.

The variable localhostPath has already contained http/https
protocol, so we can use it directly and add the path of aria2
webUI.

Signed-off-by: Zheng Qian <sotux82@gmail.com>