### PR TITLE
luci-mod-freifunk: replace calls to get_all() with separate get() calls

### DIFF
--- a/modules/luci-mod-freifunk/luasrc/view/freifunk/adminindex.htm
+++ b/modules/luci-mod-freifunk/luasrc/view/freifunk/adminindex.htm
@@ -1,22 +1,15 @@
 <%+header%>
 <%
 local uci = require "luci.model.uci".cursor()
-local contact = uci:get_all("freifunk", "contact")
+local nickname = uci:get("freifunk", "contact", "nickname") or ""
+local name = uci:get("freifunk", "contact", "name") or ""
+local mail = uci:get("freifunk", "contact", "mail") or ""
 local contacturl = luci.dispatcher.build_url(luci.dispatcher.context.path[1], "freifunk", "contact")
 local hostname = uci:get_first ("system", "system", "hostname")
 local latitude = uci:get_first ("system", "system", "latitude")
 local longitude = uci:get_first ("system", "system", "longitude")
 local location = uci:get_first ("system", "system", "location")
 local basicsurl = luci.dispatcher.build_url(luci.dispatcher.context.path[1], "freifunk", "basics")
-local nickname, name, mail
-if not contact then
-	nickname, name, mail = ""
-else
-	nickname = contact.nickname
-	name = contact.name
-	mail = contact.mail
-end
-
 %>
 
 <h2><%:Freifunk Overview%></h2>

--- a/modules/luci-mod-freifunk/luasrc/view/freifunk/contact.htm
+++ b/modules/luci-mod-freifunk/luasrc/view/freifunk/contact.htm
@@ -9,22 +9,15 @@
 
 <% 
 local uci = require "luci.model.uci".cursor()
-local contact = uci:get_all("freifunk", "contact")
-local nickname, name, mail, phone, location, note
-local lon = uci:get_first("system", "system", "longitude")
-local lat = uci:get_first("system", "system", "latitude")
-
-if not contact then
-	nickname, name, homepage, mail, phone, location, note = ""
-else
-	nickname = contact.nickname or ""
-	name = contact.name or ""
-	homepage = contact.homepage or {}
-	mail = contact.mail or ""
-	phone = contact.phone or ""
-	location = uci:get_first("system", "system", "location") or contact.location
-	note = contact.note or ""
-end
+local nickname = uci:get("freifunk", "contact", "nickname") or ""
+local name = uci:get("freifunk", "contact", "name") or ""
+local homepage = uci:get("freifunk", "contact", "homepage") or {}
+local mail = uci:get("freifunk", "contact", "mail") or ""
+local phone = uci:get("freifunk", "contact", "phone") or ""
+local location = uci:get_first("system", "system", "locaton") or uci:get("freifunk", "contact", "location") or ""
+local note = uci:get("freifunk", "contact", "note") or ""
+local lon = uci:get_first("system", "system", "longitude") or ""
+local lat = uci:get_first("system", "system", "latitude") or ""
 %>
 
 <h2 name="content"><%:Contact%></h2>

--- a/modules/luci-mod-freifunk/luasrc/view/freifunk/index.htm
+++ b/modules/luci-mod-freifunk/luasrc/view/freifunk/index.htm
@@ -9,18 +9,10 @@
 local uci = require "luci.model.uci".cursor()
 local tpl = require "luci.template"
 local fs = require "nixio.fs"
-local ff = {}
-local ff = uci:get_all("freifunk")
 
-if not ff or not ff.community.name then
-	community = "Freifunk"
-	DefaultText = ""
-	nickname = "No Nickname set"
-else
-	community = ff.community.name
-	DefaultText = ff.community.DefaultText
-	nickname = ff.contact.nickname
-end
+local community = uci:get("freifunk", "community", "name") or "Freifunk"
+local DefaultText = uci:get("freifunk", "community", "DefaultText") or ""
+local nickname = uci:get("freifunk", "contact", "nickname") or "No Nickname set"
 
 local co = "profile_" .. community
 --local community = uci:get_first(co, "community", "name") or "Freifunk"


### PR DESCRIPTION
The get_all() function has changed and how it was used before no
longer works properly.  These changes not only change to individual
get() calls, but actually adds to the readability of the code and reduces
file size.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>