### PR TITLE
luci-mod-status: Move Active Connections number to above group

### DIFF
--- a/modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm
+++ b/modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm
@@ -16,6 +16,7 @@
 		<div class="tr"><div class="td left" width="33%"><%:Total Available%></div><div class="td left"><div id="memtotal" class="cbi-progressbar" title="-"><div></div></div></div></div>
 		<div class="tr"><div class="td left" width="33%"><%:Free%></div><div class="td left"><div id="memfree" class="cbi-progressbar" title="-"><div></div></div></div></div>
 		<div class="tr"><div class="td left" width="33%"><%:Buffered%></div><div class="td left"><div id="membuff" class="cbi-progressbar" title="-"><div></div></div></div></div>
+		<div class="tr"><div class="td left" width="33%"><%:Active Connections%></div><div class="td left"><div id="conns" class="cbi-progressbar" title="-"><div></div></div></div></div>
 	</div>
 </div>
 

--- a/modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm
+++ b/modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm
@@ -10,8 +10,4 @@
 	<div id="upstream_status_table" class="network-status-table">
 		<p><em><%:Collecting data...%></em></p>
 	</div>
-
-	<div class="table" width="100%">
-		<div class="tr"><div class="td left" width="33%"><%:Active Connections%></div><div class="td left"><div id="conns" class="cbi-progressbar" title="-"><div></div></div></div></div>
-	</div>
 </div>


### PR DESCRIPTION
Move Active Connections number to above group.

![icon](http://longrunweather.com/view/static/conn.png)

Signed-off-by: xiaobo <peterwillcn@gmail.com>