### PR TITLE
luci-mod-network: Add WPA3 SAE support

### DIFF
--- a/modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua
@@ -678,6 +678,10 @@ if hwtype == "mac80211" or hwtype == "prism2" then
 	local has_ap_sae  = (os.execute("hostapd -vsae >/dev/null 2>/dev/null") == 0)
 	local has_sta_sae = (os.execute("wpa_supplicant -vsae >/dev/null 2>/dev/null") == 0)
 
+	-- Probe OWE support
+	local has_ap_owe  = (os.execute("hostapd -vowe >/dev/null 2>/dev/null") == 0)
+	local has_sta_owe = (os.execute("wpa_supplicant -vowe >/dev/null 2>/dev/null") == 0)
+
 	if hostapd and supplicant then
 		encr:value("psk", "WPA-PSK", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"}, {mode="adhoc"})
 		encr:value("psk2", "WPA2-PSK", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"}, {mode="adhoc"})
@@ -690,6 +694,9 @@ if hwtype == "mac80211" or hwtype == "prism2" then
 			encr:value("wpa", "WPA-EAP", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"})
 			encr:value("wpa2", "WPA2-EAP", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"})
 		end
+		if has_ap_owe and has_sta_owe then
+			encr:value("owe", "OWE", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"}, {mode="adhoc"})
+		end
 	elseif hostapd and not supplicant then
 		encr:value("psk", "WPA-PSK", {mode="ap"}, {mode="ap-wds"})
 		encr:value("psk2", "WPA2-PSK", {mode="ap"}, {mode="ap-wds"})
@@ -701,6 +708,9 @@ if hwtype == "mac80211" or hwtype == "prism2" then
 		if has_ap_eap then
 			encr:value("wpa", "WPA-EAP", {mode="ap"}, {mode="ap-wds"})
 			encr:value("wpa2", "WPA2-EAP", {mode="ap"}, {mode="ap-wds"})
+		end
+		if has_ap_owe then
+			encr:value("owe", "OWE", {mode="ap"}, {mode="ap-wds"})
 		end
 		encr.description = translate(
 			"WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP " ..
@@ -717,6 +727,9 @@ if hwtype == "mac80211" or hwtype == "prism2" then
 		if has_sta_eap then
 			encr:value("wpa", "WPA-EAP", {mode="sta"}, {mode="sta-wds"})
 			encr:value("wpa2", "WPA2-EAP", {mode="sta"}, {mode="sta-wds"})
+		end
+		if has_sta_owe then
+			encr:value("owe", "OWE", {mode="sta"}, {mode="sta-wds"})
 		end
 		encr.description = translate(
 			"WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP " ..
@@ -1131,10 +1144,12 @@ if hwtype == "mac80211" then
 		ieee80211w:depends({mode="ap", encryption="psk-mixed"})
 		ieee80211w:depends({mode="ap", encryption="sae"})
 		ieee80211w:depends({mode="ap", encryption="sae-mixed"})
+		ieee80211w:depends({mode="ap", encryption="owe"})
 		ieee80211w:depends({mode="ap-wds", encryption="psk2"})
 		ieee80211w:depends({mode="ap-wds", encryption="psk-mixed"})
 		ieee80211w:depends({mode="ap-wds", encryption="sae"})
 		ieee80211w:depends({mode="ap-wds", encryption="sae-mixed"})
+		ieee80211w:depends({mode="ap-wds", encryption="owe"})
 
 		max_timeout = s:taboption("encryption", Value, "ieee80211w_max_timeout",
 				translate("802.11w maximum timeout"),

--- a/modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua
@@ -674,11 +674,18 @@ if hwtype == "mac80211" or hwtype == "prism2" then
 	local has_ap_eap  = (os.execute("hostapd -veap >/dev/null 2>/dev/null") == 0)
 	local has_sta_eap = (os.execute("wpa_supplicant -veap >/dev/null 2>/dev/null") == 0)
 
+	-- Probe SAE support
+	local has_ap_sae  = (os.execute("hostapd -vsae >/dev/null 2>/dev/null") == 0)
+	local has_sta_sae = (os.execute("wpa_supplicant -vsae >/dev/null 2>/dev/null") == 0)
+
 	if hostapd and supplicant then
 		encr:value("psk", "WPA-PSK", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"}, {mode="adhoc"})
 		encr:value("psk2", "WPA2-PSK", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"}, {mode="adhoc"})
 		encr:value("psk-mixed", "WPA-PSK/WPA2-PSK Mixed Mode", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"}, {mode="adhoc"})
-		encr:value("sae", "SAE", {mode="mesh"})
+		if has_ap_sae and has_sta_sae then
+			encr:value("sae", "WPA3-SAE", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"}, {mode="adhoc"}, {mode="mesh"})
+			encr:value("sae-mixed", "WPA2-PSK/WPA3-SAE Mixed Mode", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"}, {mode="adhoc"})
+		end
 		if has_ap_eap and has_sta_eap then
 			encr:value("wpa", "WPA-EAP", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"})
 			encr:value("wpa2", "WPA2-EAP", {mode="ap"}, {mode="sta"}, {mode="ap-wds"}, {mode="sta-wds"})
@@ -687,6 +694,10 @@ if hwtype == "mac80211" or hwtype == "prism2" then
 		encr:value("psk", "WPA-PSK", {mode="ap"}, {mode="ap-wds"})
 		encr:value("psk2", "WPA2-PSK", {mode="ap"}, {mode="ap-wds"})
 		encr:value("psk-mixed", "WPA-PSK/WPA2-PSK Mixed Mode", {mode="ap"}, {mode="ap-wds"})
+		if has_ap_sae then
+			encr:value("sae", "WPA3-SAE", {mode="ap"}, {mode="ap-wds"})
+			encr:value("sae-mixed", "WPA2-PSK/WPA3-SAE Mixed Mode", {mode="ap"}, {mode="ap-wds"})
+		end
 		if has_ap_eap then
 			encr:value("wpa", "WPA-EAP", {mode="ap"}, {mode="ap-wds"})
 			encr:value("wpa2", "WPA2-EAP", {mode="ap"}, {mode="ap-wds"})
@@ -699,7 +710,10 @@ if hwtype == "mac80211" or hwtype == "prism2" then
 		encr:value("psk", "WPA-PSK", {mode="sta"}, {mode="sta-wds"}, {mode="adhoc"})
 		encr:value("psk2", "WPA2-PSK", {mode="sta"}, {mode="sta-wds"}, {mode="adhoc"})
 		encr:value("psk-mixed", "WPA-PSK/WPA2-PSK Mixed Mode", {mode="sta"}, {mode="sta-wds"}, {mode="adhoc"})
-		encr:value("sae", "SAE", {mode="mesh"})
+		if has_sta_sae then
+			encr:value("sae", "WPA3-SAE", {mode="sta"}, {mode="sta-wds"}, {mode="mesh"})
+			encr:value("sae-mixed", "WPA2-PSK/WPA3-SAE Mixed Mode", {mode="sta"}, {mode="sta-wds"})
+		end
 		if has_sta_eap then
 			encr:value("wpa", "WPA-EAP", {mode="sta"}, {mode="sta-wds"})
 			encr:value("wpa2", "WPA2-EAP", {mode="sta"}, {mode="sta-wds"})
@@ -797,6 +811,8 @@ wpakey:depends("encryption", "psk")
 wpakey:depends("encryption", "psk2")
 wpakey:depends("encryption", "psk+psk2")
 wpakey:depends("encryption", "psk-mixed")
+wpakey:depends("encryption", "sae")
+wpakey:depends("encryption", "sae-mixed")
 wpakey.datatype = "wpakey"
 wpakey.rmempty = true
 wpakey.password = true
@@ -852,21 +868,6 @@ for slot=1,4 do
 	end
 end
 
-saekey = s:taboption("encryption", Value, "_sae_key", translate("Key"))
-saekey:depends("encryption", "sae")
-saekey.rmempty = true
-saekey.datatype = "wpakey"
-saekey.password = true
-
-saekey.cfgvalue = function(self, section, value)
-	local key = m.uci:get("wireless", section, "key")
-	return key
-end
-
-saekey.write = function(self, section, value)
-	self.map.uci:set("wireless", section, "key", value)
-end
-
 if hwtype == "mac80211" or hwtype == "prism2" then
 
 	-- Probe 802.11r support (and EAP support as a proxy for Openwrt)
@@ -884,9 +885,13 @@ if hwtype == "mac80211" or hwtype == "prism2" then
 		ieee80211r:depends({mode="ap", encryption="psk"})
 		ieee80211r:depends({mode="ap", encryption="psk2"})
 		ieee80211r:depends({mode="ap", encryption="psk-mixed"})
+		ieee80211r:depends({mode="ap", encryption="sae"})
+		ieee80211r:depends({mode="ap", encryption="sae-mixed"})
 		ieee80211r:depends({mode="ap-wds", encryption="psk"})
 		ieee80211r:depends({mode="ap-wds", encryption="psk2"})
 		ieee80211r:depends({mode="ap-wds", encryption="psk-mixed"})
+		ieee80211r:depends({mode="ap-wds", encryption="sae"})
+		ieee80211r:depends({mode="ap-wds", encryption="sae-mixed"})
 	end
 	ieee80211r.rmempty = true
 
@@ -1124,8 +1129,12 @@ if hwtype == "mac80211" then
 		ieee80211w:depends({mode="ap-wds", encryption="wpa2"})
 		ieee80211w:depends({mode="ap", encryption="psk2"})
 		ieee80211w:depends({mode="ap", encryption="psk-mixed"})
+		ieee80211w:depends({mode="ap", encryption="sae"})
+		ieee80211w:depends({mode="ap", encryption="sae-mixed"})
 		ieee80211w:depends({mode="ap-wds", encryption="psk2"})
 		ieee80211w:depends({mode="ap-wds", encryption="psk-mixed"})
+		ieee80211w:depends({mode="ap-wds", encryption="sae"})
+		ieee80211w:depends({mode="ap-wds", encryption="sae-mixed"})
 
 		max_timeout = s:taboption("encryption", Value, "ieee80211w_max_timeout",
 				translate("802.11w maximum timeout"),
@@ -1153,9 +1162,13 @@ if hwtype == "mac80211" then
 	key_retries:depends({mode="ap", encryption="wpa2"})
 	key_retries:depends({mode="ap", encryption="psk2"})
 	key_retries:depends({mode="ap", encryption="psk-mixed"})
+	key_retries:depends({mode="ap", encryption="sae"})
+	key_retries:depends({mode="ap", encryption="sae-mixed"})
 	key_retries:depends({mode="ap-wds", encryption="wpa2"})
 	key_retries:depends({mode="ap-wds", encryption="psk2"})
 	key_retries:depends({mode="ap-wds", encryption="psk-mixed"})
+	key_retries:depends({mode="ap-wds", encryption="sae"})
+	key_retries:depends({mode="ap-wds", encryption="sae-mixed"})
 end
 
 if hwtype == "mac80211" or hwtype == "prism2" then


### PR DESCRIPTION
This checks if the installed hostapd supports SAE and allows to select
WPA3 Personal SAE in that case.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>