### PR TITLE
luci-theme-material: fix loading view on href

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
+++ b/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
@@ -131,24 +131,6 @@
     $(".cbi-button-up").val("");
     $(".cbi-button-down").val("");
 
-
-    /**
-     * hook other "A Label" and add hash to it.
-     */
-    $("#maincontent > .container").find("a").each(function () {
-        var that = $(this);
-        var onclick = that.attr("onclick");
-        if (onclick == undefined || onclick == "") {
-            that.click(function () {
-                var href = that.attr("href");
-                if (href.indexOf("#") == -1) {
-                    $(".main > .loading").fadeIn("fast");
-                    return true;
-                }
-            });
-        }
-    });
-
     /**
      * Sidebar expand
      */


### PR DESCRIPTION
After opening an external hyperlink in a new browser tab, LuCI hangs in the
load screen. This commit will fix this issue.

Signed-off-by: Florian Eckert <fe@dev.tdt.de>