### PR TITLE
Add PO for en 'translation' for apps I've created in the past

### DIFF
--- a/applications/luci-app-nut/po/en/nut.po
+++ b/applications/luci-app-nut/po/en/nut.po
@@ -1,0 +1,603 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2019-01-09 06:58-0500\n"
+"Last-Translator: Daniel F. Dickinson <cshored@thecshore.com>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:216
+msgid "Additional Shutdown Time(s)"
+msgstr "Additional Shutdown Time(s)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:37
+msgid "Addresses on which to listen"
+msgstr "Addresses on which to listen"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:23
+msgid "Allowed actions"
+msgstr "Allowed actions"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:20
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:188
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:217
+msgid "As configured by NUT"
+msgstr "As configured by NUT"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:150
+msgid "Bytes to read from interrupt pipe"
+msgstr "Bytes to read from interrupt pipe"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:174
+msgid "CA Certificate path"
+msgstr "CA Certificate path"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:73
+msgid "Certificate file (SSL)"
+msgstr "Certificate file (SSL)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:63
+msgid "Communications lost message"
+msgstr "Communications lost message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:60
+msgid "Communications restored message"
+msgstr "Communications restored message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:35
+msgid "Control UPS via CGI"
+msgstr "Control UPS via CGI"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:43
+msgid "Deadtime"
+msgstr "Deadtime"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+msgid "Default for UPSes without this field."
+msgstr "Default for UPSes without this field."
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:177
+msgid "Delay for kill power command"
+msgstr "Delay for kill power command"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:181
+msgid "Delay to power on UPS if power returns after kill power"
+msgstr "Delay to power on UPS if power returns after kill power"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:129
+msgid "Description (Display)"
+msgstr "Description (Display)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:32
+msgid "Display name"
+msgstr "Display name"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:169
+msgid "Don't lock port when starting driver"
+msgstr "Don't lock port when starting driver"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:132
+msgid "Driver"
+msgstr "Driver"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:114
+msgid "Driver Configuration"
+msgstr "Driver Configuration"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:77
+msgid "Driver Global Settings"
+msgstr "Driver Global Settings"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:83
+msgid "Driver Path"
+msgstr "Driver Path"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:212
+msgid "Driver Shutdown Order"
+msgstr "Driver Shutdown Order"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:106
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:244
+msgid "Driver waits for data to be consumed by upsd before publishing more."
+msgstr "Driver waits for data to be consumed by upsd before publishing more."
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:59
+msgid "Drop privileges to this user"
+msgstr "Drop privileges to this user"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:40
+msgid "Enable"
+msgstr "Enable"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:138
+msgid ""
+"Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
+"group read-write as user 'nut'"
+msgstr ""
+"Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
+"group read-write as user 'nut'"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:93
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:102
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:110
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:118
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:126
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:134
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:142
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:150
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:158
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:166
+msgid "Execute notify command"
+msgstr "Execute notify command"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:26
+msgid "Forced Shutdown"
+msgstr "Forced Shutdown"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:57
+msgid "Forced shutdown message"
+msgstr "Forced shutdown message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:10
+msgid "Global Settings"
+msgstr "Global Settings"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:13
+msgid "Go to NUT CGI"
+msgstr "Go to NUT CGI"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:16
+msgid "Host"
+msgstr "Host"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:23
+msgid "Hostname or IP address"
+msgstr "Hostname or IP address"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:191
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:220
+msgid "Hostname or address of UPS"
+msgstr "Hostname or address of UPS"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:39
+msgid "Hot Sync"
+msgstr "Hot Sync"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:41
+msgid "IP Address"
+msgstr "IP Address"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:95
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:104
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:112
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:120
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:128
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:136
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:144
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:152
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:160
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:168
+msgid "Ignore"
+msgstr "Ignore"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:142
+msgid "Ignore Low Battery"
+msgstr "Ignore Low Battery"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:29
+msgid "Instant commands"
+msgstr "Instant commands"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:146
+msgid "Interrupt Only"
+msgstr "Interrupt Only"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:150
+msgid "Interrupt Size"
+msgstr "Interrupt Size"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:54
+msgid "Low battery message"
+msgstr "Low battery message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:163
+msgid "Manufacturer (Display)"
+msgstr "Manufacturer (Display)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:34
+msgid "Master"
+msgstr "Master"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:154
+msgid "Max USB HID Length Reported"
+msgstr "Max USB HID Length Reported"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:54
+msgid "Maximum Age of Data"
+msgstr "Maximum Age of Data"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:87
+msgid "Maximum Start Delay"
+msgstr "Maximum Start Delay"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:67
+msgid "Maximum connections"
+msgstr "Maximum connections"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maximum number of times to try starting a driver."
+msgstr "Maximum number of times to try starting a driver."
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
+msgid "Maximum time in seconds between refresh of UPS status"
+msgstr "Maximum time in seconds between refresh of UPS status"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
+msgid "Maxium Retries"
+msgstr "Maxium Retries"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
+msgid "Maxium Start Delay"
+msgstr "Maxium Start Delay"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:17
+msgid "Minimum required number or power supplies"
+msgstr "Minimum required number or power supplies"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:166
+msgid "Model (Display)"
+msgstr "Model (Display)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:9
+msgid "NUT CGI Access"
+msgstr "NUT CGI Access"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:12
+msgid "NUT Users"
+msgstr "NUT Users"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:188
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:217
+msgid "Name of UPS"
+msgstr "Name of UPS"
+
+#: applications/luci-app-nut/luasrc/controller/nut.lua:11
+msgid "Network UPS Tools"
+msgstr "Network UPS Tools"
+
+#: applications/luci-app-nut/luasrc/controller/nut.lua:22
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:6
+msgid "Network UPS Tools (CGI)"
+msgstr "Network UPS Tools (CGI)"
+
+#: applications/luci-app-nut/luasrc/controller/nut.lua:18
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:7
+msgid "Network UPS Tools (Monitor)"
+msgstr "Network UPS Tools (Monitor)"
+
+#: applications/luci-app-nut/luasrc/controller/nut.lua:14
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:9
+msgid "Network UPS Tools (Server)"
+msgstr "Network UPS Tools (Server)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:7
+msgid "Network UPS Tools CGI Configuration"
+msgstr "Network UPS Tools CGI Configuration"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:8
+msgid "Network UPS Tools Monitoring Configuration"
+msgstr "Network UPS Tools Monitoring Configuration"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:10
+msgid "Network UPS Tools Server Configuration"
+msgstr "Network UPS Tools Server Configuration"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:169
+msgid "No Lock"
+msgstr "No Lock"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:72
+msgid "No communications message"
+msgstr "No communications message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:173
+msgid "No low/high voltage transfer OIDs"
+msgstr "No low/high voltage transfer OIDs"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:75
+msgid "No parent message"
+msgstr "No parent message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:90
+msgid "Notification defaults"
+msgstr "Notification defaults"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:26
+msgid "Notify command"
+msgstr "Notify command"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:99
+msgid "Notify when back online"
+msgstr "Notify when back online"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:163
+msgid "Notify when battery needs replacing"
+msgstr "Notify when battery needs replacing"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:147
+msgid "Notify when communications lost"
+msgstr "Notify when communications lost"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:139
+msgid "Notify when communications restored"
+msgstr "Notify when communications restored"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:131
+msgid "Notify when force shutdown"
+msgstr "Notify when force shutdown"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:115
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:123
+msgid "Notify when low battery"
+msgstr "Notify when low battery"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:107
+msgid "Notify when on battery"
+msgstr "Notify when on battery"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:155
+msgid "Notify when shutting down"
+msgstr "Notify when shutting down"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:177
+msgid "Off Delay(s)"
+msgstr "Off Delay(s)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:181
+msgid "On Delay(s)"
+msgstr "On Delay(s)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:51
+msgid "On battery message"
+msgstr "On battery message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:48
+msgid "Online message"
+msgstr "Online message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:208
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:237
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:19
+msgid "Password"
+msgstr "Password"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:174
+msgid "Path containing ca certificates to match against host certificate"
+msgstr "Path containing ca certificates to match against host certificate"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:83
+msgid "Path to drivers (instead of default)"
+msgstr "Path to drivers (instead of default)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:63
+msgid "Path to state file"
+msgstr "Path to state file"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:54
+msgid "Period after which data is considered stale"
+msgstr "Period after which data is considered stale"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:101
+msgid "Poll Interval"
+msgstr "Poll Interval"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:29
+msgid "Poll frequency"
+msgstr "Poll frequency"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:34
+msgid "Poll frequency alert"
+msgstr "Poll frequency alert"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:197
+msgid "Polling Frequency(s)"
+msgstr "Polling Frequency(s)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:27
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:195
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:224
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:46
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:202
+msgid "Port"
+msgstr "Port"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:200
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:229
+msgid "Power value"
+msgstr "Power value"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:206
+msgid "Product (regex)"
+msgstr "Product (regex)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:69
+msgid "Replace battery message"
+msgstr "Replace battery message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:178
+msgid "Require SSL and make sure server CN matches hostname"
+msgstr "Require SSL and make sure server CN matches hostname"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:96
+msgid "Retry Delay"
+msgstr "Retry Delay"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:32
+msgid "Role"
+msgstr "Role"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:80
+msgid "Run drivers in a chroot(2) environment"
+msgstr "Run drivers in a chroot(2) environment"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:59
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:110
+msgid "RunAs User"
+msgstr "RunAs User"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:125
+msgid "SNMP Community"
+msgstr "SNMP Community"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:222
+msgid "SNMP retries"
+msgstr "SNMP retries"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:226
+msgid "SNMP timeout(s)"
+msgstr "SNMP timeout(s)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:230
+msgid "SNMP version"
+msgstr "SNMP version"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:232
+msgid "SNMPv1"
+msgstr "SNMPv1"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:233
+msgid "SNMPv2c"
+msgstr "SNMPv2c"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:234
+msgid "SNMPv3"
+msgstr "SNMPv3"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:219
+msgid "Serial Number"
+msgstr "Serial Number"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:138
+msgid "Set USB serial port permissions"
+msgstr "Set USB serial port permissions"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:25
+msgid "Set variables"
+msgstr "Set variables"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:22
+msgid "Shutdown command"
+msgstr "Shutdown command"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:66
+msgid "Shutdown message"
+msgstr "Shutdown message"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:33
+msgid "Slave"
+msgstr "Slave"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:106
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:244
+msgid "Synchronous Communication"
+msgstr "Synchronous Communication"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:115
+msgid "The name of this section will be used as UPS name elsewhere"
+msgstr "The name of this section will be used as UPS name elsewhere"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:96
+msgid "Time in seconds between driver start retry attempts."
+msgstr "Time in seconds between driver start retry attempts."
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
+msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
+msgstr "Time in seconds that upsdrvctl will wait for driver to finish starting"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:183
+msgid "UPS Master"
+msgstr "UPS Master"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:51
+msgid "UPS Server Global Settings"
+msgstr "UPS Server Global Settings"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:212
+msgid "UPS Slave"
+msgstr "UPS Slave"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:20
+msgid "UPS name"
+msgstr "UPS name"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:121
+msgid "USB Bus(es) (regex)"
+msgstr "USB Bus(es) (regex)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:209
+msgid "USB Product Id"
+msgstr "USB Product Id"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:241
+msgid "USB Vendor Id"
+msgstr "USB Vendor Id"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:29
+msgid ""
+"Use upscmd -l to see full list which the commands your UPS supports "
+"(requires upscmd package)"
+msgstr ""
+"Use upscmd -l to see full list which the commands your UPS supports "
+"(requires upscmd package)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:110
+msgid ""
+"User as which to execute driver; requires device file accessed by driver to "
+"be read-write for that user."
+msgstr ""
+"User as which to execute driver; requires device file accessed by driver to "
+"be read-write for that user."
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:205
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:234
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:16
+msgid "Username"
+msgstr "Username"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:238
+msgid "Vendor (regex)"
+msgstr "Vendor (regex)"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:178
+msgid "Verify all connection with SSL"
+msgstr "Verify all connection with SSL"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:154
+msgid "Workaround for buggy firmware"
+msgstr "Workaround for buggy firmware"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:94
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:103
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:111
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:119
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:127
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:135
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:143
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:151
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:159
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:167
+msgid "Write to syslog"
+msgstr "Write to syslog"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:80
+msgid "chroot"
+msgstr "chroot"
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:14
+msgid "upsmon drops privileges to this user"
+msgstr "upsmon drops privileges to this user"

