### PR TITLE
luci-mod-system: fix flash activity trigger name

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -61,7 +61,6 @@ msgstr "-- Camp addicional --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Escolliu, si us plau --"
 
@@ -332,7 +331,7 @@ msgstr "Rutes <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> actives"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Rutes <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> actives"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Connexions actives"
@@ -670,7 +669,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Autenticació"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -695,7 +694,7 @@ msgstr "Refresc automàtic"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -733,9 +732,9 @@ msgstr "Disponible"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1054,12 +1053,13 @@ msgstr "Tanca la llista..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Aplegant dades..."
 
@@ -1379,7 +1379,7 @@ msgid "Description"
 msgstr "Descripció"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destí"
 
@@ -1418,6 +1418,7 @@ msgid "Diagnostics"
 msgstr "Diagnòstics"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1450,9 +1451,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1647,7 +1648,7 @@ msgstr "Habilita l'<abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1715,13 +1716,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Activa/Desactiva"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Habilitat"
 
@@ -1934,6 +1935,12 @@ msgstr "Escriptura del microprogramari a la memòria flaix"
 msgid "Flash image..."
 msgstr "Puja una imatge..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Escriu una imatge nova a la memòria flaix"
@@ -1945,12 +1952,6 @@ msgstr "Operacions a la memòria flaix"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Escrivint a la memòria flaix..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2444,7 +2445,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2458,7 +2459,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2534,11 +2535,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Script d'inici"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Scripts d'inici"
 
@@ -2897,7 +2898,7 @@ msgstr "Adreça IPv6 local"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Inici local"
 
@@ -3029,7 +3030,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3058,7 +3059,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3150,7 +3152,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Temps d'espera d'inici de mòdem"
 
@@ -3276,7 +3279,7 @@ msgstr "Màscara de xarxa"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3325,7 +3328,7 @@ msgstr "Cap fitxer trobat"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "No hi ha informació disponible"
 
@@ -3579,7 +3582,7 @@ msgstr ""
 msgid "Options"
 msgstr "Opcions"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Altres:"
 
@@ -3657,7 +3660,7 @@ msgstr "Propietari"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Contrasenya PAP/CHAP"
 
@@ -3668,7 +3671,7 @@ msgstr "Contrasenya PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Nom d'usuari PAP/CHAP"
 
@@ -3799,9 +3802,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3859,7 +3862,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Paquets"
 
@@ -3956,7 +3959,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -4098,7 +4101,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Connexions en temps real"
 
@@ -4272,7 +4275,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Reinicia"
 
@@ -4628,7 +4631,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Origen"
@@ -4675,11 +4678,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Especifiqueu el clau de xifració secret aquí."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Inici"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Prioritat d'inici"
 
@@ -4734,7 +4737,7 @@ msgid "Status"
 msgstr "Estat"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Atura"
 
@@ -4838,7 +4841,7 @@ msgstr "Propietats del sistema"
 msgid "System log buffer size"
 msgstr "Mida de la memòria intermèdia per al registre del sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5136,7 +5139,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5187,7 +5190,7 @@ msgstr ""
 "Aquesta llista mostra una vista general sobre els processos corrent al "
 "sistema actualment i el seu estat."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Aquesta pàgina ofereix una vista general de les connexions de xarxa actives "
@@ -5250,7 +5253,7 @@ msgstr "Rastre de ruta"
 msgid "Traffic"
 msgstr "Trànsit"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transferència"
 
@@ -5305,7 +5308,7 @@ msgstr "Potència Tx"
 msgid "Type"
 msgstr "Tipus"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5442,7 +5445,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5494,7 +5497,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5508,7 +5511,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5528,7 +5531,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5800,7 +5803,7 @@ msgstr "Escriure el registre del sistema al fitxer"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -59,7 +59,6 @@ msgstr "-- Doplňující pole --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Prosím vyberte --"
 
@@ -331,7 +330,7 @@ msgstr ""
 "Aktivní záznamy ve směrovací tabulce <abbr title=\"Internet Protocol Version "
 "6\">IPv6</abbr>"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Aktivní spojení"
@@ -666,7 +665,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Autentizace"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -691,7 +690,7 @@ msgstr "Automaticky obnovovat"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -729,9 +728,9 @@ msgstr "Dostupné"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1050,12 +1049,13 @@ msgstr "Zavřít seznam..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Probíhá sběr dat..."
 
@@ -1377,7 +1377,7 @@ msgid "Description"
 msgstr "Popis"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Cíl"
 
@@ -1416,6 +1416,7 @@ msgid "Diagnostics"
 msgstr "Diagnostika"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1448,9 +1449,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1649,7 +1650,7 @@ msgstr "Povolit <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Povolit dynamickou aktualizaci koncového bodu HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1717,13 +1718,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "Povolit tento swapovací oddíl"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Povolit/Zakázat"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Povoleno"
 
@@ -1938,6 +1939,12 @@ msgstr "Nahrát firmware"
 msgid "Flash image..."
 msgstr "Nahrát obraz..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Nahrát nový obraz s firmwarem"
@@ -1949,12 +1956,6 @@ msgstr "Operace nad flash pamětí"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Nahrávám..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2446,7 +2447,7 @@ msgstr "Namísto pevného uzlu zařízení připojovat pomocí názvu oddílu"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2460,7 +2461,7 @@ msgstr "Pokud není povoleno, není nastaven žádný výchozí směrovací záz
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2536,11 +2537,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Initskript"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Initskripty"
 
@@ -2902,7 +2903,7 @@ msgstr "Místní IPv6 adresa"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Místní startup"
 
@@ -3040,7 +3041,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3069,7 +3070,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Nejvyšší povolená velikost EDNS.0 UDP paketů"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Nejvyšší počet sekund čekání, než bude modem připraven"
 
@@ -3161,7 +3163,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Časový limit inicializace modemu"
 
@@ -3287,7 +3290,7 @@ msgstr "Síťová maska"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3336,7 +3339,7 @@ msgstr "Nebyly nalezeny žádné soubory"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Údaje nejsou k dispozici"
 
@@ -3589,7 +3592,7 @@ msgstr ""
 msgid "Options"
 msgstr "Možnosti"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Ostatní:"
 
@@ -3669,7 +3672,7 @@ msgstr "Vlastník"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Heslo PAP/CHAP"
 
@@ -3680,7 +3683,7 @@ msgstr "Heslo PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Uživatelské jméno PAP/CHAP"
 
@@ -3811,9 +3814,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3871,7 +3874,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Paketů"
 
@@ -3970,7 +3973,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protokol"
 
@@ -4115,7 +4118,7 @@ msgstr "Opravdu resetovat všechny změny?"
 msgid "Really switch protocol?"
 msgstr "Opravdu prohodit protokol?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Připojení v reálném čase"
 
@@ -4290,7 +4293,7 @@ msgstr "Soubor resolve"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Restart"
 
@@ -4650,7 +4653,7 @@ msgstr ""
 "wiki pro zařízení specifické instalační instrukce."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Zdroj"
@@ -4699,11 +4702,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Zde nastavte soukromý šifrovací klíč."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Start"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Priorita spouštění"
 
@@ -4761,7 +4764,7 @@ msgid "Status"
 msgstr "Stav"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Stop"
 
@@ -4865,7 +4868,7 @@ msgstr "Vlastnosti systému"
 msgid "System log buffer size"
 msgstr "Velikost bufferu systémového logu"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5172,7 +5175,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5222,7 +5225,7 @@ msgstr ""
 "V tomto seznamu vidíte přehled aktuálně běžících systémových procesů a "
 "jejich stavy."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "Tato stránka zobrazuje přehled aktivních síťových spojení."
 
@@ -5282,7 +5285,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "Provoz"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Přenos"
 
@@ -5337,7 +5340,7 @@ msgstr "Tx-Power"
 msgid "Type"
 msgstr "Typ"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5474,7 +5477,7 @@ msgstr "Použít DHCP bránu"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5526,7 +5529,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5540,7 +5543,7 @@ msgstr "Použít vlastní DNS servery"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5560,7 +5563,7 @@ msgstr "Použít výchozí bránu"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5835,7 +5838,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -61,7 +61,6 @@ msgstr "-- Zusätzliches Feld --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Bitte auswählen --"
 
@@ -333,7 +332,7 @@ msgstr "Aktive IPv4-Routen"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Aktive IPv6-Routen"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Aktive Verbindungen"
@@ -685,7 +684,7 @@ msgstr "Berechtigungsgruppe"
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr "Authentifizierungstyp"
 
@@ -710,7 +709,7 @@ msgstr "Automatisches Neuladen"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -748,9 +747,9 @@ msgstr "Verfügbar"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1081,12 +1080,13 @@ msgstr "Schließe Liste..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Sammle Daten..."
 
@@ -1417,7 +1417,7 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Ziel"
 
@@ -1456,6 +1456,7 @@ msgid "Diagnostics"
 msgstr "Diagnosen"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr "Einwahlnummer"
 
@@ -1488,9 +1489,9 @@ msgstr "Inaktivitäts-Proben deaktivieren"
 msgid "Disable this network"
 msgstr "Dieses Netzwerk deaktivieren"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1694,7 +1695,7 @@ msgstr "<abbr title=\"Spanning Tree Protocol\">STP</abbr> aktivieren"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Dynamisches HE.net IP-Adress-Update aktivieren"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "IPv6 anfordern"
 
@@ -1762,13 +1763,13 @@ msgstr "Dieses Netzwerk aktivieren"
 msgid "Enable this swap"
 msgstr "Diesen Auslagerungsspeicher aktivieren"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Aktivieren/Deaktivieren"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Aktiviert"
 
@@ -1991,6 +1992,12 @@ msgstr "Firmware aktualisieren"
 msgid "Flash image..."
 msgstr "Firmware aktualisieren..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Neues Firmware Image schreiben"
@@ -2002,12 +2009,6 @@ msgstr "Flash-Operationen"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Firmware wird installiert..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2508,7 +2509,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2522,7 +2523,7 @@ msgstr "Wenn deaktiviert, wird keine Default-Route gesetzt"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2599,11 +2600,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr "Initialisierung fehlgeschlagen"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Startscript"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Startscripte"
 
@@ -2982,7 +2983,7 @@ msgstr "Lokale IPv6 Adresse"
 msgid "Local Service Only"
 msgstr "Nur lokale Dienste"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Lokales Startskript"
 
@@ -3122,7 +3123,7 @@ msgid ""
 msgstr "Das Root-Dateisystem muss mit folgenden Kommandsos vorbereitet werden:"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3151,7 +3152,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Maximal zulässige Größe von EDNS.0 UDP Paketen"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Maximale Zeit die gewartet wird bis das Modem bereit ist (in Sekunden)"
 
@@ -3246,7 +3248,8 @@ msgid "Modem information query failed"
 msgstr "Modem-Informationsabfrage fehlgeschlagen"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Wartezeit für Modeminitialisierung"
 
@@ -3372,7 +3375,7 @@ msgstr "Netzmaske"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3421,7 +3424,7 @@ msgstr "Keine Dateien gefunden"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Keine Informationen verfügbar"
 
@@ -3691,7 +3694,7 @@ msgstr ""
 msgid "Options"
 msgstr "Optionen"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Andere:"
 
@@ -3771,7 +3774,7 @@ msgstr "Besitzer"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "PAP/CHAP Passwort"
 
@@ -3782,7 +3785,7 @@ msgstr "PAP/CHAP Passwort"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "PAP/CHAP Benutzername"
 
@@ -3913,9 +3916,9 @@ msgstr "Pfad zum inneren, privaten Schlüssel"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3973,7 +3976,7 @@ msgstr "Ping-Anfrage"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pkte."
 
@@ -4072,7 +4075,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protokoll"
 
@@ -4230,7 +4233,7 @@ msgstr "Sollen wirklich alle Änderungen verworfen werden?"
 msgid "Really switch protocol?"
 msgstr "Protokoll wirklich wechseln?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Echtzeitverbindungen"
 
@@ -4413,7 +4416,7 @@ msgstr "Resolv-Datei"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Neustarten"
 
@@ -4781,7 +4784,7 @@ msgstr ""
 "Installationsanleitungen entnehmen Sie bitte dem Wiki."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Quelle"
@@ -4836,11 +4839,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Geben Sie hier den geheimen Netzwerkschlüssel an"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Start"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Startpriorität"
 
@@ -4899,7 +4902,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Stoppen"
 
@@ -5006,7 +5009,7 @@ msgstr "Systemeigenschaften"
 msgid "System log buffer size"
 msgstr "Größe des Systemprotokoll-Puffers"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5342,7 +5345,7 @@ msgstr ""
 "wurde oder das normale Account-Passwort wenn kein separater Schlüssel "
 "gesetzt wurde."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5395,7 +5398,7 @@ msgstr ""
 "Diese Tabelle gibt eine Übersicht über aktuell laufende Systemprozesse und "
 "deren Status."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "Diese Seite gibt eine Übersicht über aktive Netzwerkverbindungen."
 
@@ -5457,7 +5460,7 @@ msgstr "Routenverfolgung"
 msgid "Traffic"
 msgstr "Traffic"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transfer"
 
@@ -5512,7 +5515,7 @@ msgstr "Sendestärke"
 msgid "Type"
 msgstr "Typ"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5649,7 +5652,7 @@ msgstr "Benutze DHCP-Gateway"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5701,7 +5704,7 @@ msgstr "Eingebautes IPv6-Management nutzen"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5715,7 +5718,7 @@ msgstr "Benutze eigene DNS-Server"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5735,7 +5738,7 @@ msgstr "Benutze Standard-Gateway"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -6018,7 +6021,7 @@ msgstr "Systemprotokoll in Datei schreiben"
 msgid "Yes"
 msgstr "Ja"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -61,7 +61,6 @@ msgstr "-- Επιπλέον Πεδίο --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Παρακαλώ επιλέξτε --"
 
@@ -332,7 +331,7 @@ msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Ενεργές Διαδρομές <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Ενεργές Συνδέσεις"
@@ -673,7 +672,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Εξουσιοδότηση"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -698,7 +697,7 @@ msgstr "Αυτόματη Ανανέωση"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -736,9 +735,9 @@ msgstr "Διαθέσιμο"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1059,12 +1058,13 @@ msgstr "Κλείσιμο λίστας..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Συλλογή δεδομένων..."
 
@@ -1386,7 +1386,7 @@ msgid "Description"
 msgstr "Περιγραφή"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Προορισμός"
 
@@ -1425,6 +1425,7 @@ msgid "Diagnostics"
 msgstr "Διαγνωστικά"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1457,9 +1458,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1661,7 +1662,7 @@ msgstr "Ενεργοποίηση <abbr title=\"Spanning Tree Protocol\">STP</abb
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Ενεργοποίηση ενημέρωσης δυναμικού τερματικού σημείου HE.net."
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1729,13 +1730,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "Ενεργοποίηση αυτής της swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Ενεργοποίηση/Απενεργοποίηση"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Ενεργοποιημένο"
 
