### PR TITLE
treewide: fix redirecting to System->Software

### DIFF
--- a/applications/luci-app-shadowsocks-libev/luasrc/model/cbi/shadowsocks-libev/rules.lua
+++ b/applications/luci-app-shadowsocks-libev/luasrc/model/cbi/shadowsocks-libev/rules.lua
@@ -99,7 +99,7 @@ else
 	o.write = function()
 		return luci.http.redirect(
 			luci.dispatcher.build_url("admin/system/opkg") ..
-			"?submit=1&install=iptables-mod-conntrack-extra"
+			"?query=iptables-mod-conntrack-extra"
 		)
 	end
 end

--- a/applications/luci-app-shadowsocks-libev/luasrc/model/cbi/shadowsocks-libev/rules.lua
+++ b/applications/luci-app-shadowsocks-libev/luasrc/model/cbi/shadowsocks-libev/rules.lua
@@ -98,7 +98,7 @@ else
 	o.inputstyle = "apply"
 	o.write = function()
 		return luci.http.redirect(
-			luci.dispatcher.build_url("admin/system/packages") ..
+			luci.dispatcher.build_url("admin/system/opkg") ..
 			"?submit=1&install=iptables-mod-conntrack-extra"
 		)
 	end

--- a/applications/luci-app-shadowsocks-libev/luasrc/model/shadowsocks-libev.lua
+++ b/applications/luci-app-shadowsocks-libev/luasrc/model/shadowsocks-libev.lua
@@ -199,7 +199,7 @@ function option_install_package(s, tab)
 
 	function p_install.write()
 		return luci.http.redirect(
-			luci.dispatcher.build_url("admin/system/packages") ..
+			luci.dispatcher.build_url("admin/system/opkg") ..
 			"?submit=1&install=%s" % opkg_package
 		)
 	end

--- a/applications/luci-app-shadowsocks-libev/luasrc/model/shadowsocks-libev.lua
+++ b/applications/luci-app-shadowsocks-libev/luasrc/model/shadowsocks-libev.lua
@@ -200,7 +200,7 @@ function option_install_package(s, tab)
 	function p_install.write()
 		return luci.http.redirect(
 			luci.dispatcher.build_url("admin/system/opkg") ..
-			"?submit=1&install=%s" % opkg_package
+			"?query=%s" % opkg_package
 		)
 	end
 end

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js
@@ -113,7 +113,7 @@ L.poll(5, L.url('admin/network/iface_status', networks.join(',')), null,
 					var e = document.getElementById(ifc.id + '-ifc-edit');
 					if (e) e.disabled = true;
 
-					var link = L.url('admin/system/packages') + '?query=luci-proto&display=available';
+					var link = L.url('admin/system/opkg') + '?query=luci-proto&display=available';
 					L.dom.content(d, [
 						E('em', _('Unsupported protocol type.')), E('br'),
 						E('a', { href: link }, _('Install protocol extensions...'))

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js
@@ -113,7 +113,7 @@ L.poll(5, L.url('admin/network/iface_status', networks.join(',')), null,
 					var e = document.getElementById(ifc.id + '-ifc-edit');
 					if (e) e.disabled = true;
 
-					var link = L.url('admin/system/opkg') + '?query=luci-proto&display=available';
+					var link = L.url('admin/system/opkg') + '?query=luci-proto';
 					L.dom.content(d, [
 						E('em', _('Unsupported protocol type.')), E('br'),
 						E('a', { href: link }, _('Install protocol extensions...'))

--- a/modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua
@@ -227,7 +227,7 @@ if not net:is_installed() then
 	function p_install.write()
 		return luci.http.redirect(
 			luci.dispatcher.build_url("admin/system/opkg") ..
-			"?submit=1&install=%s" % net:opkg_package()
+			"?query=%s" % net:opkg_package()
 		)
 	end
 end

--- a/modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua
@@ -226,7 +226,7 @@ if not net:is_installed() then
 
 	function p_install.write()
 		return luci.http.redirect(
-			luci.dispatcher.build_url("admin/system/packages") ..
+			luci.dispatcher.build_url("admin/system/opkg") ..
 			"?submit=1&install=%s" % net:opkg_package()
 		)
 	end


### PR DESCRIPTION
By replacing url "admin/system/packages" with "admin/system/opkg"

While at it, also remove query arguments as they have been invalid for quite a while.

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>