### PR TITLE
luci-app-statistics: fix collectd config generation

### DIFF
--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -276,15 +276,11 @@ plugins = {
 		{ },
 		{ }
 	},
-	curl = config_curl,
-	exec	= config_exec,
-	iptables = config_iptables,
 	logfile	= {
 		{ "LogLevel", "File" },
 		{ "Timestamp" },
 		{ }
 	},
-	network	= config_network,
 }
 
 local plugin_dir = "/usr/lib/lua/luci/statistics/plugins/"
@@ -293,7 +289,17 @@ for filename in nixio.fs.dir(plugin_dir) do
 	setfenv(plugin_fun, { _ = luci.i18n.translate })
 	local plugin = plugin_fun()
 	local name = filename:gsub("%.lua", "")
-	plugins[name] = plugin.legend
+	if (name == "exec") then
+		plugins[name] = config_exec
+	elseif (name == "iptables") then
+		plugins[name] = config_iptables
+	elseif (name == "curl") then
+		plugins[name] = config_curl
+	elseif (name == "network") then
+		plugins[name] = config_network
+	else
+		plugins[name] = plugin.legend
+	end
 end
 
 


### PR DESCRIPTION
Fix config generation for the following sections:

* curl
* exec
* network
* iptables

This was added with the following commit.
https://github.com/openwrt/luci/commit/c1380ab36797dc4a9cba5a6aa738019452178d79

Signed-off-by: Florian Eckert <fe@dev.tdt.de>