### PR TITLE
luci-app-travelmate: sync with 1.4.12

### DIFF
--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua
@@ -71,19 +71,24 @@ o4 = s:option(Flag, "trm_proactive", translate("ProActive Uplink Switch"),
 o4.default = o4.enabled
 o4.rmempty = false
 
-o5 = s:option(ListValue, "trm_iface", translate("Uplink / Trigger interface"),
+o5 = s:option(Flag, "trm_autoadd", translate("Add Open Uplinks"),
+	translate("Automatically add open uplinks like hotel captive portals to your wireless config."))
+o5.default = o5.disabled
+o5.rmempty = false
+
+o6 = s:option(ListValue, "trm_iface", translate("Uplink / Trigger interface"),
 	translate("Name of the used uplink interface."))
 if dump then
 	local i, v
 	for i, v in ipairs(dump.interface) do
 		if v.interface ~= "loopback" and v.interface ~= "lan" then
 			local device = v.l3_device or v.device or "-"
-			o5:value(v.interface, v.interface.. " (" ..device.. ")")
+			o6:value(v.interface, v.interface.. " (" ..device.. ")")
 		end
 	end
 end
-o5.default = trmiface
-o5.rmempty = false
+o6.default = trmiface
+o6.rmempty = false
 
 -- Runtime information
 

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua
@@ -138,7 +138,7 @@ elseif (tonumber(m.hidden.wpa_version) or 0) > 0 then
 end
 
 local login_section = (m.hidden.ssid or "") .. (m.hidden.bssid or "")
-login_section = login_section.lower(login_section:gsub("[^%w_]", "_"))
+login_section = login_section:gsub("[^%w_]", "_")
 local cmd = uci:get("travelmate", login_section, "command")
 cmd_list = m:field(ListValue, "cmdlist", translate("Auto Login Script"),
 	translate("External script reference which will be called for automated captive portal logins."))
@@ -188,7 +188,7 @@ function wssid.write(self, section, value)
 		uci:set("wireless", newsection, "encryption", "none")
 	end
 	local login_section = (wssid:formvalue(section) or "") .. (bssid:formvalue(section) or "")
-	login_section = login_section.lower(login_section:gsub("[^%w_]", "_"))
+	login_section = login_section:gsub("[^%w_]", "_")
 	if not uci:get("travelmate", login_section) and cmd_list:formvalue(section) ~= "none" then
 		uci:set("travelmate", login_section, "login")
 	end

--- a/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua
+++ b/applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua
@@ -131,7 +131,7 @@ if s ~= nil then
 	end
 
 	local login_section = (s.ssid or "") .. (s.bssid or "")
-	login_section = login_section.lower(login_section:gsub("[^%w_]", "_"))
+	login_section = login_section:gsub("[^%w_]", "_")
 	local cmd = uci:get("travelmate", login_section, "command")
 	cmd_list = m:field(ListValue, "cmdlist", translate("Auto Login Script"),
 		translate("External script reference which will be called for automated captive portal logins."))
@@ -175,7 +175,7 @@ function wssid.write(self, section, value)
 		end
 	end
 	local login_section = (wssid:formvalue(section) or "") .. (bssid:formvalue(section) or "")
-	login_section = login_section.lower(login_section:gsub("[^%w_]", "_"))
+	login_section = login_section:gsub("[^%w_]", "_")
 	if not uci:get("travelmate", login_section) and cmd_list:formvalue(section) ~= "none" then
 		uci:set("travelmate", login_section, "login")
 	end


### PR DESCRIPTION
* option to add open uplinks to your wireless config,
  e.g. hotel captive portals (disabled by default)

Signed-off-by: Dirk Brenken <dev@brenken.org>