### PR TITLE
luci-app-aria2: fix the log option

### DIFF
--- a/applications/luci-app-aria2/Makefile
+++ b/applications/luci-app-aria2/Makefile
@@ -14,7 +14,7 @@ PKG_VERSION:=1.0.1
 
 # Release == build
 # increase on changes of translation files
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Hsing-Wang Liao <kuoruan@gmail.com>

--- a/applications/luci-app-aria2/luasrc/model/cbi/aria2.lua
+++ b/applications/luci-app-aria2/luasrc/model/cbi/aria2.lua
@@ -89,12 +89,12 @@ o.rmempty = true
 o = s:taboption("file", Value, "config_dir", translate("Config file directory"))
 o.placeholder = "/var/etc/aria2"
 
-o = s:taboption("file", Flag, "enable_log", translate("Enable log"), translate("Log file is in the config file dir."))
+o = s:taboption("file", Flag, "enable_logging", translate("Enable log"), translate("The default log file is /var/log/aria2.log"))
 o.enabled = "true"
 o.disabled = "false"
  
 o = s:taboption("file", ListValue, "log_level", translate("Log level"))
-o:depends("enable_log", "true")
+o:depends("enable_logging", "true")
 o:value("debug", translate("Debug"))
 o:value("info", translate("Info"))
 o:value("notice", translate("Notice"))

--- a/applications/luci-app-aria2/po/pt-br/aria2.po
+++ b/applications/luci-app-aria2/po/pt-br/aria2.po
@@ -41,7 +41,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Configurações do Aria2"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:80
 msgid "Aria2 Status"
 msgstr "Estado do Aria2"
 
@@ -65,7 +65,7 @@ msgstr "Configurações do BitTorrent"
 msgid "BitTorrent listen port"
 msgstr "Porta de escuta do BitTorrent"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:82
 msgid "Collecting data..."
 msgstr "Coletando dados..."
 
@@ -132,11 +132,6 @@ msgstr "Lista de rastreadores BitTorrent adicionais"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:205
 msgid "List of extra settings"
 msgstr "Lista de configurações adicionais"
-
-#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
-msgid "Log file is in the config file dir."
-msgstr ""
-"Arquivo de registro (log) está no diretório do arquivo de configuração."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:96
 msgid "Log level"
@@ -272,6 +267,10 @@ msgstr "O serviço Aria2 está parado."
 msgid "The Aria2 service is running."
 msgstr "O serviço Aria2 está em execução."
 
+#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
+msgid "The default log file is /var/log/aria2.log"
+msgstr ""
+
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:74
 msgid "Token"
 msgstr "Chave eletrônica"
@@ -310,3 +309,7 @@ msgstr "em bytes. Você pode sufixar com K (quilo) ou M (mega)."
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:131
 msgid "in bytes/sec, You can append K or M."
 msgstr "em bytes por segundo. Você pode sufixar com K (quilo) ou M (mega)."
+
+#~ msgid "Log file is in the config file dir."
+#~ msgstr ""
+#~ "Arquivo de registro (log) está no diretório do arquivo de configuração."

--- a/applications/luci-app-aria2/po/ru/aria2.po
+++ b/applications/luci-app-aria2/po/ru/aria2.po
@@ -40,7 +40,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Настройка Aria2"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:80
 msgid "Aria2 Status"
 msgstr "Состояние Aria2"
 
@@ -64,7 +64,7 @@ msgstr "Настройки BitTorrent-а"
 msgid "BitTorrent listen port"
 msgstr "Порты BitTorrent-а"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:82
 msgid "Collecting data..."
 msgstr "Сбор данных..."
 
@@ -131,10 +131,6 @@ msgstr "Список дополнительных BT tracker-ов"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:205
 msgid "List of extra settings"
 msgstr "Список дополнительных настроек"
-
-#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
-msgid "Log file is in the config file dir."
-msgstr "Файл системного журнала находится в папке с config файлом."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:96
 msgid "Log level"
@@ -260,6 +256,10 @@ msgstr "Aria2 сервис не запущен."
 msgid "The Aria2 service is running."
 msgstr "Aria2 сервис запущен."
 
+#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
+msgid "The default log file is /var/log/aria2.log"
+msgstr ""
+
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:74
 msgid "Token"
 msgstr "Токен"
@@ -299,3 +299,6 @@ msgstr ""
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:131
 msgid "in bytes/sec, You can append K or M."
 msgstr "в байтах/секундах. Вы можете добавить суффикс K (кило) или М (мега)."
+
+#~ msgid "Log file is in the config file dir."
+#~ msgstr "Файл системного журнала находится в папке с config файлом."

--- a/applications/luci-app-aria2/po/sv/aria2.po
+++ b/applications/luci-app-aria2/po/sv/aria2.po
@@ -26,7 +26,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Inställningar för Aria2"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:80
 msgid "Aria2 Status"
 msgstr "Status för Aria2"
 
@@ -48,7 +48,7 @@ msgstr "Inställningar för BitTorrent"
 msgid "BitTorrent listen port"
 msgstr "Lyssningsport för BitTorrent"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:82
 msgid "Collecting data..."
 msgstr "Samlar in data..."
 
@@ -115,10 +115,6 @@ msgstr "Lista över extra Bt-tracker"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:205
 msgid "List of extra settings"
 msgstr "Lista över extra inställningar"
-
-#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
-msgid "Log file is in the config file dir."
-msgstr "Logg-filen är i konfigurationsfilens mapp."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:96
 msgid "Log level"
@@ -244,6 +240,10 @@ msgstr "Aria2-tjänsten körs inte."
 msgid "The Aria2 service is running."
 msgstr "Aria2-tjänsten körs."
 
