### PR TITLE
luci-mod-network: move auto option to general tab

### DIFF
--- a/modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua
@@ -247,7 +247,7 @@ for _, pr in ipairs(nw:get_protocols()) do
 end
 
 
-auto = s:taboption("advanced", Flag, "auto", translate("Bring up on boot"))
+auto = s:taboption("general", Flag, "auto", translate("Bring up on boot"))
 auto.default = (net:proto() == "none") and auto.disabled or auto.enabled
 
 delegate = s:taboption("advanced", Flag, "delegate", translate("Use builtin IPv6-management"))


### PR DESCRIPTION
Since openwrt-18.06 the auto option is set/unset if we press
connect/disconnect on the interface page. So I think we should move this
to the general tab so that we see at once if this is started on boot or
not.
This revers also to #2119 