### PR TITLE
luci-app-statistics: Voltage graph split into AC/DC, cosmetic change to battery/load and temperature graphs

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/nut.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/nut.lua
@@ -4,22 +4,34 @@ module("luci.statistics.rrdtool.definitions.nut",package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
 
-	local voltages = {
-		title = "%H: Voltages on UPS \"%pi\"",
+	local voltages_ac = {
+		title = "%H: AC voltages on UPS \"%pi\"",
 		vlabel = "V",
 		number_format = "%5.1lfV",
 		data = {
 			instances = {
-				voltage = { "battery", "input", "output" }
+				voltage = { "input", "output" }
 			},
-
 			options = {
 				voltage_output  = { color = "00e000", title = "Output voltage", noarea=true, overlay=true },
-				voltage_battery = { color = "0000ff", title = "Battery voltage", noarea=true, overlay=true },
 				voltage_input   = { color = "ffb000", title = "Input voltage", noarea=true, overlay=true }
 			}
 		}
 	}
+
+    local voltages_dc = {
+        title = "%H: Battery voltage on UPS \"%pi\"",
+        vlabel = "V",
+        number_format = "%5.1lfV",
+        data = {
+            instances = {
+                voltage = { "battery" }
+            },
+            options = {
+                voltage = { color = "0000ff", title = "Battery voltage", noarea=true, overlay=true }
+            }
+        }
+    }
 
 	local currents = {
 		title = "%H: Current on UPS \"%pi\"",
@@ -29,7 +41,6 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 			instances = {
 				current = { "battery", "output" }
 			},
-
 			options = {
 				current_output  = { color = "00e000", title = "Output current", noarea=true, overlay=true },
 				current_battery = { color = "0000ff", title = "Battery current", noarea=true, overlay=true }
@@ -48,8 +59,8 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 				percent = { "charge", "load" }
 			},
 			options = {
-				percent_charge = { color = "00ff00", title = "Charge level"  },
-				percent_load = { color = "ff0000", title = "Load"  }
+				percent_charge = { color = "00ff00", title = "Charge level", noarea=true, overlay=true },
+				percent_load = { color = "ff0000", title = "Load", noarea=true, overlay=true }
 			}
 		}
 	}
@@ -63,9 +74,8 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 			instances = {
 				temperature = "battery"
 			},
-
 			options = {
-				temperature_battery = { color = "ffb000", title = "Battery temperature" }
+				temperature_battery = { color = "ffb000", title = "Battery temperature", noarea=true }
 			}
 		}
 	}
@@ -106,12 +116,11 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 			instances = {
 				frequency = { "input", "output" }
 			},
-
 			options = {
 				frequency_output  = { color = "00e000", title = "Output frequency", noarea=true, overlay=true },
 				frequency_input   = { color = "ffb000", title = "Input frequency", noarea=true, overlay=true }
 			}
 		}
 	}
-	return { voltages, currents, percentage, temperature, timeleft, power, frequencies }
+	return { voltages_ac, voltages_dc, currents, percentage, temperature, timeleft, power, frequencies }
 end


### PR DESCRIPTION
The big difference between AC and DC voltage is masking changes in Input/Output voltages over time. This patch splits the graphs into 2 graphs like in apcups. This makes it possible to see variations in AC Input/Output voltages.
Battery charge and load are indepentent variables, this patch change overlays them and display them as simply two lines.
Battery temperature is also displayed as a line now, as an area under a temperature line makes no sense.
Removed some empty lines.

Signed-off-by: Fabian Schmid-Michels <mail@wohnheimnetz-bielefeld.de>