### PR TITLE
luci-app-statistics: adding ability for luci_stats config to have multiple UPS's

### DIFF
--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -137,7 +137,7 @@ config statistics 'collectd_netlink'
 
 config statistics 'collectd_nut'
 	option enable '0'
-	option UPS 'myupsname'
+	list UPS 'myupsname'
 
 config statistics 'collectd_olsrd'
 	option enable '0'

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -393,9 +393,9 @@ plugins = {
 	network	= config_network,
 
 	nut = {
-		{ "UPS" },
 		{ },
-		{ }
+		{ },
+		{ "UPS" }
 	},
 
 	olsrd = {


### PR DESCRIPTION
collectd can support multiple UPSs .. 

 - altered the config builder to take a list
 - altered the template to use list 