### PR TITLE
luci-app-rp-pppoe-server: Add ability to create uci sections

### DIFF
--- a/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
+++ b/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
@@ -9,7 +9,7 @@ m = Map("pppoe", translate("Roaring Penguin PPPoE Server"),
 	translate("PPPoE Server Configuration"))
 
 s = m:section(TypedSection, "pppoe_server", translate("Server Configuration"))
-s.addremove = false
+s.addremove = true
 s.anonymous = true
 
 o = s:option(Value, "interface", translate("Interface"), translate("Interface on which to listen."))

--- a/applications/luci-app-rp-pppoe-server/po/templates/rp-pppoe-server.pot
+++ b/applications/luci-app-rp-pppoe-server/po/templates/rp-pppoe-server.pot
@@ -1,0 +1,91 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:19
+msgid "Access Concentrator Name"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:32
+msgid "First remote IP"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:29
+msgid "IP of listening side"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:44
+msgid ""
+"Instead of starting at beginning and going to end, randomize session number"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:15
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:15
+msgid "Interface on which to listen."
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:62
+msgid "MSS"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:35
+msgid "Maximum sessions"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:25
+msgid "Maximum sessions per peer"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:52
+msgid "Offset"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:40
+msgid "Options file"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:52
+msgid "PPP offset"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:47
+msgid "PPP unit number"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:9
+msgid "PPPoE Server Configuration"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/controller/rp-pppoe-server.lua:11
+msgid "RP PPPoE Server"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:44
+msgid "Random session selection"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:8
+msgid "Roaring Penguin PPPoE Server"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:11
+msgid "Server Configuration"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:22
+msgid "Service Name"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:68
+msgid "Sync"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:57
+msgid "Timeout"
+msgstr ""
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:47
+msgid "Unit"
+msgstr ""


### PR DESCRIPTION
Currently if no non-commented uci sections exist in the config then
it's impossible to create a config from LuCI. Fix that, which also
allows what the initscript does, which is multiple instances. While
we're at it create the translation template.

Closes: #2431

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Run tested on Raspberry Pi B+