### PR TITLE
luci-app-unbound: match dependencies with unbound package

### DIFF
--- a/applications/luci-app-unbound/Makefile
+++ b/applications/luci-app-unbound/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Unbound Recursive DNS Resolver Configuration
-LUCI_DEPENDS:=+unbound
+LUCI_DEPENDS:=+unbound-daemon
 
 include ../../luci.mk
 


### PR DESCRIPTION
Maintainer: me
Compile tested: Linksys-WRT3200ACM (master)
Run tested: Linksys-WRT3200ACM
Supports changes in openwrt/packages#9029 to depend on unbound-daemon for clearer menu selections. This also relates to openwrt/packages#8956.