### PR TITLE
Freifunk/80211s defaults

### DIFF
--- a/contrib/package/community-profiles/files/etc/config/profile_berlin
+++ b/contrib/package/community-profiles/files/etc/config/profile_berlin
@@ -31,6 +31,9 @@ config 'defaults' 'ssidscheme'
 	option '13'	'intern-ch13.freifunk.net'
 	option '36'	'intern-ch36.freifunk.net'
 
+config 'defaults' '80211s'
+	option 'mesh_id' 'Mesh-Freifunk-Berlin'
+
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
 	option 'dns' '85.214.20.141 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12'

--- a/contrib/package/freifunk-common/files/etc/config/freifunk
+++ b/contrib/package/freifunk-common/files/etc/config/freifunk
@@ -118,3 +118,10 @@ config 'defaults' 'dhcp'
 
 config 'defaults' 'olsr_interfacedefaults'
 	option 'Ip4Broadcast' '255.255.255.255'
+
+config 'defaults' '80211s'
+	option 'mode' 'mesh'
+	option 'encryption' 'none'
+	option 'mesh_id' 'Mesh-Freifunk'
+	option 'mesh_fwding' '0'
+


### PR DESCRIPTION
Add default values for freifunk and profile_berlin.

defaults are for /etc/config/freifunk are
```
config 'defaults' '80211s'
      option 'mode' 'mesh'
      option 'encryption' 'none'
      option 'mesh_id' 'Mesh-Freifunk'
      option 'mesh_fwding' '0'
```

the defaults for profile_berlin are
```
config 'defaults' '80211s'
      option 'mesh_id' 'Mesh-Freifunk-Berlin'
```

This was discussed in issue #2503 

@jow- Can these commits be cherry picked to the 18.06 branch directly or should I make another PR?

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>