### PR TITLE
luci-base: fix typo in template

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/map.htm
+++ b/modules/luci-base/luasrc/view/cbi/map.htm
@@ -16,7 +16,7 @@
 				<div class="cbi-tabcontainer"<%=
 					attr("id", "container.m-%s.%s" %{ self.config, tab }) ..
 					attr("data-tab", tab) ..
-					attr("data-tab-title", section.title or tab))
+					attr("data-tab-title", section.title or tab)
 				%>>
 					<% section:render() %>
 				</div>


### PR DESCRIPTION
Makes tabs actually render correctly