### PR TITLE
luci-app-opkg: made 'force-overwrite' user-driven/optional plus bugfix

### DIFF
--- a/applications/luci-app-opkg/luasrc/controller/opkg.lua
+++ b/applications/luci-app-opkg/luasrc/controller/opkg.lua
@@ -26,8 +26,12 @@ end
 
 function action_exec(command, package)
 	local sys = require "luci.sys"
-	local cmd = { "/bin/opkg", "--force-removal-of-dependent-packages", "--force-overwrite" }
+	local cmd = { "/bin/opkg", "--force-removal-of-dependent-packages" }
 	local pkg = luci.http.formvalue("package")
+
+	if luci.http.formvalue("forceoverwrite") == "true" then
+		cmd[#cmd + 1] = "--force-overwrite"
+	end
 
 	if luci.http.formvalue("autoremove") == "true" then
 		cmd[#cmd + 1] = "--autoremove"


### PR DESCRIPTION
* made 'force-overwrite' flag optional, the user could set this
  like 'autoremove' today (see screenshots)
* fix erroneously as 'installed' reported packages (happens whenever
  a package installation runs into an error)
* add three dots to the first level 'Remove' button, cause it
  leads to a modal dialogue

Signed-off-by: Dirk Brenken <dev@brenken.org>