### PR TITLE
luci-mod-freifunk: fix the list of community profiles

### DIFF
--- a/modules/luci-mod-freifunk/luasrc/model/cbi/freifunk/basics.lua
+++ b/modules/luci-mod-freifunk/luasrc/model/cbi/freifunk/basics.lua
@@ -15,7 +15,7 @@ community.rmempty = false
 
 local profile
 for profile in fs.glob(profiles) do
-	local name = uci:get_first(profile, "community", "name") or "?"
+	local name = uci:get_first(string.gsub(profile, "/etc/config/", ""), "community", "name") or "?"
 	community:value(string.gsub(profile, "/etc/config/profile_", ""), name)
 end
 


### PR DESCRIPTION
Using uci:get_first with a /PATH/FILENAME as the first argument no longer works.  Now the name of the config file (profile_X) is passed to get_first instead

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>