### PR TITLE
luci-base: add new Firewall toplevel menu entry

### DIFF
--- a/applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json
+++ b/applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json
@@ -1,5 +1,5 @@
 {
-	"admin/network/firewall": {
+	"admin/firewall": {
 		"title": "Firewall",
 		"order": 60,
 		"action": {
@@ -12,7 +12,7 @@
 		}
 	},
 
-	"admin/network/firewall/zones": {
+	"admin/firewall/zones": {
 		"title": "General Settings",
 		"order": 10,
 		"action": {
@@ -21,7 +21,7 @@
 		}
 	},
 
-	"admin/network/firewall/forwards": {
+	"admin/firewall/forwards": {
 		"title": "Port Forwards",
 		"order": 20,
 		"action": {
@@ -30,7 +30,7 @@
 		}
 	},
 
-	"admin/network/firewall/rules": {
+	"admin/firewall/rules": {
 		"title": "Traffic Rules",
 		"order": 30,
 		"action": {
@@ -39,7 +39,7 @@
 		}
 	},
 
-	"admin/network/firewall/custom": {
+	"admin/firewall/custom": {
 		"title": "Custom Rules",
 		"order": 40,
 		"action": {

--- a/modules/luci-base/root/usr/share/luci/menu.d/luci-base.json
+++ b/modules/luci-base/root/usr/share/luci/menu.d/luci-base.json
@@ -59,6 +59,15 @@
 		}
 	},
 
+	"admin/firewall": {
+		"title": "Firewall",
+		"order": 60,
+		"action": {
+			"type": "firstchild",
+			"recurse": true
+		}
+	},
+
 	"admin/translations/*": {
 		"action": {
 			"type": "call",


### PR DESCRIPTION
To make the LuCI menu look cleaner, a new top level menu "Firewall" is added with this pullrequest. In a subsequent pullrequest we can also move the following application to the new firewall menu. These applications have everything to do with firewall from my point of view.

* luci-app-adblock
* luci-app-banip
* luci-app-clamav
* luci-app-nft-qos
* luci-app-privoxy
* luci-app-simple-adblock
* luci-app-tinyproxy

With this pullrequest I want to show the possibility that OpenWrt can also be used as a firewall solution like **opensense**. I realize that packages are still missing, but this is the first step