### PR TITLE
[RFC] luci-nginx and luci-ssl-nginx: collect files from nginx and uwsgi-cgi packages

### DIFF
--- a/collections/luci-nginx/Makefile
+++ b/collections/luci-nginx/Makefile
@@ -1,9 +1,3 @@
-#
-# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
-#
-# This is free software, licensed under the Apache License, Version 2.0 .
-#
-
 include $(TOPDIR)/rules.mk
 
 LUCI_TYPE:=col
@@ -12,11 +6,17 @@ LUCI_BASENAME:=nginx
 LUCI_TITLE:=LuCI interface with Nginx as Webserver
 LUCI_DESCRIPTION:=Standard OpenWrt set including full admin with ppp support and the default Bootstrap theme
 LUCI_DEPENDS:= \
-	+nginx +nginx-mod-luci +luci-mod-admin-full +luci-theme-bootstrap \
-	+luci-app-firewall +luci-proto-ppp +libiwinfo-lua +IPV6:luci-proto-ipv6 \
-	+rpcd-mod-rrdns
+	+nginx +uwsgi-cgi-plugin +luci-mod-admin-full +luci-theme-bootstrap \
+	+luci-app-firewall +luci-app-opkg +luci-proto-ppp +libiwinfo-lua \
+	+IPV6:luci-proto-ipv6 +rpcd-mod-rrdns
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
+
+define Package/luci-nginx/conffiles
+/etc/uwsgi/sites/luci.ini
+/etc/nginx/conf.d/luci.conf
+endef
 
 include ../../luci.mk
 

--- a/collections/luci-nginx/root/etc/init.d/luci
+++ b/collections/luci-nginx/root/etc/init.d/luci
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+
+START=79
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/sbin/uwsgi --ini /etc/uwsgi/sites/luci.ini
+	procd_set_param file /etc/uwsgi/sites/luci.ini
+	procd_set_param respawn
+	procd_close_instance
+	} 

--- a/collections/luci-nginx/root/etc/nginx/conf.d/luci.conf
+++ b/collections/luci-nginx/root/etc/nginx/conf.d/luci.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name localhost;
+    
+    root /www;
+
+    location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+        expires 365d;
+    }
+    
+    location /cgi-bin/luci {
+        index  index.html;
+        include uwsgi_params;
+        uwsgi_param SERVER_ADDR $server_addr;
+        uwsgi_modifier1 9;
+        uwsgi_pass unix:////var/run/luci.sock;
+    }
+
+    location /luci-static {
+    }
+
+} 

--- a/collections/luci-nginx/root/etc/uci-defaults/60-luci
+++ b/collections/luci-nginx/root/etc/uci-defaults/60-luci
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ -n "$(pgrep uhttpd)" ]; then
+	/etc/init.d/uhttpd stop
+	/etc/init.d/uhttpd disable
+fi
+if [ -n "$(pgrep nginx)" ]; then
+	/etc/init.d/nginx restart
+else
+	/etc/init.d/nginx start
+fi
+if [ -n "$(pgrep luci)" ]; then
+	/etc/init.d/luci restart
+else
+	/etc/init.d/luci start
+fi

--- a/collections/luci-nginx/root/etc/uwsgi/sites/luci.ini
+++ b/collections/luci-nginx/root/etc/uwsgi/sites/luci.ini
@@ -1,0 +1,28 @@
+[uwsgi]
+strict		= true
+plugin		= syslog, cgi
+socket		= /var/run/luci.sock
+cgi-mode	= true
+cgi		= /www/
+chdir		= /usr/lib/lua/luci/
+master		= true
+buffer-size	= 10000
+reload-mercy	= 8
+max-requests	= 2000
+limit-as	= 200
+reload-on-as	= 256
+reload-on-rss	= 192
+no-orphans	= true
+vacuum		= true
+enable-threads	= true
+post-buffering	= 8192
+socket-timeout	= 120
+thunder-lock	= true
+logger		= syslog:luci-uwsgi
+disable-logging	= true
+log-format	= %(addr) %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs
+pidfile		= /var/run/luci.pid
+die-on-term	= true
+threads		= 3
+processes	= 3
+chmod-socket	= 666 

--- a/collections/luci-ssl-nginx/Makefile
+++ b/collections/luci-ssl-nginx/Makefile
@@ -1,24 +1,24 @@
-#
-# Copyright (C) 2008-2016 The LuCI Team
-#
-# This is free software, licensed under the Apache License, Version 2.0 .
-#
-
 include $(TOPDIR)/rules.mk
 
 LUCI_TYPE:=col
-LUCI_BASENAME:=ssl
+LUCI_BASENAME:=ssl-nginx
 
 LUCI_TITLE:=LuCI with HTTPS support on Nginx (OpenSSL as SSL backend)
 LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
- OpenSSL cmd tools (openssl-util) are used by nginx for SSL key generation. \
- 
+ OpenSSL cmd tools (openssl-util) are used by Nginx for SSL key generation \
+ instead of the default px5g. (If px5g is installed, Nginx will prefer that.)
 LUCI_DEPENDS:= \
-	+nginx-ssl +nginx-mod-luci-ssl +luci-mod-admin-full +luci-theme-bootstrap \
-	+luci-app-firewall +luci-proto-ppp +libiwinfo-lua +IPV6:luci-proto-ipv6 \
-	+rpcd-mod-rrdns +openssl-util
+	+nginx-ssl +uwsgi-cgi-plugin +luci-mod-admin-full +luci-theme-bootstrap \
+	+luci-app-firewall +luci-app-opkg +luci-proto-ppp +libiwinfo-lua \
+	+IPV6:luci-proto-ipv6 +rpcd-mod-rrdns +openssl-util
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
+
+define Package/luci-ssl-nginx/conffiles
+/etc/uwsgi/sites/luci.ini
+/etc/nginx/conf.d/luci.conf
+endef
 
 include ../../luci.mk
 