@@ -1951,6 +1952,12 @@ msgstr "Φλασάρισμα Firmware"
 msgid "Flash image..."
 msgstr "Φλασάρισμα εικόνας..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Φλασάρισμα νέας εικόνας υλικολογισμικού"
@@ -1962,12 +1969,6 @@ msgstr "Λειτουργίες φλασάρισματος"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Φλασάρεται..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2464,7 +2465,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2478,7 +2479,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2554,11 +2555,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Σενάριο εκκίνησης"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Σενάρια Εκκίνησης"
 
@@ -2915,7 +2916,7 @@ msgstr "Τοπική διεύθυνση IPv6"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -3047,7 +3048,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3076,7 +3077,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Μέγιστο επιτρεπόμενο μέγεθος EDNS.0 UDP πακέτων"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 "Μέγιστος αριθμός δευτερολέπτων αναμονής ώστε το modem να καταστεί έτοιμο"
@@ -3169,7 +3171,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3296,7 +3299,7 @@ msgstr "Μάσκα δικτύου"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3345,7 +3348,7 @@ msgstr "Δε βρέθηκαν αρχεία"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Δεν υπάρχουν πληροφορίες διαθέσιμες"
 
@@ -3599,7 +3602,7 @@ msgstr ""
 msgid "Options"
 msgstr "Επιλογές"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3677,7 +3680,7 @@ msgstr "Κάτοχος"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3688,7 +3691,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3819,9 +3822,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3879,7 +3882,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Πκτ."
 
@@ -3977,7 +3980,7 @@ msgstr "Πρωτ."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Πρωτόκολλο"
 
@@ -4119,7 +4122,7 @@ msgstr "Αρχικοποίηση όλων των αλλαγών;"
 msgid "Really switch protocol?"
 msgstr "Αλλαγή πρωτοκόλλου;"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Συνδέσεις πραγματικού χρόνου"
 
@@ -4293,7 +4296,7 @@ msgstr "Αρχείο Resolve"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Επανεκκίνηση"
 
@@ -4650,7 +4653,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Πηγή"
@@ -4699,11 +4702,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Ορίστε το κρυφό κλειδί κρυπτογράφησης."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Αρχή"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Προτεραιότητα εκκίνησης"
 
@@ -4758,7 +4761,7 @@ msgid "Status"
 msgstr "Κατάσταση"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr ""
 
@@ -4862,7 +4865,7 @@ msgstr "Ιδιότητες Συστήματος"
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5145,7 +5148,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5193,7 +5196,7 @@ msgstr ""
 "Αυτή η λίστα δίνει μία εικόνα των τρέχοντων εργασιών συστήματος και της "
 "κατάστασής τους."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Αυτή η σελίδα δίνει μία εικόνα για τις τρέχουσες ενεργές συνδέσεις δικτύου."
@@ -5255,7 +5258,7 @@ msgstr ""
 msgid "Traffic"
 msgstr "Κίνηση"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Μεταφέρθηκαν"
 
@@ -5310,7 +5313,7 @@ msgstr "Ισχύς Εκπομπής"
 msgid "Type"
 msgstr "Τύπος"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5444,7 +5447,7 @@ msgstr "Χρήση πύλης DHCP"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5496,7 +5499,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5510,7 +5513,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5530,7 +5533,7 @@ msgstr "Χρήση προεπιλεγμένης πύλης"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5800,7 +5803,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -61,7 +61,6 @@ msgstr "-- Additional Field --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Please choose --"
 
@@ -330,7 +329,7 @@ msgstr "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Active Connections"
@@ -664,7 +663,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Authentication"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -689,7 +688,7 @@ msgstr "Auto Refresh"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -727,9 +726,9 @@ msgstr "Available"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1047,12 +1046,13 @@ msgstr "Close list..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Collecting data..."
 
@@ -1375,7 +1375,7 @@ msgid "Description"
 msgstr "Description"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destination"
 
@@ -1414,6 +1414,7 @@ msgid "Diagnostics"
 msgstr "Diagnostics"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1444,9 +1445,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1641,7 +1642,7 @@ msgstr "Enable <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1709,13 +1710,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Enable/Disable"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Enabled"
 
@@ -1928,6 +1929,12 @@ msgstr "Flash Firmware"
 msgid "Flash image..."
 msgstr ""
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr ""
@@ -1938,12 +1945,6 @@ msgstr ""
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2435,7 +2436,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2449,7 +2450,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2524,11 +2525,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Initscript"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Initscripts"
 
@@ -2885,7 +2886,7 @@ msgstr ""
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -3017,7 +3018,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3046,7 +3047,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3138,7 +3140,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3264,7 +3267,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3313,7 +3316,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr ""
 
@@ -3567,7 +3570,7 @@ msgstr ""
 msgid "Options"
 msgstr "Options"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3645,7 +3648,7 @@ msgstr "Owner"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3656,7 +3659,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3787,9 +3790,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3847,7 +3850,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pkts."
 
@@ -3944,7 +3947,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -4086,7 +4089,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr ""
 
@@ -4260,7 +4263,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Restart"
 
@@ -4615,7 +4618,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Source"
@@ -4662,11 +4665,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Start"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Start priority"
 
@@ -4721,7 +4724,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Stop"
 
@@ -4825,7 +4828,7 @@ msgstr ""
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr ""
 
@@ -5106,7 +5109,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5152,7 +5155,7 @@ msgstr ""
 "This list gives an overview over currently running system processes and "
 "their status."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "This page gives an overview over currently active network connections."
 
@@ -5212,7 +5215,7 @@ msgstr ""
 msgid "Traffic"
 msgstr "Traffic"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transfer"
 
@@ -5267,7 +5270,7 @@ msgstr ""
 msgid "Type"
 msgstr "Type"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr ""
 
@@ -5401,7 +5404,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5453,7 +5456,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5467,7 +5470,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5487,7 +5490,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5759,7 +5762,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -61,7 +61,6 @@ msgstr "-- Campo adicional --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Por favor elija --"
 
@@ -335,7 +334,7 @@ msgstr "Rutas <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> activas"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Rutas <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> activas"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Conexiones activas"
@@ -686,7 +685,7 @@ msgstr "Grupo de autenticaciones"
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr "Tipo de autenticación"
 
@@ -711,7 +710,7 @@ msgstr "Autorefrescar"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -751,9 +750,9 @@ msgstr "Disponible"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1081,12 +1080,13 @@ msgstr "Cerrar lista..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Un momento..."
 
@@ -1420,7 +1420,7 @@ msgid "Description"
 msgstr "Descripción"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destino"
 
@@ -1459,6 +1459,7 @@ msgid "Diagnostics"
 msgstr "Diagnósticos"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr "Marcar el número"
 
@@ -1491,9 +1492,9 @@ msgstr "Deshabilitar el sondeo de inactividad"
 msgid "Disable this network"
 msgstr "Deshabilitar esta red"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1696,7 +1697,7 @@ msgstr "Habilitar <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Habilitar actualización dinámica de punto final HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "Habilitar negociación IPv6"
 
@@ -1765,13 +1766,13 @@ msgstr "Habilitar esta red"
 msgid "Enable this swap"
 msgstr "Habilitar este swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Habilitar/Deshabilitar"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Habilitado"
 
@@ -1993,6 +1994,12 @@ msgstr "Grabar firmware"
 msgid "Flash image..."
 msgstr "Grabar imagen..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Grabar nueva imagen de firmware"
@@ -2004,12 +2011,6 @@ msgstr "Operaciones de grabado"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Grabando..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr "Acceso de escritura de memoria flash (%s)"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2509,7 +2510,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2523,7 +2524,7 @@ msgstr "Si está desmarcado no se configurará una ruta por defecto"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2603,11 +2604,11 @@ msgstr "Información"
 msgid "Initialization failure"
 msgstr "Fallo de inicialización"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Nombre del script de inicio"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Scripts de inicio"
 
@@ -2978,7 +2979,7 @@ msgstr "Dirección local IPv6"
 msgid "Local Service Only"
 msgstr "Solo servicio local"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Arranque local"
 
@@ -3118,7 +3119,7 @@ msgstr ""
 "siguientes comandos:"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3147,7 +3148,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Tamaño máximo de paquetes EDNS.0 paquetes UDP"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Segundos máximos de espera a que el módem esté activo"
 
@@ -3241,7 +3243,8 @@ msgid "Modem information query failed"
 msgstr "Error en la consulta de información del módem"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Espera de inicialización del modem"
 
@@ -3367,7 +3370,7 @@ msgstr "Máscara de red"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3416,7 +3419,7 @@ msgstr "No se han encontrado archivos"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "No hay información disponible"
 
@@ -3684,7 +3687,7 @@ msgstr "Opcional. Puerto UDP utilizado para paquetes salientes y entrantes."
 msgid "Options"
 msgstr "Opciones"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Otros:"
 
@@ -3764,7 +3767,7 @@ msgstr "Propietario"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Contraseña PAP/CHAP"
 
@@ -3775,7 +3778,7 @@ msgstr "Contraseña PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Nombre de usuario PAP/CHAP"
 
@@ -3906,9 +3909,9 @@ msgstr "Ruta a la clave privada interna"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3966,7 +3969,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Paq."
 
@@ -4065,7 +4068,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocolo"
 
@@ -4224,7 +4227,7 @@ msgstr "¿Está seguro de restablecer todos los cambios?"
 msgid "Really switch protocol?"
 msgstr "¿Está seguro de querer cambiar el protocolo?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Conexiones en tiempo real"
 
@@ -4405,7 +4408,7 @@ msgstr "Archivo de resolución"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -4771,7 +4774,7 @@ msgstr ""
 "instalación específicas."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Origen"
@@ -4827,11 +4830,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Especifique la clave de encriptación."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Iniciar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Prioridad de inicio"
 
@@ -4890,7 +4893,7 @@ msgid "Status"
 msgstr "Estado"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Detener"
 
@@ -4996,7 +4999,7 @@ msgstr "Propiedades del sistema"
 msgid "System log buffer size"
 msgstr "Tamaño del buffer de registro del sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5328,7 +5331,7 @@ msgstr ""
 "contraseña de la cuenta si no se ha configurado ninguna clave de "
 "actualización"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5380,7 +5383,7 @@ msgid ""
 "their status."
 msgstr "Procesos del sistema que se están ejecutando actualmente y su estado."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "Conexiones de red activas."
 
@@ -5441,7 +5444,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "Tráfico"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transferencia"
 
@@ -5496,7 +5499,7 @@ msgstr "Potencia-TX"
 msgid "Type"
 msgstr "Tipo"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5633,7 +5636,7 @@ msgstr "Usar puerta de enlace DHCP"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5685,7 +5688,7 @@ msgstr "Utilizar la gestión integrada de IPv6"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5699,7 +5702,7 @@ msgstr "Usar servidores DNS personalizados"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5719,7 +5722,7 @@ msgstr "Utilizar la puerta de enlace predeterminada"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -6000,7 +6003,7 @@ msgstr "Escribe el registro del sistema al archivo"
 msgid "Yes"
 msgstr "Si"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "
@@ -6495,6 +6498,9 @@ msgstr "Si"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Volver"
+
+#~ msgid "Flashmemory write access (%s)"
+#~ msgstr "Acceso de escritura de memoria flash (%s)"
 
 #~ msgid ""
 #~ "one of:\n"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -61,7 +61,6 @@ msgstr "-- Champ Supplémentaire --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Choisir --"
 
@@ -335,7 +334,7 @@ msgstr "Routes <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> actives"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Routes <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> actives"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Connexions actives"
@@ -676,7 +675,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Authentification"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -701,7 +700,7 @@ msgstr "Rafraîchissement automatique"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -739,9 +738,9 @@ msgstr "Disponible"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1062,12 +1061,13 @@ msgstr "Fermer la liste…"
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Récupération de données..."
 
@@ -1390,7 +1390,7 @@ msgid "Description"
 msgstr "Description"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destination"
 
@@ -1429,6 +1429,7 @@ msgid "Diagnostics"
 msgstr "Diagnostics"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1461,9 +1462,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1665,7 +1666,7 @@ msgstr "Activer le protocole <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Activer la mise à jour dynamique de l'extrémité du tunnel chez HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1733,13 +1734,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "Activer cette mémoire d'échange (swap)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Activer/Désactiver"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Activé"
 
@@ -1957,6 +1958,12 @@ msgstr "Mise à jour du micrologiciel"
 msgid "Flash image..."
 msgstr "Écriture de l'image…"
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Écrire l'image du nouveau micrologiciel"
@@ -1968,12 +1975,6 @@ msgstr "Opérations d'écriture"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Écriture…"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2470,7 +2471,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2484,7 +2485,7 @@ msgstr "Décoché, aucune route par défaut n'est configurée"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2558,11 +2559,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Script d'initialisation"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Scripts d'initialisation"
 
@@ -2926,7 +2927,7 @@ msgstr "Adresse IPv6 locale"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Démarrage local"
 
@@ -3067,7 +3068,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3096,7 +3097,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Taille maximum autorisée des paquets UDP EDNS.0"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Délai d'attente maximum que le modem soit prêt"
 
@@ -3188,7 +3190,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Délai max. d'initialisation du modem"
 
@@ -3314,7 +3317,7 @@ msgstr "Masque de réseau"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3363,7 +3366,7 @@ msgstr "Aucun fichier trouvé"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Information indisponible"
 
@@ -3615,7 +3618,7 @@ msgstr ""
 msgid "Options"
 msgstr "Options"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Autres :"
 
@@ -3695,7 +3698,7 @@ msgstr "Propriétaire"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Mot de passe PAP/CHAP"
 
@@ -3706,7 +3709,7 @@ msgstr "Mot de passe PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Identifiant PAP/CHAP"
 
@@ -3837,9 +3840,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3897,7 +3900,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pqts."
 
@@ -3996,7 +3999,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocole"
 
@@ -4140,7 +4143,7 @@ msgstr "Voulez-vous vraiment ré-initialiser toutes les modifications ?"
 msgid "Really switch protocol?"
 msgstr "Voulez-vous vraiment changer de protocole ?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Connexions temps-réel"
 
@@ -4314,7 +4317,7 @@ msgstr "Fichier de résolution des noms"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Redémarrer"
 
@@ -4677,7 +4680,7 @@ msgstr ""
 "matériel."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Source"
@@ -4726,11 +4729,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Spécifiez ici la clé secrète de chiffrage."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Démarrer"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Priorité de démarrage"
 
@@ -4789,7 +4792,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Arrêter"
 