+#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
+msgid "The default log file is /var/log/aria2.log"
+msgstr ""
+
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:74
 msgid "Token"
 msgstr "Tecken"
@@ -282,3 +282,6 @@ msgstr "i bytes, Du kan bifoga K eller M."
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:131
 msgid "in bytes/sec, You can append K or M."
 msgstr "i bytes/sek, Du kan bifoga K eller M."
+
+#~ msgid "Log file is in the config file dir."
+#~ msgstr "Logg-filen är i konfigurationsfilens mapp."

--- a/applications/luci-app-aria2/po/templates/aria2.pot
+++ b/applications/luci-app-aria2/po/templates/aria2.pot
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Aria2 Settings"
 msgstr ""
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:80
 msgid "Aria2 Status"
 msgstr ""
 
@@ -48,7 +48,7 @@ msgstr ""
 msgid "BitTorrent listen port"
 msgstr ""
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:82
 msgid "Collecting data..."
 msgstr ""
 
@@ -114,10 +114,6 @@ msgstr ""
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:205
 msgid "List of extra settings"
-msgstr ""
-
-#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
-msgid "Log file is in the config file dir."
 msgstr ""
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:96
@@ -242,6 +238,10 @@ msgstr ""
 
 #: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:7
 msgid "The Aria2 service is running."
+msgstr ""
+
+#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
+msgid "The default log file is /var/log/aria2.log"
 msgstr ""
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:74

--- a/applications/luci-app-aria2/po/zh-cn/aria2.po
+++ b/applications/luci-app-aria2/po/zh-cn/aria2.po
@@ -1,5 +1,6 @@
 #
 # Yangfl <mmyangfl@gmail.com>, 2017, 2018.
+# Zheng Qian <sotux82@gmail.com>, 2018.
 #
 msgid ""
 msgstr ""
@@ -8,7 +9,7 @@ msgstr ""
 "Language-Team:  <debian-l10n-chinese@lists.debian.org>\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"PO-Revision-Date: 2018-10-01 10:05+0800\n"
+"PO-Revision-Date: 2018-12-15 21:32+0800\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:110
@@ -36,7 +37,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Aria2 配置"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:80
 msgid "Aria2 Status"
 msgstr "Aria2 状态"
 
@@ -58,7 +59,7 @@ msgstr "BitTorrent 设置"
 msgid "BitTorrent listen port"
 msgstr "BitTorrent 监听端口"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:82
 msgid "Collecting data..."
 msgstr "正在收集数据..."
 
@@ -125,10 +126,6 @@ msgstr "附加 Bt tracker 列表"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:205
 msgid "List of extra settings"
 msgstr "附加选项列表"
-
-#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
-msgid "Log file is in the config file dir."
-msgstr "日志文件在配置文件目录下"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:96
 msgid "Log level"
@@ -254,6 +251,10 @@ msgstr "Aria2 未运行"
 msgid "The Aria2 service is running."
 msgstr "Aria2 正在运行"
 
+#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
+msgid "The default log file is /var/log/aria2.log"
+msgstr "默认的 log 文件是 /var/log/aria2.log"
+
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:74
 msgid "Token"
 msgstr "令牌"
@@ -292,6 +293,9 @@ msgstr "单位 B, 您可以在数字后跟上 K 或 M。"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:131
 msgid "in bytes/sec, You can append K or M."
 msgstr "单位 B/s, 您可以在数字后跟上 K 或 M。"
+
+#~ msgid "Log file is in the config file dir."
+#~ msgstr "日志文件在配置文件目录下"
 
 #~ msgid "General settings"
 #~ msgstr "基本设置"

--- a/applications/luci-app-aria2/po/zh-tw/aria2.po
+++ b/applications/luci-app-aria2/po/zh-tw/aria2.po
@@ -36,7 +36,7 @@ msgstr "Aria2"
 msgid "Aria2 Settings"
 msgstr "Aria2 配置"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:77
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:80
 msgid "Aria2 Status"
 msgstr "Aria2 狀態"
 
@@ -58,7 +58,7 @@ msgstr "BitTorrent 設定"
 msgid "BitTorrent listen port"
 msgstr "BitTorrent 監聽埠"
 
-#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:79
+#: applications/luci-app-aria2/luasrc/view/aria2/overview_status.htm:82
 msgid "Collecting data..."
 msgstr "正在收集資料..."
 
@@ -125,10 +125,6 @@ msgstr "附加 Bt tracker 列表"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:205
 msgid "List of extra settings"
 msgstr "附加選項列表"
-
-#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
-msgid "Log file is in the config file dir."
-msgstr "日誌檔案在配置檔案目錄下"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:96
 msgid "Log level"
@@ -254,6 +250,10 @@ msgstr "Aria2 未執行"
 msgid "The Aria2 service is running."
 msgstr "Aria2 正在執行"
 
+#: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:92
+msgid "The default log file is /var/log/aria2.log"
+msgstr ""
+
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:74
 msgid "Token"
 msgstr "令牌"
@@ -292,6 +292,9 @@ msgstr "單位 B, 您可以在數字後跟上 K 或 M。"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2.lua:131
 msgid "in bytes/sec, You can append K or M."
 msgstr "單位 B/s, 您可以在數字後跟上 K 或 M。"
+
+#~ msgid "Log file is in the config file dir."
+#~ msgstr "日誌檔案在配置檔案目錄下"
 
 #~ msgid "General settings"
 #~ msgstr "基本設定"


### PR DESCRIPTION
According to the package aria2, the log option
is enable_logging, so fix this option name.

As luci-app-aria2 can't set custom log file dir,
the default log file is /var/log/aria2.log but not
in the config file dir.

Some discussion is here. [packages PR 7665](https://github.com/openwrt/packages/pull/7665)