--- a/collections/luci-ssl-nginx/root/etc/init.d/luci
+++ b/collections/luci-ssl-nginx/root/etc/init.d/luci
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+
+START=79
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/sbin/uwsgi --ini /etc/uwsgi/sites/luci.ini
+	procd_set_param file /etc/uwsgi/sites/luci.ini
+	procd_set_param respawn
+	procd_close_instance
+	} 

--- a/collections/luci-ssl-nginx/root/etc/nginx/conf.d/luci.conf
+++ b/collections/luci-ssl-nginx/root/etc/nginx/conf.d/luci.conf
@@ -1,0 +1,31 @@
+server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    server_name localhost;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:DHE+AESGCM:DHE:!RSA!aNULL:!eNULL:!LOW:!RC4:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!CAMELLIA:!SEED";
+    ssl_session_tickets off;
+
+    ssl_certificate /etc/nginx/nginx.cer;
+    ssl_certificate_key /etc/nginx/nginx.key;
+    
+    root /www;
+
+    location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+        expires 365d;
+    }
+    
+    location /cgi-bin/luci {
+        index  index.html;
+        include uwsgi_params;
+        uwsgi_param SERVER_ADDR $server_addr;
+        uwsgi_modifier1 9;
+        uwsgi_pass unix:////var/run/luci.sock;
+    }
+
+    location /luci-static {
+    }
+
+} 

--- a/collections/luci-ssl-nginx/root/etc/uci-defaults/70-luci
+++ b/collections/luci-ssl-nginx/root/etc/uci-defaults/70-luci
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+if [ -n "$(pgrep uhttpd)" ]; then
+	/etc/init.d/uhttpd stop
+	/etc/init.d/uhttpd disable
+fi
+if [ -n "$(pgrep nginx)" ]; then
+	/etc/init.d/nginx restart
+else
+	/etc/init.d/nginx start
+fi
+if [ -n "$(pgrep luci)" ]; then
+	/etc/init.d/luci restart
+else
+	/etc/init.d/luci start
+fi
+if [ ! -f "/etc/nginx/nginx.key" ]; then
+	
+	NGINX_KEY=/etc/nginx/nginx.key
+	NGINX_CER=/etc/nginx/nginx.cer
+	OPENSSL_BIN=/usr/bin/openssl
+	PX5G_BIN=/usr/sbin/px5g
+	
+	# Prefer px5g for certificate generation (existence evaluated last)
+	GENKEY_CMD=""
+	UNIQUEID=$(dd if=/dev/urandom bs=1 count=4 | hexdump -e '1/1 "%02x"')
+	[ -x "$OPENSSL_BIN" ] && GENKEY_CMD="$OPENSSL_BIN req -x509 -nodes"
+	[ -x "$PX5G_BIN" ] && GENKEY_CMD="$PX5G_BIN selfsigned"
+	[ -n "$GENKEY_CMD" ] && {
+		$GENKEY_CMD \
+			-days 730 -newkey rsa:2048 -keyout "${NGINX_KEY}.new" -out "${NGINX_CER}.new" \
+			-subj /C="ZZ"/ST="Somewhere"/L="Unknown"/O="OpenWrt""$UNIQUEID"/CN="OpenWrt"
+		sync
+		mv "${NGINX_KEY}.new" "${NGINX_KEY}"
+		mv "${NGINX_CER}.new" "${NGINX_CER}"
+	}
+fi 

--- a/collections/luci-ssl-nginx/root/etc/uwsgi/sites/luci.ini
+++ b/collections/luci-ssl-nginx/root/etc/uwsgi/sites/luci.ini
@@ -1,0 +1,28 @@
+[uwsgi]
+strict		= true
+plugin		= syslog, cgi
+socket		= /var/run/luci.sock
+cgi-mode	= true
+cgi		= /www/
+chdir		= /usr/lib/lua/luci/
+master		= true
+buffer-size	= 10000
+reload-mercy	= 8
+max-requests	= 2000
+limit-as	= 200
+reload-on-as	= 256
+reload-on-rss	= 192
+no-orphans	= true
+vacuum		= true
+enable-threads	= true
+post-buffering	= 8192
+socket-timeout	= 120
+thunder-lock	= true
+logger		= syslog:luci-uwsgi
+disable-logging	= true
+log-format	= %(addr) %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs
+pidfile		= /var/run/luci.pid
+die-on-term	= true
+threads		= 3
+processes	= 3
+chmod-socket	= 666 


### PR DESCRIPTION
I am new to contributing and I am not sure if this change is a good idea. I tried to collect the files that are needed to run luci on nginx from the uwsgi-cgi and the nginx package and would move it here. See my other draft PRs in packages, too:
<strike>https://github.com/openwrt/packages/pull/9736 ([RFC] package etesync and its dependencies and move luci on nginx)</strike>
[uwsgi: add packages with modules](https://github.com/openwrt/packages/pull/9855) and [nginx: enable /etc/nginx/conf.d directory](https://github.com/openwrt/packages/pull/9859).
I would do this only if Ansuel approves it since it is his project.

See also the topic at:
https://forum.openwrt.org/t/package-etesync-and-its-dependencies/42269
I hope it is understandable what I try to do.