### PR TITLE
luci-app-aria2: fix showRPCURL when using https

### DIFF
--- a/applications/luci-app-aria2/Makefile
+++ b/applications/luci-app-aria2/Makefile
@@ -14,7 +14,7 @@ PKG_VERSION:=1.0.1
 
 # Release == build
 # increase on changes of translation files
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Hsing-Wang Liao <kuoruan@gmail.com>

--- a/applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm
+++ b/applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm
@@ -45,11 +45,14 @@ function showRPCURL() {
 	var auth_method = document.getElementById("cbid.aria2.main.rpc_auth_method");
 	var auth_port = document.getElementById("cbid.aria2.main.rpc_listen_port");
 	var auth_port_value;
+	if (window.location.protocol == "https:") {                                  
+		protocol += "s";                                                     
+	}
 	if (auth_port.value == "") {
-		auth_port_value = "6800"
+		auth_port_value = "6800";
 	} else {
-		auth_port_value = auth_port.value
-	};
+		auth_port_value = auth_port.value;
+	}
 	if (auth_method.value == "token") {
 		var auth_token = document.getElementById("cbid.aria2.main.rpc_secret");
 		newTextNode.value = protocol + "://token:" + auth_token.value + "@" + document.domain + ":" + auth_port_value + "/jsonrpc";
@@ -68,7 +71,7 @@ function openWebUI(path) {
 	var pos = curWwwPath.indexOf(pathName);
 	var localhostPath = curWwwPath.substring(0, pos);
 	var url = localhostPath + "/" + path;
-	window.open(url)
+	window.open(url);
 };
 //]]>
 </script>


### PR DESCRIPTION
if login luci-admin with https, RPC protocol should be https or wss.

Signed-off-by: Zheng Qian <sotux82@gmail.com>