### PR TITLE
luci-app-firewall: bring back 'MSS clamping' column/option

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -117,7 +117,7 @@ return L.view.extend({
 		o.editable = true;
 
 		o = s.taboption('general', form.Flag, 'mtu_fix', _('MSS clamping'));
-		o.modalonly = true;
+		o.editable = true;
 
 		o = s.taboption('general', widgets.NetworkSelect, 'network', _('Covered networks'));
 		o.modalonly = true;


### PR DESCRIPTION
* 'MSS clamping' is missing in current Zones setup

Signed-off-by: Dirk Brenken <dev@brenken.org>