### PR TITLE
luci-mod-network: os-release variables have been renamed to OPENWRT_

### DIFF
--- a/modules/luci-mod-network/root/etc/uci-defaults/50_luci-mod-admin-full
+++ b/modules/luci-mod-network/root/etc/uci-defaults/50_luci-mod-admin-full
@@ -5,7 +5,7 @@ if [ "$(uci -q get luci.diag)" != "internal" ]; then
 
 	if [ -s /etc/os-release ]; then
 		. /etc/os-release
-		host="${HOME_URL:-${BUG_URL:-$LEDE_DEVICE_MANUFACTURER_URL}}"
+		host="${HOME_URL:-${BUG_URL:-$OPENWRT_DEVICE_MANUFACTURER_URL}}"
 		host="${host#*://}"
 		host="${host%%/*}"
 	fi


### PR DESCRIPTION
This is a followup to commit 8a34a54b6aa6 ("base-files: use OPENWRT prefix for os-release variables") in the base repo.  It changes the prefix of the os-release variables from LEDE_ to OPENWRT_.  

luci-mod-network was the only place I found where any of these variables were in use

Signed-off-by: Bjørn Mork <bjorn@mork.no>