### PR TITLE
address: Replace ualarm with setitimer

### DIFF
--- a/libs/luci-lib-nixio/src/address.c
+++ b/libs/luci-lib-nixio/src/address.c
@@ -24,6 +24,7 @@
 
 #ifdef __linux__
 
+#include <sys/time.h>
 #include <signal.h>
 #include <setjmp.h>
 #include <unistd.h>
@@ -287,6 +288,7 @@ static int nixio_getnameinfo(lua_State *L) {
 	const char *family = luaL_optstring(L, 2, NULL);
 
 #ifdef __linux__
+	const struct itimerval t = { {timeout * 1000 * 1000, 0} , {0, 0} };
 	struct sigaction sa_new, sa_old;
 	int timeout = luaL_optnumber(L, 3, 0);
 	if (timeout > 0 && timeout < 1000)
@@ -308,7 +310,7 @@ static int nixio_getnameinfo(lua_State *L) {
 			return 3;
 		}
 
-		ualarm(timeout * 1000, 0);
+		setitimer(ITIMER_REAL, &t, NULL);
 	}
 #endif
 
@@ -339,7 +341,7 @@ static int nixio_getnameinfo(lua_State *L) {
 #ifdef __linux__
 	if (timeout > 0 && timeout < 1000)
 	{
-		ualarm(0, 0);
+		alarm(0);
 		sigaction(SIGALRM, &sa_old, NULL);
 	}
 #endif


### PR DESCRIPTION
ualarm has been deprecated and may not be available in the libc.

Signed-off-by: Rosen Penev <rosenp@gmail.com>