@@ -4893,7 +4896,7 @@ msgstr "Propriétés système"
 msgid "System log buffer size"
 msgstr "Taille du tampon du journal système"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP :"
 
@@ -5211,7 +5214,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5262,7 +5265,7 @@ msgstr ""
 "Cette liste donne une vue d'ensemble des processus en exécution et leur "
 "statut."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Cette page donne une vue d'ensemble des connexions réseaux actuellement "
@@ -5325,7 +5328,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "Trafic"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transfert"
 
@@ -5380,7 +5383,7 @@ msgstr "Puissance d'émission"
 msgid "Type"
 msgstr "Type"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP :"
 
@@ -5518,7 +5521,7 @@ msgstr "Utiliser la passerelle DHCP"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5570,7 +5573,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5584,7 +5587,7 @@ msgstr "Utiliser des serveurs DNS spécifiques"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5604,7 +5607,7 @@ msgstr "Utiliser la passerelle par défaut"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5880,7 +5883,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -59,7 +59,6 @@ msgstr "-- שדה נוסף --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- נא לבחור --"
 
@@ -323,7 +322,7 @@ msgstr ""
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "חיבורים פעילים"
@@ -665,7 +664,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "אימות"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -690,7 +689,7 @@ msgstr "רענון אוטומטי"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -728,9 +727,9 @@ msgstr "זמין"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1041,12 +1040,13 @@ msgstr "סגור רשימה..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "אוסף מידע..."
 
@@ -1368,7 +1368,7 @@ msgid "Description"
 msgstr "תיאור"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "יעד"
 
@@ -1407,6 +1407,7 @@ msgid "Diagnostics"
 msgstr "אבחון"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1437,9 +1438,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1627,7 +1628,7 @@ msgstr "אפשר <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1695,13 +1696,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "אפשר"
 
@@ -1914,6 +1915,12 @@ msgstr ""
 msgid "Flash image..."
 msgstr ""
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr ""
@@ -1924,12 +1931,6 @@ msgstr ""
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2419,7 +2420,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2433,7 +2434,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2503,11 +2504,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr ""
 
@@ -2861,7 +2862,7 @@ msgstr "כתובת IPv6 מקומית"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -2993,7 +2994,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3022,7 +3023,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3114,7 +3116,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3238,7 +3241,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3287,7 +3290,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr ""
 
@@ -3535,7 +3538,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3613,7 +3616,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3624,7 +3627,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3755,9 +3758,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3815,7 +3818,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr ""
 
@@ -3912,7 +3915,7 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr ""
 
@@ -4052,7 +4055,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr ""
 
@@ -4226,7 +4229,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr ""
 
@@ -4582,7 +4585,7 @@ msgstr ""
 "אל ה-wiki של OpenWrt עבור הוראות ספציפיות למכשיר שלך."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "מקור"
@@ -4629,11 +4632,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr ""
 
@@ -4691,7 +4694,7 @@ msgid "Status"
 msgstr "מצב"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "עצור"
 
@@ -4795,7 +4798,7 @@ msgstr ""
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5065,7 +5068,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5107,7 +5110,7 @@ msgid ""
 "their status."
 msgstr "רשימה זו מציגה סקירה של תהליכי המערכת הרצים כרגע ואת מצבם."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "דף זה מציג סקירה של חיבורי הרשת הפעילים כרגע."
 
@@ -5165,7 +5168,7 @@ msgstr ""
 msgid "Traffic"
 msgstr "תעבורה"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "העברה"
 
@@ -5220,7 +5223,7 @@ msgstr "עוצמת שידור"
 msgid "Type"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5354,7 +5357,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5406,7 +5409,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5420,7 +5423,7 @@ msgstr "השתמש בשרתי DNS מותאמים אישית"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5440,7 +5443,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5710,7 +5713,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -59,7 +59,6 @@ msgstr "-- További mező --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Kérem válasszon --"
 
@@ -330,7 +329,7 @@ msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Aktív <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> útvonalak"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Aktív kapcsolatok"
@@ -669,7 +668,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Hitelesítés"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -694,7 +693,7 @@ msgstr "Automatikus frissítés"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -732,9 +731,9 @@ msgstr "Elérhető"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1057,12 +1056,13 @@ msgstr "Lista bezárása..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Adatok összegyűjtése..."
 
@@ -1384,7 +1384,7 @@ msgid "Description"
 msgstr "Leírás"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Cél"
 
@@ -1423,6 +1423,7 @@ msgid "Diagnostics"
 msgstr "Diagnosztika"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1455,9 +1456,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1658,7 +1659,7 @@ msgstr "<abbr title=\"Spanning Tree Protocol\">STP</abbr> engedélyezése"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "HE.net dinamikus végpont frissítésének engedélyezése"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1726,13 +1727,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "A lapozó terület engedélyezése"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Engedélyezés/Letiltás"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Engedélyezve"
 
@@ -1946,6 +1947,12 @@ msgstr "Firmware flash-elés"
 msgid "Flash image..."
 msgstr "Flash image..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Új firmware image flash-elése"
@@ -1957,12 +1964,6 @@ msgstr "Flash műveletek"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Flash-elés..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2457,7 +2458,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2471,7 +2472,7 @@ msgstr "Ha nincs kiválasztva, akkor nincs alapértelmezett útvonal beállítva
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2548,11 +2549,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Indítási állomány"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Indítási állományok"
 
@@ -2916,7 +2917,7 @@ msgstr "Helyi IPv6 cím"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Helyi indítóscript"
 
@@ -3056,7 +3057,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3085,7 +3086,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "EDNS.0 UDP csomagok maximális mérete"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Maximális várakozási idő a modem kész állapotára (másodpercben)"
 
@@ -3177,7 +3179,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Modem inicializálás időtúllépés"
 
@@ -3303,7 +3306,7 @@ msgstr "Hálózati maszk"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3352,7 +3355,7 @@ msgstr "Nem találhatók fájlok"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Nincs elérhető információ"
 
@@ -3605,7 +3608,7 @@ msgstr ""
 msgid "Options"
 msgstr "Lehetőségek"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Egyéb:"
 
@@ -3685,7 +3688,7 @@ msgstr "Tulajdonos"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "PAP/CHAP jelszó"
 
@@ -3696,7 +3699,7 @@ msgstr "PAP/CHAP jelszó"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "PAP/CHAP felhasználói név"
 
@@ -3827,9 +3830,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3887,7 +3890,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "csom."
 
@@ -3986,7 +3989,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protokoll"
 
@@ -4131,7 +4134,7 @@ msgstr "Biztos, hogy visszavonja az összes módosítást?"
 msgid "Really switch protocol?"
 msgstr "Biztos, hogy cserélni szeretné a protokollt?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Valósidejű kapcsolatok"
 
@@ -4306,7 +4309,7 @@ msgstr "Resolv fájl"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Újraindítás"
 
@@ -4667,7 +4670,7 @@ msgstr ""
 "utasításokért keresse fel az wiki-t."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Forrás"
@@ -4717,11 +4720,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Itt adja meg a titkosító kulcsot."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Indítás"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Indítás prioritása"
 
@@ -4780,7 +4783,7 @@ msgid "Status"
 msgstr "Állapot"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Leállítás"
 
@@ -4884,7 +4887,7 @@ msgstr "Rendszer tulajdonságok"
 msgid "System log buffer size"
 msgstr "Rendszer napló puffer méret"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5199,7 +5202,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5251,7 +5254,7 @@ msgstr ""
 "Ez a lista a rendszerben jelenleg futó folyamatokról és azok állapotáról ad "
 "áttekintést."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Ez a lap a rendszerben jelenleg aktív hálózati kapcsolatokról ad áttekintést."
@@ -5313,7 +5316,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "Forgalom"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Átvitel"
 
@@ -5368,7 +5371,7 @@ msgstr "Adóteljesítmény"
 msgid "Type"
 msgstr "Típus"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5505,7 +5508,7 @@ msgstr "DHCP kiszolgáló használata"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5557,7 +5560,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5571,7 +5574,7 @@ msgstr "Egyedi DNS szerverek használata"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5591,7 +5594,7 @@ msgstr "Alapértelmezett átjáró használata"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5867,7 +5870,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -61,7 +61,6 @@ msgstr "-- Campo aggiuntivo --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Per favore scegli --"
 
@@ -339,7 +338,7 @@ msgstr ""
 "Instradamento <abbr title=\"Protocollo Internet Versione 6\">IPv6</abbr> "
 "attivo"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Connessioni attive"
@@ -678,7 +677,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Autenticazione PEAP"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -703,7 +702,7 @@ msgstr "Aggiornamento Automatico"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -741,9 +740,9 @@ msgstr "Disponibile"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1063,12 +1062,13 @@ msgstr "Scegliere dall'elenco..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Raccolgo i dati..."
 
@@ -1391,7 +1391,7 @@ msgid "Description"
 msgstr "Descrizione"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destinazione"
 
@@ -1430,6 +1430,7 @@ msgid "Diagnostics"
 msgstr "Diagnostica"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1462,9 +1463,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1662,7 +1663,7 @@ msgstr "Abilita <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Abilitazione aggiornamento endpoint dinamico HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "Abilita negoziazione IPv6"
 
@@ -1730,13 +1731,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "Abilita questo swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Abilita/Disabilita"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Abilitato"
 
@@ -1951,6 +1952,12 @@ msgstr "Flash Firmware"
 msgid "Flash image..."
 msgstr "Flash immagine..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Flash immagine nuovo firmware"
@@ -1962,12 +1969,6 @@ msgstr "Operazioni Flash"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Flashing..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2465,7 +2466,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2479,7 +2480,7 @@ msgstr "Se deselezionata, alcun percorso predefinito è configurato"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2556,11 +2557,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Script di avvio"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Scripts di avvio"
 
@@ -2919,7 +2920,7 @@ msgstr "Indirizzo IPv6 locale"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Avvio Locale"
 
@@ -3057,7 +3058,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3086,7 +3087,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3178,7 +3180,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3304,7 +3307,7 @@ msgstr "Maschera di rete"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3353,7 +3356,7 @@ msgstr "Nessun file trovato"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Nessuna informazione disponibile"
 
@@ -3606,7 +3609,7 @@ msgstr ""
 msgid "Options"
 msgstr "Opzioni"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Altro:"
 
@@ -3686,7 +3689,7 @@ msgstr "Proprietario"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3697,7 +3700,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3828,9 +3831,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3888,7 +3891,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr ""
 
@@ -3985,7 +3988,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocollo"
 
@@ -4130,7 +4133,7 @@ msgstr "Azzerare veramente tutte le modifiche?"
 msgid "Really switch protocol?"
 msgstr "Cambiare veramente il protocollo?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Connessioni in Tempo Reale"
 
@@ -4304,7 +4307,7 @@ msgstr "File Resolve"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Riavvia"
 
@@ -4663,7 +4666,7 @@ msgstr ""
 "specifici."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Origine"
@@ -4714,11 +4717,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Specificare la chiave di cifratura qui."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Inizio"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Priorità di avvio"
 
@@ -4777,7 +4780,7 @@ msgid "Status"
 msgstr "Stato"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Ferma"
 
@@ -4881,7 +4884,7 @@ msgstr "Proprietà di Sistema"
 msgid "System log buffer size"
 msgstr "Dimensione Buffer Log di Sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5172,7 +5175,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5220,7 +5223,7 @@ msgstr ""
 "Questa lista da un riassunto dei processi correntemente attivi e del loro "
 "stato."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "Questa pagina ti da una riassunto delle connessioni al momento attive."
 
@@ -5280,7 +5283,7 @@ msgstr ""
 msgid "Traffic"
 msgstr "Traffico"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr ""
 
@@ -5335,7 +5338,7 @@ msgstr ""
 msgid "Type"
 msgstr "Tipo"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr ""
 
@@ -5472,7 +5475,7 @@ msgstr "Usa il DHCP del gateway"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5524,7 +5527,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5538,7 +5541,7 @@ msgstr "Usa server DNS personalizzati"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5558,7 +5561,7 @@ msgstr "Usa il gateway predefinito"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5836,7 +5839,7 @@ msgstr "Scrivi registro di sistema su file"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -61,7 +61,6 @@ msgstr "-- 追加項目 --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- 選択してください --"
 
@@ -332,7 +331,7 @@ msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "稼働中の <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-経路情報"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "アクティブ コネクション"
@@ -672,7 +671,7 @@ msgstr "認証グループ"
 msgid "Authentication"
 msgstr "認証"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -697,7 +696,7 @@ msgstr "自動更新"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -735,9 +734,9 @@ msgstr "使用可"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1064,12 +1063,13 @@ msgstr "リストを閉じる"
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "データ収集中です..."
 
@@ -1400,7 +1400,7 @@ msgid "Description"
 msgstr "詳細"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "宛先"
 
@@ -1439,6 +1439,7 @@ msgid "Diagnostics"
 msgstr "診断機能"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1471,9 +1472,9 @@ msgstr "非アクティブ状態ポーリングを無効化"
 msgid "Disable this network"
 msgstr "このネットワークを無効にします"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1675,7 +1676,7 @@ msgstr "<abbr title=\"Spanning Tree Protocol\">STP</abbr>を有効にする"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "HE.netの動的endpoint更新を有効にします"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "IPv6 ネゴシエーションの有効化"
 
@@ -1743,13 +1744,13 @@ msgstr "このネットワークを有効にします"
 msgid "Enable this swap"
 msgstr "スワップ設定を有効にする"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "有効 / 無効"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "有効"
 
@@ -1968,6 +1969,12 @@ msgstr "ファームウェアの更新"
 msgid "Flash image..."
 msgstr "更新"
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "ファームウェアの更新"
@@ -1979,12 +1986,6 @@ msgstr "更新機能"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "更新中..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr "フラッシュメモリー 書込アクセス (%s)"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2481,7 +2482,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2495,7 +2496,7 @@ msgstr "チェックされていない場合、デフォルト ルートは構�
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2572,11 +2573,11 @@ msgstr "情報"
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "起動スクリプト"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "起動スクリプト"
 
@@ -2941,7 +2942,7 @@ msgstr "ローカル IPv6 アドレス"
 msgid "Local Service Only"
 msgstr "ローカルサービスのみ"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "ローカル スタートアップ"
 
@@ -3081,7 +3082,7 @@ msgstr ""
 "以下のようなコマンドを使用して、ルート ファイルシステムを複製してください:"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3110,7 +3111,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "EDNS.0 UDP パケットサイズの許可される最大数"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "モデムが準備完了状態になるまでの最大待ち時間"
 
@@ -3204,7 +3206,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "モデム初期化タイムアウト"
 
