### PR TITLE
luci-theme-material: make top level menu fontcolor configurable

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -571,7 +571,7 @@ header > .fill > .container > .status > * {
 	display: block;
 	padding: .5rem 1rem;
 	text-decoration: none;
-	color: #202124;
+	color: var(--menu-color);
 }
 
 .main > .main-left > .nav > li:hover,


### PR DESCRIPTION
If you change the color of the submenues then the colors of the toplevel
should also be changed into the same color.