### PR TITLE
luci-app-shadowsocks-libev: fix cidr datatype

### DIFF
--- a/modules/luci-base/luasrc/cbi/datatypes.lua
+++ b/modules/luci-base/luasrc/cbi/datatypes.lua
@@ -132,6 +132,10 @@ function ip6prefix(val)
 	return ( val and val >= 0 and val <= 128 )
 end
 
+function cidr(val)
+	return cidr4(val) or cidr6(val)
+end
+
 function cidr4(val)
 	local ip, mask = val:match("^([^/]+)/([^/]+)$")
 


### PR DESCRIPTION
* fix unknown cidr datatype (#2671)

Signed-off-by: Dirk Brenken <dev@brenken.org>