### PR TITLE
luci-app-statistics: more extensibility

### DIFF
--- a/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
+++ b/applications/luci-app-statistics/luasrc/controller/luci_statistics/luci_statistics.lua
@@ -22,52 +22,24 @@ function index()
 		s_output	= _("Output plugins"),
 		s_general	= _("General plugins"),
 		s_network	= _("Network plugins"),
-
-		apcups		= _("APC UPS"),
-		conntrack	= _("Conntrack"),
-		contextswitch	= _("Context Switches"),
-		cpu		= _("Processor"),
-		cpufreq		= _("CPU Frequency"),
-		csv		= _("CSV Output"),
-		curl		= _("cUrl"),
-		df		= _("Disk Space Usage"),
-		disk		= _("Disk Usage"),
-		dns		= _("DNS"),
-		email		= _("Email"),
-		entropy		= _("Entropy"),
-		exec		= _("Exec"),
-		interface	= _("Interfaces"),
-		iptables	= _("Firewall"),
-		irq		= _("Interrupts"),
-		iwinfo		= _("Wireless"),
-		load		= _("System Load"),
-		memory		= _("Memory"),
-		netlink		= _("Netlink"),
-		network		= _("Network"),
-		nut		= _("UPS"),
-		olsrd		= _("OLSRd"),
-		openvpn		= _("OpenVPN"),
-		ping		= _("Ping"),
-		processes	= _("Processes"),
-		rrdtool		= _("RRDTool"),
-		sensors		= _("Sensors"),
-		splash_leases	= _("Splash Leases"),
-		tcpconns	= _("TCP Connections"),
-		thermal		= _("Thermal"),
-		unixsock	= _("UnixSock"),
-		uptime		= _("Uptime")
 	}
 
 	-- our collectd menu
 	local collectd_menu = {
-		output  = { "csv", "network", "rrdtool", "unixsock" },
-		general = { "apcups", "contextswitch", "cpu", "cpufreq", "df",
-			"disk", "email", "entropy", "exec", "irq", "load", "memory",
-			"nut", "processes", "sensors", "thermal", "uptime" },
-		network = { "conntrack", "curl", "dns", "interface", "iptables",
-			"netlink", "olsrd", "openvpn", "ping",
-			"splash_leases", "tcpconns", "iwinfo" }
+		output  = { },
+		general = { },
+		network = { }
 	}
