### PR TITLE
luci-base: add cbi tsection error msg option

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/tsection.htm
+++ b/modules/luci-base/luasrc/view/cbi/tsection.htm
@@ -2,6 +2,11 @@
 	<% if self.title and #self.title > 0 then -%>
 		<legend><%=self.title%></legend>
 	<%- end %>
+	<% if self.error_msg and #self.error_msg > 0 then -%>
+		<div class="cbi-section-error">
+			<%=self.error_msg%>
+		</div>
+	<%- end %>
 	<% if self.description and #self.description > 0 then -%>
 		<div class="cbi-section-descr"><%=self.description%></div>
 	<%- end %>


### PR DESCRIPTION
In some situation it is usefull to inform the use that this section
could not get delete, because this config is referenced or is in use.

Example pseudo code:

```
function s.remove(self, sid)
  <check if secation could get deleted>
  if output == nil then
    self.error_msg = translatef("Unable to remove this section")
    return nil
  end
end
```

Signed-off-by: Florian Eckert <fe@dev.tdt.de>