### PR TITLE
luci-app-lxc: add aarch64 to target map

### DIFF
--- a/applications/luci-app-lxc/luasrc/controller/lxc.lua
+++ b/applications/luci-app-lxc/luasrc/controller/lxc.lua
@@ -152,6 +152,7 @@ function lxc_get_arch_target(url)
 			armv6  = "armel",
 			armv7  = "armhf",
 			armv8  = "arm64",
+			aarch64  = "arm64",
 			i686   = "i386",
 			x86_64 = "amd64"
 		}


### PR DESCRIPTION
Turris MOX uses aarch64 architecture and according to [stackoverflow.com](https://stackoverflow.com/questions/31851611/differences-between-arm64-and-aarch64), it is also called arm64.

With this commit, It was able to show me templates from images.linuxcontainers.org, create them, start them and so on. 
![image](https://user-images.githubusercontent.com/4096468/51944681-f46d5180-241c-11e9-8847-de810993dfdd.png)

I think it would be great to ask review from @dibdot as he seems to be most active about luci-app-lxc even it's one row, however, I don't know anything about Lua so he may have a better solution.