### PR TITLE
luci-base: Add generic password confirmation logic

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -619,6 +619,25 @@ var CBIValidatorPrototype = {
 		hexstring: function() {
 			return this.assert(this.value.match(/^([a-f0-9][a-f0-9]|[A-F0-9][A-F0-9])+$/),
 				_('hexadecimal encoded value'));
+		},
+
+		passconf: function() {
+			var confirmoption = this.field.getAttribute('data-confirmoption');
+			if (! confirmoption) {
+				return this.assert(false, _("password confirmation."));
+			}
+			var confe = document.getElementById(confirmoption);
+			if (confe && (this.field.value != confe.value)) {
+				return this.assert(false, _("confirmation matching password."));
+			}
+			this.field.removeAttribute('data-tooltip');
+			this.field.removeAttribute('data-tooltip-style');
+			this.field.dispatchEvent(new CustomEvent('validation-success', { bubbles: true }));
+			if (confe.getAttribute('data-tooltip')) {
+				confe.focus();
+			}
+
+			return this.assert(true);
 		}
 	}
 };

--- a/modules/luci-base/luasrc/cbi.lua
+++ b/modules/luci-base/luasrc/cbi.lua
@@ -1547,6 +1547,13 @@ end
 
 function Value.parse(self, section, novld)
 	if self.readonly then return end
+	if self.datatype == "passconf" and self.confirmoption then
+		if self:formvalue(section) ~=
+			self.confirmoption:formvalue(section)
+			then
+				return nil, _("Password confirmation doesn't match password!")
+		end
+	end
 	AbstractValue.parse(self, section, novld)
 end
 

--- a/modules/luci-base/luasrc/cbi/datatypes.lua
+++ b/modules/luci-base/luasrc/cbi/datatypes.lua
@@ -464,3 +464,7 @@ end
 function unique(val)
 	return true
 end
+
+function passconf(val)
+	return val and (val ~= "")
+end

--- a/modules/luci-base/luasrc/view/cbi/value.htm
+++ b/modules/luci-base/luasrc/view/cbi/value.htm
@@ -4,12 +4,17 @@
 			attr("name", "password." .. cbid)
 		%> />
 	<%- end -%>
+	<%- passwordconfirm=""
+	    if self.password and self.confirmoption and self.confirmoption.cbid then
+		passwordconfirm = attr("data-confirmoption", self.confirmoption:cbid(section))
+	    end -%>
 	<input data-update="change"<%=
 		attr("id", cbid) ..
 		attr("name", cbid) ..
 		attr("type", self.password and "password" or "text") ..
 		attr("class", self.password and "cbi-input-password" or "cbi-input-text") ..
 		attr("value", self:cfgvalue(section) or self.default) ..
+		passwordconfirm ..
 		ifattr(self.password, "autocomplete", "new-password") ..
 		ifattr(self.size, "size") ..
 		ifattr(self.placeholder, "placeholder") ..


### PR DESCRIPTION
Entering passwords and their confirmation is a common task, so create
a generic mechanism for doing password + confirm dialogues.

To use this:

o = section:option(Value, "some_password", translate("Value Name"))
p = section:option(Value, "some_password_confirm", translate("Confirm Value"))

o.password = true
o.datatype="passconf"
o.confirmoption=p
p.password = true
p.datatype="passconf"
p.confirmoption=o

This will result in javascript flagging the password + confirmation as errors
until they match.  A non-JS (Lua) fallback is also included.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

@feckert This might interest you in relation to #2443.

@jow- @hnyman Comments?