### PR TITLE
luci-app-attendedupgrades: Fix errors when no upgrades or only package upgrades are available

### DIFF
--- a/applications/luci-app-attendedsysupgrade/root/www/luci-static/resources/attendedsysupgrade.js
+++ b/applications/luci-app-attendedsysupgrade/root/www/luci-static/resources/attendedsysupgrade.js
@@ -157,19 +157,22 @@ function upgrade_check_callback(request_text) {
 
 	// create simple output to tell user what's going to be upgrade (release/packages)
 	var info_output = ""
+	var have_upgrades = false;
 	if(request_json.version != undefined) {
 		info_output += "<h3>New firmware release available</h3>"
 		info_output += data.release.version + " to " + request_json.version
 		data.latest_version = request_json.version;
+		have_upgrades = true;
 	}
-	if(request_json.upgrades != undefined) {
+	if(request_json.upgrades != undefined && Object.keys(request_json.upgrades).length > 0) {
 		info_output += "<h3>Package upgrades available</h3>"
 		for (var upgrade in request_json.upgrades) {
 			info_output += "<b>" + upgrade + "</b>: " + request_json.upgrades[upgrade][1] + " to " + request_json.upgrades[upgrade][0] + "<br />"
 		}
+		have_upgrades = true;
 	}
 	data.packages = request_json.packages
-	set_status("success", info_output)
+	set_status("success", have_upgrades ? info_output : "<h3>System is up to date</h3>")
 
 	if(data.advanced_mode == 1) {
 		show("#edit_button");

--- a/applications/luci-app-attendedsysupgrade/root/www/luci-static/resources/attendedsysupgrade.js
+++ b/applications/luci-app-attendedsysupgrade/root/www/luci-static/resources/attendedsysupgrade.js
@@ -202,7 +202,7 @@ function upgrade_request() {
 	hide("#keep_container");
 
 	var request_dict = {}
-	request_dict.version = data.latest_version;
+	request_dict.version = data.latest_version?data.latest_version:data.release.version;
 	request_dict.board = data.board_name
 	request_dict.model = data.model
 

--- a/applications/luci-app-attendedsysupgrade/root/www/luci-static/resources/attendedsysupgrade.js
+++ b/applications/luci-app-attendedsysupgrade/root/www/luci-static/resources/attendedsysupgrade.js
@@ -171,7 +171,11 @@ function upgrade_check_callback(request_text) {
 		}
 		have_upgrades = true;
 	}
-	data.packages = request_json.packages
+	if (request_json.packages != undefined) {
+		data.packages = request_json.packages
+	} else {
+		data.packages = Object.keys(data.packages);
+	}
 	set_status("success", have_upgrades ? info_output : "<h3>System is up to date</h3>")
 
 	if(data.advanced_mode == 1) {


### PR DESCRIPTION
Currently, there are errors in luci-app-attendedupgrades in any of these cases:
* Installed system is up to date
  * A misleading message is displayed to the user ("Package upgrades available" with an empty packages list)
  * "Edit packages" and "Request upgrade" buttons are displayed, but do not work
* No full upgrade available, but some packages can be upgraded
  * "Edit packages" and "Request upgrade" buttons are displayed, but do not work

See also aparcar/attendedsysupgrade-server/issues/152

The changes in this pull request fix three separate bugs that together are the cause for these problems.