### PR TITLE
luci-base: Fix addr:port validate always fails

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -443,10 +443,10 @@ var CBIValidatorPrototype = {
 			    m6 = this.value.match((bracket == 1) ? /^\[(.+)\]:(\d+)$/ : /^([^\[\]]+):(\d+)$/);
 
 			if (m4)
-				return this.assert(this.apply('ip4addr', m4[0], [true]) && this.apply('port', m4[1]),
+				return this.assert(this.apply('ip4addr', m4[1], [true]) && this.apply('port', m4[2]),
 					_('valid address:port'));
 
-			return this.assert(m6 && this.apply('ip6addr', m6[0], [true]) && this.apply('port', m6[1]),
+			return this.assert(m6 && this.apply('ip6addr', m6[1], [true]) && this.apply('port', m6[2]),
 				_('valid address:port'));
 		},
 


### PR DESCRIPTION
In cbi.js there is an error which causes ipaddrport validation to always fail.
JS match() return the entire match as ret[0] and individual matches (for multiple ()) as the
subsequent list members.  So we fix it by just fixing the index in the calls that want the
individual parts.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>