### PR TITLE
luci-mod-system: add button to sync with ntp server

### DIFF
--- a/modules/luci-mod-system/luasrc/controller/admin/system.lua
+++ b/modules/luci-mod-system/luasrc/controller/admin/system.lua
@@ -9,6 +9,7 @@ function index()
 
 	entry({"admin", "system", "system"}, cbi("admin_system/system"), _("System"), 1)
 	entry({"admin", "system", "clock_status"}, post_on({ set = true }, "action_clock_status"))
+	entry({"admin", "system", "ntp_restart"}, call("action_ntp_restart"), nil).leaf = true
 
 	entry({"admin", "system", "admin"}, firstchild(), _("Administration"), 2)
 	entry({"admin", "system", "admin", "password"}, template("admin_system/password"), _("Router Password"), 1)
@@ -62,6 +63,14 @@ function action_clock_status()
 
 	luci.http.prepare_content("application/json")
 	luci.http.write_json({ timestring = os.date("%c") })
+end
+
+function action_ntp_restart()
+	if nixio.fs.access("/etc/init.d/sysntpd") then
+		os.execute("/etc/init.d/sysntpd restart")
+	end
+	luci.http.prepare_content("text/plain")
+	luci.http.write("0")
 end
 
 local function image_supported(image)

--- a/modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm
+++ b/modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm
@@ -28,9 +28,29 @@
 
 		return false;
 	}
+
+	function btn_action(action)
+	{
+		if (action.name === "do_ntp_restart")
+		{
+			new XHR.get('<%=luci.dispatcher.build_url("admin", "system", "ntp_restart")%>', null,
+			function(x)
+			{
+				if (!x)
+				{
+					return;
+				}
+			});
+		}
+	}
+
 //]]></script>
 
 <span id="<%=self.option%>-clock-status"><em><%:Collecting data...%></em></span>
 <input type="button" class="cbi-button cbi-button-apply" value="<%:Sync with browser%>" onclick="return sync_clock(this)" />
+
+<% if require("nixio.fs").access("/etc/init.d/sysntpd") then %>
+<input type="button" class="cbi-button cbi-button-apply" name="do_ntp_restart" value="<%:Sync with NTP-Server%>" onclick="btn_action(this)" />
+<% end %>
 
 <%+cbi/valuefooter%>


### PR DESCRIPTION
Especially for systems without RTC this change has two advantages

* manual time sync with time server during configuration
* test possibility of the time sync over the configured servers

Signed-off-by: Florian Eckert <fe@dev.tdt.de>