--- a/applications/luci-app-rp-pppoe-server/po/en/rp-pppoe-server.po
+++ b/applications/luci-app-rp-pppoe-server/po/en/rp-pppoe-server.po
@@ -1,0 +1,101 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2019-01-09 07:01-0500\n"
+"Last-Translator: Daniel F. Dickinson <cshored@thecshore.com>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:19
+msgid "Access Concentrator Name"
+msgstr "Access Concentrator Name"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:32
+msgid "First remote IP"
+msgstr "First remote IP"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:29
+msgid "IP of listening side"
+msgstr "IP of listening side"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:44
+msgid ""
+"Instead of starting at beginning and going to end, randomize session number"
+msgstr ""
+"Instead of starting at beginning and going to end, randomize session number"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:15
+msgid "Interface"
+msgstr "Interface"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:15
+msgid "Interface on which to listen."
+msgstr "Interface on which to listen."
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:62
+msgid "MSS"
+msgstr "MSS"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:35
+msgid "Maximum sessions"
+msgstr "Maximum sessions"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:25
+msgid "Maximum sessions per peer"
+msgstr "Maximum sessions per peer"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:52
+msgid "Offset"
+msgstr "Offset"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:40
+msgid "Options file"
+msgstr "Options file"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:52
+msgid "PPP offset"
+msgstr "PPP offset"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:47
+msgid "PPP unit number"
+msgstr "PPP unit number"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:9
+msgid "PPPoE Server Configuration"
+msgstr "PPPoE Server Configuration"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/controller/rp-pppoe-server.lua:11
+msgid "RP PPPoE Server"
+msgstr "RP PPPoE Server"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:44
+msgid "Random session selection"
+msgstr "Random session selection"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:8
+msgid "Roaring Penguin PPPoE Server"
+msgstr "Roaring Penguin PPPoE Server"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:11
+msgid "Server Configuration"
+msgstr "Server Configuration"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:22
+msgid "Service Name"
+msgstr "Service Name"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:68
+msgid "Sync"
+msgstr "Sync"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:57
+msgid "Timeout"
+msgstr "Timeout"
+
+#: applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua:47
+msgid "Unit"
+msgstr "Unit"

