### PR TITLE
luci-mod-status: Convert bytes into KB / MB / GB on progress bar

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
@@ -3,8 +3,8 @@ function progressbar(query, value, max, byte)
 	var pg = document.querySelector(query),
 	    vn = parseInt(value) || 0,
 	    mn = parseInt(max) || 100,
-	    fv = byte ? String.format('%.2mB ', value) : value,
-	    fm = byte ? String.format('%.2mB ', max) : max,
+	    fv = byte ? String.format('%1024.2mB', value) : value,
+	    fm = byte ? String.format('%1024.2mB', max) : max,
 	    pc = Math.floor((100 / mn) * vn);
 
 	if (pg) {

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
@@ -3,8 +3,8 @@ function progressbar(query, value, max, byte)
 	var pg = document.querySelector(query),
 	    vn = parseInt(value) || 0,
 	    mn = parseInt(max) || 100,
-	    fv = byte ? String.format('%.2mB ', value) : value;
-	    fm = byte ? String.format('%.2mB ', max) : max;
+	    fv = byte ? String.format('%.2mB ', value) : value,
+	    fm = byte ? String.format('%.2mB ', max) : max,
 	    pc = Math.floor((100 / mn) * vn);
 
 	if (pg) {

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
@@ -1,13 +1,15 @@
-function progressbar(q, v, m)
+function progressbar(query, value, max, byte)
 {
-	var pg = document.querySelector(q),
-	    vn = parseInt(v) || 0,
-	    mn = parseInt(m) || 100,
+	var pg = document.querySelector(query),
+	    vn = parseInt(value) || 0,
+	    mn = parseInt(max) || 100,
+	    fv = byte ? String.format('%.2mB ', value) : value;
+	    fm = byte ? String.format('%.2mB ', max) : max;
 	    pc = Math.floor((100 / mn) * vn);
 
 	if (pg) {
 		pg.firstElementChild.style.width = pc + '%';
-		pg.setAttribute('title', '%s / %s (%d%%)'.format(v, m, pc));
+		pg.setAttribute('title', '%s / %s (%d%%)'.format(fv, fm, pc));
 	}
 }
 
@@ -189,27 +191,32 @@ L.poll(5, L.location(), { status: 1 },
 			);
 
 		progressbar('#memtotal',
-			((info.memory.free + info.memory.buffered) / 1024) + ' ' + _('kB'),
-			(info.memory.total / 1024) + ' ' + _('kB'));
+			info.memory.free + info.memory.buffered,
+			info.memory.total,
+			true);
 
 		progressbar('#memfree',
-			(info.memory.free / 1024) + ' ' + _('kB'),
-			(info.memory.total / 1024) + ' ' + _('kB'));
+			info.memory.free,
+			info.memory.total,
+			true);
 
 		progressbar('#membuff',
-			(info.memory.buffered / 1024) + ' ' + _('kB'),
-			(info.memory.total / 1024) + ' ' + _('kB'));
+			info.memory.buffered,
+			info.memory.total,
+			true);
 
 		progressbar('#swaptotal',
-			(info.swap.free / 1024) + ' ' + _('kB'),
-			(info.swap.total / 1024) + ' ' + _('kB'));
+			info.swap.free,
+			info.swap.total,
+			true);
 
 		progressbar('#swapfree',
-			(info.swap.free / 1024) + ' ' + _('kB'),
-			(info.swap.total / 1024) + ' ' + _('kB'));
+			info.swap.free,
+			info.swap.total,
+			true);
 
 		progressbar('#conns',
-			info.conncount, info.connmax);
+			info.conncount, info.connmax, false);
 
 	}
 );


### PR DESCRIPTION
Currently on the system status page the the memory usage is shown in kB only. If you have a system with 1 GB of Ram its hard to read the large numbers. This automatically formats the byte numbers more human readable into KB / MB / GB.

Signed-off-by: Claudio Marelli <camarelli@gmx.net>