### PR TITLE
[openwrt 18.06] luci-app-lxc: add aarch64 to target map

### DIFF
--- a/applications/luci-app-lxc/luasrc/controller/lxc.lua
+++ b/applications/luci-app-lxc/luasrc/controller/lxc.lua
@@ -152,6 +152,7 @@ function lxc_get_arch_target(url)
 			armv6  = "armel",
 			armv7  = "armhf",
 			armv8  = "arm64",
+			aarch64  = "arm64",
 			x86_64 = "amd64"
 		}
 		local k, v


### PR DESCRIPTION
Today this was merged to master and would be great to backport it as well to an upcoming version of OpenWrt 18.06, which should be released soon according to the mailing list.

I was asking about it on IRC and was told by @jow-  that it shouldn't be an issue. 