### PR TITLE
Fix a overview page style issue for various themes

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1985,6 +1985,7 @@ table table td,
 
 .network-status-table .ifacebox-body > span {
 	flex: 10 10 auto;
+	height: 100%;
 }
 
 .network-status-table .ifacebox-body > div {

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1776,6 +1776,7 @@ td > .ifacebadge,
 
 .network-status-table .ifacebox-body > span {
 	flex: 10 10 auto;
+	height: 100%;
 }
 
 .network-status-table .ifacebox-body > div {

--- a/themes/luci-theme-rosy/htdocs/luci-static/rosy/cascade.css
+++ b/themes/luci-theme-rosy/htdocs/luci-static/rosy/cascade.css
@@ -1632,6 +1632,7 @@ td > .ifacebadge,
 .network-status-table .ifacebox-body > span {
 	flex: 10 10 auto;
 	font-size: 12px;
+	height: 100%;
 }
 
 .network-status-table .ifacebox-body > div {


### PR DESCRIPTION
This PR should fix a style issue with interface boxes, which is described in PR #2758.

Tested with browsers:
- Google Chrome 75.0.3770.100
- Mozilla Firefox 67.0.4
- Opera 60.0.3255.170
- Internet Explorer 11.0.9600.18817
