### PR TITLE
luci-theme-rosy: fix table overflow on network/switch

### DIFF
--- a/themes/luci-theme-rosy/htdocs/luci-static/rosy/js/script.js
+++ b/themes/luci-theme-rosy/htdocs/luci-static/rosy/js/script.js
@@ -276,6 +276,6 @@
 
     });
 
-    $('#cbi-network-switch_vlan .table').wrap('#vlan_table');
+    $('#cbi-network-switch_vlan .table').wrap('<div id="vlan_table"></div>');
     
 })(window, jQuery);


### PR DESCRIPTION
Fix https://github.com/openwrt/luci/issues/2645

@yglb @fantom-x  @hnyman 

Signed-off-by: Rosy Song <rosysong@rosinson.com>
Signed-off-by: Yan Lan Shen <yanlan.shen@rosinson.com>

![rosyui-network-switch](https://user-images.githubusercontent.com/37688994/57187744-49da6280-6f26-11e9-9503-ca3fe3e2a9e6.png)

![rosyui-network-switch2](https://user-images.githubusercontent.com/37688994/57187745-4a72f900-6f26-11e9-86e6-28448c3103e8.png)


