### PR TITLE
luci-app-travelmate: sync with update 1.4.8

### DIFF
--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
@@ -139,4 +139,10 @@ e8.default = 60
 e8.datatype = "range(30,300)"
 e8.rmempty = false
 
+e10 = e:option(Value, "trm_scanbuffer", translate("Scan Buffer Size"),
+  translate("Buffer size in bytes to prepare nearby scan results."))
+e10.default = 1024
+e10.datatype = "range(512,4096)"
+e10.optional = true
+
 return m

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua
@@ -1,4 +1,4 @@
--- Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
+-- Copyright 2017-2019 Dirk Brenken (dev@brenken.org)
 -- This is free software, licensed under the Apache License, Version 2.0
 
 local fs   = require("nixio.fs")
@@ -29,8 +29,8 @@ if s ~= nil then
 	bssid.default = s.bssid or ""
 
 	s.cipher = "auto"
-	if string.match(s.encryption, '\+') and not string.match(s.encryption, '^wep') then
-		s.pos = string.find(s.encryption, '\+')
+	if string.match(s.encryption, '%+') and not string.match(s.encryption, '^wep') then
+		s.pos = string.find(s.encryption, '%+')
 		s.cipher = string.sub(s.encryption, s.pos + 1)
 		s.encryption = string.sub(s.encryption, 0, s.pos - 1)
 	end

--- a/applications/luci-app-travelmate/po/pt-br/travelmate.po
+++ b/applications/luci-app-travelmate/po/pt-br/travelmate.po
@@ -595,3 +595,11 @@ msgstr ""
 
 #~ msgid "Restrict travelmate to a dedicated radio, e.g. 'radio0'."
 #~ msgstr "Restringir o travelmate a um rádio dedicado (ex: 'radio0')."
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:142
+msgid "Scan Buffer Size"
+msgstr ""
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:143
+msgid "Buffer size in bytes to prepare nearby scan results."
+msgstr ""

--- a/applications/luci-app-travelmate/po/ru/travelmate.po
+++ b/applications/luci-app-travelmate/po/ru/travelmate.po
@@ -688,3 +688,11 @@ msgstr ""
 
 #~ msgid "running"
 #~ msgstr "работает"
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:142
+msgid "Scan Buffer Size"
+msgstr ""
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:143
+msgid "Buffer size in bytes to prepare nearby scan results."
+msgstr ""

--- a/applications/luci-app-travelmate/po/templates/travelmate.pot
+++ b/applications/luci-app-travelmate/po/templates/travelmate.pot
@@ -539,3 +539,11 @@ msgstr ""
 #: applications/luci-app-travelmate/luasrc/view/travelmate/runtime.htm:197
 msgid "with SSID"
 msgstr ""
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:142
+msgid "Scan Buffer Size"
+msgstr ""
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:143
+msgid "Buffer size in bytes to prepare nearby scan results."
+msgstr ""

--- a/applications/luci-app-travelmate/po/zh-cn/travelmate.po
+++ b/applications/luci-app-travelmate/po/zh-cn/travelmate.po
@@ -557,3 +557,11 @@ msgstr "隐藏"
 #: applications/luci-app-travelmate/luasrc/view/travelmate/runtime.htm:197
 msgid "with SSID"
 msgstr "带 SSID"
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:142
+msgid "Scan Buffer Size"
+msgstr ""
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:143
+msgid "Buffer size in bytes to prepare nearby scan results."
+msgstr ""

--- a/applications/luci-app-travelmate/po/zh-tw/travelmate.po
+++ b/applications/luci-app-travelmate/po/zh-tw/travelmate.po
@@ -558,3 +558,11 @@ msgstr "隱藏"
 #: applications/luci-app-travelmate/luasrc/view/travelmate/runtime.htm:197
 msgid "with SSID"
 msgstr "帶 SSID"
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:142
+msgid "Scan Buffer Size"
+msgstr ""
+
+#: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:143
+msgid "Buffer size in bytes to prepare nearby scan results."
+msgstr ""


### PR DESCRIPTION
* add optional 'trm_scanbuffer' parm
* fix wrong lua escape character in wifi edit
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>