### PR TITLE
luci-mod-status: Mobile styling for progressbar

### DIFF
--- a/modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm
+++ b/modules/luci-mod-status/luasrc/view/admin_status/index/20-memory.htm
@@ -12,7 +12,7 @@
 <div class="cbi-section">
 	<h3><%:Memory%></h3>
 
-	<div class="table" width="100%">
+	<div class="table cbi-progressbar-container" width="100%">
 		<div class="tr"><div class="td left" width="33%"><%:Total Available%></div><div class="td left"><div id="memtotal" class="cbi-progressbar" title="-"><div></div></div></div></div>
 		<div class="tr"><div class="td left" width="33%"><%:Free%></div><div class="td left"><div id="memfree" class="cbi-progressbar" title="-"><div></div></div></div></div>
 		<div class="tr"><div class="td left" width="33%"><%:Buffered%></div><div class="td left"><div id="membuff" class="cbi-progressbar" title="-"><div></div></div></div></div>
@@ -23,7 +23,7 @@
 <div class="cbi-section">
 	<h3><%:Swap%></h3>
 
-	<div class="table" width="100%">
+	<div class="table cbi-progressbar-container" width="100%">
 		<div class="tr"><div class="td left" width="33%"><%:Total Available%></div><div class="td left"><div id="swaptotal" class="cbi-progressbar" title="-"><div></div></div></div></div>
 		<div class="tr"><div class="td left" width="33%"><%:Free%></div><div class="td left"><div id="swapfree" class="cbi-progressbar" title="-"><div></div></div></div></div>
 	</div>

--- a/modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm
+++ b/modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm
@@ -11,7 +11,7 @@
 		<p><em><%:Collecting data...%></em></p>
 	</div>
 
-	<div class="table" width="100%">
+	<div class="table cbi-progressbar-container" width="100%">
 		<div class="tr"><div class="td left" width="33%"><%:Active Connections%></div><div class="td left"><div id="conns" class="cbi-progressbar" title="-"><div></div></div></div></div>
 	</div>
 </div>

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
@@ -377,6 +377,11 @@ header h3 a, header .brand {
 }
 
 @media screen and (max-width: 375px) {
+	.cbi-progressbar-container .td {
+		flex-grow: 0;
+		flex-basis: 95%;
+	}
+
 	.td .ifacebox {
 		width: 100%;
 		margin: 0 !important;

--- a/themes/luci-theme-freifunk-generic/htdocs/luci-static/freifunk-generic/cascade.css
+++ b/themes/luci-theme-freifunk-generic/htdocs/luci-static/freifunk-generic/cascade.css
@@ -1663,6 +1663,13 @@ td.cbi-value-error {
 	}
 }
 
+@media screen and (max-width: 375px) {
+	.cbi-progressbar-container .td {
+		flex-grow: 0;
+		flex-basis: 95%;
+	}
+}
+
 @media screen and (max-width: 480px) {
 	body {
 		font-size: 12pt;

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -2736,6 +2736,13 @@ input[name="nslookup"] {
 	}
 }
 
+@media screen and (max-width: 375px) {
+	.cbi-progressbar-container .td {
+		flex-grow: 0;
+		flex-basis: 95%;
+	}
+}
+
 @media screen and (max-width: 600px) {
 	body {
 		font-size: .8rem;

--- a/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
+++ b/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
@@ -1891,6 +1891,13 @@ select + .cbi-button {
 	}
 }
 
+@media screen and (max-width: 375px) {
+	.cbi-progressbar-container .td {
+		flex-basis: 95%;
+		flex-grow: 0;
+	}
+}
+
 @media screen and (max-width: 480px) {
 	body {
 		font-size: 16px;

--- a/themes/luci-theme-rosy/htdocs/luci-static/rosy/cascade.css
+++ b/themes/luci-theme-rosy/htdocs/luci-static/rosy/cascade.css
@@ -2897,6 +2897,13 @@ body.login {
 	}
 }
 
+@media screen and (max-width: 375px) {
+	.cbi-progressbar-container .td {
+		flex-grow: 0;
+		flex-basis: 95%;
+	}
+}
+
 @media screen and (max-width: 600px) {
 	body {
 		font-size: .8rem;


### PR DESCRIPTION
On a small screen the progressbar is too big to show all three values (value /
max value / percentage). This will put the label on one line and below
the progressbar.

Signed-off-by: Claudio Marelli <camarelli@gmx.net>