### PR TITLE
luci-proto-ppp: fix wrong pppoe host_uniq datatype

### DIFF
--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua
@@ -119,7 +119,7 @@ host_uniq = section:taboption("advanced", Value, "host_uniq",
 	translate("Raw hex-encoded bytes. Leave empty unless your ISP require this"))
 
 host_uniq.placeholder = translate("auto")
-host_uniq.datatype    = "hex"
+host_uniq.datatype    = "hexstring"
 
 
 demand = section:taboption("advanced", Value, "demand",


### PR DESCRIPTION
My previous addition of host_uniq tag setting for pppoe protocol (#1937 ) uses a wrong `hex` datatype for filed validation, `hexstring` is the correct one instead. This fixes bad validation error for that field.

Signed-off-by: Luca Piccirillo <luca.piccirillo@gmail.com>