@@ -3330,7 +3333,7 @@ msgstr "ネットマスク"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3379,7 +3382,7 @@ msgstr "ファイルが見つかりませんでした"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "情報がありません"
 
@@ -3639,7 +3642,7 @@ msgstr "発信パケットと受信パケットに使用されるUDPポート（
 msgid "Options"
 msgstr "オプション"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "その他:"
 
@@ -3719,7 +3722,7 @@ msgstr "所有者"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "PAP/CHAP パスワード"
 
@@ -3730,7 +3733,7 @@ msgstr "PAP/CHAP パスワード"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "PAP/CHAP ユーザー名"
 
@@ -3861,9 +3864,9 @@ msgstr "秘密鍵のパス"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3921,7 +3924,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "パケット"
 
@@ -4020,7 +4023,7 @@ msgstr "プロトコル"
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "プロトコル"
 
@@ -4175,7 +4178,7 @@ msgstr "本当に全ての変更をリセットしますか?"
 msgid "Really switch protocol?"
 msgstr "本当にプロトコルを切り替えますか?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "リアルタイム・コネクション"
 
@@ -4351,7 +4354,7 @@ msgstr "リゾルバファイル"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "再起動"
 
@@ -4714,7 +4717,7 @@ msgstr ""
 "デバイスのインストール手順を参照してください。"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "送信元"
@@ -4765,11 +4768,11 @@ msgid "Specify the secret encryption key here."
 msgstr "暗号鍵を設定します。"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "開始"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "優先順位"
 
@@ -4827,7 +4830,7 @@ msgid "Status"
 msgstr "ステータス"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "停止"
 
@@ -4933,7 +4936,7 @@ msgstr "システム プロパティ"
 msgid "System log buffer size"
 msgstr "システムログ バッファサイズ"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5254,7 +5257,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5306,7 +5309,7 @@ msgstr ""
 "このリストは現在システムで動作しているプロセスとそのステータスを表示していま"
 "す。"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "このページでは、現在アクティブなネットワーク接続を表示します。"
 
@@ -5366,7 +5369,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "トラフィック"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "転送"
 
@@ -5421,7 +5424,7 @@ msgstr "送信電力"
 msgid "Type"
 msgstr "タイプ"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5559,7 +5562,7 @@ msgstr "DHCPゲートウェイを使用する"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5611,7 +5614,7 @@ msgstr "ビルトインのIPv6-マネジメントを使用する"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5625,7 +5628,7 @@ msgstr "DNSサーバーを手動で設定"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5645,7 +5648,7 @@ msgstr "デフォルト ゲートウェイを使用する"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5925,7 +5928,7 @@ msgstr "システムログをファイルに書き込む"
 msgid "Yes"
 msgstr "はい"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "
@@ -6419,6 +6422,9 @@ msgstr "はい"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 戻る"
+
+#~ msgid "Flashmemory write access (%s)"
+#~ msgstr "フラッシュメモリー 書込アクセス (%s)"
 
 #~ msgid ""
 #~ "one of:\n"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -61,7 +61,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr ""
 
@@ -325,7 +324,7 @@ msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Route 경로"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Active 연결수"
@@ -658,7 +657,7 @@ msgstr ""
 msgid "Authentication"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -683,7 +682,7 @@ msgstr "자동 Refresh"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -721,9 +720,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1041,12 +1040,13 @@ msgstr "목록 닫기..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Data 를 수집중입니다..."
 
@@ -1369,7 +1369,7 @@ msgid "Description"
 msgstr "설명"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr ""
 
@@ -1408,6 +1408,7 @@ msgid "Diagnostics"
 msgstr "진단"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1440,9 +1441,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1635,7 +1636,7 @@ msgstr "<abbr title=\"Spanning Tree Protocol\">STP</abbr> 활성화"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1703,13 +1704,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "활성/비활성"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "활성화됨"
 
@@ -1922,6 +1923,12 @@ msgstr ""
 msgid "Flash image..."
 msgstr "이미지로 Flash..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "새로운 firmware 이미지로 flash"
@@ -1932,12 +1939,6 @@ msgstr "Flash 작업"
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2428,7 +2429,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2442,7 +2443,7 @@ msgstr "체크하지 않을 경우, 기본 route 가 설정되지 않습니다"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2512,11 +2513,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Initscript 들"
 
@@ -2872,7 +2873,7 @@ msgstr ""
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Local 시작 프로그램"
 
@@ -3004,7 +3005,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3033,7 +3034,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "허용된 최대 EDNS.0 UDP 패킷 크기"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3125,7 +3127,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3249,7 +3252,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3298,7 +3301,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "이용 가능한 정보가 없습니다"
 
@@ -3552,7 +3555,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3632,7 +3635,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3643,7 +3646,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3774,9 +3777,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3834,7 +3837,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pkts."
 
@@ -3931,7 +3934,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "프로토콜"
 
@@ -4073,7 +4076,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr "정말 프로토콜 변경을 원하세요?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "실시간 연결수"
 
@@ -4247,7 +4250,7 @@ msgstr "Resolve 파일"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "재시작"
 
@@ -4602,7 +4605,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr ""
@@ -4649,11 +4652,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "시작"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "시작 우선순위"
 
@@ -4711,7 +4714,7 @@ msgid "Status"
 msgstr "상태"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "정지"
 
@@ -4815,7 +4818,7 @@ msgstr "시스템 등록 정보"
 msgid "System log buffer size"
 msgstr "System log 버퍼 크기"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr ""
 
@@ -5099,7 +5102,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5144,7 +5147,7 @@ msgid ""
 msgstr ""
 "이 목록은 현재 실행중인 시스템 프로세스와 해당 상태에 대한 개요를 보여줍니다."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "이 페이지는 현재 active 상태인 네트워크 연결을 보여줍니다."
 
@@ -5204,7 +5207,7 @@ msgstr ""
 msgid "Traffic"
 msgstr "트래픽"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "전송량"
 
@@ -5259,7 +5262,7 @@ msgstr ""
 msgid "Type"
 msgstr "유형"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr ""
 
@@ -5396,7 +5399,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5448,7 +5451,7 @@ msgstr "자체 내장 IPv6-관리 기능 사용"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5462,7 +5465,7 @@ msgstr "임의의 DNS 서버 사용"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5482,7 +5485,7 @@ msgstr "Default gateway 사용"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5757,7 +5760,7 @@ msgstr "System log 출력 파일 경로"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -61,7 +61,6 @@ msgstr "-- Gelanggang Tambahan --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Sila pilih --"
 
@@ -320,7 +319,7 @@ msgstr "Aktive IPv4-Routen"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Aktif IPv6-Laluan"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Sambungan Aktif"
@@ -653,7 +652,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -678,7 +677,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -716,9 +715,9 @@ msgstr "Boleh didapati"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1026,12 +1025,13 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgid "Description"
 msgstr "Keterangan"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Tempat tujuan"
 
@@ -1388,6 +1388,7 @@ msgid "Diagnostics"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1418,9 +1419,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1612,7 +1613,7 @@ msgstr "Mengaktifkan <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1680,13 +1681,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr ""
 
@@ -1899,6 +1900,12 @@ msgstr "Firmware Flash"
 msgid "Flash image..."
 msgstr ""
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr ""
@@ -1909,12 +1916,6 @@ msgstr ""
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2406,7 +2407,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2420,7 +2421,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2495,11 +2496,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr ""
 
@@ -2857,7 +2858,7 @@ msgstr ""
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -2989,7 +2990,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3018,7 +3019,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3110,7 +3112,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3236,7 +3239,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3285,7 +3288,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr ""
 
@@ -3538,7 +3541,7 @@ msgstr ""
 msgid "Options"
 msgstr "Pilihan"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3616,7 +3619,7 @@ msgstr "Pemilik"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3627,7 +3630,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3758,9 +3761,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3818,7 +3821,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pkts."
 
@@ -3915,7 +3918,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protokol"
 
@@ -4056,7 +4059,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr ""
 
@@ -4230,7 +4233,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr ""
 
@@ -4585,7 +4588,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Sumber"
@@ -4632,11 +4635,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Mula"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr ""
 
@@ -4691,7 +4694,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr ""
 
@@ -4795,7 +4798,7 @@ msgstr ""
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr ""
 
@@ -5078,7 +5081,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5124,7 +5127,7 @@ msgstr ""
 "Senarai ini memberikan gambaran lebih pada proses sistem yang sedang "
 "berjalan dan statusnya."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Laman ini memberikan gambaran lebih dari saat ini sambungan rangkaian yang "
@@ -5183,7 +5186,7 @@ msgstr ""
 msgid "Traffic"
 msgstr "Lalu lintas"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Pemindahan"
 
@@ -5238,7 +5241,7 @@ msgstr ""
 msgid "Type"
 msgstr "Jenis"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr ""
 
@@ -5372,7 +5375,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5424,7 +5427,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5438,7 +5441,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5458,7 +5461,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5730,7 +5733,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -56,7 +56,6 @@ msgstr "-- Tilleggs Felt --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Vennligst velg --"
 
@@ -329,7 +328,7 @@ msgstr "Aktive <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Ruter"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Ruter"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Aktive Tilkoblinger"
@@ -662,7 +661,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Godkjenning"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -687,7 +686,7 @@ msgstr "Automatisk oppdatering"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -725,9 +724,9 @@ msgstr "Tilgjengelig"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1047,12 +1046,13 @@ msgstr "Lukk liste..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Henter data..."
 
@@ -1374,7 +1374,7 @@ msgid "Description"
 msgstr "Beskrivelse"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destinasjon"
 
@@ -1413,6 +1413,7 @@ msgid "Diagnostics"
 msgstr "Nettverksdiagnostikk"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1445,9 +1446,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1646,7 +1647,7 @@ msgstr "Aktiver <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Aktiver HE,net dynamisk endepunkt oppdatering"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1714,13 +1715,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "Aktiver denne swapenhet"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Aktiver/Deaktiver"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Aktivert"
 
@@ -1934,6 +1935,12 @@ msgstr "Firmware Oppradering"
 msgid "Flash image..."
 msgstr "Flash firmware..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Flash nytt firmware image"
@@ -1945,12 +1952,6 @@ msgstr "Flash operasjoner"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Flasher..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2443,7 +2444,7 @@ msgstr "Hvis oppgitt vil denne enheten bli montert utfra dens Volumnavn"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2457,7 +2458,7 @@ msgstr "Dersom ikke avmerket blir ingen standard rute konfigurert"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2531,11 +2532,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Oppstartskript"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Oppstartsskript"
 
@@ -2895,7 +2896,7 @@ msgstr "Lokal IPv6 adresse"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Lokal Oppstart"
 
@@ -3032,7 +3033,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3061,7 +3062,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Maksimal tillatt størrelse på EDNS.0 UDP-pakker"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Maksimalt antall sekunder å vente på at modemet skal bli klart"
 
@@ -3153,7 +3155,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Modem initiering tidsavbrudd"
 
@@ -3279,7 +3282,7 @@ msgstr "Nettmaske"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3328,7 +3331,7 @@ msgstr "Ingen filer funnet"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Ingen informasjon tilgjengelig"
 
@@ -3582,7 +3585,7 @@ msgstr ""
 msgid "Options"
 msgstr "Alternativer"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Andre:"
 
@@ -3662,7 +3665,7 @@ msgstr "Eier"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "PAP/CHAP passord"
 
@@ -3673,7 +3676,7 @@ msgstr "PAP/CHAP passord"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "PAP/CHAP brukernavn"
 
@@ -3804,9 +3807,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3864,7 +3867,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pakker."
 
@@ -3963,7 +3966,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protokoll"
 
@@ -4107,7 +4110,7 @@ msgstr "Vil du nullstille alle endringer?"
 msgid "Really switch protocol?"
 msgstr "Vil du endre protokoll?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Tilkoblinger Sanntid"
 
@@ -4281,7 +4284,7 @@ msgstr "<abbr title=\"Resolvefile\">Oppslagsfil</abbr>"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Omstart"
 
@@ -4642,7 +4645,7 @@ msgstr ""
 "enheter."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Kilde"
@@ -4690,11 +4693,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Angi krypteringsnøkkelen her."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Start"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Start prioritet"
 
@@ -4752,7 +4755,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Stop"
 
@@ -4856,7 +4859,7 @@ msgstr "System Egenskaper"
 msgid "System log buffer size"
 msgstr "System logg buffer størrelse"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5169,7 +5172,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5218,7 +5221,7 @@ msgid ""
 "their status."
 msgstr "Denne listen gir en oversikt over kjørende prosesser og deres status."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Denne siden gir en oversikt over gjeldende aktive nettverkstilkoblinger."
@@ -5280,7 +5283,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "Trafikk"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Overføring"
 
@@ -5335,7 +5338,7 @@ msgstr "Tx-Styrke"
 msgid "Type"
 msgstr "Type"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5472,7 +5475,7 @@ msgstr "Bruk DHCP gateway"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5524,7 +5527,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5538,7 +5541,7 @@ msgstr "Bruk egendefinerte DNS servere"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5558,7 +5561,7 @@ msgstr "Bruk standard gateway"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5834,7 +5837,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -62,7 +62,6 @@ msgstr "-- Dodatkowe pole --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Proszę wybrać --"
 
@@ -339,7 +338,7 @@ msgstr ""
 "Aktywne trasy routingu <abbr title=\"Internet Protocol Version 6\">IPv6</"
 "abbr>"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Aktywne połączenia"
@@ -684,7 +683,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -709,7 +708,7 @@ msgstr "Automatyczne odświeżanie"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -747,9 +746,9 @@ msgstr "Dostępne"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1071,12 +1070,13 @@ msgstr "Zamknij listę..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Zbieranie danych..."
 
@@ -1406,7 +1406,7 @@ msgid "Description"
 msgstr "Opis"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Przeznaczenie"
 
@@ -1445,6 +1445,7 @@ msgid "Diagnostics"
 msgstr "Diagnostyka"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1477,9 +1478,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr "Wyłącz tą sieć"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1682,7 +1683,7 @@ msgstr "Włącz <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Włącz dynamiczną aktualizację punktu końcowego sieci HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "Włącz negocjację IPv6"
 
@@ -1750,13 +1751,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "Włącz ten swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Wlącz/Wyłącz"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Włączony"
 
@@ -1975,6 +1976,12 @@ msgstr "Aktualizuj firmware"
 msgid "Flash image..."
 msgstr "Wgraj obraz..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Wgraj nowy firmware"
@@ -1986,12 +1993,6 @@ msgstr "Operacje aktualizacji"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Flashowanie..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr "Dostęp do zapisu flashmemory (%s)"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2492,7 +2493,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2506,7 +2507,7 @@ msgstr "Jeśli odznaczone, nie ma zdefiniowanej domyślnej ścieżki routingu"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2581,11 +2582,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr "Błąd inicjalizacji"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Skrypt startowy"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Skrypty startowe"
 
