### PR TITLE
luci-app-advanced-reboot: secondary partition fix for Linksys EA6350v3

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -13,7 +13,7 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 
 LUCI_DEPENDS:=+luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=38
+PKG_RELEASE:=39
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
@@ -7,7 +7,7 @@ devices = {
   -- deviceName, boardName, partition1, partition2, offset, envVar1, envVar1Value1, envVar1Value2, envVar2, envVar2Value1, envVar2Value2
   {"Linksys EA3500", "linksys-audi", "mtd3", "mtd5", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
   {"Linksys E4200v2/EA4500", "linksys-viper", "mtd3", "mtd5", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},
-  {"Linksys EA6350v3", "linksys-ea6350v3", "mtd10", "mtd11", 192, "boot_part", 1, 2},
+  {"Linksys EA6350v3", "linksys-ea6350v3", "mtd10", "mtd12", 192, "boot_part", 1, 2},
   {"Linksys EA8500", "ea8500", "mtd13", "mtd15", 32, "boot_part", 1, 2},
 --  {"Linksys EA9500", "linksys-panamera", "mtd3", "mtd6", 28, "boot_part", 1, 2},
   {"Linksys WRT1200AC", "linksys-caiman", "mtd4", "mtd6", 32, "boot_part", 1, 2, "bootcmd", "run nandboot", "run altnandboot"},


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.net>

Tested and confirmed working properly with ```mtd12``` by [imi2003](https://forum.openwrt.org/u/imi2003).