### PR TITLE
luci-mod-network: 802.11w config in station mode

### DIFF
--- a/modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua
+++ b/modules/luci-mod-network/luasrc/model/cbi/admin_network/wifi.lua
@@ -1151,6 +1151,18 @@ if hwtype == "mac80211" then
 		ieee80211w:depends({mode="ap-wds", encryption="sae"})
 		ieee80211w:depends({mode="ap-wds", encryption="sae-mixed"})
 		ieee80211w:depends({mode="ap-wds", encryption="owe"})
+		ieee80211w:depends({mode="sta", encryption="wpa2"})
+		ieee80211w:depends({mode="sta-wds", encryption="wpa2"})
+		ieee80211w:depends({mode="sta", encryption="psk2"})
+		ieee80211w:depends({mode="sta", encryption="psk-mixed"})
+		ieee80211w:depends({mode="sta", encryption="sae"})
+		ieee80211w:depends({mode="sta", encryption="sae-mixed"})
+		ieee80211w:depends({mode="sta", encryption="owe"})
+		ieee80211w:depends({mode="sta-wds", encryption="psk2"})
+		ieee80211w:depends({mode="sta-wds", encryption="psk-mixed"})
+		ieee80211w:depends({mode="sta-wds", encryption="sae"})
+		ieee80211w:depends({mode="sta-wds", encryption="sae-mixed"})
+		ieee80211w:depends({mode="sta-wds", encryption="owe"})
 
 		max_timeout = s:taboption("encryption", Value, "ieee80211w_max_timeout",
 				translate("802.11w maximum timeout"),


### PR DESCRIPTION
@hauke LIttle bugfix as I've been using two routers in WPA3-SAE mode for a few months.

802.11w has to be enabled in station mode to be effective. If the AP is using WPA3-SAE or requires 11w, station will not connect unless 11w is enabled via this option.