### PR TITLE
luci-mod-status: use available and cached memory for progress bars

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
@@ -31,10 +31,13 @@ return L.Class.extend({
 		    swap = L.isObject(systeminfo.swap) ? systeminfo.swap : {};
 
 		var fields = [
-			_('Total Available'), (mem.total && mem.free && mem.buffered) ? mem.free + mem.buffered : null,
+			_('Total Available'), (mem.available) ? mem.available : (mem.total && mem.free && mem.buffered) ? mem.free + mem.buffered : null,
 			_('Free'),            (mem.total && mem.free) ? mem.free : null,
 			_('Buffered'),        (mem.total && mem.buffered) ? mem.buffered : null
 		];
+
+		if (mem.cached)
+			fields.push(_('Cached'), mem.cached);
 
 		if (swap.total > 0)
 			fields.push(_('Swap free'), swap.free);


### PR DESCRIPTION
Ref: https://github.com/openwrt/luci/issues/1148

Uses available and cached memory from /proc/meminfo via procd, and carefully
handles the cases where they are nil or zero, so as to not require specific
linux or procd versions to function

MemAvailable is a better estimate than free + buffered/cached, see:
git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0

Also adds a new progressbar that shows cached memory if not nil

Related procd [patch](http://lists.infradead.org/pipermail/openwrt-devel/2019-February/015762.html)