### PR TITLE
luci-app-travelmate: sync with 1.4.10

### DIFF
--- a/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/stations.htm
@@ -34,7 +34,7 @@ This is free software, licensed under the Apache License, Version 2.0
 					if (view)
 					{
 						view.setAttribute("name", "station_nok");
-						view.setAttribute("style", "color: #a22; font-weight: bold");
+						view.setAttribute("style", "text-align: left !important; color: #a22; font-weight: bold");
 					}
 				}
 			}
@@ -59,7 +59,7 @@ This is free software, licensed under the Apache License, Version 2.0
 				view   = document.getElementById(search);
 				if (view)
 				{
-					view.setAttribute("style", "color: #37c; font-weight: bold");
+					view.setAttribute("style", "text-align: left !important; color: #37c; font-weight: bold");
 				}
 			}
 		}
@@ -122,10 +122,10 @@ This is free software, licensed under the Apache License, Version 2.0
 						local encr    = s.encryption or "-"
 			-%>
 			<div class="tr cbi-section-table-row cbi-rowstyle-1" name="station_ok" id="1_<%=device%>/<%=ssid%>/<%=bssid%>">
-				<div class="td left" name="station_ok" id="2_<%=device%>/<%=ssid%>/<%=bssid%>"><%=device%></div>
-				<div class="td left" name="station_ok" id="3_<%=device%>/<%=ssid%>/<%=bssid%>"><%=ssid%></div>
-				<div class="td left" name="station_ok" id="4_<%=device%>/<%=ssid%>/<%=bssid%>"><%=bssid%></div>
-				<div class="td left" name="station_ok" id="5_<%=device%>/<%=ssid%>/<%=bssid%>"><%=encr%></div>
+				<div class="td left" style="text-align: left !important" name="station_ok" id="2_<%=device%>/<%=ssid%>/<%=bssid%>"><%=device%></div>
+				<div class="td left" style="text-align: left !important" name="station_ok" id="3_<%=device%>/<%=ssid%>/<%=bssid%>"><%=ssid%></div>
+				<div class="td left" style="text-align: left !important" name="station_ok" id="4_<%=device%>/<%=ssid%>/<%=bssid%>"><%=bssid%></div>
+				<div class="td left" style="text-align: left !important" name="station_ok" id="5_<%=device%>/<%=ssid%>/<%=bssid%>"><%=encr%></div>
 				<div class="td middle cbi-section-actions">
 					<div>
 						<input class="cbi-button cbi-button-up" type="button" value="<%:Up%>" onclick="location.href='<%=luci.dispatcher.build_url('admin/services/travelmate/wifiorder')%>?cfg=<%=section%>&amp;dir=up'" alt="<%:Move up%>" title="<%:Move up%>" />

--- a/applications/luci-app-travelmate/luasrc/view/travelmate/wifi_scan.htm
+++ b/applications/luci-app-travelmate/luasrc/view/travelmate/wifi_scan.htm
@@ -52,16 +52,16 @@ This is free software, licensed under the Apache License, Version 2.0
 			</div>
 			<%- for i, net in ipairs(iw.scanlist or { }) do -%>
 			<div class="tr cbi-section-table-row cbi-rowstyle-1">
-				<div class="td left">
+				<div class="td left" style="text-align: left !important">
 					<%=net.ssid and utl.pcdata(net.ssid) or "<em>%s</em>" % translate("hidden")%>
 				</div>
-				<div class="td left">
+				<div class="td left" style="text-align: left !important">
 					<%=net.bssid and utl.pcdata(net.bssid)%>
 				</div>
-				<div class="td left">
+				<div class="td left" style="text-align: left !important">
 					<%=format_wifi_encryption(net.encryption)%>
 				</div>
-				<div class="td left">
+				<div class="td left" style="text-align: left !important">
 					<%=percent_wifi_signal(net)%> %
 				</div>
 				<div class="td cbi-section-actions">


### PR DESCRIPTION
* wifi add/edit: add a select box to reference an external script
  for automated captive portal logins
* fix a visual issue with material theme

Signed-off-by: Dirk Brenken <dev@brenken.org>