### PR TITLE
luci-mod-network: permit WPS push-button on WPA3

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -1762,7 +1762,7 @@ msgid "Enable VLAN functionality"
 msgstr "Habilita la funcionalitat VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5803,7 +5803,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -1765,7 +1765,7 @@ msgid "Enable VLAN functionality"
 msgstr "Povolit funkcionalitu VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5829,7 +5829,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -1809,8 +1809,8 @@ msgid "Enable VLAN functionality"
 msgstr "VLAN-Funktionalität aktivieren"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "WPS-via-Knopfdruck aktivieren, erfordert WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "WPS-via-Knopfdruck aktivieren, erfordert WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -6013,10 +6013,10 @@ msgstr "Benutzer Schlüsselindex"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 "Wird als RADIUS-NAS-ID und als 802.11r R0KH-ID verwendet. Nicht benötigt für "
-"WPA(2)-PSK."
+"WPA(2)-PSK/WPA3-SAE."
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110
 msgid "User certificate (PEM encoded)"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -1777,7 +1777,7 @@ msgid "Enable VLAN functionality"
 msgstr "Ενεργοποίηση λειτουργίας VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5809,7 +5809,7 @@ msgstr "Χρησιμοποιούμενη Υποδοχή Κλειδιού"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -1757,7 +1757,7 @@ msgid "Enable VLAN functionality"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5769,7 +5769,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -1812,8 +1812,8 @@ msgid "Enable VLAN functionality"
 msgstr "Habilitar funcionalidad VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "Habilitar botón WPS, requiere WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "Habilitar botón WPS, requiere WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -5995,7 +5995,7 @@ msgstr "Espacio de clave usado"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 "Se utiliza para dos propósitos diferentes: RADIUS NAS ID y 802.11r R0KH-ID. "
 "No es necesario con WPA normal (2)-PSK."

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -1781,7 +1781,7 @@ msgid "Enable VLAN functionality"
 msgstr "Acviter la gestion des VLANs"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5873,7 +5873,7 @@ msgstr "Clé utilisée"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -1743,7 +1743,7 @@ msgid "Enable VLAN functionality"
 msgstr "אפשר תפקוד VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5726,7 +5726,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -1774,7 +1774,7 @@ msgid "Enable VLAN functionality"
 msgstr "VLAN funkció engedélyezése"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5861,7 +5861,7 @@ msgstr "Használt kulcsindex"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -1778,8 +1778,8 @@ msgid "Enable VLAN functionality"
 msgstr "Abilita la funzionalità VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "Abilita pulsante WPS, richiede WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "Abilita pulsante WPS, richiede WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -5835,7 +5835,7 @@ msgstr "Slot Chiave Usata"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -1796,8 +1796,8 @@ msgid "Enable VLAN functionality"
 msgstr "VLAN機能を有効にする"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "WPS プッシュボタンを有効化するには、WPA(2)-PSKが必要です。"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "WPS プッシュボタンを有効化するには、WPA(2)-PSK/WPA3-SAEが必要です。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -5932,7 +5932,7 @@ msgstr "使用するキースロット"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -1751,7 +1751,7 @@ msgid "Enable VLAN functionality"
 msgstr "VLAN 기능 활성화"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5764,7 +5764,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -1728,7 +1728,7 @@ msgid "Enable VLAN functionality"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5741,7 +5741,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -1762,7 +1762,7 @@ msgid "Enable VLAN functionality"
 msgstr "Aktiver VLAN funksjonalitet"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5827,7 +5827,7 @@ msgstr "Brukte Nøkler"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -1796,8 +1796,8 @@ msgid "Enable VLAN functionality"
 msgstr "Włącz funkcjonalność VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "Włącz przycisk WPS, wymaga WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "Włącz przycisk WPS, wymaga WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -5916,7 +5916,7 @@ msgstr "Użyte gniazdo klucza"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -1841,8 +1841,8 @@ msgid "Enable VLAN functionality"
 msgstr "Ativar funcionalidade de VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "Habilite o botão WPS. requer WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "Habilite o botão WPS. requer WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -6051,10 +6051,10 @@ msgstr "Posição da Chave Usada"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 "Usado para dois diferentes propósitos: identificador do RADIUS NAS e do "
