### PR TITLE
luci-mod-status: expand storage index page with mount points

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/25_storage.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/25_storage.js
@@ -7,6 +7,20 @@ var callSystemInfo = rpc.declare({
 	method: 'info'
 });
 
+var callMountPoints = rpc.declare({
+	object: 'luci',
+	method: 'getMountPoints',
+	expect: { result: [] }
+});
+
+var MountSkipList = [
+	"/rom",
+	"/tmp",
+	"/dev",
+	"/overlay",
+	"/",
+]
+
 function progressbar(value, max, byte) {
 	var vn = parseInt(value) || 0,
 	    mn = parseInt(max) || 100,
@@ -24,16 +38,33 @@ return baseclass.extend({
 	title: _('Storage'),
 
 	load: function() {
-		return L.resolveDefault(callSystemInfo(), {});
+		return Promise.all([
+			L.resolveDefault(callSystemInfo(), {}),
+			L.resolveDefault(callMountPoints(), {}),
+		]);
 	},
 
-	render: function(systeminfo) {
-		var root = L.isObject(systeminfo.root) ? systeminfo.root : {},
+	render: function(data) {
+		var systeminfo = data[0],
+		    mounts = data[1],
+		    root = L.isObject(systeminfo.root) ? systeminfo.root : {},
 		    tmp = L.isObject(systeminfo.tmp) ? systeminfo.tmp : {};
 
 		var fields = [];
 		fields.push(_('Disk space'), root.used*1024, root.total*1024);
 		fields.push(_('Temp space'), tmp.used*1024, tmp.total*1024);
+
+		for (var i = 0; i < mounts.length; i++) {
+			var entry = mounts[i];
+
+			if (MountSkipList.includes(entry.mount))
+				continue;
+
+			var name = entry.device + ' (' + entry.mount +')',
+			    used = entry.size - entry.free;
+
+			fields.push(name, used, entry.size)
+		}
 
 		var table = E('table', { 'class': 'table' });
 

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
@@ -19,9 +19,10 @@
 	},
 
 	"luci-mod-status-index-storage": {
-		"description": "Grant access to Storage status display",
+		"description": "Grant access to Storage and Mount status display",
 		"read": {
 			"ubus": {
+				"luci": [ "getMountPoints" ],
 				"system": [ "info" ]
 			}
 		}

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
@@ -18,6 +18,15 @@
 		}
 	},
 
+	"luci-mod-status-index-storage": {
+		"description": "Grant access to Storage status display",
+		"read": {
+			"ubus": {
+				"system": [ "info" ]
+			}
+		}
+	},
+
 	"luci-mod-status-index-dhcp": {
 		"description": "Grant access to DHCP status display",
 		"read": {


### PR DESCRIPTION
Expand storage index page with mount points. For custom mounts point we
use the device name and we reference the mount point between ().

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>