### PR TITLE
Fix a bug when loading luci translation

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/map.htm
+++ b/modules/luci-base/luasrc/view/cbi/map.htm
@@ -16,7 +16,7 @@
 				<div class="cbi-tabcontainer"<%=
 					attr("id", "container.m-%s.%s" %{ self.config, tab }) ..
 					attr("data-tab", tab) ..
-					attr("data-tab-title", section.title or tab))
+					attr("data-tab-title", section.title or tab)
 				%>>
 					<% section:render() %>
 				</div>


### PR DESCRIPTION
Fix errors caused by an extra brackets
/usr/lib/lua/luci/template.lua:74: Failed to load template 'cbi/map'.