### PR TITLE
[18.06]build: add circleci

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:9
+
+
+# Configuration version history
+# v1.0   - Initial version by Etienne Champetier
+# v1.0.1 - Run as non-root, add unzip, xz-utils
+# v1.0.2 - Add bzr
+
+RUN apt update && apt install -y \
+build-essential \
+curl \
+jq \
+gawk \
+gettext \
+git \
+libncurses5-dev \
+libssl-dev \
+python \
+subversion \
+bzr \
+time \
+wget \
+zlib1g-dev \
+unzip \
+xz-utils \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN useradd -c "OpenWrt Builder" -m -d /home/build -s /bin/bash build
+USER build
+ENV HOME /home/build
+
+# LEDE Build System (LEDE GnuPG key for unattended build jobs)
+RUN curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/626471F1.asc' | gpg --import \
+ && echo '54CC74307A2C6DC9CE618269CD84BCED626471F1:6:' | gpg --import-ownertrust
+
+# LEDE Release Builder (17.01 "Reboot" Signing Key)
+RUN curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/D52BBB6B.asc' | gpg --import \
+ && echo 'B09BE781AE8A0CD4702FDCD3833C6010D52BBB6B:6:' | gpg --import-ownertrust
+
+# OpenWrt Release Builder (18.06 Signing Key)
+RUN curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/17E1CE16.asc' | gpg --import \
+ && echo '6768C55E79B032D77A28DA5F0F20257417E1CE16:6:' | gpg --import-ownertrust

--- a/.circleci/README
+++ b/.circleci/README
@@ -1,0 +1,6 @@
+# Build/update the docker image
+
+docker pull debian:9
+docker build --rm -t docker.io/openwrtorg/packages-cci:latest .
+docker tag <IMAGE ID> docker.io/openwrtorg/packages-cci:<VERSION-TAG>
+docker push docker.io/openwrtorg/packages-cci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,144 @@
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: docker.io/openwrtorg/packages-cci:v1.0.2
+    environment:
+      - SDK_HOST: "downloads.openwrt.org"
+      - SDK_PATH: "snapshots/targets/arx71xx/generic"
+      - SDK_FILE: "openwrt-sdk-18.06.1-ar71xx-generic_*.Linux-x86_64.tar.xz"
+      - BRANCH: "openwrt-18.06"
+    steps:
+      - checkout:
+          path: ~/openwrt_luci
+
+      - run:
+          name: Check changes / verify commits
+          working_directory: ~/openwrt_luci
+          command: |
+             cat >> $BASH_ENV <<EOF
+             echo_red()   { printf "\033[1;31m\$*\033[m\n"; }
+             echo_green() { printf "\033[1;32m\$*\033[m\n"; }
+             echo_blue()  { printf "\033[1;34m\$*\033[m\n"; }
+             EOF
+             source $BASH_ENV
+
+             RET=0
+             for commit in $(git rev-list HEAD ^origin/$BRANCH); do
+               echo_blue "=== Checking commit '$commit'"
+               if git show --format='%P' -s $commit | grep -qF ' '; then
+                 echo_red "Pull request should not include merge commits"
+                 RET=1
+               fi
+
+               author="$(git show -s --format=%aN $commit)"
+               if echo $author | grep -q '\S\+\s\+\S\+'; then
+                 echo_green "Author name ($author) seems ok"
+               else
+                 echo_red "Author name ($author) need to be your real name 'firstname lastname'"
+                 RET=1
+               fi
+
+               subject="$(git show -s --format=%s $commit)"
+               if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_-]\+: ' -e '^Revert '; then
+                 echo_green "Commit subject line seems ok ($subject)"
+               else
+                 echo_red "Commit subject line MUST start with '<package name>: ' ($subject)"
+                 RET=1
+               fi
+
+               body="$(git show -s --format=%b $commit)"
+               sob="$(git show -s --format='Signed-off-by: %aN <%aE>' $commit)"
+               if echo "$body" | grep -qF "$sob"; then
+                 echo_green "Signed-off-by match author"
+               else
+                 echo_red "Signed-off-by is missing or doesn't match author (should be '$sob')"
+                 RET=1
+               fi
+             done
+
+             exit $RET
+
+      - run:
+          name: Download the SDK
+          working_directory: ~/sdk
+          command: |
+             curl "https://$SDK_HOST/$SDK_PATH/sha256sums" -sS -o sha256sums
+             curl "https://$SDK_HOST/$SDK_PATH/sha256sums.asc" -sS -o sha256sums.asc
+             gpg --with-fingerprint --verify sha256sums.asc sha256sums
+             rsync -av "$SDK_HOST::downloads/$SDK_PATH/$SDK_FILE" .
+             sha256sum -c --ignore-missing sha256sums
+
+      - run:
+          name: Prepare build_dir
+          working_directory: ~/build_dir
+          command: |
+             tar Jxf ~/sdk/$SDK_FILE --strip=1
+             cat > feeds.conf <<EOF
+             src-git base https://github.com/openwrt/openwrt.git;$BRANCH
+             src-git packages https://github.com/openwrt/packages.git;$BRANCH
+             src-link luci $HOME/openwrt_luci
+             EOF
+             cat feeds.conf
+             ./scripts/feeds update -a > /dev/null
+             make defconfig > /dev/null
+             # enable BUILD_LOG
+             sed -i 's/# CONFIG_BUILD_LOG is not set/CONFIG_BUILD_LOG=y/' .config
+
+      - run:
+          name: Download source, check package, compile
+          working_directory: ~/build_dir
+          command: |
+             set +o pipefail
+             PKGS=$(cd ~/openwrt_luci; git diff --diff-filter=d --name-only "origin/$BRANCH..." | awk -F/ '{ print $2 }' | uniq)
+             if [ -z "$PKGS" ] ; then
+                 echo_blue "WARNING: No new or modified packages found!"
+                 exit 0
+             fi
+
+             echo_blue "=== Found new/modified packages: $PKGS"
+             for PKG in $PKGS ; do
+                 echo_blue "===+ Install: $PKG"
+                 ./scripts/feeds install $PKG
+
+                 echo_blue "===+ Download: $PKG"
+                 make "package/$PKG/download" V=s
+
+                 echo_blue "===+ Check package: $PKG"
+                 make "package/$PKG/check" V=s 2>&1 | tee logtmp
+                 RET=${PIPESTATUS[0]}
+
+                 if [ $RET -ne 0 ]; then
+                     echo_red   "=> Package check failed: $RET)"
+                     exit $RET
+                 fi
+
+                 badhash_msg="HASH does not match "
+                 badhash_msg+="|HASH uses deprecated hash,"
+                 badhash_msg+="|HASH is missing,"
+                 if grep -qE "$badhash_msg" logtmp; then
+                     echo_red   "=> Package HASH check failed"
+                     exit 1
+                 fi
+                 echo_green "=> Package check OK"
+             done
+
+             for PKG in $PKGS ; do
+                 echo_blue "===+ Building: $PKG"
+                 make "package/$PKG/compile" -j$(nproc) || make "package/$PKG/compile" V=s
+             done
+
+      - store_artifacts:
+          path: ~/build_dir/logs
+
+      - store_artifacts:
+          path: ~/build_dir/bin
+
+workflows:
+  version: 2
+  buildpr:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: master


### PR DESCRIPTION
This automatically performs formal checks and also checks and compiles
the packages. The resulting packages are then stored as artifacts and
easily testable on running machines.

Signed-off-by: Paul Spooren <mail@aparcar.org>