@@ -2947,7 +2948,7 @@ msgstr "Lokalny adres IPv6"
 msgid "Local Service Only"
 msgstr "Tylko serwis lokalny"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Lokalny autostart"
 
@@ -3087,7 +3088,7 @@ msgstr ""
 "poleceń poniżej:"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3116,7 +3117,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Maksymalny dozwolony rozmiar pakietu EDNS.0 UDP"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Maksymalny czas podany w sekundach do pełnej gotowości modemu"
 
@@ -3208,7 +3210,8 @@ msgid "Modem information query failed"
 msgstr "Zapytanie dotyczące modemu nie powiodło się"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Limit czasu inicjacji modemu"
 
@@ -3334,7 +3337,7 @@ msgstr "Maska sieci"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3383,7 +3386,7 @@ msgstr "Nie znaleziono plików"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Brak dostępnych informacji"
 
@@ -3642,7 +3645,7 @@ msgstr ""
 msgid "Options"
 msgstr "Opcje"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Inne:"
 
@@ -3722,7 +3725,7 @@ msgstr "Właściciel"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Hasło PAP/CHAP"
 
@@ -3733,7 +3736,7 @@ msgstr "Hasło PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Nazwa użytkownika PAP/CHAP"
 
@@ -3864,9 +3867,9 @@ msgstr "Ścieżka do wewnętrznego klucza prywatnego "
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3924,7 +3927,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pktw."
 
@@ -4023,7 +4026,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protokół"
 
@@ -4176,7 +4179,7 @@ msgstr "Naprawdę usunąć wszelkie zmiany?"
 msgid "Really switch protocol?"
 msgstr "Naprawdę zmienić protokół?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Połączenia w czasie rzeczywistym"
 
@@ -4352,7 +4355,7 @@ msgstr "Plik Resolve"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Uruchom ponownie"
 
@@ -4719,7 +4722,7 @@ msgstr ""
 "urządzenia."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Źródło"
@@ -4769,11 +4772,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Określ tajny klucz szyfrowania."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Uruchomienie"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Priorytet uruchomienia"
 
@@ -4832,7 +4835,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Stop"
 
@@ -4937,7 +4940,7 @@ msgstr "Właściwości systemu"
 msgid "System log buffer size"
 msgstr "Rozmiar bufora loga systemu"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5265,7 +5268,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5318,7 +5321,7 @@ msgstr ""
 "Poniższa lista przedstawia aktualnie uruchomione procesy systemowe i ich "
 "status."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "Poniższa strona przedstawia aktualnie aktywne połączenia sieciowe."
 
@@ -5378,7 +5381,7 @@ msgstr "Trasa routowania"
 msgid "Traffic"
 msgstr "Ruch"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transfer"
 
@@ -5433,7 +5436,7 @@ msgstr "Moc nadawania"
 msgid "Type"
 msgstr "Typ"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5571,7 +5574,7 @@ msgstr "Użyj bramy DHCP"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5623,7 +5626,7 @@ msgstr "Skorzystaj z wbudowanego zarządzania protokołem IPv6"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5637,7 +5640,7 @@ msgstr "Użyj własne serwery DNS"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5657,7 +5660,7 @@ msgstr "Użyj domyślnej bramy"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5936,7 +5939,7 @@ msgstr "Zapisz log systemowy do pliku"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "
@@ -6433,6 +6436,9 @@ msgstr "tak"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Wróć"
+
+#~ msgid "Flashmemory write access (%s)"
+#~ msgstr "Dostęp do zapisu flashmemory (%s)"
 
 #~ msgid ""
 #~ "Your Internet Explorer is too old to display this page correctly. Please "

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -61,7 +61,6 @@ msgstr "-- Campo Adicional --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Por favor, escolha --"
 
@@ -353,7 +352,7 @@ msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Rotas <abbr title=\"Protocolo de Internet Versão 6\">IPv6</abbr> ativas"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Conexões Ativas"
@@ -704,7 +703,7 @@ msgstr "Grupo de Autenticação"
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr "Tipo de Autenticação"
 
@@ -729,7 +728,7 @@ msgstr "Atualização Automática"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -771,9 +770,9 @@ msgstr "Disponível"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1100,12 +1099,13 @@ msgstr "Fechar a lista..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Coletando dados..."
 
@@ -1441,7 +1441,7 @@ msgid "Description"
 msgstr "Descrição"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destino"
 
@@ -1481,6 +1481,7 @@ msgid "Diagnostics"
 msgstr "Diagnóstico"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr "Número de discagem"
 
@@ -1513,9 +1514,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr "Desabilitar esta rede"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1727,7 +1728,7 @@ msgstr "Ativar <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Ativar a atualização de ponto final dinâmico HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "Ativar a negociação de IPv6"
 
@@ -1796,13 +1797,13 @@ msgstr "Habilitar esta rede"
 msgid "Enable this swap"
 msgstr "Ativar este espaço de troca (swap)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Ativar/Desativar"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -2030,6 +2031,12 @@ msgstr "Gravar Firmware"
 msgid "Flash image..."
 msgstr "Gravar imagem..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Gravar nova imagem do firmware"
@@ -2041,12 +2048,6 @@ msgstr "Operações na memória flash"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Gravando na flash..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2559,7 +2560,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2573,7 +2574,7 @@ msgstr "Se desmarcado, nenhuma rota padrão será configurada"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2653,11 +2654,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr "Falha na iniciação"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Script de iniciação"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Scripts de iniciação"
 
@@ -3036,7 +3037,7 @@ msgstr "Endereço IPv6 local"
 msgid "Local Service Only"
 msgstr "Somente Serviço Local"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Iniciação Local"
 
@@ -3181,7 +3182,7 @@ msgstr ""
 "abaixo:"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3212,7 +3213,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Tamanho máximo permitido dos pacotes UDP EDNS.0"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Tempo máximo, em segundos, para esperar que o modem fique pronto"
 
@@ -3306,7 +3308,8 @@ msgid "Modem information query failed"
 msgstr "A consulta das informações do modem falhou"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Estouro de tempo da iniciação do modem"
 
@@ -3432,7 +3435,7 @@ msgstr "Máscara de rede"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3481,7 +3484,7 @@ msgstr "Nenhum arquivo encontrado"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Nenhuma informação disponível"
 
@@ -3753,7 +3756,7 @@ msgstr "Opcional. Porta UDP usada para pacotes saintes ou entrantes."
 msgid "Options"
 msgstr "Opções"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Outro:"
 
@@ -3836,7 +3839,7 @@ msgstr "Dono"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Senha do PAP/CHAP"
 
@@ -3847,7 +3850,7 @@ msgstr "Senha do PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Usuário do PAP/CHAP"
 
@@ -3978,9 +3981,9 @@ msgstr "Caminho para a Chave Privada interna"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -4038,7 +4041,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pcts."
 
@@ -4138,7 +4141,7 @@ msgstr "Protocolo"
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocolo"
 
@@ -4293,7 +4296,7 @@ msgstr "Realmente limpar todas as mudanças?"
 msgid "Really switch protocol?"
 msgstr "Realmente trocar o protocolo?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Conexões em Tempo Real"
 
@@ -4473,7 +4476,7 @@ msgstr "Arquivo Resolv"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -4845,7 +4848,7 @@ msgstr ""
 "instruções específicas da instalação deste dispositivo."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Origem"
@@ -4900,11 +4903,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Especifique a chave de cifragem secreta aqui."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Iniciar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Prioridade de iniciação"
 
@@ -4963,7 +4966,7 @@ msgid "Status"
 msgstr "Estado"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Parar"
 
@@ -5069,7 +5072,7 @@ msgstr "Propriedades do Sistema"
 msgid "System log buffer size"
 msgstr "Tamanho do buffer de registro do sistema"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5400,7 +5403,7 @@ msgstr ""
 "Isto é a \"Update Key\" configurada para o túnel ou a senha da cpnta se não "
 "tem uma \"Update Keu\" configurada"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5453,7 +5456,7 @@ msgid ""
 msgstr ""
 "Esta lista fornece uma visão geral sobre os processos em execução no sistema."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "Esta página fornece informações sobre as conexões de rede ativas."
 
@@ -5514,7 +5517,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "Tráfego"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transferências"
 
@@ -5569,7 +5572,7 @@ msgstr "Potência de transmissão"
 msgid "Type"
 msgstr "Tipo"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5710,7 +5713,7 @@ msgstr "Use o roteador do DHCP"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5764,7 +5767,7 @@ msgstr "Use o gerenciamento do IPv6 embarcado"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5778,7 +5781,7 @@ msgstr "Use servidores DNS personalizados"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5798,7 +5801,7 @@ msgstr "Use o roteador padrão"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -6077,7 +6080,7 @@ msgstr "Escrever registro do sistema (log) no arquivo"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -61,7 +61,6 @@ msgstr "-- Campo Adicional --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Por favor escolha --"
 
@@ -337,7 +336,7 @@ msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Rotas-<abbr title=\"Protocolo de Internet Versão 6\">IPv6</abbr> ativas"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Ligações Ativas"
@@ -675,7 +674,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -700,7 +699,7 @@ msgstr "Actualização Automática"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -738,9 +737,9 @@ msgstr "Disponível"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1060,12 +1059,13 @@ msgstr "Fechar lista..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "A obter dados..."
 
@@ -1388,7 +1388,7 @@ msgid "Description"
 msgstr "Descrição"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destino"
 
@@ -1427,6 +1427,7 @@ msgid "Diagnostics"
 msgstr "Diagnósticos"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1459,9 +1460,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1662,7 +1663,7 @@ msgstr "Ativar <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Ativar a atualização dinâmica de ponto final HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1730,13 +1731,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "Ativar esta swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Ativar/Desativar"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -1952,6 +1953,12 @@ msgstr "Gravar Firmware"
 msgid "Flash image..."
 msgstr "Flashar imagem..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Flashar nova imagem do firmware"
@@ -1963,12 +1970,6 @@ msgstr ""
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "A programar...."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2463,7 +2464,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2477,7 +2478,7 @@ msgstr "Se desmarcado, não é configurada uma rota pré-definida"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2553,11 +2554,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Script de inicialização"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Scripts de Inicialização"
 
@@ -2918,7 +2919,7 @@ msgstr "Endereço IPv6 Local"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Arranque Local"
 
@@ -3055,7 +3056,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3084,7 +3085,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Número máximo de segundos a esperar pelo modem para ficar pronto"
 
@@ -3176,7 +3178,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3302,7 +3305,7 @@ msgstr "Mascara de rede"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3351,7 +3354,7 @@ msgstr "Não foram encontrados ficheiros"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Sem informação disponível"
 
@@ -3605,7 +3608,7 @@ msgstr ""
 msgid "Options"
 msgstr "Opções"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Outro:"
 
@@ -3683,7 +3686,7 @@ msgstr "Dono"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Password PAP/CHAP"
 
@@ -3694,7 +3697,7 @@ msgstr "Password PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Utilizador PAP/CHAP"
 
@@ -3825,9 +3828,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3885,7 +3888,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pkts."
 
@@ -3982,7 +3985,7 @@ msgstr "Protocolo"
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocolo"
 
@@ -4126,7 +4129,7 @@ msgstr "Deseja mesmo limpar todas as alterações?"
 msgid "Really switch protocol?"
 msgstr "Deseja mesmo trocar o protocolo?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Ligações em Tempo Real"
 
@@ -4300,7 +4303,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -4657,7 +4660,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Origem"
@@ -4704,11 +4707,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Iniciar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Prioridade de inicialização"
 
@@ -4763,7 +4766,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Parar"
 
@@ -4867,7 +4870,7 @@ msgstr "Propriedades do Sistema"
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5173,7 +5176,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5220,7 +5223,7 @@ msgid ""
 msgstr ""
 "Esta lista fornece uma visão geral sobre os processos em execução no sistema."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "Esta página fornece informações sobre as ligações de rede ativas."
 
@@ -5280,7 +5283,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "Tráfego"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transferências"
 
@@ -5335,7 +5338,7 @@ msgstr "Potência de Tx"
 msgid "Type"
 msgstr "Tipo"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5469,7 +5472,7 @@ msgstr "Usar a gateway do DHCP"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5521,7 +5524,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5535,7 +5538,7 @@ msgstr "Usar servidores DNS personalizados"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5555,7 +5558,7 @@ msgstr "Usar gateway pre-definida"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5827,7 +5830,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -60,7 +60,6 @@ msgstr "-- Camp suplimentar --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Te rog sa alegi --"
 
@@ -326,7 +325,7 @@ msgstr "Rute active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Rute active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Conexiuni active"
@@ -661,7 +660,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Autentificare"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -686,7 +685,7 @@ msgstr "Reimprospatare automata"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -724,9 +723,9 @@ msgstr "Disponibil"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1036,12 +1035,13 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Colectez datele.."
 
@@ -1359,7 +1359,7 @@ msgid "Description"
 msgstr "Descriere"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Destinatie"
 
@@ -1398,6 +1398,7 @@ msgid "Diagnostics"
 msgstr "Diagnosticuri"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1430,9 +1431,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1618,7 +1619,7 @@ msgstr "Activeaza <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1686,13 +1687,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Activeaza/Dezactiveaza"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Activat"
 
@@ -1905,6 +1906,12 @@ msgstr "Rescrie firmware"
 msgid "Flash image..."
 msgstr ""
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr ""
@@ -1915,12 +1922,6 @@ msgstr ""
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2413,7 +2414,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2427,7 +2428,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2497,11 +2498,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Script de initializare"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Scripturi de initializare"
 
@@ -2858,7 +2859,7 @@ msgstr "Adresa IPv6 locala"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -2990,7 +2991,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3019,7 +3020,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3111,7 +3113,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3235,7 +3238,7 @@ msgstr "Netmask"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3284,7 +3287,7 @@ msgstr "Nici un fisier gasit"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Nici o informatie disponibila"
 
@@ -3532,7 +3535,7 @@ msgstr ""
 msgid "Options"
 msgstr "Optiuni"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Altele:"
 
@@ -3610,7 +3613,7 @@ msgstr "Proprietar"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3621,7 +3624,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3752,9 +3755,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3812,7 +3815,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Packete."
 
@@ -3909,7 +3912,7 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -4051,7 +4054,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Conexiuni in timp real"
 
@@ -4225,7 +4228,7 @@ msgstr "Fisierul de rezolvare"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Restart"
 
@@ -4579,7 +4582,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Sursa"
@@ -4626,11 +4629,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Start"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr ""
 
@@ -4685,7 +4688,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Stop"
 
@@ -4789,7 +4792,7 @@ msgstr "Proprietati sistem"
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr ""
 
