### PR TITLE
luci-app-ddns: check existence of nslookup util rather than making DNS request

### DIFF
--- a/applications/luci-app-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/tools/ddns.lua
@@ -103,7 +103,7 @@ function env_info(type)
 		end
 
 		local function has_nslookup()
-			return (SYS.call( [[$(which nslookup) localhost 2>&1 | grep -qF "(null)"]] ) ~= 0)
+			return (SYS.call( [[which nslookup >/dev/null 2>&1]] ) == 0)
 		end
 
 		if type == "has_bindhost" then


### PR DESCRIPTION
This saves a DNS request whenever the nslookup check is performed.  For systems with nameservers configured in `/etc/resolv.conf`, nslookup will send a request to those servers (eg bypassing /etc/hosts), thus taking a lot more time than necessary.  For nameservers that are remote, this will take a *lot* longer than just checking if the nslookup util exists.

This change follows in the same vein as all the other checks that currently exist in the file which just use `which` without actually invoking each util's functionality.

Signed-off-by: David Beitey <david@davidjb.com>