### PR TITLE
[18.06]luci-base: Fix Content-Type

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/xhr.js
+++ b/modules/luci-base/htdocs/luci-static/resources/xhr.js
@@ -88,7 +88,7 @@ XHR = function()
 		{
 			if (xhr.readyState == 4) {
 				var json = null;
-				if (xhr.getResponseHeader("Content-Type") == "application/json") {
+				if (/^application\/json\b/.test(xhr.getResponseHeader("Content-Type"))) {
 					try { json = JSON.parse(xhr.responseText); }
 					catch(e) { json = null; }
 				}


### PR DESCRIPTION
On my router, the response header `Content-Type` is `application/json; charset=UTF-8` instead of `application/json`, so almost every feature is broken.
The default http server installed is lighttpd on my device.

In past days, I use command `wget -O- 'https://github.com/openwrt/luci/raw/openwrt-18.06/modules/luci-base/htdocs/luci-static/resources/xhr.js' > '/www/luci-static/resources/xhr.js'` to do the patch. But I found the link is broken today.

So I hope this issue can be fixed on branch 18.06