@@ -5060,7 +5063,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5102,7 +5105,7 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
@@ -5159,7 +5162,7 @@ msgstr ""
 msgid "Traffic"
 msgstr "Trafic"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Transfer"
 
@@ -5214,7 +5217,7 @@ msgstr "Puterea TX"
 msgid "Type"
 msgstr "Tip"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5348,7 +5351,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5400,7 +5403,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5414,7 +5417,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5434,7 +5437,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5706,7 +5709,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -63,7 +63,6 @@ msgstr "-- Дополнительно --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Сделайте выбор --"
 
@@ -338,7 +337,7 @@ msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Активные <abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-маршруты"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Активные соединения"
@@ -689,7 +688,7 @@ msgstr "Группа аутентификации"
 msgid "Authentication"
 msgstr "Аутентификация"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr "Тип аутентификации"
 
@@ -714,7 +713,7 @@ msgstr "Автообновление"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -758,9 +757,9 @@ msgstr "Доступно"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1090,12 +1089,13 @@ msgstr "Закрыть список..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Сбор данных..."
 
@@ -1427,7 +1427,7 @@ msgid "Description"
 msgstr "Описание"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Направление"
 
@@ -1466,6 +1466,7 @@ msgid "Diagnostics"
 msgstr "Диагностика"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr "Dial номер"
 
@@ -1498,9 +1499,9 @@ msgstr "Отключить отслеживание неактивности к�
 msgid "Disable this network"
 msgstr "Отключить данную сеть"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1703,7 +1704,7 @@ msgstr "Включить <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Включить динамическое обновление оконечной точки HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "Включить IPv6 negotiation"
 
@@ -1771,13 +1772,13 @@ msgstr "Включить данную сеть"
 msgid "Enable this swap"
 msgstr "Включить этот раздел подкачки"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Включить/выключить"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Включено"
 
@@ -1998,6 +1999,12 @@ msgstr "Установить прошивку"
 msgid "Flash image..."
 msgstr "Установить..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Установить новый образ прошивки"
@@ -2009,12 +2016,6 @@ msgstr "Операции с прошивкой"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Прошивка..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr "Запись во флешпамять (%s)"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2511,7 +2512,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2525,7 +2526,7 @@ msgstr "Если не выбрано, то маршрут по умолчани�
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2604,11 +2605,11 @@ msgstr "Информация"
 msgid "Initialization failure"
 msgstr "Ошибка инициализации"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Скрипт инициализации"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Скрипты инициализации"
 
@@ -2980,7 +2981,7 @@ msgstr "Локальный IPv6-адрес"
 msgid "Local Service Only"
 msgstr "Только локальный DNS"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Запуск пакетов и служб пользователя, при включении устройства"
 
@@ -3121,7 +3122,7 @@ msgstr ""
 "используйте команды приведенные ниже:"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3150,7 +3151,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Максимально допустимый размер UDP пакетов EDNS.0"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Максимальное время ожидания готовности модема (секунды)"
 
@@ -3244,7 +3246,8 @@ msgid "Modem information query failed"
 msgstr "Ошибка запроса информации о модеме"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Время ожидания инициализации модема"
 
@@ -3370,7 +3373,7 @@ msgstr "Маска сети"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3419,7 +3422,7 @@ msgstr "Файлы не найдены"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Нет доступной информации"
 
@@ -3689,7 +3692,7 @@ msgstr ""
 msgid "Options"
 msgstr "Опции"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Другие:"
 
@@ -3769,7 +3772,7 @@ msgstr "Пользователь"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Пароль PAP/CHAP"
 
@@ -3780,7 +3783,7 @@ msgstr "Пароль PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Имя пользователя PAP/CHAP"
 
@@ -3911,9 +3914,9 @@ msgstr "Путь к внутреннему Приватному ключу"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3971,7 +3974,7 @@ msgstr "Пинг-запрос"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Пакетов"
 
@@ -4070,7 +4073,7 @@ msgstr "Прот."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Протокол"
 
@@ -4228,7 +4231,7 @@ msgstr "Действительно сбросить все изменения?"
 msgid "Really switch protocol?"
 msgstr "Вы действительно хотите изменить протокол?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Соединения в реальном времени"
 
@@ -4411,7 +4414,7 @@ msgstr "Файл resolv"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Перезапустить"
 
@@ -4775,7 +4778,7 @@ msgstr ""
 "инструкций для вашего устройства."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Источник"
@@ -4829,11 +4832,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Укажите закрытый ключ."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Старт"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Приоритет"
 
@@ -4891,7 +4894,7 @@ msgid "Status"
 msgstr "Состояние"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Остановить"
 
@@ -4997,7 +5000,7 @@ msgstr "Свойства системы"
 msgid "System log buffer size"
 msgstr "Размер системного журнала"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5321,7 +5324,7 @@ msgstr ""
 "Это либо \"Update Key\", настроенный для туннеля, либо пароль учетной "
 "записи, если ключ обновления не был настроен"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5372,7 +5375,7 @@ msgid ""
 "their status."
 msgstr "Страница содержит работающие процессы и их состояние."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Страница содержит список всех активных на данный момент сетевых соединений."
@@ -5434,7 +5437,7 @@ msgstr "Трассировка"
 msgid "Traffic"
 msgstr "Трафик"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Передача"
 
@@ -5489,7 +5492,7 @@ msgstr "Мощность передатчика"
 msgid "Type"
 msgstr "Тип"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5627,7 +5630,7 @@ msgstr "Использовать шлюз DHCP"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5679,7 +5682,7 @@ msgstr "Использовать встроенный IPv6-менеджмент"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5693,7 +5696,7 @@ msgstr "Использовать собственные DNS сервера"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5713,7 +5716,7 @@ msgstr "Использовать шлюз по умолчанию"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5999,7 +6002,7 @@ msgstr "Записывать системные события в файл"
 msgid "Yes"
 msgstr "Да"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "
@@ -6495,6 +6498,9 @@ msgstr "да"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Flashmemory write access (%s)"
+#~ msgstr "Запись во флешпамять (%s)"
 
 #~ msgid ""
 #~ "one of:\n"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -57,7 +57,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr ""
 
@@ -315,7 +314,7 @@ msgstr ""
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr ""
@@ -648,7 +647,7 @@ msgstr ""
 msgid "Authentication"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -673,7 +672,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -711,9 +710,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1020,12 +1019,13 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr ""
 
@@ -1343,7 +1343,7 @@ msgid "Description"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr ""
 
@@ -1382,6 +1382,7 @@ msgid "Diagnostics"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1412,9 +1413,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1600,7 +1601,7 @@ msgstr ""
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1668,13 +1669,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr ""
 
@@ -1887,6 +1888,12 @@ msgstr ""
 msgid "Flash image..."
 msgstr ""
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr ""
@@ -1897,12 +1904,6 @@ msgstr ""
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2392,7 +2393,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2406,7 +2407,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2476,11 +2477,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr ""
 
@@ -2834,7 +2835,7 @@ msgstr ""
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -2966,7 +2967,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -2995,7 +2996,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3087,7 +3089,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3211,7 +3214,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3260,7 +3263,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr ""
 
@@ -3508,7 +3511,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3586,7 +3589,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3597,7 +3600,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3728,9 +3731,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3788,7 +3791,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr ""
 
@@ -3885,7 +3888,7 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr ""
 
@@ -4025,7 +4028,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr ""
 
@@ -4199,7 +4202,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr ""
 
@@ -4552,7 +4555,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr ""
@@ -4599,11 +4602,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr ""
 
@@ -4658,7 +4661,7 @@ msgid "Status"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr ""
 
@@ -4762,7 +4765,7 @@ msgstr ""
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr ""
 
@@ -5031,7 +5034,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5073,7 +5076,7 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
@@ -5130,7 +5133,7 @@ msgstr ""
 msgid "Traffic"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr ""
 
@@ -5185,7 +5188,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr ""
 
@@ -5319,7 +5322,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5371,7 +5374,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5385,7 +5388,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5405,7 +5408,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5675,7 +5678,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -59,7 +59,6 @@ msgstr "-- Ytterligare fält --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Vänligen välj --"
 
@@ -322,7 +321,7 @@ msgstr "Aktiva <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-rutter"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Aktiva <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-rutter"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Aktiva anslutningar"
@@ -658,7 +657,7 @@ msgstr "Autentiseringsgrupp"
 msgid "Authentication"
 msgstr "Autentisering"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr "Typ av autentisering"
 
@@ -683,7 +682,7 @@ msgstr "Uppdatera automatiskt"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -721,9 +720,9 @@ msgstr "Tillgänglig"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1033,12 +1032,13 @@ msgstr "Stäng ner lista..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Samlar in data..."
 
@@ -1356,7 +1356,7 @@ msgid "Description"
 msgstr "Beskrivning"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Plats"
 
@@ -1395,6 +1395,7 @@ msgid "Diagnostics"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr "Slå nummer"
 
@@ -1427,9 +1428,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1619,7 +1620,7 @@ msgstr "Aktivera <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1687,13 +1688,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "Aktivera den här swap"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Aktivera/Inaktivera"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Aktiverad"
 
@@ -1906,6 +1907,12 @@ msgstr ""
 msgid "Flash image..."
 msgstr ""
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr ""
@@ -1917,12 +1924,6 @@ msgstr ""
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Skriver..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2411,7 +2412,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2425,7 +2426,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2495,11 +2496,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Initskript"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Initskripten"
 
@@ -2854,7 +2855,7 @@ msgstr "Lokal IPv6-adress"
 msgid "Local Service Only"
 msgstr "Enbart lokal tjänst"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Lokal uppstart"
 
@@ -2986,7 +2987,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3015,7 +3016,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3107,7 +3109,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3231,7 +3234,7 @@ msgstr "Nätmask"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3280,7 +3283,7 @@ msgstr "Inga filer hittades"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Ingen information tillgänglig"
 
@@ -3528,7 +3531,7 @@ msgstr ""
 msgid "Options"
 msgstr "Alternativ"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Andra:"
 
@@ -3606,7 +3609,7 @@ msgstr "Ägare"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "PAP/CHAP-lösenord"
 
@@ -3617,7 +3620,7 @@ msgstr "PAP/CHAP-lösenord"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "PAP/CHAP-användarnamn"
 
@@ -3748,9 +3751,9 @@ msgstr "Genväg till den inre privata nyckeln"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3808,7 +3811,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "Pkt."
 
@@ -3905,7 +3908,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protokoll"
 
@@ -4047,7 +4050,7 @@ msgstr "Verkligen återställa alla ändringar?"
 msgid "Really switch protocol?"
 msgstr "Verkligen byta protokoll?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Anslutningar i realtid"
 
@@ -4221,7 +4224,7 @@ msgstr "Resolv-fil"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Starta om"
 
@@ -4574,7 +4577,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Källa"
@@ -4621,11 +4624,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Ange den hemliga krypteringsnyckeln här."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr ""
 
@@ -4680,7 +4683,7 @@ msgid "Status"
 msgstr "Status"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr ""
 
@@ -4784,7 +4787,7 @@ msgstr "Systemets egenskaper"
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5055,7 +5058,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5097,7 +5100,7 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
@@ -5156,7 +5159,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "Trafik"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Överför"
 
@@ -5211,7 +5214,7 @@ msgstr ""
 msgid "Type"
 msgstr "Typ"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5345,7 +5348,7 @@ msgstr "Använd DHCP-gateway"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5397,7 +5400,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5411,7 +5414,7 @@ msgstr "Använd anpassade DNS-servrar"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5431,7 +5434,7 @@ msgstr "Använd standard-gateway"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5702,7 +5705,7 @@ msgstr "Skriv systemlogg till fil"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -49,7 +49,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr ""
 
@@ -307,7 +306,7 @@ msgstr ""
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr ""
@@ -640,7 +639,7 @@ msgstr ""
 msgid "Authentication"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -665,7 +664,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -703,9 +702,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1012,12 +1011,13 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
-msgid "Custom flash intervall (%s)"
+msgid "Custom flash interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:4
@@ -1335,7 +1335,7 @@ msgid "Description"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr ""
 
@@ -1374,6 +1374,7 @@ msgid "Diagnostics"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1404,9 +1405,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1592,7 +1593,7 @@ msgstr ""
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1660,13 +1661,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr ""
 
@@ -1879,6 +1880,12 @@ msgstr ""
 msgid "Flash image..."
 msgstr ""
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr ""
@@ -1889,12 +1896,6 @@ msgstr ""
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2085,7 +2086,7 @@ msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:56
-msgid "Heartbeat intervall (%s)"
+msgid "Heartbeat interval (%s)"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua:14
@@ -2384,7 +2385,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2398,7 +2399,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2468,11 +2469,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr ""
 
@@ -2826,7 +2827,7 @@ msgstr ""
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -2958,7 +2959,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -2987,7 +2988,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3079,7 +3081,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3203,7 +3206,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3252,7 +3255,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr ""
 
@@ -3500,7 +3503,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3578,7 +3581,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3589,7 +3592,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3720,9 +3723,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3780,7 +3783,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr ""
 
@@ -3877,7 +3880,7 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr ""
 
@@ -4017,7 +4020,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr ""
 
@@ -4191,7 +4194,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr ""
 
@@ -4544,7 +4547,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr ""
@@ -4591,11 +4594,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr ""
 
@@ -4650,7 +4653,7 @@ msgid "Status"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr ""
 
@@ -4754,7 +4757,7 @@ msgstr ""
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr ""
 
@@ -5023,7 +5026,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5065,7 +5068,7 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
@@ -5122,7 +5125,7 @@ msgstr ""
 msgid "Traffic"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr ""
 
@@ -5177,7 +5180,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr ""
 
@@ -5311,7 +5314,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5363,7 +5366,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5377,7 +5380,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5397,7 +5400,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5667,7 +5670,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -60,7 +60,6 @@ msgstr "-- Ek Alan--"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Lütfen seçiniz --"
 
@@ -326,7 +325,7 @@ msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr ""
 "Aktif <abbr title=\"İnternet Protokolü Sürüm 4\">IPv6</abbr>-Yönlendiriciler"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Aktif Bağlantılar"
@@ -661,7 +660,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Kimlik Doğrulama"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr "Kimlik doğrulama türü"
 
@@ -686,7 +685,7 @@ msgstr "Otomatik Yenileme"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -724,9 +723,9 @@ msgstr "Kullanılabilir"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1035,12 +1034,13 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgid "Description"
 msgstr "Açıklama"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Hedef"
 
@@ -1397,6 +1397,7 @@ msgid "Diagnostics"
 msgstr "Tanı"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr "Arama numarası"
 
@@ -1429,9 +1430,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr "Ağ devre dışı"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1617,7 +1618,7 @@ msgstr ""
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1685,13 +1686,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr ""
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr ""
 
