### PR TITLE
luci-base: add new VPN toplevel menu entry

### DIFF
--- a/applications/luci-app-ocserv/luasrc/controller/ocserv.lua
+++ b/applications/luci-app-ocserv/luasrc/controller/ocserv.lua
@@ -10,24 +10,24 @@ function index()
 
 	local page
 
-	page = entry({"admin", "services", "ocserv"}, alias("admin", "services", "ocserv", "main"),
+	page = entry({"admin", "vpn", "ocserv"}, alias("admin", "vpn", "ocserv", "main"),
 		_("OpenConnect VPN"))
 	page.dependent = true
 	
-	page = entry({"admin", "services", "ocserv", "main"},
+	page = entry({"admin", "vpn", "ocserv", "main"},
 		cbi("ocserv/main"),
 		_("Server Settings"), 200)
 	page.dependent = true
 
-	page = entry({"admin", "services", "ocserv", "users"},
+	page = entry({"admin", "vpn", "ocserv", "users"},
 		cbi("ocserv/users"),
 		_("User Settings"), 300)
 	page.dependent = true
 
-	entry({"admin", "services", "ocserv", "status"},
+	entry({"admin", "vpn", "ocserv", "status"},
 		call("ocserv_status")).leaf = true
 
-	entry({"admin", "services", "ocserv", "disconnect"},
+	entry({"admin", "vpn", "ocserv", "disconnect"},
 		post("ocserv_disconnect")).leaf = true
 
 end

--- a/applications/luci-app-ocserv/luasrc/view/ocserv_status.htm
+++ b/applications/luci-app-ocserv/luasrc/view/ocserv_status.htm
@@ -1,7 +1,7 @@
 <script type="text/javascript">//<![CDATA[
 
 	function ocserv_disconnect(idx) {
-		(new XHR()).post('<%=url('admin/services/ocserv/disconnect')%>/' + idx, { token: '<%=token%>' },
+		(new XHR()).post('<%=url('admin/vpn/ocserv/disconnect')%>/' + idx, { token: '<%=token%>' },
 			function(x)
 			{
 				var tb = document.getElementById('ocserv_status_table');
@@ -11,7 +11,7 @@
 		);
 	}
 
-	XHR.poll(-1, '<%=url('admin/services/ocserv/status')%>', null,
+	XHR.poll(-1, '<%=url('admin/vpn/ocserv/status')%>', null,
 		function(x, st)
 		{
 			var tb = document.getElementById('ocserv_status_table');

--- a/applications/luci-app-openvpn/luasrc/controller/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/controller/openvpn.lua
@@ -5,11 +5,11 @@
 module("luci.controller.openvpn", package.seeall)
 
 function index()
-	entry( {"admin", "services", "openvpn"}, cbi("openvpn"), _("OpenVPN") )
-	entry( {"admin", "services", "openvpn", "basic"},    cbi("openvpn-basic"),    nil ).leaf = true
-	entry( {"admin", "services", "openvpn", "advanced"}, cbi("openvpn-advanced"), nil ).leaf = true
-	entry( {"admin", "services", "openvpn", "file"},     form("openvpn-file"),    nil ).leaf = true
-	entry( {"admin", "services", "openvpn", "upload"},   call("ovpn_upload"))
+	entry( {"admin", "vpn", "openvpn"}, cbi("openvpn"), _("OpenVPN") )
+	entry( {"admin", "vpn", "openvpn", "basic"},    cbi("openvpn-basic"),    nil ).leaf = true
+	entry( {"admin", "vpn", "openvpn", "advanced"}, cbi("openvpn-advanced"), nil ).leaf = true
+	entry( {"admin", "vpn", "openvpn", "file"},     form("openvpn-file"),    nil ).leaf = true
+	entry( {"admin", "vpn", "openvpn", "upload"},   call("ovpn_upload"))
 end
 
 function ovpn_upload()
@@ -50,5 +50,5 @@ function ovpn_upload()
 			end
 		end
 	end
-	http.redirect(luci.dispatcher.build_url('admin/services/openvpn'))
+	http.redirect(luci.dispatcher.build_url('admin/vpn/openvpn'))
 end

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -800,7 +800,7 @@ local cts = { }
 local params = { }
 
 local m = Map("openvpn")
-m.redirect = luci.dispatcher.build_url("admin", "services", "openvpn")
+m.redirect = luci.dispatcher.build_url("admin", "vpn", "openvpn")
 m.apply_on_parse = true
 
 local p = m:section( SimpleSection )

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-basic.lua
@@ -95,7 +95,7 @@ local basicParams = {
 
 
 local m = Map("openvpn")
-m.redirect = luci.dispatcher.build_url("admin", "services", "openvpn")
+m.redirect = luci.dispatcher.build_url("admin", "vpn", "openvpn")
 m.apply_on_parse = true
 
 local p = m:section( SimpleSection )

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn.lua
@@ -18,9 +18,9 @@ local cfg = s:option(DummyValue, "config")
 function cfg.cfgvalue(self, section)
 	local file_cfg = self.map:get(section, "config")
 	if file_cfg then
-		s.extedit = luci.dispatcher.build_url("admin", "services", "openvpn", "file", "%s")
+		s.extedit = luci.dispatcher.build_url("admin", "vpn", "openvpn", "file", "%s")
 	else
-		s.extedit = luci.dispatcher.build_url("admin", "services", "openvpn", "basic", "%s")
+		s.extedit = luci.dispatcher.build_url("admin", "vpn", "openvpn", "basic", "%s")
 	end
 end
 
@@ -117,7 +117,7 @@ end
 local updown = s:option( Button, "_updown", translate("Start/Stop") )
 updown._state = false
 updown.redirect = luci.dispatcher.build_url(
-	"admin", "services", "openvpn"
+	"admin", "vpn", "openvpn"
 )
 function updown.cbid(self, section)
 	local pid = s.getPID(section)

--- a/applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm
+++ b/applications/luci-app-openvpn/luasrc/view/openvpn/cbi-select-input-add.htm
@@ -54,7 +54,7 @@
 		if (form)
 		{
 			form.enctype = 'multipart/form-data';
-			form.action  = '<%=url('admin/services/openvpn/upload')%>';
+			form.action  = '<%=url('admin/vpn/openvpn/upload')%>';
 			form.submit();
 		}
 	}

--- a/applications/luci-app-openvpn/luasrc/view/openvpn/pageswitch.htm
+++ b/applications/luci-app-openvpn/luasrc/view/openvpn/pageswitch.htm
@@ -8,21 +8,21 @@
 
 <div class="cbi-section">
 	<h3>
-		<a href="<%=url('admin/services/openvpn')%>"><%:Overview%></a> &#187;
+		<a href="<%=url('admin/vpn/openvpn')%>"><%:Overview%></a> &#187;
 		<%=luci.i18n.translatef("Instance \"%s\"", self.instance)%>
 	</h3>
 	<% if self.mode == "basic" then %>
-		<a href="<%=url('admin/services/openvpn/advanced', self.instance, "Service")%>"><%:Switch to advanced configuration%> &#187;</a><p/>
+		<a href="<%=url('admin/vpn/openvpn/advanced', self.instance, "Service")%>"><%:Switch to advanced configuration%> &#187;</a><p/>
 		<hr />
 	<% elseif self.mode == "advanced" then %>
-		<a href="<%=url('admin/services/openvpn/basic', self.instance)%>"><%:Switch to basic configuration%> &#187;</a><p/>
+		<a href="<%=url('admin/vpn/openvpn/basic', self.instance)%>"><%:Switch to basic configuration%> &#187;</a><p/>
 		<hr />
 		<%:Configuration category%>:
 		<% for i, c in ipairs(self.categories) do %>
 			<% if c == self.category then %>
 				<strong><%=translate(c)%></strong>
 			<% else %>
-				<a href="<%=luci.dispatcher.build_url("admin", "services", "openvpn", "advanced", self.instance, c)%>"><%=translate(c)%></a>
+				<a href="<%=luci.dispatcher.build_url("admin", "vpn", "openvpn", "advanced", self.instance, c)%>"><%=translate(c)%></a>
 			<% end %>
 			<% if next(self.categories, i) then %>|<% end %>
 		<% end %>

--- a/modules/luci-base/luasrc/controller/admin/index.lua
+++ b/modules/luci-base/luasrc/controller/admin/index.lua
@@ -51,6 +51,13 @@ function index()
 	toplevel_page(page, "admin/system/system", alias("admin", "system", "system"))
 
 	-- Only used if applications add items
+	page = node("admin", "vpn")
+	page.title = _("VPN")
+	page.order = 30
+	page.index = true
+	toplevel_page(page, false, false)
+
+	-- Only used if applications add items
 	page = node("admin", "services")
 	page.title = _("Services")
 	page.order = 40


### PR DESCRIPTION
There is always more and more vpn services. To make the LuCI menu look cleaner, a new top level menu "VPN" will be added with this pullrequest. All luci-app-* that have something to do with VPN should move to this new menu entry.

* Add new vpn menu section
* Move luci-app-openvpn to the new vpn section
* Move luci-app-ocserv to the new vpn section

The luci-app-vpnbypass should also go to this section.