### PR TITLE
luci-app-banip: change maxqueue default / sync with banIP 0.1.1

### DIFF
--- a/applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua
+++ b/applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua
@@ -125,9 +125,9 @@ e5:depends("ban_backup", 1)
 e5.rmempty = true
 
 e6 = e:option(Value, "ban_maxqueue", translate("Max. Download Queue"),
-	translate("Size of the download queue to handle downloads &amp; IPset processing in parallel (default '8'). ")
-	.. translate("For further performance improvements you can raise this value, e.g. '16' or '32' should be safe."))
-e6.default = 8
+	translate("Size of the download queue to handle downloads &amp; IPset processing in parallel (default '4'). ")
+	.. translate("For further performance improvements you can raise this value, e.g. '8' or '16' should be safe."))
+e6.default = 4
 e6.datatype = "range(1,32)"
 e6.rmempty = false
 


### PR DESCRIPTION
* change maxqueue default to '4' to reduce the overall system load

Signed-off-by: Dirk Brenken <dev@brenken.org>