@@ -1904,6 +1905,12 @@ msgstr "Firmware Güncelle"
 msgid "Flash image..."
 msgstr "Dosyayı yaz..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Yeni firmware dosyasını yaz"
@@ -1914,12 +1921,6 @@ msgstr ""
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2409,7 +2410,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2423,7 +2424,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2493,11 +2494,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr ""
 
@@ -2851,7 +2852,7 @@ msgstr ""
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -2983,7 +2984,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3012,7 +3013,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3104,7 +3106,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3228,7 +3231,7 @@ msgstr "Ağ Maskesi"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3277,7 +3280,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr ""
 
@@ -3525,7 +3528,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3603,7 +3606,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3614,7 +3617,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3745,9 +3748,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3805,7 +3808,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr ""
 
@@ -3902,7 +3905,7 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protokol"
 
@@ -4042,7 +4045,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr ""
 
@@ -4216,7 +4219,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Tekrar başlat"
 
@@ -4569,7 +4572,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Kaynak"
@@ -4616,11 +4619,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Başlat"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr ""
 
@@ -4675,7 +4678,7 @@ msgid "Status"
 msgstr "Durum"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Durdur"
 
@@ -4779,7 +4782,7 @@ msgstr ""
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr ""
 
@@ -5048,7 +5051,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5090,7 +5093,7 @@ msgid ""
 "their status."
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
@@ -5147,7 +5150,7 @@ msgstr ""
 msgid "Traffic"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr ""
 
@@ -5202,7 +5205,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr ""
 
@@ -5336,7 +5339,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5388,7 +5391,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5402,7 +5405,7 @@ msgstr "Özel DNS sunucularını kullan"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5422,7 +5425,7 @@ msgstr "Varsayılan ağ geçidini kullan"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5692,7 +5695,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -57,7 +57,6 @@ msgstr "-- Додаткові поля --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- Оберіть --"
 
@@ -350,7 +349,7 @@ msgstr "<abbr title=\"Інтернет-протокол версії 4\">IPv4</a
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "<abbr title=\"Інтернет-протокол версії 6\">IPv6</abbr>-маршрути"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "Активні підключення"
@@ -701,7 +700,7 @@ msgstr "Група автентифікації"
 msgid "Authentication"
 msgstr "Автентифікація"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr "Тип автентифікації"
 
@@ -726,7 +725,7 @@ msgstr "Автоматичне оновлення"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -765,9 +764,9 @@ msgstr "Доступно"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1094,12 +1093,13 @@ msgstr "Згорнути список..."
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "Збирання даних..."
 
@@ -1435,7 +1435,7 @@ msgid "Description"
 msgstr "Опис"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Призначення"
 
@@ -1474,6 +1474,7 @@ msgid "Diagnostics"
 msgstr "Діагностика"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr "Набір номера"
 
@@ -1506,9 +1507,9 @@ msgstr "Вимкнути опитування неактивності"
 msgid "Disable this network"
 msgstr "Вимкнути цю мережу"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1716,7 +1717,7 @@ msgstr "Увімкнути <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "Увімкнути динамічне оновлення кінцевої точки HE.net"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "Увімкнути узгодження IPv6"
 
@@ -1784,13 +1785,13 @@ msgstr "Увімкнути цю мережу"
 msgid "Enable this swap"
 msgstr "Увімкнути цей своп"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Увімкнено/Вимкнено"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "Увімкнено"
 
@@ -2008,6 +2009,12 @@ msgstr "Прошиваємо мікропрограму"
 msgid "Flash image..."
 msgstr "Прошити образ..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "Прошити новий образ мікропрограми"
@@ -2019,12 +2026,6 @@ msgstr "Операції прошивання"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "Перепрошиваємо..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr "Доступ до запису флеш-пам’яті (%s)"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2527,7 +2528,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2541,7 +2542,7 @@ msgstr "Якщо не позначено, типовий маршрут не н�
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2620,11 +2621,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr "Помилка ініціалізації"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Скрипт ініціалізації"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Скрипти ініціалізації"
 
@@ -3005,7 +3006,7 @@ msgstr "Локальна адреса IPv6"
 msgid "Local Service Only"
 msgstr "Тільки локальна служба"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "Локальний запуск"
 
@@ -3148,7 +3149,7 @@ msgstr ""
 "команди:"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3177,7 +3178,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "Максимально допустимий розмір UDP-пакетів EDNS.0"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "Максимальний час очікування готовності модему (секунд)"
 
@@ -3271,7 +3273,8 @@ msgid "Modem information query failed"
 msgstr "Помилка запиту інформації про модем"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "Тайм-аут ініціалізації модему"
 
@@ -3397,7 +3400,7 @@ msgstr "Маска мережі"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3446,7 +3449,7 @@ msgstr "Файли не знайдено"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "Інформація відсутня"
 
@@ -3715,7 +3718,7 @@ msgstr ""
 msgid "Options"
 msgstr "Опції"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "Інше:"
 
@@ -3796,7 +3799,7 @@ msgstr "Власник"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "Пароль PAP/CHAP"
 
@@ -3807,7 +3810,7 @@ msgstr "Пароль PAP/CHAP"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "Ім’я користувача PAP/CHAP"
 
@@ -3940,9 +3943,9 @@ msgstr "Шлях до внутрішнього закритого ключа"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -4000,7 +4003,7 @@ msgstr "Ехо-запит"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "пакетів"
 
@@ -4099,7 +4102,7 @@ msgstr "Прот."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Протокол"
 
@@ -4255,7 +4258,7 @@ msgstr "Дійсно скинути всі зміни?"
 msgid "Really switch protocol?"
 msgstr "Дійсно змінити протокол?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "Підключення у реальному часі"
 
@@ -4436,7 +4439,7 @@ msgstr "Файл resolv"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "Перезавантажити"
 
@@ -4803,7 +4806,7 @@ msgstr ""
 "конкретного пристрою."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Джерело"
@@ -4858,11 +4861,11 @@ msgid "Specify the secret encryption key here."
 msgstr "Вкажіть тут секретний ключ шифрування."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Запустити"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Стартовий пріоритет"
 
@@ -4921,7 +4924,7 @@ msgid "Status"
 msgstr "Стан"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "Зупинити"
 
@@ -5027,7 +5030,7 @@ msgstr "Властивості системи"
 msgid "System log buffer size"
 msgstr "Розмір буфера системного журналу"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -5354,7 +5357,7 @@ msgstr ""
 "Це або \"Update Key\", сконфігурований для тунелю, або пароль облікового "
 "запису, якщо ключ оновлення не налаштовано"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5408,7 +5411,7 @@ msgid ""
 "their status."
 msgstr "У цьому списку наведено працюючі наразі системні процеси та їх стан."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "Ця сторінка надає огляд поточних активних мережевих підключень."
 
@@ -5469,7 +5472,7 @@ msgstr "Трасування"
 msgid "Traffic"
 msgstr "Трафік"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Передано"
 
@@ -5524,7 +5527,7 @@ msgstr "Потужність передавача"
 msgid "Type"
 msgstr "Тип"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5661,7 +5664,7 @@ msgstr "Використовувати DHCP-шлюз"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5713,7 +5716,7 @@ msgstr "Використовувати вбудоване керування IPv
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5727,7 +5730,7 @@ msgstr "Використовувати особливі DNS-сервери"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5747,7 +5750,7 @@ msgstr "Використовувати типовий шлюз"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -6030,7 +6033,7 @@ msgstr "Записувати cистемний журнал до файлу"
 msgid "Yes"
 msgstr "Так"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "
@@ -6528,6 +6531,9 @@ msgstr "так"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Flashmemory write access (%s)"
+#~ msgstr "Доступ до запису флеш-пам’яті (%s)"
 
 #~ msgid ""
 #~ "one of:\n"

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -61,7 +61,6 @@ msgstr "---Mục bổ sung---"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "--Hãy chọn--"
 
@@ -321,7 +320,7 @@ msgstr "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "kết nối đang hoạt động"
@@ -654,7 +653,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "Xác thực"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -679,7 +678,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -717,9 +716,9 @@ msgstr "Sẵn có"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1026,12 +1025,13 @@ msgstr ""
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr ""
 
@@ -1351,7 +1351,7 @@ msgid "Description"
 msgstr "Mô tả"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "Điểm đến"
 
@@ -1390,6 +1390,7 @@ msgid "Diagnostics"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1420,9 +1421,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1617,7 +1618,7 @@ msgstr "Kích hoạt <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr ""
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1685,13 +1686,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "Cho kích hoạt/ Vô hiệu hóa"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr ""
 
@@ -1904,6 +1905,12 @@ msgstr "Phần cứng flash"
 msgid "Flash image..."
 msgstr ""
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr ""
@@ -1914,12 +1921,6 @@ msgstr ""
 
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
-msgstr ""
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
@@ -2411,7 +2412,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2425,7 +2426,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2500,11 +2501,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "Initscript"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "Initscripts"
 
@@ -2861,7 +2862,7 @@ msgstr ""
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr ""
 
@@ -2993,7 +2994,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3022,7 +3023,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr ""
 
@@ -3114,7 +3116,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr ""
 
@@ -3240,7 +3243,7 @@ msgstr ""
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3289,7 +3292,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr ""
 
@@ -3543,7 +3546,7 @@ msgstr ""
 msgid "Options"
 msgstr "Lựa chọn "
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr ""
 
@@ -3621,7 +3624,7 @@ msgstr "Owner"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr ""
 
@@ -3632,7 +3635,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr ""
 
@@ -3763,9 +3766,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3823,7 +3826,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr ""
 
@@ -3920,7 +3923,7 @@ msgstr "Prot."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "Protocol"
 
@@ -4062,7 +4065,7 @@ msgstr ""
 msgid "Really switch protocol?"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr ""
 
@@ -4236,7 +4239,7 @@ msgstr ""
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr ""
 
@@ -4591,7 +4594,7 @@ msgid ""
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "Nguồn"
@@ -4638,11 +4641,11 @@ msgid "Specify the secret encryption key here."
 msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "Bắt đầu "
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "Bắt đầu ưu tiên"
 
@@ -4697,7 +4700,7 @@ msgid "Status"
 msgstr "Tình trạng"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr ""
 
@@ -4801,7 +4804,7 @@ msgstr ""
 msgid "System log buffer size"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr ""
 
@@ -5080,7 +5083,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5126,7 +5129,7 @@ msgstr ""
 "List này đưa ra một tầm nhìn tổng quát về xử lý hệ thống đang chạy và tình "
 "trạng của chúng."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Trang này cung cấp một tổng quan về đang hoạt động kết nối mạng hiện tại."
@@ -5184,7 +5187,7 @@ msgstr ""
 msgid "Traffic"
 msgstr ""
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "Chuyển giao"
 
@@ -5239,7 +5242,7 @@ msgstr ""
 msgid "Type"
 msgstr "Loại "
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr ""
 
@@ -5373,7 +5376,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5425,7 +5428,7 @@ msgstr ""
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5439,7 +5442,7 @@ msgstr ""
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5459,7 +5462,7 @@ msgstr ""
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5729,7 +5732,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -61,7 +61,6 @@ msgstr "-- 更多选项 --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- 请选择 --"
 
@@ -329,7 +328,7 @@ msgstr "活动的 <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> 路由
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "活动的 <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> 路由"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "活动连接"
@@ -663,7 +662,7 @@ msgstr "认证组"
 msgid "Authentication"
 msgstr "认证"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr "认证类型"
 
@@ -688,7 +687,7 @@ msgstr "自动刷新"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -726,9 +725,9 @@ msgstr "可用"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1041,12 +1040,13 @@ msgstr "关闭列表…"
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "正在收集数据…"
 
@@ -1372,7 +1372,7 @@ msgid "Description"
 msgstr "描述"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "目标地址"
 
@@ -1411,6 +1411,7 @@ msgid "Diagnostics"
 msgstr "网络诊断"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr "拨号号码"
 
@@ -1443,9 +1444,9 @@ msgstr "禁用不活动轮询"
 msgid "Disable this network"
 msgstr "禁用此网络"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1639,7 +1640,7 @@ msgstr "开启 <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "启用 HE.net 动态终端更新"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr "启用 IPv6 协商"
 
@@ -1707,13 +1708,13 @@ msgstr "启用此网络"
 msgid "Enable this swap"
 msgstr "启用此 swap 分区"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "启用/禁用"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "已启用"
 
@@ -1926,6 +1927,12 @@ msgstr "刷新固件"
 msgid "Flash image..."
 msgstr "刷写固件…"
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "刷写新的固件"
@@ -1937,12 +1944,6 @@ msgstr "刷新操作"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "正在刷写…"
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr "闪存写访问（%s）"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2433,7 +2434,7 @@ msgstr "如果指定，则通过分区卷标而不是固定的设备文件来挂
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2447,7 +2448,7 @@ msgstr "留空则不配置默认路由"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2523,11 +2524,11 @@ msgstr "信息"
 msgid "Initialization failure"
 msgstr "初始化失败"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "启动脚本"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "启动脚本"
 
@@ -2889,7 +2890,7 @@ msgstr "本地 IPv6 地址"
 msgid "Local Service Only"
 msgstr "仅本地服务"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "本地启动脚本"
 
@@ -3021,7 +3022,7 @@ msgid ""
 msgstr "确保使用以下命令来复制根文件系统："
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3050,7 +3051,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "允许的最大 EDNS.0 UDP 数据包大小"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "调制解调器就绪的最大等待时间（秒）"
 
@@ -3144,7 +3146,8 @@ msgid "Modem information query failed"
 msgstr "调制解调器信息查询失败"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "调制解调器初始化超时"
 
@@ -3268,7 +3271,7 @@ msgstr "子网掩码"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3317,7 +3320,7 @@ msgstr "未找到文件"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "无可用信息"
 
@@ -3575,7 +3578,7 @@ msgstr "可选，用于传出和传入数据包的 UDP 端口。"
 msgid "Options"
 msgstr "选项"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "其余："
 
@@ -3653,7 +3656,7 @@ msgstr "用户名"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "PAP/CHAP 密码"
 
@@ -3664,7 +3667,7 @@ msgstr "PAP/CHAP 密码"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "PAP/CHAP 用户名"
 
@@ -3795,9 +3798,9 @@ msgstr "内部私钥的路径"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3855,7 +3858,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "数据包"
 
@@ -3952,7 +3955,7 @@ msgstr "协议"
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "协议"
 
@@ -4100,7 +4103,7 @@ msgstr "确定要放弃所有更改？"
 msgid "Really switch protocol?"
 msgstr "确定要切换协议？"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "实时连接"
 
@@ -4278,7 +4281,7 @@ msgstr "解析文件"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "重启"
 
