### PR TITLE
luci-app-statistics: some code cleanup

### DIFF
--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/collectd.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/collectd.lua
@@ -1,7 +1,7 @@
 -- Copyright 2008 Freifunk Leipzig / Jo-Philipp Wich <jow@openwrt.org>
 -- Licensed to the public under the Apache License 2.0.
 
-require("luci.sys")
+local sys = require("luci.sys")
 
 
 m = Map("luci_statistics",
@@ -17,7 +17,7 @@ s = m:section( NamedSection, "collectd", "luci_statistics" )
 
 -- general.hostname (Hostname)
 hostname = s:option( Value, "Hostname", translate("Hostname") )
-hostname.default  = luci.sys.hostname()
+hostname.default  = sys.hostname()
 hostname.optional = true
 
 -- general.basedir (BaseDir)

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/conntrack.lua
@@ -1,13 +1,5 @@
---[[
-
-Copyright 2011 Jo-Philipp Wich <jow@openwrt.org>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-]]--
+-- Copyright 2011 Jo-Philipp Wich <jow@openwrt.org>
+-- Licensed to the public under the Apache License 2.0.
 
 m = Map("luci_statistics",
 	translate("Conntrack Plugin Configuration"),

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/dns.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/dns.lua
@@ -1,7 +1,7 @@
 -- Copyright 2008 Freifunk Leipzig / Jo-Philipp Wich <jow@openwrt.org>
 -- Licensed to the public under the Apache License 2.0.
 
-require("luci.sys")
+local sys = require("luci.sys")
 
 
 m = Map("luci_statistics",
@@ -24,7 +24,7 @@ interfaces.widget = "select"
 interfaces.size   = 5
 interfaces:depends( "enable", 1 )
 interfaces:value("any")
-for k, v in pairs(luci.sys.net.devices()) do
+for k, v in pairs(sys.net.devices()) do
         interfaces:value(v)
 end
          

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/interface.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/interface.lua
@@ -1,7 +1,7 @@
 -- Copyright 2008 Freifunk Leipzig / Jo-Philipp Wich <jow@openwrt.org>
 -- Licensed to the public under the Apache License 2.0.
 
-require("luci.sys")
+local sys = require("luci.sys")
 
 
 m = Map("luci_statistics",
@@ -23,7 +23,7 @@ interfaces = s:option( MultiValue, "Interfaces", translate("Monitor interfaces")
 interfaces.widget = "select"
 interfaces.size   = 5
 interfaces:depends( "enable", 1 )
-for k, v in pairs(luci.sys.net.devices()) do
+for k, v in pairs(sys.net.devices()) do
 	interfaces:value(v)
 end
 

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/iptables.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/iptables.lua
@@ -1,13 +1,12 @@
 -- Copyright 2008 Freifunk Leipzig / Jo-Philipp Wich <jow@openwrt.org>
 -- Licensed to the public under the Apache License 2.0.
 
-require("luci.sys.iptparser")
+local ip = require("luci.sys.iptparser").IptParser()
 
-ip = luci.sys.iptparser.IptParser()
-chains  = { }
-targets = { }
+local chains  = { }
+local targets = { }
 
-for i, rule in ipairs( ip:find() ) do 
+for i, rule in ipairs( ip:find() ) do
 	if rule.chain and rule.target then
 		chains[rule.chain] = true
 		targets[rule.target] = true

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/memory.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/memory.lua
@@ -1,13 +1,5 @@
---[[
-
-Copyright 2011 Manuel Munz <freifunk at somakoma dot de>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-]]--
+-- Copyright 2011 Manuel Munz <freifunk at somakoma dot de>
+-- Licensed to the public under the Apache License 2.0.
 
 m = Map("luci_statistics",
 	translate("Memory Plugin Configuration"),

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/netlink.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/netlink.lua
@@ -1,9 +1,9 @@
 -- Copyright 2008 Freifunk Leipzig / Jo-Philipp Wich <jow@openwrt.org>
 -- Licensed to the public under the Apache License 2.0.
 
-require("luci.sys")
+local sys = require("luci.sys")
 
-local devices = luci.sys.net.devices()
+local devices = sys.net.devices()
 
 
 m = Map("luci_statistics",

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/openvpn.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/openvpn.lua
@@ -1,10 +1,7 @@
 -- Copyright 2015 Jo-Philipp Wich <jow@openwrt.org>
 -- Licensed to the public under the Apache License 2.0.
 
-require "luci.sys"
-
 local m, s, o
-
 
 m = Map("luci_statistics",
 	translate("OpenVPN Plugin Configuration"),

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/sensors.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/sensors.lua
@@ -1,8 +1,6 @@
 -- Copyright 2015 Jo-Philipp Wich <jow@openwrt.org>
 -- Licensed to the public under the Apache License 2.0.
 
-require "luci.sys"
-
 local m, s, o
 local sensor_types = {
 	["12v"] = "voltage",

--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/uptime.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/uptime.lua
@@ -1,13 +1,5 @@
---[[
-
-Copyright 2013 Thomas Endt <tmo26@gmx.de>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-]]--
+-- Copyright 2013 Thomas Endt <tmo26@gmx.de>
+-- Licensed to the public under the Apache License 2.0.
 
 m = Map("luci_statistics",
         translate("Uptime Plugin Configuration"),

--- a/applications/luci-app-statistics/luasrc/statistics/i18n.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/i18n.lua
@@ -3,15 +3,14 @@
 
 module("luci.statistics.i18n", package.seeall)
 
-require("luci.util")
-require("luci.i18n")
+local util = require("luci.util")
+local i18n = require("luci.i18n")
 
 
-Instance = luci.util.class()
-
+Instance = util.class()
 
 function Instance.__init__( self, graph )
-	self.i18n  = luci.i18n
+	self.i18n  = i18n
 	self.graph = graph
 end
 

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
@@ -3,30 +3,28 @@
 
 module("luci.statistics.rrdtool", package.seeall)
 
-require("luci.statistics.datatree")
-require("luci.statistics.rrdtool.colors")
-require("luci.statistics.i18n")
-require("luci.model.uci")
-require("luci.util")
-require("luci.sys")
+local tree   = require("luci.statistics.datatree")
+local colors = require("luci.statistics.rrdtool.colors")
+local i18n   = require("luci.statistics.i18n")
+local uci    = require("luci.model.uci").cursor()
+local util   = require("luci.util")
+local sys    = require("luci.sys")
+local fs     = require("nixio.fs")
 
-local fs = require "nixio.fs"
 
-
-Graph = luci.util.class()
+Graph = util.class()
 
 function Graph.__init__( self, timespan, opts )
 
 	opts = opts or { }
 
-	local uci = luci.model.uci.cursor()
 	local sections = uci:get_all( "luci_statistics" )
 
 	-- options
 	opts.timespan  = timespan       or sections.rrdtool.default_timespan or 900
 	opts.rrasingle = opts.rrasingle or ( sections.collectd_rrdtool.RRASingle == "1" )
 	opts.rramax    = opts.rramax    or ( sections.collectd_rrdtool.RRAMax == "1" )
-	opts.host      = opts.host      or sections.collectd.Hostname        or luci.sys.hostname()
+	opts.host      = opts.host      or sections.collectd.Hostname        or sys.hostname()
 	opts.width     = opts.width     or sections.rrdtool.image_width      or 400
 	opts.rrdpath   = opts.rrdpath   or sections.collectd_rrdtool.DataDir or "/tmp/rrd"
 	opts.imgpath   = opts.imgpath   or sections.rrdtool.image_path       or "/tmp/rrdimg"
@@ -34,9 +32,9 @@ function Graph.__init__( self, timespan, opts )
 	opts.imgpath   = opts.imgpath:gsub("/$","")
 
 	-- helper classes
-	self.colors = luci.statistics.rrdtool.colors.Instance()
-	self.tree   = luci.statistics.datatree.Instance(opts.host)
-	self.i18n   = luci.statistics.i18n.Instance( self )
+	self.colors = colors.Instance()
+	self.tree   = tree.Instance(opts.host)
+	self.i18n   = i18n.Instance( self )
 
 	-- rrdtool default args
 	self.args = {
@@ -102,7 +100,7 @@ function Graph._rrdtool( self, def, rrd )
 			opt = opt:gsub( "{file}", rrd )
 		end
 
-		cmdline[#cmdline+1] = luci.util.shellquote(opt)
+		cmdline[#cmdline+1] = util.shellquote(opt)
 	end
 
 	-- execute rrdtool

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/colors.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/colors.lua
@@ -3,10 +3,10 @@
 
 module("luci.statistics.rrdtool.colors", package.seeall)
 
-require("luci.util")
+local util = require("luci.util")
 
 
-Instance = luci.util.class()
+Instance = util.class()
 
 function Instance.from_string( self, s )
 	return {

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/apcups.lua
@@ -19,8 +19,7 @@ function rrdargs( graph, plugin, plugin_instance )
 		ups_inst[t] = graph.tree:data_instances( plugin, plugin_instance, t )
 	end
 
-
-    -- Check if hash table or array is empty or nil-filled
+	-- Check if hash table or array is empty or nil-filled
 
 	local function empty( t )
 		for _, v in pairs(t) do
@@ -57,8 +56,8 @@ function rrdargs( graph, plugin, plugin_instance )
 	end
 
 
-    -- Graph definitions for APC UPS measurements MUST use only 'instances':
-    -- e.g. instances = { voltage = {  "input", "output" } }
+	-- Graph definitions for APC UPS measurements MUST use only 'instances':
+	-- e.g. instances = { voltage = {  "input", "output" } }
 
 	local voltagesdc = {
 		title = "%H: Voltages on APC UPS - Battery",

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/conntrack.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/conntrack.lua
@@ -4,6 +4,7 @@
 module("luci.statistics.rrdtool.definitions.conntrack",package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
+
 	return {
 		title = "%H: Conntrack entries",
 		vlabel = "Count",

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/curl.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/curl.lua
@@ -4,6 +4,7 @@
 module("luci.statistics.rrdtool.definitions.curl", package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
+
 	return {
 		title = "%H: cUrl Response Time for #%pi",
 		y_min = "0",

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/disk.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/disk.lua
@@ -4,6 +4,7 @@
 module("luci.statistics.rrdtool.definitions.disk", package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
+
 	return {
 		{
 			title = "%H: Disk I/O operations on %pi",

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/netlink.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/netlink.lua
@@ -37,7 +37,6 @@ function rrdargs( graph, plugin, plugin_instance )
 		}
 	}
 
-
 	--
 	-- packet diagram
 	--
@@ -119,7 +118,6 @@ function rrdargs( graph, plugin, plugin_instance )
 		}
 	}
 
-
 	--
 	-- multicast diagram
 	--
@@ -144,7 +142,6 @@ function rrdargs( graph, plugin, plugin_instance )
 		}
 	}
 
-
 	--
 	-- collision diagram
 	--
@@ -168,7 +165,6 @@ function rrdargs( graph, plugin, plugin_instance )
 			}
 		}
 	}
-
 
 	--
 	-- error diagram
@@ -205,7 +201,6 @@ function rrdargs( graph, plugin, plugin_instance )
 			}
 		}
 	}
-
 
 	return { traffic, packets, multicast, collisions, errors }
 end

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/olsrd.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/olsrd.lua
@@ -9,18 +9,18 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 	if plugin_instance == "routes" then
 
 		g[#g+1] = {
-	                -- diagram data description
+			-- diagram data description
 			title = "%H: Total amount of OLSR routes", vlabel = "n",
 			number_format = "%5.0lf", data = {
-                        	types = { "routes" },
+				types = { "routes" },
 				options = {
 					routes = {
 						color = "ff0000",
 						title = "Total number of routes"
 					}
 				}
-	                }
-        	}
+			}
+		}
 
 		g[#g+1] = {
 			title = "%H: Average route ETX", vlabel = "ETX", detail = true,
@@ -80,7 +80,7 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 				number_format = "%5.2lf", detail = true,
 				data = {
 					types = { "signal_quality" },
-	
+
 					instances = {
 						signal_quality = { instances[i], instances[i+1] },
 					},
@@ -106,7 +106,7 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 			title= "%H: Total amount of OLSR links", vlabel = "n",
 			number_format = "%5.0lf", data = {
 				instances = { "" },
-	                        types = { "links" },
+				types = { "links" },
 				options = {
 					links = {
 						color = "0000ff",
@@ -114,7 +114,7 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 					}
 				}
 			}
-	        }
+		}
 
 		g[#g+1] = {
 			title= "%H: Average signal quality", vlabel = "n",

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
@@ -4,6 +4,7 @@
 module("luci.statistics.rrdtool.definitions.ping", package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
+
 	return {
 		-- Ping roundtrip time
 		{ title = "%H: ICMP Round Trip Time",

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/processes.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/processes.lua
@@ -5,8 +5,8 @@ module("luci.statistics.rrdtool.definitions.processes", package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
 
-    if  plugin_instance == "" then
-	return {
+	if  plugin_instance == "" then
+		return {
 			title = "%H: Processes",
 			vlabel = "Processes/s",
 			data = {
@@ -26,9 +26,9 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 					ps_state_zombies  = { color = "ff0000", title = "Zombies" }
 				}
 			}
-	}
-    else
-	return {
+		}
+	else
+		return {
 		{
 			title = "%H: CPU time used by %pi",
 			vlabel = "Jiffies",
@@ -113,5 +113,5 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 			}
 		}
 	}
-    end
+	end
 end

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/sensors.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/sensors.lua
@@ -4,6 +4,7 @@
 module("luci.statistics.rrdtool.definitions.sensors", package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance )
+
 	return {
 		{
 			per_instance = true,

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/splash_leases.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/splash_leases.lua
@@ -1,27 +1,26 @@
 -- Copyright 2013 Freifunk Augsburg / Michael Wendland <michael@michiwend.com>
 -- Licensed to the public under the Apache License 2.0.
 
-    
 module("luci.statistics.rrdtool.definitions.splash_leases", package.seeall)
-                                       
-function rrdargs( graph, plugin, plugin_instance, dtype )
-                             
-    return {
-        title = "%H: Splash Leases",
-        vlabel = "Active Clients",  
-        y_min = "0",          
-        number_format = "%5.1lf",
-        data = {         
-            sources = {
-                splash_leases = { "leased", "whitelisted", "blacklisted" }
-            },                                
-              
-            options = {
-                splash_leases__leased      = { color = "00CC00", title = "Leased",      overlay = false },
-                splash_leases__whitelisted = { color = "0000FF", title = "Whitelisted", overlay = false },
-                splash_leases__blacklisted = { color = "FF0000", title = "Blacklisted", overlay = false } 
-            }                                                 
-        }    
-    }
 
-end 
+function rrdargs( graph, plugin, plugin_instance, dtype )
+
+	return {
+		title = "%H: Splash Leases",
+		vlabel = "Active Clients",
+		y_min = "0",
+		number_format = "%5.1lf",
+		data = {
+			sources = {
+				splash_leases = { "leased", "whitelisted", "blacklisted" }
+			},
+
+			options = {
+				splash_leases__leased      = { color = "00CC00", title = "Leased",      overlay = false },
+				splash_leases__whitelisted = { color = "0000FF", title = "Whitelisted", overlay = false },
+				splash_leases__blacklisted = { color = "FF0000", title = "Blacklisted", overlay = false }
+			}
+		}
+	}
+
+end

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/tcpconns.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/tcpconns.lua
@@ -4,6 +4,7 @@
 module("luci.statistics.rrdtool.definitions.tcpconns", package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
+
 	return {
 		title = "%H: TCP connections to port %pi",
 		vlabel = "Connections/s",

--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/uptime.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/uptime.lua
@@ -13,15 +13,14 @@ module("luci.statistics.rrdtool.definitions.uptime", package.seeall)
 
 function rrdargs( graph, plugin, plugin_instance, dtype )
 
-        return {
-                title = "%H: Uptime", vlabel = "seconds",
-                number_format = "%5.0lf%s", data = {
-                        types = { "uptime" },
-                        options = {
-                                uptime = { title = "Uptime %di", noarea = true }
-                        }
-                }
-        }
-
+	return {
+		title = "%H: Uptime", vlabel = "seconds",
+		number_format = "%5.0lf%s", data = {
+			types = { "uptime" },
+			options = {
+				uptime = { title = "Uptime %di", noarea = true }
+			}
+		}
+	}
 end
 


### PR DESCRIPTION
- fix whitespaces in rrdtool definitions
- reduce copyright headers
- only include lua modules into local scope
- remove unused luci.sys include
- only include lua modules in rrd statistics into local scope