### PR TITLE
luci-mod-status: make Overview page configurable

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/status/include/70_ddns.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/status/include/70_ddns.js
@@ -5,6 +5,8 @@
 return L.Class.extend({
 	title: _('Dynamic DNS'),
 
+	index_id:' ddns',
+
 	callDDnsGetServicesStatus: rpc.declare({
 		object: 'luci.ddns',
 		method: 'get_services_status',

--- a/applications/luci-app-minidlna/htdocs/luci-static/resources/view/status/include/80_minidlna.js
+++ b/applications/luci-app-minidlna/htdocs/luci-static/resources/view/status/include/80_minidlna.js
@@ -5,6 +5,8 @@
 return L.Class.extend({
 	title: _('miniDLNA Status'),
 
+	index_id: 'minidlna',
+
 	load: function() {
 		return uci.load('minidlna').then(function() {
 			var port = +uci.get_first('minidlna', 'minidlna', 'port');

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
@@ -28,6 +28,8 @@ handleDelRule = function(num, ev) {
 return L.Class.extend({
 	title: _('Active UPnP Redirects'),
 
+	index_id: 'upnp',
+
 	load: function() {
 		return Promise.all([
 			callUpnpGetStatus(),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/10_system.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/10_system.js
@@ -15,6 +15,8 @@ var callSystemInfo = rpc.declare({
 return L.Class.extend({
 	title: _('System'),
 
+	index_id: 'system',
+
 	load: function() {
 		return Promise.all([
 			L.resolveDefault(callSystemBoard(), {}),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
@@ -22,6 +22,8 @@ function progressbar(value, max, byte) {
 return L.Class.extend({
 	title: _('Memory'),
 
+	index_id: 'memory',
+
 	load: function() {
 		return L.resolveDefault(callSystemInfo(), {});
 	},

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
@@ -61,6 +61,8 @@ function renderbox(ifc, ipv6) {
 return L.Class.extend({
 	title: _('Network'),
 
+	index_id: 'network',
+
 	load: function() {
 		return Promise.all([
 			fs.trimmed('/proc/sys/net/netfilter/nf_conntrack_count'),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -11,6 +11,8 @@ var callLuciDHCPLeases = rpc.declare({
 return L.Class.extend({
 	title: '',
 
+	index_id: 'dhcp',
+
 	load: function() {
 		return Promise.all([
 			L.resolveDefault(callLuciDHCPLeases(), {}),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
@@ -43,6 +43,8 @@ function renderbox(dsl) {
 return L.Class.extend({
 	title: _('DSL'),
 
+	index_id: 'dsl',
+
 	load: function() {
 		return L.resolveDefault(callLuciDSLStatus(), {});
 	},

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js
@@ -76,6 +76,8 @@ function wifirate(rt) {
 return L.Class.extend({
 	title: _('Wireless'),
 
+	index_id: 'wireless',
+
 	handleDelClient: function(wifinet, mac, ev) {
 		L.dom.parent(ev.currentTarget, '.tr').style.opacity = 0.5;
 		ev.currentTarget.classList.add('spinning');


### PR DESCRIPTION
This is stil WIP. I'm pushing this to have some hint and a quick revision. 
I moved the LuCI setting to a separate lua file as the System page is already very heavy with settings. 
I still don't know if this is the right way of doing this. 
I think a good thing would be to have a shared function to get the list of the included files (as the code to get them is the same) 
Also to me having a cursor in the index page just to check that option looks very unefficent.  
By default every page is active. 
This creates a new section in luci config file called index_display. 
I'm also dubious about the "translation table" for the include file. 