### PR TITLE
luci-app-statistics: scale up ping_droprate to range 0-100

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua
@@ -27,7 +27,7 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 		  data = {
 			types   = { "ping_droprate" },
 			options = { ping_droprate = {
-				noarea = true, overlay = true, title = "%di" } }
+				noarea = true, overlay = true, title = "%di", transform_rpn = "100,*" } }
 		} }
 	}
 end


### PR DESCRIPTION
In original collectd, values of this metric are in range 0-1.  OpenWrt
previously have a custom patch scaling them up to range 0-100.  That
patch has been removed to align with possibly other deployments.

Ref: https://github.com/openwrt/packages/pull/9677
Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>

/hold

- [x] Test the effect
- [x] Wait openwrt/pacakges#9677 to be merged first