### PR TITLE
luci-base: fix multiple parameter in cbi templates

### DIFF
--- a/modules/luci-base/luasrc/view/cbi/dropdown.htm
+++ b/modules/luci-base/luasrc/view/cbi/dropdown.htm
@@ -4,7 +4,7 @@
 		id = cbid,
 		name = cbid,
 		sort = self.keylist,
-		multi = self.multiple,
+		multiple = self.multiple,
 		datatype = self.datatype,
 		optional = self.optional or self.rmempty,
 		readonly = self.readonly,

--- a/modules/luci-base/luasrc/view/cbi/mvalue.htm
+++ b/modules/luci-base/luasrc/view/cbi/mvalue.htm
@@ -13,7 +13,7 @@
 		name = cbid,
 		size = self.size,
 		sort = self.keylist,
-		multi = true,
+		multiple = true,
 		widget = self.widget,
 		datatype = self.datatype,
 		optional = self.optional or self.rmempty,


### PR DESCRIPTION
In the dc0211803e commit, the parameter "multi" in ui.js is replaced with "multiple" everywhere. Thus, it must also be changed in the cbi templates.