+
+	local plugin_dir = "/usr/lib/lua/luci/statistics/plugins/"
+	for filename in nixio.fs.dir(plugin_dir) do
+		local plugin_fun = loadfile(plugin_dir .. filename)
+		setfenv(plugin_fun, { _ = luci.i18n.translate })
+		local plugin = plugin_fun()
+		local name = filename:gsub("%.lua", "")
+		table.insert(collectd_menu[plugin.category], name)
+		labels[name] = plugin.label
+	end
 
 	-- create toplevel menu nodes
 	local st = entry({"admin", "statistics"}, template("admin_statistics/index"), _("Statistics"), 80)

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/apcups.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/apcups.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ "Host", "Port" },
+		{ },
+		{ }
+	},
+	label = _("APC UPS"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/conntrack.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/conntrack.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ },
+		{ }
+	},
+	label = _("Conntrack"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/contextswitch.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/contextswitch.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ },
+		{ }
+	},
+	label = _("Context Switches"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/cpu.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/cpu.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ },
+		{ }
+	},
+	label = _("Processor"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/cpufreq.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/cpufreq.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ },
+		{ }
+	},
+	label = _("CPU Frequency"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/csv.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/csv.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ "DataDir" },
+		{ "StoreRates" },
+		{ }
+	},
+	label = _("CSV Output"),
+	category = "output"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/curl.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/curl.lua
@@ -1,0 +1,4 @@
+return {
+	label = _("cUrl"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/df.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/df.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ "IgnoreSelected" },
+		{ "Devices", "MountPoints", "FSTypes" }
+	},
+	label = _("Disk Space Usage"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/disk.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/disk.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ "IgnoreSelected" },
+		{ "Disks" }
+	},
+	label = _("Disk Usage"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/dns.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/dns.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ },
+		{ "Interfaces", "IgnoreSources" }
+	},
+	label = _("DNS"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/email.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/email.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ "SocketFile", "SocketGroup", "SocketPerms", "MaxConns" },
+		{ },
+		{ }
+	},
+	label = _("Email"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/entropy.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/entropy.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ },
+		{ }
+	},
+	label = _("Entropy"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/exec.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/exec.lua
@@ -1,0 +1,4 @@
+return {
+	label = _("Exec"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/interface.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/interface.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ "IgnoreSelected" },
+		{ "Interfaces" }
+	},
+	label = _("Interfaces"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/iptables.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/iptables.lua
@@ -1,0 +1,4 @@
+return {
+	label = _("Firewall"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/irq.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/irq.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ "IgnoreSelected" },
+		{ "Irqs" }
+	},
+	label = _("Interrupts"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/iwinfo.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/iwinfo.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ "IgnoreSelected" },
+		{ "Interfaces" }
+	},
+	label = _("Wireless"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/load.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/load.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ },
+		{ }
+	},
+	label = _("System Load"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/memory.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/memory.lua
@@ -1,0 +1,9 @@
+return {
+	legend = { 
+		{ },
+		{ },
+		{ }
+	},
+	label = _("Memory"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/netlink.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/netlink.lua
@@ -1,0 +1,9 @@
+return {
+	legend = {
+		{ },
+		{ "IgnoreSelected" },
+		{ "Interfaces", "VerboseInterfaces", "QDiscs", "Classes", "Filters" }
+	},
+	label = _("Netlink"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/network.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/network.lua
@@ -1,0 +1,4 @@
+return {
+	label = _("Network"),
+	category = "output"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/nut.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/nut.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ },
+		{ },
+		{ "UPS" }
+	},
+	label = _("UPS"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/olsrd.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/olsrd.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ "Host", "Port", "CollectLinks","CollectRoutes","CollectTopology"},
+		{ },
+		{ }
+	},
+	label = _("OLSRd"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/openvpn.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/openvpn.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ },
+		{ "CollectIndividualUsers", "CollectUserCount", "CollectCompression", "ImprovedNamingSchema" },
+		{ "StatusFile" }
+	},
+	label = _("OpenVPN"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/ping.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/ping.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ "TTL", "Interval", "AddressFamily" },
+		{ },
+		{ "Hosts" }
+	},
+	label = _("Ping"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/processes.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/processes.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ },
+		{ },
+		{ "Processes" }
+	},
+	label = _("Processes"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/rrdtool.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/rrdtool.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ "DataDir", "StepSize", "HeartBeat", "RRARows", "XFF", "CacheFlush", "CacheTimeout" },
+		{ "RRASingle" },
+		{ "RRATimespans" }
+	},
+	label = _("RRDTool"),
+	category = "output"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/sensors.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/sensors.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ },
+		{ "IgnoreSelected" },
+		{ "Sensor" }
+	},
+	label = _("Sensors"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/splash_leases.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/splash_leases.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ },
+		{ },
+		{ }
+	},
+	label = _("Splash Leases"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/tcpconns.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/tcpconns.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ },
+		{ "ListeningPorts" },
+		{ "LocalPorts", "RemotePorts" }
+	},
+	label = _("TCP Connections"),
+	category = "network"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/thermal.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/thermal.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ },
+		{ "IgnoreSelected" },
+		{ "Device" }
+	},
+	label = _("Thermal"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/unixsock.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/unixsock.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ "SocketFile", "SocketGroup", "SocketPerms" },
+		{ },
+		{ }
+	},
+	label = _("UnixSock"),
+	category = "output"
+}

--- a/applications/luci-app-statistics/luasrc/statistics/plugins/uptime.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/plugins/uptime.lua
@@ -1,0 +1,9 @@
+return {
+    legend = {
+		{ },
+		{ },
+		{ }
+	},
+	label = _("Uptime"),
+	category = "general"
+}

--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -19,6 +19,7 @@ $Id$
 require("luci.model.uci")
 require("luci.sys.iptparser")
 require("luci.util")
+require("nixio.fs")
 
 local ipt = luci.sys.iptparser.IptParser()
 local uci = luci.model.uci.cursor()
