### PR TITLE
luci-app-watchat: fix ucitrack file

### DIFF
--- a/applications/luci-app-watchcat/root/etc/uci-defaults/40_luci-watchcat
+++ b/applications/luci-app-watchcat/root/etc/uci-defaults/40_luci-watchcat
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 uci -q batch <<-EOF >/dev/null
-        add ucitrack system
-        set ucitrack.@system[-1].init=watchcat
-        commit ucitrack
+	delete ucitrack.@watchcat[-1]
+	add ucitrack watchcat
+	set ucitrack.@watchcat[-1].init=watchcat
+	commit ucitrack
 EOF
 
 rm -f /tmp/luci-indexcache


### PR DESCRIPTION
I do not use this application but I think the ucitrack configuration generation file is wrong.
The related issue is https://github.com/openwrt/packages/issues/9506
