### PR TITLE
luci-app-firewall: remove unnecessary quotation in Ukrainian translation

### DIFF
--- a/applications/luci-app-firewall/po/uk/firewall.po
+++ b/applications/luci-app-firewall/po/uk/firewall.po
@@ -129,7 +129,7 @@ msgstr ""
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:85
 msgid "Conntrack Settings"
 msgstr ""
-"Параметри відслідковування з'єднань (<abbr title=\"Connection tracking\">""
+"Параметри відслідковування з'єднань (<abbr title=\"Connection tracking\">"
 "Conntrack</abbr>)"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:214


### PR DESCRIPTION
Removed unnecessary double quotation at the end of the line. It was
reported as an error by i18n-sync.sh script.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>