### PR TITLE
[18.06]Fix broken link in `luci-app-advanced-reboot` package description

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -9,7 +9,7 @@ PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot supported Linksys and ZyXEL routers to\
 	an altnerative partition. Also provides Web UI to shut down (power off) your device. 	Supported dual-partition\
-	routers are listed at https://github.com/stangri/openwrt-luci/blob/luci-app-advanced-reboot/applications/luci-app-advanced-reboot/README.md
+	routers are listed at https://github.com/openwrt/luci/blob/master/applications/luci-app-advanced-reboot/README.md
 
 LUCI_DEPENDS:=+luci-mod-admin-full
 LUCI_PKGARCH:=all


### PR DESCRIPTION
The old URL was pointing to a 404 page belonging to GitHub user `stangri`.
Changed to point to location inside the `luci` project.