-"802.11r R0KH. Não necessário com o WPA(2)-PSK normal."
+"802.11r R0KH. Não necessário com o WPA(2)-PSK/WPA3-SAE normal."
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110
 msgid "User certificate (PEM encoded)"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -1778,7 +1778,7 @@ msgid "Enable VLAN functionality"
 msgstr "Ativar a funcionalidade VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5827,7 +5827,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -1734,7 +1734,7 @@ msgid "Enable VLAN functionality"
 msgstr "Activeaza VLAN-urile"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5721,7 +5721,7 @@ msgstr "Slot de cheie folosit"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -1817,8 +1817,8 @@ msgid "Enable VLAN functionality"
 msgstr "Включить поддержку VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "Включить WPS при нажатии на кнопку, в режиме WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "Включить WPS при нажатии на кнопку, в режиме WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -5991,10 +5991,10 @@ msgstr "Используемый слот ключа"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 "Используется для двух различных целей: RADIUS NAS ID и 802.11r R0KH-ID. Не "
-"используется с обычным WPA(2)-PSK."
+"используется с обычным WPA(2)-PSK/WPA3-SAE."
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110
 msgid "User certificate (PEM encoded)"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -1716,7 +1716,7 @@ msgid "Enable VLAN functionality"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5693,7 +5693,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -1735,8 +1735,8 @@ msgid "Enable VLAN functionality"
 msgstr "Aktivera VLAN-funktionalitet"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "Aktivera WPS-tryckknapp, kräver WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "Aktivera WPS-tryckknapp, kräver WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -5719,7 +5719,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -1708,7 +1708,7 @@ msgid "Enable VLAN functionality"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5685,7 +5685,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -1733,7 +1733,7 @@ msgid "Enable VLAN functionality"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5710,7 +5710,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -1830,8 +1830,8 @@ msgid "Enable VLAN functionality"
 msgstr "Увімкнути підтримку VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "Увімкнути кнопку WPS, потребує WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "Увімкнути кнопку WPS, потребує WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -6025,11 +6025,11 @@ msgstr "Використовується слот ключа"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 "Використовується для двох різних цілей: RADIUS NAS ID і 802.11r <abbr title="
 "\"ідентифікатор власника ключа R0\">R0KH-ID</abbr>. Не потрібно за "
-"звичайного WPA(2)-PSK."
+"звичайного WPA(2)-PSK/WPA3-SAE."
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110
 msgid "User certificate (PEM encoded)"

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -1733,7 +1733,7 @@ msgid "Enable VLAN functionality"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
@@ -5741,7 +5741,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -1755,8 +1755,8 @@ msgid "Enable VLAN functionality"
 msgstr "启用 VLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "启用 WPS 一键加密按钮，需要 WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "启用 WPS 一键加密按钮，需要 WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -5794,9 +5794,9 @@ msgstr "启用密码组"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
-"用于两种不同的用途：RADIUS NAS ID 和 802.11r R0KH-ID，普通 WPA(2)-PSK 不需"
+"用于两种不同的用途：RADIUS NAS ID 和 802.11r R0KH-ID，普通 WPA(2)-PSK/WPA3-SAE 不需"
 "要。"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -1745,8 +1745,8 @@ msgid "Enable VLAN functionality"
 msgstr "啟用VLAN功能"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
-msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
-msgstr "啟用 WPS 按鈕, 這需要 WPA(2)-PSK"
+msgid "Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE"
+msgstr "啟用 WPS 按鈕, 這需要 WPA(2)-PSK/WPA3-SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -5764,7 +5764,7 @@ msgstr "已使用的關鍵插槽"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
-"needed with normal WPA(2)-PSK."
+"needed with normal WPA(2)-PSK/WPA3-SAE."
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:110

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1592,13 +1592,15 @@ return L.view.extend({
 						o.depends({ mode: 'ap-wds', encryption: 'sae-mixed' });
 
 						if (L.hasSystemFeature('hostapd', 'cli') && L.hasSystemFeature('wpasupplicant')) {
-							o = ss.taboption('encryption', form.Flag, 'wps_pushbutton', _('Enable WPS pushbutton, requires WPA(2)-PSK'))
+							o = ss.taboption('encryption', form.Flag, 'wps_pushbutton', _('Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE'))
 							o.enabled = '1';
 							o.disabled = '0';
 							o.default = o.disabled;
 							o.depends('encryption', 'psk');
 							o.depends('encryption', 'psk2');
 							o.depends('encryption', 'psk-mixed');
+							o.depends('encryption', 'sae');
+							o.depends('encryption', 'sae-mixed');
 						}
 					}
 				}


### PR DESCRIPTION
Currently WPS push-button is dropped when SAE or SAE-Mixed is selected. WPS is still supported in WPA3.

@jow- 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>