### PR TITLE
luci-app-statistics: add address family configuration for ping

### DIFF
--- a/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/ping.lua
+++ b/applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/ping.lua
@@ -20,6 +20,14 @@ hosts = s:option( Value, "Hosts", translate("Monitor hosts"), translate ("Add mu
 hosts.default = "127.0.0.1"
 hosts:depends( "enable", 1 )
 
+-- collectd_ping.adressfamily (AddressFamily)
+addressfamily = s:option( ListValue, "AddressFamily", translate("Address family") )
+addressfamily.default = "any"
+addressfamily:value( "any" )
+addressfamily:value( "ipv4" )
+addressfamily:value( "ipv6" )
+addressfamily:depends( "enable", 1 )
+
 -- collectd_ping.ttl (TTL)
 ttl = s:option( Value, "TTL", translate("TTL for ping packets") )
 ttl.isinteger = true

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -411,7 +411,7 @@ plugins = {
 	},
 
 	ping	= {
-		{ "TTL", "Interval" },
+		{ "TTL", "Interval", "AddressFamily" },
 		{ },
 		{ "Hosts" }
 	},


### PR DESCRIPTION
It allows to force ipv4 or ipv6 when the DNS returns both addresses, but
only one works (for example if there is no ipv6 connectivity).

Signed-off-by: Loïc Yhuel <loic.yhuel@gmail.com>