### PR TITLE
luci-mod-system: fix some led trigger name translations

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -1197,7 +1197,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2142,7 +2142,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -1193,7 +1193,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2144,7 +2144,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -1235,7 +1235,7 @@ msgstr ""
 "Werkseinstellungen zurückgesetzt werden."
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2203,7 +2203,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr "Anzahl Header-Error-Code-Fehler (HEC)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -1202,7 +1202,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2158,7 +2158,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -1190,7 +1190,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2134,7 +2134,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -1235,7 +1235,7 @@ msgstr ""
 "sistema. Para evitar esto, primero realice un restablecimiento de fábrica."
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr "Intervalo de flash personalizado (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2204,7 +2204,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr "Errores de código de error de encabezado (HEC)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr "Intervalo de ritmo (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -1205,7 +1205,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2165,7 +2165,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -1184,7 +1184,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2120,7 +2120,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -1200,7 +1200,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2154,7 +2154,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -1206,7 +1206,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2159,7 +2159,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -1216,7 +1216,7 @@ msgstr ""
 "防ぐには、まず最初に factory-reset を行います。"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr "カスタムな点滅間隔 (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2177,7 +2177,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr "ハートビート (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -1184,7 +1184,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2128,7 +2128,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -1169,7 +1169,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2105,7 +2105,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -1190,7 +1190,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2141,7 +2141,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -1222,7 +1222,7 @@ msgstr ""
 "temu, wykonaj najpierw reset do ustawień fabrycznych"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr "Własny interwał flash (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2184,7 +2184,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr "Błędy kodu nagłówka (HEC)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr "Interwał Heartbeata (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -1254,7 +1254,7 @@ msgstr ""
 "Para evitar isso, restaure antes as configurações inicias."
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2246,7 +2246,7 @@ msgstr ""
 "abbr>)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -1203,7 +1203,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2159,7 +2159,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -1179,7 +1179,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2112,7 +2112,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -1242,7 +1242,7 @@ msgstr ""
 "Чтобы этого не произошло, выполните сначала сброс к заводским настройкам."
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr "Произвольный интервал мигания (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2206,7 +2206,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr "Ошибки контроля ошибок заголовка (HEC)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr "Интервал heartbeat (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -1163,7 +1163,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2093,7 +2093,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -1176,7 +1176,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2112,7 +2112,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -1178,7 +1178,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2110,7 +2110,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -1248,7 +1248,7 @@ msgstr ""
 "початкового стану."
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr "Користувацький інтервал спалаху (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2218,7 +2218,7 @@ msgstr ""
 "abbr>)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr "Інтервал пульсації (%s)"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -1169,7 +1169,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2110,7 +2110,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -1190,7 +1190,7 @@ msgstr ""
 "自定义文件（证书、脚本）会保留在系统上。若无需保留，请先执行恢复出厂设置。"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr "自定义闪烁间隔（%s）"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2134,7 +2134,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr "请求头错误代码错误（HEC）"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr "心跳间隔（%s）"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -1178,7 +1178,7 @@ msgid ""
 msgstr "已修改的檔案(如憑證和腳本)可能會殘留在系統中.如果要避免這項問題,您可以先行重設裝置"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -2121,7 +2121,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14

--- a/modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua
+++ b/modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua
@@ -49,11 +49,11 @@ for t in triggers:gmatch("[%w-]+") do
 	elseif t == "none" then
 		trigger:value(t, translatef("Always off (%s)", t))
 	elseif t == "timer" then
-		trigger:value(t, translatef("Custom flash intervall (%s)", t))
+		trigger:value(t, translatef("Custom flash interval (%s)", t))
 	elseif t == "netdev" then
 		trigger:value(t, translatef("Network device activity (%s)", t))
 	elseif t == "heartbeat" then
-		trigger:value(t, translatef("Heartbeat intervall (%s)", t))
+		trigger:value(t, translatef("Heartbeat interval (%s)", t))
 	elseif t == "nand-disk" then
 		trigger:value(t, translatef("Flashmemory write access (%s)", t))
 	elseif t == "mtd" then


### PR DESCRIPTION
@feckert This fixes 2 typos introduced by commit a56935c241f84f5870057555b9d029a7732ef049