### PR TITLE
[WIP] luci-base: Hack to bypass node users verification

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -178,9 +178,7 @@ local function session_retrieve(sid, allowed_users)
 
 	if type(sdat) == "table" and
 	   type(sdat.values) == "table" and
-	   type(sdat.values.token) == "string" and
-	   (not allowed_users or
-	    util.contains(allowed_users, sdat.values.username))
+	   type(sdat.values.token) == "string"
 	then
 		uci:set_session_id(sid)
 		return sid, sdat.values
@@ -190,7 +188,7 @@ local function session_retrieve(sid, allowed_users)
 end
 
 local function session_setup(user, pass, allowed_users)
-	if util.contains(allowed_users, user) then
+	if user ~= nil and user ~= '' then
 		local login = util.ubus("session", "login", {
 			username = user,
 			password = pass,


### PR DESCRIPTION
Since openwrt-18.06, users different than root should be hardcoded in the code to be able to log in Luci. Because of this it is not possible to dynamically register/unregister users.

The check on "allowed_users" is done before checking RPCd. Why not just check RPCd and keep the rights inside ? 