### PR TITLE
Various improvements of the German translation

### DIFF
--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -408,7 +408,7 @@ msgstr "Administration"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:25
 msgid "Advanced"
-msgstr ""
+msgstr "Erweitert"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/dhcp.lua:22
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:189
@@ -461,7 +461,7 @@ msgstr "Erlaube Anmeldung per Passwort"
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:545
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
-"Erlaubt dem Access-Point die Trennung von Clients mit schlechter "
+"Erlaube dem Access-Point die Trennung von Clients mit schlechter "
 "Signalqualität"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:462
@@ -471,7 +471,7 @@ msgstr "Alle außer gelistete erlauben"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:236
 msgid "Allow legacy 802.11b rates"
-msgstr "Veraltete 802.11b Raten erlauben"
+msgstr "Veraltete 802.11b-Raten erlauben"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:461
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:588
@@ -1212,18 +1212,18 @@ msgstr "Kritisch"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:103
 msgid "Cron Log Level"
-msgstr "Cron Protokolllevel"
+msgstr "Cron Protokoll-Level"
 
 #: modules/luci-base/luasrc/view/cbi/network_ifacelist.htm:51
 #: modules/luci-base/luasrc/view/cbi/network_ifacelist.htm:53
 #: modules/luci-base/luasrc/view/cbi/network_ifacelist.htm:82
 #: modules/luci-base/luasrc/view/cbi/network_ifacelist.htm:83
 msgid "Custom Interface"
-msgstr "benutzerdefinierte Schnittstelle"
+msgstr "Benutzerdefinierte Schnittstelle"
 
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:40
 msgid "Custom delegated IPv6-prefix"
-msgstr "Delegierter IPv6-Präfix"
+msgstr "Delegiertes IPv6-Präfix"
 
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:53
 msgid ""
@@ -2347,7 +2347,7 @@ msgstr "IPv4 Bereich"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6rd.lua:42
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:30
 msgid "IPv4 prefix length"
-msgstr "Länge des IPv4 Präfix"
+msgstr "Länge des IPv4-Präfix"
 
 #: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:43
 msgid "IPv4+IPv6"
@@ -2432,17 +2432,17 @@ msgstr "IPv6-Netzwerk in Addresse/Netzmaske-Notation"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6rd.lua:26
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:37
 msgid "IPv6 prefix"
-msgstr "IPv6 Präfix"
+msgstr "IPv6-Präfix"
 
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6rd.lua:34
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:45
 msgid "IPv6 prefix length"
-msgstr "Länge des IPv6 Präfix"
+msgstr "Länge des IPv6-Präfix"
 
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:138
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6in4.lua:33
 msgid "IPv6 routed prefix"
-msgstr "Gerouteter IPv6-Präfix"
+msgstr "Geroutetes IPv6-Präfix"
 
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:143
 msgid "IPv6 suffix"
@@ -2456,7 +2456,7 @@ msgstr "IPv6-Adresse"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/iface_status.js:33
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:104
 msgid "IPv6-PD"
-msgstr "IPv6 Präfixdelegation (PD)"
+msgstr "IPv6 Präfix-Delegation (PD)"
 
 #: protocols/luci-proto-ipv6/luasrc/model/network/proto_6x4.lua:13
 msgid "IPv6-in-IPv4 (RFC4213)"
@@ -3329,7 +3329,7 @@ msgstr "NAT-T Modus"
 
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_464xlat.lua:9
 msgid "NAT64 Prefix"
-msgstr "NAT64 Präfix"
+msgstr "NAT64-Präfix"
 
 #: protocols/luci-proto-ncm/luasrc/model/network/proto_ncm.lua:26
 msgid "NCM"
@@ -4210,7 +4210,7 @@ msgid ""
 msgstr ""
 "Diese Schnittstelle wirklich löschen? Das Löschen kann nicht rückgängig "
 "gemacht werden! Der Kontakt zum Gerät könnte verloren gehen wenn die "
-"Verbidung über diese Schnittstelle erfolgt."
+"Verbindung über diese Schnittstelle erfolgt."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2
 msgid ""
@@ -5092,7 +5092,7 @@ msgstr ""
 msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
-"Vom Provider zugewiesener IPv6 Präfix, endet normalerweise mit <code>::</"
+"Vom Provider zugewiesenes IPv6-Präfix, endet normalerweise mit <code>::</"
 "code>"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/iface_add.lua:18
@@ -5196,13 +5196,13 @@ msgid ""
 "The length of the IPv4 prefix in bits, the remainder is used in the IPv6 "
 "addresses."
 msgstr ""
-"Länge des IPv4 Präfix in Bits, die übrigen Bits werden in der IPv6 Adresse "
+"Länge des IPv4-Präfix in Bits, die übrigen Bits werden in der IPv6-Adresse "
 "verwendet."
 
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6rd.lua:35
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:46
 msgid "The length of the IPv6 prefix in bits"
-msgstr "Länge des IPv6 Präfix in Bits"
+msgstr "Länge des IPv6-Präfix in Bits"
 
 #: protocols/luci-proto-ipip/luasrc/model/cbi/admin_network/proto_ipip.lua:12
 msgid "The local IPv4 address over which the tunnel is created (optional)."
@@ -6357,7 +6357,7 @@ msgstr "gültige IP-Adresse"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:310
 msgid "valid IP address or prefix"
-msgstr "gültige IP-Adresse oder gültigen IP-Präfix"
+msgstr "gültige IP-Adresse oder gültiges IP-Präfix"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:345
 msgid "valid IPv4 CIDR"
@@ -6385,7 +6385,7 @@ msgstr "gültige IPv4- oder IPv6-CIDR-Notation"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:331
 msgid "valid IPv4 prefix value (0-32)"
-msgstr "gültigen IPv4-Präfix-Wert (0-32)"
+msgstr "gültiger IPv4-Präfix-Wert (0-32)"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:350
 msgid "valid IPv6 CIDR"
@@ -6397,7 +6397,7 @@ msgstr "gültige IPv6-Adresse"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:326
 msgid "valid IPv6 address or prefix"
-msgstr "gültige IPv6-Addresse oder gültiges IPv6-Präfix"
+msgstr "gültige IPv6-Addresse oder gültiger IPv6-Präfix"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:368
 msgid "valid IPv6 host id"
@@ -6409,7 +6409,7 @@ msgstr "gültiges IPv6-Netzwerk"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:336
 msgid "valid IPv6 prefix value (0-128)"
-msgstr "gültigen IPv6-Präfix-Wert (0-128)"
+msgstr "gültiger IPv6-Präfix-Wert (0-128)"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:404
 msgid "valid MAC address"


### PR DESCRIPTION
The following changes are included:
* properly handle "Präfix" as neuter
* add missing hyphens to many appearances of "Präfix"
* fix spelling
* add few missing translations