@@ -270,206 +271,31 @@ end
 
 
 plugins = {
-	apcups = {
-		{ "Host", "Port" },
-		{ },
-		{ }
-	},
-
 	collectd = {
 		{ "BaseDir", "Include", "PIDFile", "PluginDir", "TypesDB", "Interval", "ReadThreads", "Hostname" },
 		{ },
 		{ }
 	},
-
-	conntrack = {
-		{ },
-		{ },
-		{ }
-	},
-
-	cpu	= {
-		{ },
-		{ },
-		{ }
-	},
-
-	cpufreq	= {
-		{ },
-		{ },
-		{ }
-	},
-
-        contextswitch = {
-                { },
-                { },
-                { }
-        },
-
-	csv	= {
-		{ "DataDir" },
-		{ "StoreRates" },
-		{ }
-	},
-
 	curl = config_curl,
-
-	df	= {
-		{ },
-		{ "IgnoreSelected" },
-		{ "Devices", "MountPoints", "FSTypes" }
-	},
-
-	disk	= {
-		{ },
-		{ "IgnoreSelected" },
-		{ "Disks" }
-	},
-
-	dns	= {
-		{ },
-		{ },
-		{ "Interfaces", "IgnoreSources" }
-	},
-
-	email	= {
-		{ "SocketFile", "SocketGroup", "SocketPerms", "MaxConns" },
-		{ },
-		{ }
-	},
-
-	entropy = {
-		{ },
-		{ },
-		{ }
-	},
-
 	exec	= config_exec,
-
-	interface = {
-		{ },
-		{ "IgnoreSelected" },
-		{ "Interfaces" }
-	},
-
 	iptables = config_iptables,
-
-	irq	= {
-		{ },
-		{ "IgnoreSelected" },
-		{ "Irqs" }
-	},
-
-	iwinfo = {
-		{ },
-		{ "IgnoreSelected" },
-		{ "Interfaces" }
-	},
-
-	load	= {
-		{ },
-		{ },
-		{ }
-	},
-
 	logfile	= {
 		{ "LogLevel", "File" },
 		{ "Timestamp" },
 		{ }
 	},
-
-	memory = { 
-		{ },
-		{ },
-		{ }
-	},
-
-	netlink	= {
-		{ },
-		{ "IgnoreSelected" },
-		{ "Interfaces", "VerboseInterfaces", "QDiscs", "Classes", "Filters" }
-	},
-
 	network	= config_network,
-
-	nut = {
-		{ },
-		{ },
-		{ "UPS" }
-	},
-
-	olsrd = {
-		{ "Host", "Port", "CollectLinks","CollectRoutes","CollectTopology"},
-		{ },
-		{ }
-	},
-
-	openvpn = {
-		{ },
-		{ "CollectIndividualUsers", "CollectUserCount", "CollectCompression", "ImprovedNamingSchema" },
-		{ "StatusFile" }
-	},
-
-	ping	= {
-		{ "TTL", "Interval", "AddressFamily" },
-		{ },
-		{ "Hosts" }
-	},
-
-	processes = {
-		{ },
-		{ },
-		{ "Processes" }
-	},
-
-	rrdtool	= {
-		{ "DataDir", "StepSize", "HeartBeat", "RRARows", "XFF", "CacheFlush", "CacheTimeout" },
-		{ "RRASingle" },
-		{ "RRATimespans" }
-	},
-
-	sensors = {
-		{ },
-		{ "IgnoreSelected" },
-		{ "Sensor" }
-	},
-
-        splash_leases = {
-          { },
-          { },
-          { }
-        },
-
-	tcpconns = {
-		{ },
-		{ "ListeningPorts" },
-		{ "LocalPorts", "RemotePorts" }
-	},
-
-	thermal	= {
-		{ },
-		{ "IgnoreSelected" },
-		{ "Device" }
-	},
-
-	unixsock = {
-		{ "SocketFile", "SocketGroup", "SocketPerms" },
-		{ },
-		{ }
-	},
-
-	uptime = {
-		{ },
-		{ },
-		{ }
-	},
-
-	wireless = {
-		{ },
-		{ },
-		{ }
-	},
 }
+
+local plugin_dir = "/usr/lib/lua/luci/statistics/plugins/"
+for filename in nixio.fs.dir(plugin_dir) do
+	local plugin_fun = loadfile(plugin_dir .. filename)
+	setfenv(plugin_fun, { _ = luci.i18n.translate })
+	local plugin = plugin_fun()
+	local name = filename:gsub("%.lua", "")
+	plugins[name] = plugin.legend
+end
+
 
 preprocess = {
 	RRATimespans = function(val)


### PR DESCRIPTION
Hi all, hi @jow-,

I recently wrote my own collectd plugin and I wanted to be able to display the resulting data in OpenWrt using RRDtool. Of course luci-app-statistics doesn't support my collectd plugin, and there isn't currently a way to non-intrusively add support for new collectd plugins to luci-app-statistics. Therefore I decided to create this PR to make it possible to extend luci-app-statistics without modifying the source code.

Today there's a .lua file for every supported collectd plugin in `/usr/lib/lua/luci/model/cbi/luci_statistics`. To add support for a new plugin one needs to add a new model there, but one also needs to add a bit of extra information in some hard-coded tables in the luci-app-statistics source code. The idea is to load this information from files in `/usr/lib/lua/luci/statistics/plugins` instead. A third-party developer can then simply dump some `.lua` files in those directories and luci-app-statistics will pick them up; zero source code modifications are necessary. It should also work nicely with package managers: you can package your collectd plugin with these two lua files and things will just work.

What do you think about the idea? I haven't done a lot of Lua before, so I'd be grateful for any comments you might have!