### PR TITLE
luci-mod-status: Remove port suffix where not applicable

### DIFF
--- a/modules/luci-mod-status/luasrc/view/admin_status/connections.htm
+++ b/modules/luci-mod-status/luasrc/view/admin_status/connections.htm
@@ -165,8 +165,8 @@
 							rows.push([
 								c.layer3.toUpperCase(),
 								c.layer4.toUpperCase(),
-								src + ':' + c.sport,
-								dst + ':' + c.dport,
+								c.hasOwnProperty('sport') ? (src + ':' + c.sport) : src,
+								c.hasOwnProperty('dport') ? (dst + ':' + c.dport) : dst,
 								'%1024.2mB (%d <%:Pkts.%>)'.format(c.bytes, c.packets)
 							]);
 						}


### PR DESCRIPTION
In the Realtime Connections table, a :port suffix is added to the end of each address. Only TCP/UDP connections have these properties "sport" and "dport". As a result, addresses for non-TCP/UDP connections are displayed like this:

![row1](https://user-images.githubusercontent.com/38528110/52486053-e0ff7a80-2bc2-11e9-908b-591ab7d4a01a.JPG)

This simple commit removes the :port suffix from connections that shouldn't have them, and it looks like this:

![row2](https://user-images.githubusercontent.com/38528110/52486626-4dc74480-2bc4-11e9-83be-f5b6cebb39bf.JPG)

The :port suffix is still shown for TCP/UDP connections.

Signed-off-by: Olli Asikainen [olli.asikainen@gmail.com](mailto:olli.asikainen@gmail.com)