--- a/applications/luci-app-uhttpd/po/en/uhttpd.po
+++ b/applications/luci-app-uhttpd/po/en/uhttpd.po
@@ -1,0 +1,265 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2019-01-09 07:00-0500\n"
+"Last-Translator: Daniel F. Dickinson <cshored@theshore.com>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid ""
+"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
+msgstr ""
+"(/old/path=/new/path) or (just /old/path which becomes /cgi-prefix/old/path)"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:145
+msgid "404 Error"
+msgstr "404 Error"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:7
+msgid "A lightweight single-threaded HTTP(S) server"
+msgstr "A lightweight single-threaded HTTP(S) server"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:20
+msgid "Advanced Settings"
+msgstr "Advanced Settings"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:135
+msgid "Aliases"
+msgstr "Aliases"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:149
+msgid "Base directory for files to be served"
+msgstr "Base directory for files to be served"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:22
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:50
+msgid "Bind to specific interface:port (by specifying interface address"
+msgstr "Bind to specific interface:port (by specifying interface address"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid "CGI filetype handler"
+msgstr "CGI filetype handler"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "CGI is disabled if not present."
+msgstr "CGI is disabled if not present."
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:142
+msgid "Config file (e.g. for credentials for Basic Auth)"
+msgstr "Config file (e.g. for credentials for Basic Auth)"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:187
+msgid "Connection reuse"
+msgstr "Connection reuse"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:221
+msgid "Country"
+msgstr "Country"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:173
+msgid "Disable JSON-RPC authorization via ubus session API"
+msgstr "Disable JSON-RPC authorization via ubus session API"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:129
+msgid "Do not follow symlinks outside document root"
+msgstr "Do not follow symlinks outside document root"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:132
+msgid "Do not generate directory listings."
+msgstr "Do not generate directory listings."
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:148
+msgid "Document root"
+msgstr "Document root"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:122
+msgid "E.g specify with index.html and index.php when using PHP"
+msgstr "E.g specify with index.html and index.php when using PHP"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:160
+msgid "Embedded Lua interpreter is disabled if not present."
+msgstr "Embedded Lua interpreter is disabled if not present."
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:169
+msgid "Enable JSON-RPC Cross-Origin Resource Support"
+msgstr "Enable JSON-RPC Cross-Origin Resource Support"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:19
+msgid "For settings primarily geared to serving more than the web UI"
+msgstr "For settings primarily geared to serving more than the web UI"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:19
+msgid "Full Web Server Settings"
+msgstr "Full Web Server Settings"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:160
+msgid "Full real path to handler for Lua scripts"
+msgstr "Full real path to handler for Lua scripts"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:18
+msgid "General Settings"
+msgstr "General Settings"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:22
+msgid "HTTP listeners (address:port)"
+msgstr "HTTP listeners (address:port)"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:94
+msgid "HTTPS Certificate (DER Encoded)"
+msgstr "HTTPS Certificate (DER Encoded)"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:96
+msgid "HTTPS Private Key (DER Encoded)"
+msgstr "HTTPS Private Key (DER Encoded)"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:50
+msgid "HTTPS listener (address:port)"
+msgstr "HTTPS listener (address:port)"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:90
+msgid "Ignore private IPs on public interface"
+msgstr "Ignore private IPs on public interface"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:122
+msgid "Index page(s)"
+msgstr "Index page(s)"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:126
+msgid ""
+"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
+"usr/bin/php-cgi')"
+msgstr ""
+"Interpreter to associate with file endings ('suffix=handler', e.g. '.php=/"
+"usr/bin/php-cgi')"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:214
+msgid "Length of key in bits"
+msgstr "Length of key in bits"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:227
+msgid "Location"
+msgstr "Location"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:197
+msgid "Maximum number of connections"
+msgstr "Maximum number of connections"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:201
+msgid "Maximum number of script requests"
+msgstr "Maximum number of script requests"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:177
+msgid "Maximum wait time for Lua, CGI, or ubus execution"
+msgstr "Maximum wait time for Lua, CGI, or ubus execution"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:182
+msgid "Maximum wait time for network activity"
+msgstr "Maximum wait time for network activity"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:166
+msgid "Override path for ubus socket"
+msgstr "Override path for ubus socket"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:153
+msgid "Path prefix for CGI scripts"
+msgstr "Path prefix for CGI scripts"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:90
+msgid ""
+"Prevent access from private (RFC1918) IPs on an interface if it has an "
+"public IP address"
+msgstr ""
+"Prevent access from private (RFC1918) IPs on an interface if it has an "
+"public IP address"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:138
+msgid "Realm for Basic Auth"
+msgstr "Realm for Basic Auth"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:86
+msgid "Redirect all HTTP to HTTPS"
+msgstr "Redirect all HTTP to HTTPS"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:109
+msgid "Remove configuration for certificate and key"
+msgstr "Remove configuration for certificate and key"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:98
+msgid "Remove old certificate and key"
+msgstr "Remove old certificate and key"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:218
+msgid "Server Hostname"
+msgstr "Server Hostname"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:20
+msgid ""
+"Settings which are either rarely needed or which affect serving the WebUI"
+msgstr ""
+"Settings which are either rarely needed or which affect serving the WebUI"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:224
+msgid "State"
+msgstr "State"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:192
+msgid "TCP Keepalive"
+msgstr "TCP Keepalive"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:110
+msgid "This permanently deletes the cert, key, and configuration to use same."
+msgstr "This permanently deletes the cert, key, and configuration to use same."
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:210
+msgid "Valid for # of Days"
+msgstr "Valid for # of Days"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:145
+msgid ""
+"Virtual URL or CGI script to display on status '404 Not Found'. Must begin "
+"with '/'"
+msgstr ""
+"Virtual URL or CGI script to display on status '404 Not Found'. Must begin "
+"with '/'"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:156
+msgid "Virtual path prefix for Lua scripts"
+msgstr "Virtual path prefix for Lua scripts"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:163
+msgid "Virtual path prefix for ubus via JSON-RPC integration"
+msgstr "Virtual path prefix for ubus via JSON-RPC integration"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:142
+msgid "Will not use HTTP authentication if not present"
+msgstr "Will not use HTTP authentication if not present"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:218
+msgid "a.k.a CommonName"
+msgstr "a.k.a CommonName"
+
+#: applications/luci-app-uhttpd/luasrc/controller/uhttpd/uhttpd.lua:13
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:6
+msgid "uHTTPd"
+msgstr "uHTTPd"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:205
+msgid "uHTTPd Self-signed Certificate Parameters"
+msgstr "uHTTPd Self-signed Certificate Parameters"
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:99
+msgid ""
+"uHTTPd will generate a new self-signed certificate using the configuration "
+"shown below."
+msgstr ""
+"uHTTPd will generate a new self-signed certificate using the configuration "
+"shown below."
+
+#: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:163
+msgid "ubus integration is disabled if not present"
+msgstr "ubus integration is disabled if not present"


### PR DESCRIPTION
This adds the 'en' 'translation' for various luci-apps I've created in the past.