### PR TITLE
Fix a software page style issue for rosy, Fix #2965.

### DIFF
--- a/themes/luci-theme-rosy/htdocs/luci-static/rosy/cascade.css
+++ b/themes/luci-theme-rosy/htdocs/luci-static/rosy/cascade.css
@@ -55,6 +55,8 @@
 	line-height: normal;
 	display: table-cell;
 	padding: .5em;
+	word-break: break-all;
+	word-wrap: break-word;
 	text-align: center;
 	vertical-align: middle;
 }
@@ -136,6 +138,7 @@
 
 .col-10 {
 	flex: 10 10 300px !important;
+	width: 60%;
 }
 
 /* dom 元素 */


### PR DESCRIPTION
The software page is out of the parent box, and the same is true in chrome and firefox.
