### PR TITLE
system-wide: fix escaping of magic chars

### DIFF
--- a/applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua
+++ b/applications/luci-app-ocserv/luasrc/model/cbi/ocserv/users.lua
@@ -26,7 +26,7 @@ pwd.password = false
 
 function pwd.write(self, section, value)
 	local pass
-	if string.match(value, "^\$%d\$.*") then
+	if string.match(value, "^%$%d%$.*") then
 		pass = value
 	else
 		local t = tonumber(nixio.getpid()*os.time())

--- a/modules/luci-base/luasrc/cbi/datatypes.lua
+++ b/modules/luci-base/luasrc/cbi/datatypes.lua
@@ -418,7 +418,7 @@ function maxlength(val, max)
 end
 
 function phonedigit(val)
-	return (val:match("^[0-9\*#!%.]+$") ~= nil)
+	return (val:match("^[0-9%*#!%.]+$") ~= nil)
 end
 
 function timehhmmss(val)

--- a/modules/luci-base/luasrc/util.lua
+++ b/modules/luci-base/luasrc/util.lua
@@ -207,9 +207,8 @@ end
 -- handling.  It may actually be a property of the getopt function
 -- rather than the shell proper.
 function shellstartsqescape(value)
-   res, _ = string.gsub(value, "^\-", "\\-")
-   res, _ = string.gsub(res, "^-", "\-")
-   return shellsqescape(value)
+   res, _ = string.gsub(value, "^%-", "\\-")
+   return shellsqescape(res)
 end
 
 -- containing the resulting substrings. The optional max parameter specifies


### PR DESCRIPTION
* fix escaping of magic lua chars (#2800)
* fix redundant second gsub line in shellstartsqescape function
* fix return value of shellstartsqescape function

Signed-off-by: Dirk Brenken <dev@brenken.org>