### PR TITLE
luci-mod-admin-full: add dependency for channel auto

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm
+++ b/modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm
@@ -4,6 +4,7 @@
 	var freqlist = <%= luci.http.write_json(self.iwinfo.freqlist) %>;
 	var hwmodes  = <%= luci.http.write_json(self.iwinfo.hwmodelist or {}) %>;
 	var htmodes  = <%= luci.http.write_json(self.iwinfo.htmodelist) %>;
+	var acs =  <%= luci.http.write_json(self.hostapd_acs or 0) %>;
 
 	var channels = {
 		'11g': [
@@ -13,6 +14,10 @@
 			'auto', 'auto', true
 		]
 	};
+
+	if (acs < 1) {
+		channels[(freqlist[freqlist.length - 1].mhz > 2484) ? '11a' : '11g'].length = 0;
+	}
 
 	for (var i = 0; i < freqlist.length; i++)
 		channels[(freqlist[i].mhz > 2484) ? '11a' : '11g'].push(

--- a/modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua
@@ -177,6 +177,7 @@ if found_sta then
 else
 	ch = s:taboption("general", Value, "_mode_freq", '<br />'..translate("Operating frequency"))
 	ch.iwinfo = iw
+	ch.hostapd_acs = (os.execute("hostapd -vacs >/dev/null 2>/dev/null") == 0)
 	ch.template = "cbi/wireless_modefreq"
 
 	function ch.cfgvalue(self, section)


### PR DESCRIPTION
Do not show 'auto' channel option if hostapd is not compiled with CONFIG_ACS

Signed-off-by: Enrique Giraldo <hgiraldos@gmail.com>