@@ -4637,7 +4640,7 @@ msgstr ""
 "设备的固件更新说明。"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "源地址"
@@ -4684,11 +4687,11 @@ msgid "Specify the secret encryption key here."
 msgstr "在此指定密钥。"
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "开始"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "启动优先级"
 
@@ -4745,7 +4748,7 @@ msgid "Status"
 msgstr "状态"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "关闭"
 
@@ -4849,7 +4852,7 @@ msgstr "系统属性"
 msgid "System log buffer size"
 msgstr "系统日志缓冲区大小"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP："
 
@@ -5140,7 +5143,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr "如果更新密钥没有设置的话，隧道的“更新密钥”或者账户密码必须填写。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5185,7 +5188,7 @@ msgid ""
 "their status."
 msgstr "系统中正在运行的进程概况和它们的状态信息。"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "活跃的网络连接概况。"
 
@@ -5244,7 +5247,7 @@ msgstr "Traceroute"
 msgid "Traffic"
 msgstr "流量"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "传输"
 
@@ -5299,7 +5302,7 @@ msgstr "传输功率"
 msgid "Type"
 msgstr "类型"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP："
 
@@ -5435,7 +5438,7 @@ msgstr "使用 DHCP 网关"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5487,7 +5490,7 @@ msgstr "使用内置的 IPv6 管理"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5501,7 +5504,7 @@ msgstr "使用自定义的 DNS 服务器"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5521,7 +5524,7 @@ msgstr "使用默认网关"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5800,7 +5803,7 @@ msgstr "将系统日志写入文件"
 msgid "Yes"
 msgstr "是"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "
@@ -6292,6 +6295,9 @@ msgstr "是"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 后退"
+
+#~ msgid "Flashmemory write access (%s)"
+#~ msgstr "闪存写访问（%s）"
 
 #~ msgid ""
 #~ "one of:\n"

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -59,7 +59,6 @@ msgstr "-- 更多選項 --"
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:849
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:26
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:36
 msgid "-- Please choose --"
 msgstr "-- 請選擇 --"
 
@@ -324,7 +323,7 @@ msgstr "啟用 <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-路由"
 msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 msgstr "啟用 <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-路由"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:315
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:15
 msgid "Active Connections"
 msgstr "啟用連線"
@@ -657,7 +656,7 @@ msgstr ""
 msgid "Authentication"
 msgstr "認證"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:35
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
 msgid "Authentication Type"
 msgstr ""
 
@@ -682,7 +681,7 @@ msgstr "自動更新"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:53
 #: protocols/luci-proto-hnet/luasrc/model/cbi/admin_network/proto_hnet.lua:7
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:17
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:63
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:67
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:36
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:42
@@ -720,9 +719,9 @@ msgstr "可用"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:290
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:300
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:326
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:336
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:346
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:357
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:377
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:255
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:265
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:275
@@ -1035,12 +1034,13 @@ msgstr "關閉清單"
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_join.htm:40
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:30
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_status.htm:8
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:367
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
 #: modules/luci-mod-status/luasrc/view/admin_status/index/50-dsl.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:17
 #: modules/luci-mod-status/luasrc/view/admin_status/iptables.htm:68
 #: modules/luci-mod-system/luasrc/view/admin_system/clock_status.htm:49
+#: themes/luci-theme-material/luasrc/view/themes/material/header.htm:222
 msgid "Collecting data..."
 msgstr "收集資料中..."
 
@@ -1175,7 +1175,9 @@ msgstr ""
 msgid ""
 "Custom files (certificates, scripts) may remain on the system. To prevent "
 "this, perform a factory-reset first."
-msgstr "已修改的檔案(如憑證和腳本)可能會殘留在系統中.如果要避免這項問題,您可以先行重設裝置"
+msgstr ""
+"已修改的檔案(如憑證和腳本)可能會殘留在系統中.如果要避免這項問題,您可以先行重"
+"設裝置"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:52
 msgid "Custom flash interval (%s)"
@@ -1362,7 +1364,7 @@ msgid "Description"
 msgstr "描述"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:62
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:361
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:392
 msgid "Destination"
 msgstr "目的地"
 
@@ -1401,6 +1403,7 @@ msgid "Diagnostics"
 msgstr "診斷"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:45
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:60
 msgid "Dial number"
 msgstr ""
 
@@ -1432,9 +1435,9 @@ msgstr ""
 msgid "Disable this network"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:43
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:44
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:54
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:64
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:68
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:37
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:43
@@ -1627,7 +1630,7 @@ msgstr "啟用 <abbr title=\"Spanning Tree Protocol\">STP</abbr>"
 msgid "Enable HE.net dynamic endpoint update"
 msgstr "啟用HE.net服務代管動態更新"
 
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:51
 msgid "Enable IPv6 negotiation"
 msgstr ""
 
@@ -1695,13 +1698,13 @@ msgstr ""
 msgid "Enable this swap"
 msgstr "啟用swap功能"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:36
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:37
 msgid "Enable/Disable"
 msgstr "啟用/關閉"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:152
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:251
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:40
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:41
 msgid "Enabled"
 msgstr "啟用"
 
@@ -1915,6 +1918,12 @@ msgstr "韌體更新"
 msgid "Flash image..."
 msgstr "更新映像檔中..."
 
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
+msgid "Flash memory activity (%s)"
+msgstr ""
+
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:99
 msgid "Flash new firmware image"
 msgstr "更新新版韌體映像檔"
@@ -1926,12 +1935,6 @@ msgstr "執行更新"
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
 msgid "Flashing..."
 msgstr "更新中..."
-
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:58
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:60
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua:62
-msgid "Flashmemory write access (%s)"
-msgstr ""
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:498
 msgid "Force"
@@ -2420,7 +2423,7 @@ msgstr "假若指定的話, 掛載設備的分割標籤取代固定的設備節�
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:29
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:33
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:68
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:81
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:85
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:25
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:32
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:45
@@ -2434,7 +2437,7 @@ msgstr "如果沒打勾點選, 將不會設置預設路由"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:34
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:86
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:35
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:95
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:99
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:47
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:60
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:66
@@ -2508,11 +2511,11 @@ msgstr ""
 msgid "Initialization failure"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:34
 msgid "Initscript"
 msgstr "初始化腳本"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid "Initscripts"
 msgstr "初始化腳本"
 
@@ -2867,7 +2870,7 @@ msgstr "本地IPv6位址"
 msgid "Local Service Only"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:77
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:81
 msgid "Local Startup"
 msgstr "本地啟動"
 
@@ -3000,7 +3003,7 @@ msgid ""
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:55
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:65
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:69
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:26
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:44
@@ -3029,7 +3032,8 @@ msgid "Maximum allowed size of EDNS.0 UDP packets"
 msgstr "允許EDNS.0 協定的UDP封包最大數量"
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:63
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:73
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:77
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:57
 msgid "Maximum amount of seconds to wait for the modem to become ready"
 msgstr "等待數據機待命的最大秒數"
 
@@ -3121,7 +3125,8 @@ msgid "Modem information query failed"
 msgstr ""
 
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:62
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:72
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:76
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:56
 msgid "Modem init timeout"
 msgstr "數據機初始化終結時間"
 
@@ -3245,7 +3250,7 @@ msgstr "網路遮罩"
 #: modules/luci-base/luasrc/controller/admin/index.lua:62
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua:402
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:358
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:101
@@ -3294,7 +3299,7 @@ msgstr "尚未發現任何檔案"
 
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:100
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:174
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:180
 msgid "No information available"
 msgstr "尚無可運用資訊"
 
@@ -3546,7 +3551,7 @@ msgstr ""
 msgid "Options"
 msgstr "選項"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:374
 msgid "Other:"
 msgstr "其它:"
 
@@ -3624,7 +3629,7 @@ msgstr "持有者"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:34
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:14
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:18
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:32
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:43
 msgid "PAP/CHAP password"
 msgstr "PAP/CHAP驗證密碼"
 
@@ -3635,7 +3640,7 @@ msgstr "PAP/CHAP驗證密碼"
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua:11
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua:15
-#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:29
+#: protocols/luci-proto-qmi/luasrc/model/cbi/admin_network/proto_qmi.lua:37
 msgid "PAP/CHAP username"
 msgstr "PAP/CHAP驗證用戶名"
 
@@ -3766,9 +3771,9 @@ msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:293
 #: modules/luci-mod-status/luasrc/view/admin_status/bandwidth.htm:303
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:329
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:339
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:349
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:370
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:380
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:258
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:268
 #: modules/luci-mod-status/luasrc/view/admin_status/load.htm:278
@@ -3826,7 +3831,7 @@ msgstr "Ping"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:87
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:88
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:55
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:170
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:176
 msgid "Pkts."
 msgstr "封包數."
 
@@ -3923,7 +3928,7 @@ msgstr "協定."
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:216
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:79
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:359
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:390
 msgid "Protocol"
 msgstr "協定"
 
@@ -4067,7 +4072,7 @@ msgstr "確定要回復原廠設定?"
 msgid "Really switch protocol?"
 msgstr "確定要更換協定?"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:310
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:341
 msgid "Realtime Connections"
 msgstr "即時連線"
 
@@ -4241,7 +4246,7 @@ msgstr "解析檔"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:28
 #: modules/luci-mod-network/luasrc/view/admin_network/wifi_overview.htm:14
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:67
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
 msgid "Restart"
 msgstr "重啟"
 
@@ -4597,7 +4602,7 @@ msgstr ""
 "設備安裝指引."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:61
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:360
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:391
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:103
 msgid "Source"
 msgstr "來源"
@@ -4644,11 +4649,11 @@ msgid "Specify the secret encryption key here."
 msgstr "指定加密金鑰在此."
 
 #: modules/luci-mod-network/luasrc/model/cbi/admin_network/ifaces.lua:475
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:61
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:64
 msgid "Start"
 msgstr "啟用"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:32
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:33
 msgid "Start priority"
 msgstr "啟用優先權順序"
 
@@ -4705,7 +4710,7 @@ msgid "Status"
 msgstr "狀態"
 
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_overview.htm:35
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:71
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:75
 msgid "Stop"
 msgstr "停止"
 
@@ -4809,7 +4814,7 @@ msgstr "系統屬性"
 msgid "System log buffer size"
 msgstr "系統日誌緩衝大小"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:333
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:364
 msgid "TCP:"
 msgstr "TCP:"
 
@@ -4943,8 +4948,8 @@ msgid ""
 "compare them with the original file to ensure data integrity.<br /> Click "
 "\"Proceed\" below to start the flash procedure."
 msgstr ""
-"即將刷入的映像檔已上傳.下面是這個校驗碼和檔案大小詳細資訊, 用原始檔比對他們以確保資料"
-"完整性.<br />按下面的\"繼續\"便可以開始更新程序."
+"即將刷入的映像檔已上傳.下面是這個校驗碼和檔案大小詳細資訊, 用原始檔比對他們以"
+"確保資料完整性.<br />按下面的\"繼續\"便可以開始更新程序."
 
 #: modules/luci-base/luasrc/view/admin_uci/revert.htm:19
 msgid "The following changes have been reverted"
@@ -5104,7 +5109,7 @@ msgid ""
 "password if no update key has been configured"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:78
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:82
 msgid ""
 "This is the content of /etc/rc.local. Insert your own commands here (in "
 "front of 'exit 0') to execute them at the end of the boot process."
@@ -5150,7 +5155,7 @@ msgid ""
 "their status."
 msgstr "這清單提供目前正在執行的系統的執行緒和狀態的預覽."
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:312
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:343
 msgid "This page gives an overview over currently active network connections."
 msgstr "這一頁提供目前正在活動中網路連線的預覽."
 
@@ -5209,7 +5214,7 @@ msgstr "路由追蹤"
 msgid "Traffic"
 msgstr "流量"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:362
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:393
 msgid "Transfer"
 msgstr "傳輸"
 
@@ -5264,7 +5269,7 @@ msgstr "傳送-功率"
 msgid "Type"
 msgstr "型態"
 
-#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:323
+#: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:354
 msgid "UDP:"
 msgstr "UDP:"
 
@@ -5400,7 +5405,7 @@ msgstr "使用DHCP的閘道"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_dhcp.lua:33
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:85
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:34
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:94
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:98
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:46
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:59
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:65
@@ -5452,7 +5457,7 @@ msgstr "使用內建的IPv6管理功能"
 #: modules/luci-base/luasrc/model/cbi/admin_network/proto_static.lua:109
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:92
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:45
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:101
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:105
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:53
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:66
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua:72
@@ -5466,7 +5471,7 @@ msgstr "使用自定的DNS伺服器"
 #: protocols/luci-proto-3g/luasrc/model/cbi/admin_network/proto_3g.lua:70
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:16
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dhcpv6.lua:28
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:80
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:84
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:24
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:44
@@ -5486,7 +5491,7 @@ msgstr "使用預設閘道"
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_6to4.lua:23
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua:39
 #: protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_map.lua:74
-#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:86
+#: protocols/luci-proto-ncm/luasrc/model/cbi/admin_network/proto_ncm.lua:90
 #: protocols/luci-proto-openconnect/luasrc/model/cbi/admin_network/proto_openconnect.lua:31
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_l2tp.lua:38
 #: protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua:51
@@ -5761,7 +5766,7 @@ msgstr "將系統日誌寫入檔案"
 msgid "Yes"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:25
+#: modules/luci-mod-system/luasrc/model/cbi/admin_system/startup.lua:26
 msgid ""
 "You can enable or disable installed init scripts here. Changes will applied "
 "after a device reboot.<br /><strong>Warning: If you disable essential init "

--- a/modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua
+++ b/modules/luci-mod-system/luasrc/model/cbi/admin_system/leds.lua
@@ -55,11 +55,11 @@ for t in triggers:gmatch("[%w-]+") do
 	elseif t == "heartbeat" then
 		trigger:value(t, translatef("Heartbeat interval (%s)", t))
 	elseif t == "nand-disk" then
-		trigger:value(t, translatef("Flashmemory write access (%s)", t))
+		trigger:value(t, translatef("Flash memory activity (%s)", t))
 	elseif t == "mtd" then
-		trigger:value(t, translatef("Flashmemory write access (%s)", t))
+		trigger:value(t, translatef("Flash memory activity (%s)", t))
 	elseif t:match("mmc[0-9]") then
-		trigger:value(t, translatef("Flashmemory write access (%s)", t))
+		trigger:value(t, translatef("Flash memory activity (%s)", t))
 	elseif t:match("switch[0-9]") then
 		trigger:value(t, translatef("Switchport activity (%s)", t))
 	elseif t:match("phy[0-9]rx") then


### PR DESCRIPTION
The former name "Flashmemory write access" is wrong. The triggers also
indicate read/erase access to the flash memories.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>