### PR TITLE
luci-app-ddns: fix typo for has_curlssl()

### DIFF
--- a/applications/luci-app-ddns/luasrc/tools/ddns.lua
+++ b/applications/luci-app-ddns/luasrc/tools/ddns.lua
@@ -21,7 +21,7 @@ function env_info(type)
 		end
 
 		local function has_curlssl()
-			return (SYS.call( [[$(which curl) -V 2>&1 | grep "Protocols:" | grep -qF "https"]] ) ~= 0)
+			return (SYS.call( [[$(which curl) -V 2>&1 | grep "Protocols:" | grep -qF "https"]] ) == 0)
 		end
 
 		local function has_fetch()


### PR DESCRIPTION
Fixes the incorrect message "HTTPS not supported please disable !" when curl with https support is present.
grep returns exit code 0 when a match is found.

```
root@OpenWrt:~# ($(which curl) -V 2>&1 | grep "Protocols:" | grep -qF "https")
root@OpenWrt:~# echo $?
0
```

Signed-off-by: Leong Hui Wong <wong.leonghui@gmail.com>