### PR TITLE
luci-base and apps: update Spanish translation

### DIFF
--- a/applications/luci-app-adblock/po/es/adblock.po
+++ b/applications/luci-app-adblock/po/es/adblock.po
@@ -3,12 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2019-02-22 16:32-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
-"Last-Translator: \n"
+"X-Generator: Poedit 2.2.3\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
@@ -68,7 +68,7 @@ msgstr "Lista negra"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:169
 msgid "Blacklist File"
-msgstr ""
+msgstr "Archivo de lista negra"
 
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:274
 msgid "Blocked DNS Queries"
@@ -127,11 +127,11 @@ msgstr "DNS Backend (Directorio DNS)"
 
 #: applications/luci-app-adblock/luasrc/view/adblock/runtime.htm:169
 msgid "DNS Backend, DNS Directory"
-msgstr ""
+msgstr "Servidor DNS, Directorio DNS"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:34
 msgid "DNS Blocking Variant"
-msgstr ""
+msgstr "Variante de bloqueo de DNS"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:164
 msgid "DNS Directory"
@@ -139,11 +139,11 @@ msgstr "Directorio DNS"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:127
 msgid "DNS File Reset"
-msgstr ""
+msgstr "Restablecimiento de archivos DNS"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:197
 msgid "DNS Inotify"
-msgstr ""
+msgstr "DNS Inotify"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:20
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:134
@@ -152,7 +152,7 @@ msgstr "Informe de consulta de DNS"
 
 #: applications/luci-app-adblock/luasrc/view/adblock/runtime.htm:175
 msgid "DNS Variant, DNS File Reset"
-msgstr ""
+msgstr "Variante DNS, Restablecimiento de archivos DNS"
 
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:81
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:89
@@ -168,18 +168,24 @@ msgid ""
 "Disable adblock triggered restarts and the 'DNS File Reset' for dns backends "
 "with autoload features."
 msgstr ""
+"Deshabilite los reinicios activados por adblock y el 'Restablecimiento de "
+"archivos DNS' para back-end dns con funciones de carga automática."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:187
 msgid ""
 "Disable the toplevel domain compression, if the number of blocked domains is "
 "greater than this threshold."
 msgstr ""
+"Deshabilite la compresión de dominio de nivel superior, si el número de "
+"dominios bloqueados es mayor que este umbral."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:36
 msgid ""
 "Dnsmasq also supports 'null' block variants, which may provide better "
 "response times."
 msgstr ""
+"Dnsmasq también admite variantes de bloque 'nulo', que pueden proporcionar "
+"mejores tiempos de respuesta."
 
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:28
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:71
@@ -202,27 +208,27 @@ msgstr "Utilidad de descarga (Biblioteca SSL)"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:152
 msgid "E-Mail Notification"
-msgstr ""
+msgstr "Notificación del E-Mail"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:260
 msgid "E-Mail Notification Count"
-msgstr ""
+msgstr "Conteo de notificaciones por E-Mail"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:255
 msgid "E-Mail Profile"
-msgstr ""
+msgstr "Perfil del E-Mail"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:157
 msgid "E-Mail Receiver Address"
-msgstr ""
+msgstr "Dirección del destinatario del E-Mail"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:245
 msgid "E-Mail Sender Address"
-msgstr ""
+msgstr "Dirección del remitente del E-Mail"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:250
 msgid "E-Mail Topic"
-msgstr ""
+msgstr "Tema del E-Mail"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:24
 msgid "Edit Blacklist"
@@ -300,7 +306,7 @@ msgstr "Forzar DNS local"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:170
 msgid "Full path to the blacklist file."
-msgstr ""
+msgstr "Ruta completa al archivo de la lista negra."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:176
 msgid "Full path to the whitelist file."
@@ -348,6 +354,8 @@ msgid ""
 "List of supported DNS blocking variants. By default 'nxdomain' will be used "
 "for all DNS backends."
 msgstr ""
+"Lista de variantes de bloqueo de DNS compatibles. Por defecto, 'nxdomain' se "
+"usará para todos los servidores DNS."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:44
 msgid "List of supported and fully pre-configured download utilities."
@@ -362,7 +370,7 @@ msgstr "Cargando"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:192
 msgid "Local FW/DNS Ports"
-msgstr ""
+msgstr "Puertos locales FW/DNS"
 
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:22
 msgid "Logfile"
@@ -375,6 +383,8 @@ msgstr "Servicio con prioridad baja"
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:256
 msgid "Mail profile used in 'msmtp' for adblock notification E-Mails."
 msgstr ""
+"Perfil de correo utilizado en 'msmtp' para notificaciones de E-Mails de "
+"adblock."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:120
 msgid "Max. Download Queue"
@@ -445,16 +455,20 @@ msgid ""
 "Raise the minimum notification count, to get E-Mails if the overall count is "
 "less or equal to the given limit (default 0),"
 msgstr ""
+"Aumente el recuento mínimo de notificaciones para obtener E-Mails si el "
+"recuento general es menor o igual al límite dado (valor predeterminado 0),"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:158
 msgid "Receiver address for adblock notification E-Mails."
-msgstr ""
+msgstr "Dirección del receptor para la notificación de bloqueos electrónicos."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:117
 msgid ""
 "Redirect all DNS queries from 'lan' zone to the local resolver, applies to "
 "udp and tcp protocol on ports 53, 853 and 5353."
 msgstr ""
+"Redireccionar todas las consultas DNS desde la zona 'lan' al resolvedor "
+"local, se aplica al protocolo udp y tcp en los puertos 53, 853 y 5353."
 
 #: applications/luci-app-adblock/luasrc/view/adblock/runtime.htm:28
 #: applications/luci-app-adblock/luasrc/view/adblock/runtime.htm:39
@@ -515,6 +529,8 @@ msgid ""
 "Resets the final DNS blockfile 'adb_list.overall' after loading through the "
 "DNS backend."
 msgstr ""
+"Restablece el archivo de bloque DNS final 'adb_list.overall' después de "
+"cargarlo a través del backend de DNS."
 
 #: applications/luci-app-adblock/luasrc/view/adblock/runtime.htm:37
 msgid "Resume"
@@ -539,10 +555,12 @@ msgid ""
 "Send notification E-Mails in case of a processing error or if domain count "
 "is &le; 0."
 msgstr ""
+"Enviar notificaciones por E-Mail en caso de un error de procesamiento o si "
+"el recuento de dominios es &le 0."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:246
 msgid "Sender address for adblock notification E-Mails."
-msgstr ""
+msgstr "Dirección del remitente para los E-Mails de notificación de adblock."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:110
 msgid ""
@@ -557,11 +575,15 @@ msgid ""
 "Size of the download queue to handle downloads &amp; list processing in "
 "parallel (default '4')."
 msgstr ""
+"Tamaño de la cola de descarga para manejar descargas &amp; procesamiento de "
+"la lista en paralelo (predeterminado '4')."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:193
 msgid ""
 "Space separated list of firewall ports which should be redirected locally."
 msgstr ""
+"Lista de puertos de firewall separados por espacios que deben redirigirse "
+"localmente."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:226
 msgid ""
@@ -590,19 +612,25 @@ msgstr "Suspender / Reanudar Adblock"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:186
 msgid "TLD Compression Threshold"
-msgstr ""
+msgstr "Umbral de compresión de TLD"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:147
 msgid ""
 "Target directory for adblock source backups. Default is '/tmp', please use "
 "preferably a non-volatile disk if available."
 msgstr ""
+"Directorio de destino para copias de seguridad de origen de adblock. El "
+"valor predeterminado es '/tmp', utilice preferiblemente un disco no volátil "
+"si está disponible."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:140
 msgid ""
 "Target directory for dns related report files. Default is '/tmp', please use "
 "preferably a non-volatile disk if available."
 msgstr ""
+"Directorio de destino para archivos de informes relacionados con dns. El "
+"valor predeterminado es '/tmp', utilice preferiblemente un disco no volátil "
+"si está disponible."
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:165
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
@@ -667,6 +695,8 @@ msgid ""
 "This option saves an enormous amount of storage space, but starts a small "
 "ubus/adblock monitor in the background."
 msgstr ""
+"Esta opción ahorra una enorme cantidad de espacio de almacenamiento, pero "
+"inicia un pequeño monitor ubus/adblock en segundo plano."
 
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:82
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:89
@@ -687,7 +717,7 @@ msgstr "Top 10 de informes"
 
 #: applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua:251
 msgid "Topic for adblock notification E-Mails."
-msgstr ""
+msgstr "Tema para la notificación de bloqueos de E-Mails."
 
 #: applications/luci-app-adblock/luasrc/view/adblock/report.htm:268
 msgid "Total DNS Queries"
@@ -722,6 +752,8 @@ msgid ""
 "e.g. to receive an E-Mail notification with every adblock run set this value "
 "to 200000."
 msgstr ""
+"p.ej. para recibir una notificación por E-Mail con cada ejecución de bloque "
+"de anuncios, establezca este valor en 200000."
 
 #~ msgid "'Jail' Blocklist Creation"
 #~ msgstr "Creación de listas de bloqueo 'Jail'"

--- a/applications/luci-app-advanced-reboot/po/es/advanced-reboot.po
+++ b/applications/luci-app-advanced-reboot/po/es/advanced-reboot.po
@@ -3,12 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2019-09-17 22:29-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
-"Last-Translator: \n"
+"X-Generator: Poedit 2.2.3\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
@@ -81,7 +81,7 @@ msgstr "Reinicie el dispositivo a una partición alternativa"
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:50
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:74
 msgid "Reboot to alternative partition..."
-msgstr "Reiniciar a partición alternativa ..."
+msgstr "Reiniciar a la partición alternativa ..."
 
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:45
 #: applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/advanced_reboot.htm:69

--- a/applications/luci-app-aria2/po/es/aria2.po
+++ b/applications/luci-app-aria2/po/es/aria2.po
@@ -3,12 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2019-09-17 23:29-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.2\n"
-"Last-Translator: \n"
+"X-Generator: Poedit 2.2.3\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
@@ -19,19 +19,19 @@ msgstr ""
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:414
 msgid "Additional BT tracker"
-msgstr ""
+msgstr "Tracker BT adicional"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:419
 msgid "Advanced Options"
-msgstr ""
+msgstr "Opciones avanzadas"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:169
 msgid "All proxy"
-msgstr ""
+msgstr "Todos los proxy"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:228
 msgid "Append HEADERs to HTTP request header."
-msgstr ""
+msgstr "Añadir encabezados al encabezado de solicitud HTTP."
 
 #: applications/luci-app-aria2/luasrc/controller/aria2.lua:18
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:35
@@ -45,18 +45,19 @@ msgid ""
 "Aria2 is a lightweight multi-protocol &amp; multi-source, cross platform "
 "download utility."
 msgstr ""
+"Aria2 es un multiprotocolo ligero &amp; utilidad de descarga multiplataforma."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:428
 msgid "Auto save interval"
-msgstr ""
+msgstr "Intervalo de guardado automático"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:56
 msgid "Basic Options"
-msgstr ""
+msgstr "Opciones avanzadas"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:276
 msgid "BitTorrent Options"
-msgstr ""
+msgstr "Opciones de BitTorrent"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:335
 msgid "BitTorrent listen port"
@@ -64,21 +65,23 @@ msgstr "BitTorrent escucha puerto"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:189
 msgid "CA certificate"
-msgstr ""
+msgstr "Certificado CA"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:195
 msgid "Certificate"
-msgstr ""
+msgstr "Certificado"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:182
 msgid "Check certificate"
-msgstr ""
+msgstr "Comprobar certificado"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:242
 msgid ""
 "Close connection if download speed is lower than or equal to this "
 "value(bytes per sec). 0 means has no lowest speed limit."
 msgstr ""
+"Cierre la conexión si la velocidad de descarga es menor o igual a este valor "
+"(bytes por segundo). 0 significa que no tiene límite de velocidad mínima."
 
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:49
 #: applications/luci-app-aria2/luasrc/view/aria2/settings_header.htm:29
@@ -91,23 +94,23 @@ msgstr "Directorio de archivos de configuración"
 
 #: applications/luci-app-aria2/luasrc/controller/aria2.lua:21
 msgid "Configuration"
-msgstr ""
+msgstr "Configuración"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:230
 msgid "Connect timeout"
-msgstr ""
+msgstr "Tiempo de espera de conexión"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/files.lua:19
 msgid "Content of config file: <code>%s</code>"
-msgstr ""
+msgstr "Contenido del archivo de configuración: <code>%s</code>"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/files.lua:29
 msgid "Content of session file: <code>%s</code>"
-msgstr ""
+msgstr "Contenido del archivo de sesión: <code>%s</code>"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:341
 msgid "DHT Listen port"
-msgstr ""
+msgstr "Puerto de DHT"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:87
 msgid "Debug"
@@ -118,6 +121,8 @@ msgid ""
 "Disable IPv6. This is useful if you have to use broken DNS and want to avoid "
 "terribly slow AAAA record lookup."
 msgstr ""
+"Deshabilitar IPv6. Esto es útil si tiene que usar DNS roto y desea evitar "
+"una búsqueda de registros AAAA terriblemente lenta."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:440
 msgid "Disk cache"
@@ -126,51 +131,54 @@ msgstr "Caché de disco"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:259
 msgid "Don't split less than 2*SIZE byte range. Possible values: 1M-1024M."
 msgstr ""
+"No divida menos de 2*TAMAÑO de rango de bytes. Valores posibles: 1M-1024M."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:254
 msgid "Download a file using N connections."
-msgstr ""
+msgstr "Descargue un archivo usando N conexiones."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:69
 msgid "Download directory"
-msgstr ""
+msgstr "Directorio de descarga"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/files.lua:26
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/files.lua:36
 msgid "Empty file."
-msgstr ""
+msgstr "Archivo vacío."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:280
 msgid "Enable IPv4 DHT functionality. It also enables UDP tracker support."
 msgstr ""
+"Habilite la funcionalidad DHT IPv4. También habilita el soporte de tracker "
+"UDP."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:290
 msgid "Enable IPv6 DHT functionality."
-msgstr ""
+msgstr "Habilite la funcionalidad DHT IPv6 ."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:298
 msgid "Enable Local Peer Discovery."
-msgstr ""
+msgstr "Habilitar el descubrimiento de pares locales."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:307
 msgid "Enable Peer Exchange extension."
-msgstr ""
+msgstr "Habilite la extensión de intercambio de pares."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:442
 msgid "Enable disk cache (in bytes), set 0 to disabled."
-msgstr ""
+msgstr "Habilite el caché de disco (en bytes), establezca 0 para deshabilitar."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:77
 msgid "Enable logging"
-msgstr ""
+msgstr "Habilitar el registro"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:305
 msgid "Enable peer exchange"
-msgstr ""
+msgstr "Habilitar el intercambio entre pares"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:166
 msgid "Enable proxy"
-msgstr ""
+msgstr "Habilitar proxy"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:58
 msgid "Enabled"
@@ -182,7 +190,7 @@ msgstr "Error"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:44
 msgid "Error: Can't find aria2c in PATH, please reinstall aria2."
-msgstr ""
+msgstr "Error: no se puede encontrar aria2c en PATH, reinstale aria2."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:482
 msgid "Extra Settings"
@@ -190,25 +198,25 @@ msgstr "Configuraciones extra"
 
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:39
 msgid "Failed to load log data."
-msgstr ""
+msgstr "Error al cargar los datos del registro."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:350
 msgid "False"
-msgstr ""
+msgstr "Falso"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:447
 msgid "File allocation"
-msgstr ""
+msgstr "Asignación de archivos"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/files.lua:25
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/files.lua:35
 msgid "File does not exist."
-msgstr ""
+msgstr "El archivo no existe."
 
 #: applications/luci-app-aria2/luasrc/controller/aria2.lua:24
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/files.lua:14
 msgid "Files"
-msgstr ""
+msgstr "Archivos"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:348
 msgid "Follow torrent"
@@ -216,11 +224,11 @@ msgstr "Seguir torrent"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:38
 msgid "For more information, please visit: %s"
-msgstr ""
+msgstr "Para obtener más información, visite: %s"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:460
 msgid "Force save"
-msgstr ""
+msgstr "Forzar guardado"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:129
 msgid "Generate Randomly"
@@ -228,35 +236,35 @@ msgstr "Generar aleatoriamente"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:210
 msgid "HTTP accept gzip"
-msgstr ""
+msgstr "HTTP acepta gzip"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:219
 msgid "HTTP no cache"
-msgstr ""
+msgstr "HTTP sin caché"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:164
 msgid "HTTP/FTP/SFTP Options"
-msgstr ""
+msgstr "Opciones HTTP/FTP/SFTP"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:227
 msgid "Header"
-msgstr ""
+msgstr "Encabezamiento"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/files.lua:15
 msgid "Here shows the files used by aria2."
-msgstr ""
+msgstr "Aquí se muestran los archivos utilizados por aria2."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:278
 msgid "IPv4 <abbr title=\"Distributed Hash Table\">DHT</abbr> enabled"
-msgstr ""
+msgstr "<abbr title=\"Distributed Hash Table\">DHT</abbr> IPv4 habilitado"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:288
 msgid "IPv6 <abbr title=\"Distributed Hash Table\">DHT</abbr> enabled"
-msgstr ""
+msgstr "<abbr title=\"Distributed Hash Table\">DHT</abbr> IPv6 habilitado"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:421
 msgid "IPv6 disabled"
-msgstr ""
+msgstr "IPv6 deshabilitado"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:379
 msgid ""
@@ -265,6 +273,10 @@ msgid ""
 "Configuring this option with your preferred download speed can increase your "
 "download speed in some cases."
 msgstr ""
+"Si toda la velocidad de descarga de cada torrent es inferior a SPEED, aria2 "
+"aumenta temporalmente el número de pares para intentar obtener más velocidad "
+"de descarga. Configurar esta opción con su velocidad de descarga preferida "
+"puede aumentar su velocidad de descarga en algunos casos."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:88
 msgid "Info"
@@ -272,53 +284,55 @@ msgstr "Información"
 
 #: applications/luci-app-aria2/luasrc/view/aria2/settings_header.htm:33
 msgid "Installed web interface:"
-msgstr ""
+msgstr "Interfaz web instalada:"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:158
 msgid "Json-RPC URL"
-msgstr ""
+msgstr "URL de Json-RPC"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:351
 msgid "Keep in memory"
-msgstr ""
+msgstr "Guardar en la memoria"
 
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:34
 msgid "Last 50 lines of log file:"
-msgstr ""
+msgstr "Últimas 50 líneas del archivo de registro:"
 
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:36
 msgid "Last 50 lines of syslog:"
-msgstr ""
+msgstr "Últimas 50 líneas de syslog:"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:62
 msgid "Leave blank to use default user."
-msgstr ""
+msgstr "Déjelo en blanco para usar el usuario predeterminado."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:415
 msgid "List of additional BitTorrent tracker's announce URI."
-msgstr ""
+msgstr "Lista de URI de anuncio de trackers de BitTorrent adicionales."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:488
 msgid ""
 "List of extra settings. Format: option=value, eg. <code>netrc-path=/tmp/."
 "netrc</code>."
 msgstr ""
+"Lista de configuraciones adicionales. Formato: opción=valor, p. Ej. "
+"<code>netrc-path=/tmp/.netrc</code>."
 
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:48
 msgid "Loading"
-msgstr ""
+msgstr "Cargando"
 
 #: applications/luci-app-aria2/luasrc/controller/aria2.lua:27
 msgid "Log"
-msgstr ""
+msgstr "Registro"
 
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:45
 msgid "Log Data"
-msgstr ""
+msgstr "Dato de registro"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:80
 msgid "Log file"
-msgstr ""
+msgstr "Archivo de registro"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:85
 msgid "Log level"
@@ -326,7 +340,7 @@ msgstr "Nivel de registro"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:240
 msgid "Lowest speed limit"
-msgstr ""
+msgstr "Límite de velocidad mínima"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:94
 msgid "Max concurrent downloads"
@@ -338,7 +352,7 @@ msgstr "Máxima conexiones por servidor"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:475
 msgid "Max download limit"
-msgstr ""
+msgstr "Límite máximo de descarga"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:253
 msgid "Max number of split"
@@ -346,27 +360,27 @@ msgstr "Número máximo de división"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:367
 msgid "Max open files"
-msgstr ""
+msgstr "Máx. archivos abiertos"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:468
 msgid "Max overall download limit"
-msgstr ""
+msgstr "Límite máximo de descarga total"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:353
 msgid "Max overall upload limit"
-msgstr ""
+msgstr "Límite total máximo de carga"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:372
 msgid "Max peers"
-msgstr ""
+msgstr "Máx. pares"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:262
 msgid "Max tries"
-msgstr ""
+msgstr "Máx. de intentos"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:360
 msgid "Max upload limit"
-msgstr ""
+msgstr "Límite máximo de carga"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:258
 msgid "Min split size"
@@ -379,11 +393,11 @@ msgstr "Sin autenticacion"
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:35
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:37
 msgid "No log data."
-msgstr ""
+msgstr "No hay datos de registro."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:454
 msgid "None"
-msgstr ""
+msgstr "Ninguno"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:89
 msgid "Notice"
@@ -391,23 +405,24 @@ msgstr "Aviso"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:99
 msgid "Pause"
-msgstr ""
+msgstr "Pausa"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:99
 msgid "Pause download after added."
-msgstr ""
+msgstr "Pausa la descarga después de añadir."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:105
 msgid "Pause downloads created as a result of metadata download."
 msgstr ""
+"Pausa las descargas creadas como resultado de la descarga de metadatos."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:104
 msgid "Pause metadata"
-msgstr ""
+msgstr "Pausar metadatos"
 
 #: applications/luci-app-aria2/luasrc/view/aria2/settings_header.htm:64
 msgid "Please input token length:"
-msgstr ""
+msgstr "Ingrese la longitud del token:"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:393
 msgid "Prefix of peer ID"
@@ -415,19 +430,19 @@ msgstr "Prefijo de ID de par"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:203
 msgid "Private key"
-msgstr ""
+msgstr "Clave privada"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:177
 msgid "Proxy password"
-msgstr ""
+msgstr "Contraseña de proxy"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:174
 msgid "Proxy user"
-msgstr ""
+msgstr "Usuario de proxy"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:97
 msgid "RPC Options"
-msgstr ""
+msgstr "Opciones de RPC"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:114
 msgid "RPC authentication method"
@@ -435,7 +450,7 @@ msgstr "Método de autenticación RPC"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:140
 msgid "RPC certificate"
-msgstr ""
+msgstr "Certificado de RPC"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:122
 msgid "RPC password"
@@ -447,21 +462,24 @@ msgstr "Puerto RPC"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:149
 msgid "RPC private key"
-msgstr ""
+msgstr "Clave privada de RPC"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:133
 msgid "RPC secure"
-msgstr ""
+msgstr "RPC seguro"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:126
 msgid "RPC token"
-msgstr ""
+msgstr "Token RPC"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:134
 msgid ""
 "RPC transport will be encrypted by SSL/TLS. The RPC clients must use https "
 "scheme to access the server. For WebSocket client, use wss scheme."
 msgstr ""
+"El transporte RPC será encriptado por SSL/TLS. Los clientes RPC deben usar "
+"el esquema https para acceder al servidor. Para el cliente WebSocket, use el "
+"esquema wss."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:119
 msgid "RPC username"
@@ -469,11 +487,11 @@ msgstr "Nombre de usuario RPC"
 
 #: applications/luci-app-aria2/luasrc/view/aria2/log_template.htm:51
 msgid "Refresh every 10 seconds."
-msgstr ""
+msgstr "Actualiza cada 10 segundos."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:322
 msgid "Remove unselected file"
-msgstr ""
+msgstr "Eliminar archivo no seleccionado"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:323
 msgid ""
@@ -481,14 +499,17 @@ msgid ""
 "Please use this option with care because it will actually remove files from "
 "your disk."
 msgstr ""
+"Elimina los archivos no seleccionados cuando se completa la descarga en "
+"BitTorrent. Utilice esta opción con cuidado porque en realidad eliminará los "
+"archivos de su disco."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:377
 msgid "Request peer speed limit"
-msgstr ""
+msgstr "Solicitar límite de velocidad del par"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:266
 msgid "Retry wait"
-msgstr ""
+msgstr "Espera de reintento"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:61
 msgid "Run daemon as user"
@@ -496,13 +517,15 @@ msgstr "Ejecutar demonio como usuario"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:315
 msgid "Sava metadata"
-msgstr ""
+msgstr "Guardar metadatos"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:429
 msgid ""
 "Save a control file(*.aria2) every N seconds. If 0 is given, a control file "
 "is not saved during download."
 msgstr ""
+"Guarde un archivo de control (*.aria2) cada N segundos. Si se da 0, no se "
+"guarda un archivo de control durante la descarga."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:461
 msgid ""
@@ -510,12 +533,18 @@ msgid ""
 "This option also saves control file in that situations. This may be useful "
 "to save BitTorrent seeding which is recognized as completed state."
 msgstr ""
+"Guarde la descarga en el archivo de sesión incluso si la descarga se ha "
+"completado o eliminado. Esta opción también guarda el archivo de control en "
+"esas situaciones. Esto puede ser útil para guardar la siembra de BitTorrent "
+"que se reconoce como estado completado."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:435
 msgid ""
 "Save error/unfinished downloads to session file every N seconds. If 0 is "
 "given, file will be saved only when aria2 exits."
 msgstr ""
+"Guarde el error/descargas inacabadas en el archivo de sesión cada N "
+"segundos. Si se da 0, el archivo se guardará solo cuando salga aria2."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:316
 msgid ""
@@ -523,26 +552,30 @@ msgid ""
 "BitTorrent Magnet URI is used. The file name is hex encoded info hash with "
 "suffix \".torrent\"."
 msgstr ""
+"Guardar metadatos como archivo \".torrent\". Esta opción solo tiene efecto "
+"cuando se utiliza el URI de imán de BitTorrent. El nombre del archivo es "
+"hash de información codificado hexadecimal con sufijo \".torrent\"."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:434
 msgid "Save session interval"
-msgstr ""
+msgstr "Guardar intervalo de sesión"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:330
 msgid "Seed previously downloaded files without verifying piece hashes."
 msgstr ""
+"Sembrar archivos descargados previamente sin verificar hashes de piezas."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:401
 msgid "Seed ratio"
-msgstr ""
+msgstr "Proporción de semilla"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:408
 msgid "Seed time"
-msgstr ""
+msgstr "Tiempo de semilla"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:329
 msgid "Seed unverified"
-msgstr ""
+msgstr "Semilla sin verificar"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:211
 msgid ""
@@ -550,6 +583,9 @@ msgid ""
 "if remote server responds with <code>Content-Encoding: gzip</code> or "
 "<code>Content-Encoding: deflate</code>."
 msgstr ""
+"Enviar <code>Aceptar: deflate, gzip</code> encabezado de solicitud e inflar "
+"respuesta si el servidor remoto responde con <code>Content-Encoding: gzip</"
+"code> o <code Content-Encoding: deflate</code>."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:220
 msgid ""
@@ -558,6 +594,10 @@ msgid ""
 "you can add Cache-Control header with a directive you like using \"Header\" "
 "option."
 msgstr ""
+"Envíe el encabezado <code>Cache-Control: no-cache</code> y <code>Pragma: no-"
+"cache</code> para evitar el contenido en caché. Si está deshabilitado, estos "
+"encabezados no se envían y puede agregar el encabezado Cache-Control con una "
+"directiva que le guste usando la opción \"Encabezado\"."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:336
 msgid ""
@@ -565,30 +605,44 @@ msgid ""
 "\"6881-6999\" and \"6881-6889,6999\". Make sure that the specified ports are "
 "open for incoming TCP traffic."
 msgstr ""
+"Establezca el número de puerto TCP para las descargas de BitTorrent. Formato "
+"de aceptación: \"6881,6885\", \"6881-6999\" y \"6881-6889,6999\". Asegúrese "
+"de que los puertos especificados estén abiertos para el tráfico TCP entrante."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:342
 msgid ""
 "Set UDP listening port used by DHT(IPv4, IPv6) and UDP tracker. Make sure "
 "that the specified ports are open for incoming UDP traffic."
 msgstr ""
+"Configure el puerto de escucha UDP utilizado por DHT (IPv4, IPv6) y el "
+"tracker UDP. Asegúrese de que los puertos especificados estén abiertos para "
+"el tráfico UDP entrante."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:477
 msgid ""
 "Set max download speed per each download in bytes/sec. 0 means unrestricted."
 msgstr ""
+"Establezca la velocidad máxima de descarga por cada descarga en bytes/seg. 0 "
+"significa sin restricciones."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:470
 msgid "Set max overall download speed in bytes/sec. 0 means unrestricted."
 msgstr ""
+"Establezca la velocidad máxima de descarga global en bytes/seg. 0 significa "
+"sin restricciones."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:355
 msgid "Set max overall upload speed in bytes/sec. 0 means unrestricted."
 msgstr ""
+"Establezca la velocidad máxima de carga general en bytes/seg. 0 significa "
+"sin restricciones."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:362
 msgid ""
 "Set max upload speed per each torrent in bytes/sec. 0 means unrestricted."
 msgstr ""
+"Establezca la velocidad máxima de carga por cada torrent en bytes/seg. 0 "
+"significa sin restricciones."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:231
 msgid ""
@@ -596,30 +650,35 @@ msgid ""
 "server. After the connection is established, this option makes no effect and "
 "\"Timeout\" option is used instead."
 msgstr ""
+"Establezca el tiempo de espera de conexión en segundos para establecer la "
+"conexión al servidor HTTP/FTP/proxy. Una vez establecida la conexión, esta "
+"opción no tiene efecto y en su lugar se utiliza la opción \"Tiempo de espera"
+"\"."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:267
 msgid "Set the seconds to wait between retries."
-msgstr ""
+msgstr "Establezca los segundos para esperar entre reintentos."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:272
 msgid "Set user agent for HTTP(S) downloads."
-msgstr ""
+msgstr "Establecer agente de usuario para descargas HTTP(S)."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:35
 msgid "Settings"
-msgstr ""
+msgstr "Configuraciones"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:483
 msgid "Settings in this section will be added to config file."
 msgstr ""
+"La configuración de esta sección se agregará al archivo de configuración."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:487
 msgid "Settings list"
-msgstr ""
+msgstr "Lista de configuraciones"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:161
 msgid "Show URL"
-msgstr ""
+msgstr "Mostrar URL"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:448
 msgid ""
@@ -631,12 +690,22 @@ msgid ""
 "FAT32 because it takes almost same time as \"prealloc\" and it blocks aria2 "
 "entirely until allocation finishes."
 msgstr ""
+"Especifique el método de asignación de archivos. Si está utilizando sistemas "
+"de archivos más nuevos como ext4 (con soporte de extensión), btrfs, xfs o "
+"NTFS (solo compilación MinGW), \"falloc\" es su mejor opción. Asigna "
+"archivos grandes (pocos GiB) casi instantáneamente, pero puede no estar "
+"disponible si su sistema no tiene la función posix_fallocate(3). No use "
+"\"falloc\" con sistemas de archivos heredados como ext3 y FAT32 porque toma "
+"casi el mismo tiempo que \"prealloc\" y bloquea completamente aria2 hasta "
+"que finaliza la asignación."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:368
 msgid ""
 "Specify maximum number of files to open in multi-file BitTorrent download "
 "globally."
 msgstr ""
+"Especifique el número máximo de archivos para abrir en la descarga de "
+"BitTorrent de varios archivos a nivel mundial."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:409
 msgid ""
@@ -644,6 +713,10 @@ msgid ""
 "with this option, seeding ends when at least one of the conditions is "
 "satisfied. Specifying 0 disables seeding after download completed."
 msgstr ""
+"Especifique el tiempo de siembra en minutos. Si se especifica la opción "
+"\"Proporción de semillas\" junto con esta opción, la siembra finaliza cuando "
+"se cumple al menos una de las condiciones. Especificar 0 deshabilita la "
+"siembra después de completar la descarga."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:402
 msgid ""
@@ -651,10 +724,16 @@ msgid ""
 "RATIO. You are strongly encouraged to specify equals or more than 1.0 here. "
 "Specify 0.0 if you intend to do seeding regardless of share ratio."
 msgstr ""
+"Especificar proporción de participación. La semilla ha completado torrents "
+"hasta que la proporción de participación alcance la PROPORCIÓN. Le "
+"recomendamos encarecidamente que especifique iguales o más de 1.0 aquí. "
+"Especifique 0.0 si tiene la intención de sembrar, independientemente de la "
+"proporción de acciones."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:373
 msgid "Specify the maximum number of peers per torrent, 0 means unlimited."
 msgstr ""
+"Especifique el número máximo de pares por torrent, 0 significa ilimitado."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:394
 msgid ""
@@ -663,16 +742,22 @@ msgid ""
 "than 20 bytes are specified, random byte data are added to make its length "
 "20 bytes."
 msgstr ""
+"Especifique el prefijo de la ID del par. La ID del par en BitTorrent tiene "
+"20 bytes de longitud. Si se especifican más de 20 bytes, solo se utilizan "
+"los primeros 20 bytes. Si se especifican menos de 20 bytes, se agregan datos "
+"de bytes aleatorios para que su longitud sea de 20 bytes."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:388
 msgid ""
 "Stop BitTorrent download if download speed is 0 in consecutive N seconds. If "
 "0 is given, this feature is disabled."
 msgstr ""
+"Detenga la descarga de BitTorrent si la velocidad de descarga es 0 en N "
+"segundos consecutivos. Si se da 0, esta característica está deshabilitada."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:387
 msgid "Stop timeout"
-msgstr ""
+msgstr "Detener tiempo de espera"
 
 #: applications/luci-app-aria2/luasrc/view/aria2/settings_header.htm:48
 msgid "The Aria2 service is not running."
@@ -685,18 +770,22 @@ msgstr "El servicio Aria2 se está ejecutando."
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:74
 msgid "The directory to store the config file, session file and DHT file."
 msgstr ""
+"El directorio para almacenar el archivo de configuración, el archivo de "
+"sesión y el archivo DHT."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:70
 msgid "The directory to store the downloaded file. eg. <code>/mnt/sda1</code>"
 msgstr ""
+"El directorio para almacenar el archivo descargado. p.ej. <code>/mnt/sda1</"
+"code>"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:81
 msgid "The file name of the log file."
-msgstr ""
+msgstr "El nombre del archivo de registro."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:249
 msgid "The maximum number of connections to one server for each download."
-msgstr ""
+msgstr "El número máximo de conexiones a un servidor para cada descarga."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:281
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:291
@@ -704,10 +793,11 @@ msgstr ""
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:308
 msgid "This option will be ignored if a private flag is set in a torrent."
 msgstr ""
+"Esta opción se ignorará si se establece un indicador privado en un torrent."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:236
 msgid "Timeout"
-msgstr ""
+msgstr "Tiempo de espera"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:117
 msgid "Token"
@@ -715,7 +805,7 @@ msgstr "Token"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:349
 msgid "True"
-msgstr ""
+msgstr "Verdadero"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:156
 msgid "Use WebSocket"
@@ -723,13 +813,16 @@ msgstr "Utilizar websocket"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:170
 msgid "Use a proxy server for all protocols."
-msgstr ""
+msgstr "Use un servidor proxy para todos los protocolos."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:190
 msgid ""
 "Use the certificate authorities in FILE to verify the peers. The certificate "
 "file must be in PEM format and can contain multiple CA certificates."
 msgstr ""
+"Use las autoridades de certificación en ARCHIVO para verificar los pares. El "
+"archivo del certificado debe estar en formato .PEM y puede contener "
+"múltiples certificados de CA."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:141
 msgid ""
@@ -739,6 +832,12 @@ msgid ""
 "PKCS12 files with a blank import password can be opened!<br/>When using PEM, "
 "you have to specify the \"RPC private key\" as well."
 msgstr ""
+"Utilice el certificado en ARCHIVO para el servidor RPC. El certificado debe "
+"estar en PKCS12 (.p12, .pfx) o en formato .PEM. <br/>Los archivos PKCS12 "
+"deben contener el certificado, una clave y, opcionalmente, una cadena de "
+"certificados adicionales. ¡Solo se pueden abrir archivos PKCS12 con una "
+"contraseña de importación en blanco!<br/>Al usar PEM, también debe "
+"especificar la \"clave privada RPC\"."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:196
 msgid ""
@@ -748,22 +847,32 @@ msgid ""
 "PKCS12 files with a blank import password can be opened!<br/>When using PEM, "
 "you have to specify the \"Private key\" as well."
 msgstr ""
+"Use el certificado del cliente en ARCHIVO. El certificado debe estar en "
+"PKCS12 (.p12, .pfx) o en formato PEM.<br/>Los archivos PKCS12 deben contener "
+"el certificado, una clave y, opcionalmente, una cadena de certificados "
+"adicionales. ¡Solo se pueden abrir archivos PKCS12 con una contraseña de "
+"importación en blanco!<br/>Al usar PEM, también debe especificar la \"Clave "
+"privada\"."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:150
 msgid ""
 "Use the private key in FILE for RPC server. The private key must be "
 "decrypted and in PEM format."
 msgstr ""
+"Use la clave privada en ARCHIVO para el servidor RPC. La clave privada debe "
+"ser descifrada y en formato .PEM."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:204
 msgid ""
 "Use the private key in FILE. The private key must be decrypted and in PEM "
 "format. The behavior when encrypted one is given is undefined."
 msgstr ""
+"Use la clave privada en ARCHIVO. La clave privada debe ser descifrada y en "
+"formato .PEM. El comportamiento cuando se da cifrado uno no está definido."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:271
 msgid "User agent"
-msgstr ""
+msgstr "Agente de usuario"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:116
 msgid "Username & Password"
@@ -773,6 +882,8 @@ msgstr "Nombre de usuario y contraseña"
 msgid ""
 "Verify the peer using certificates specified in \"CA certificate\" option."
 msgstr ""
+"Verifique el par utilizando los certificados especificados en la opción "
+"\"Certificado CA\"."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:90
 msgid "Warn"
@@ -786,19 +897,19 @@ msgstr "Advertir"
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:471
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:478
 msgid "You can append K or M."
-msgstr ""
+msgstr "Puedes agregar K o M."
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:457
 msgid "falloc"
-msgstr ""
+msgstr "falloc"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:455
 msgid "prealloc"
-msgstr ""
+msgstr "prealloc"
 
 #: applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua:456
 msgid "trunc"
-msgstr ""
+msgstr "trunc"
 
 #~ msgid "\"Falloc\" is not available in all cases."
 #~ msgstr "\"Falloc\" no está disponible en todos los casos."

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -2,12 +2,12 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: 2019-07-25 19:35-0300\n"
+"POT-Creation-Date: 2019-07-23 22:17-0300\n"
+"PO-Revision-Date: 2019-09-17 22:33-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 2.2.3\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
@@ -49,6 +49,9 @@ msgid ""
 "permanently in the local blacklist. Disable this option to prevent the local "
 "save."
 msgstr ""
+"Los complementos automáticos de la lista negra se almacenan temporalmente en "
+"el IPSet y se guardan permanentemente en la lista negra local. Deshabilite "
+"esta opción para evitar el guardado local."
 
 #: applications/luci-app-banip/luasrc/view/banip/ipsetview.htm:45
 msgid "Check the current available IPSets."
@@ -165,7 +168,7 @@ msgstr "Información de IPSet"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:58
 msgid "IPSet Sources"
-msgstr ""
+msgstr "Fuentes de IPSet"
 
 #: applications/luci-app-banip/luasrc/controller/banip.lua:18
 msgid "IPSet-Lookup"
@@ -223,11 +226,11 @@ msgstr "CArgando..."
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:116
 msgid "Local Save Blacklist Addons"
-msgstr ""
+msgstr "Complementos locales para guardar la lista negra"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:121
 msgid "Local Save Whitelist Addons"
-msgstr ""
+msgstr "Complementos locales para guardar la lista blanca"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:89
 msgid "Low Priority Service"
@@ -275,11 +278,11 @@ msgstr "Buscar RIPE"
 #: applications/luci-app-banip/luasrc/view/banip/runtime.htm:18
 #: applications/luci-app-banip/luasrc/view/banip/runtime.htm:153
 msgid "Refresh"
-msgstr ""
+msgstr "Actualizar"
 
 #: applications/luci-app-banip/luasrc/view/banip/runtime.htm:151
 msgid "Refresh IPSets"
-msgstr ""
+msgstr "Actualizar IPSets"
 
 #: applications/luci-app-banip/luasrc/view/banip/runtime.htm:21
 #: applications/luci-app-banip/luasrc/view/banip/runtime.htm:160
@@ -288,7 +291,7 @@ msgstr "Recargar"
 
 #: applications/luci-app-banip/luasrc/view/banip/runtime.htm:158
 msgid "Reload IPSet Sources"
-msgstr ""
+msgstr "Recargar las fuentes de IPSet"
 
 #: applications/luci-app-banip/luasrc/view/banip/runtime.htm:112
 msgid "Runtime Information"
@@ -308,7 +311,7 @@ msgstr "SRC/DST"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:109
 msgid "SSH Daemon"
-msgstr ""
+msgstr "Demonio SSH"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/blacklist_tab.lua:27
 #: applications/luci-app-banip/luasrc/model/cbi/banip/configuration_tab.lua:26
@@ -319,10 +322,12 @@ msgstr "Guardar"
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:110
 msgid "Select the SSH daemon for logfile parsing, to detect break-in events."
 msgstr ""
+"Seleccione el demonio SSH para el análisis del archivo de registro, para "
+"detectar eventos de intrusión."
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:135
 msgid "Select the used start type during boot."
-msgstr ""
+msgstr "Seleccione el tipo de inicio utilizado durante el arranque."
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:90
 msgid ""
@@ -354,13 +359,16 @@ msgstr ""
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:134
 msgid "Start Type"
-msgstr ""
+msgstr "Tipo de inicio"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:97
 msgid ""
 "Target directory for banIP backups. Default is '/tmp', please use preferably "
 "a non-volatile disk if available."
 msgstr ""
+"Directorio de destino para copias de seguridad de banIP. El valor "
+"predeterminado es '/tmp', utilice preferiblemente un disco no volátil si "
+"está disponible."
 
 #: applications/luci-app-banip/luasrc/view/banip/ripeview.htm:77
 msgid ""
@@ -509,6 +517,9 @@ msgid ""
 "permanently in the local whitelist. Disable this option to prevent the local "
 "save."
 msgstr ""
+"Los complementos automáticos de la lista blanca se almacenan temporalmente "
+"en el IPSet y se guardan permanentemente en la lista blanca local. "
+"Deshabilite esta opción para evitar el guardado local."
 
 #: applications/luci-app-banip/luasrc/view/banip/ripeview.htm:93
 msgid "Whois Information"

--- a/applications/luci-app-ddns/po/es/ddns.po
+++ b/applications/luci-app-ddns/po/es/ddns.po
@@ -2,15 +2,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: luci-app-ddns 2.4.0-1\n"
 "POT-Creation-Date: 2016-01-30 11:07+0100\n"
-"PO-Revision-Date: 2019-05-15 20:11-0300\n"
-"Last-Translator: José Vicente <josevteg@gmail.com>\n"
+"PO-Revision-Date: 2019-09-17 22:38-0300\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 2.2.3\n"
 
 #: applications/luci-app-ddns/luasrc/view/ddns/overview_status.htm:145
 msgid "&"
@@ -28,7 +28,7 @@ msgstr "-- Predeterminado --"
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:53
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:264
 msgid "Advanced Settings"
-msgstr "Ajustes avanzados"
+msgstr "Configuración avanzada"
 
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua:46
 msgid "Allow non-public IP's"
@@ -42,7 +42,7 @@ msgstr "Aplicando cambios"
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:50
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:263
 msgid "Basic Settings"
-msgstr "Ajustes básicos"
+msgstr "Configuración básica"
 
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/hints.lua:25
 msgid ""
@@ -376,7 +376,7 @@ msgstr "GNU Wget usará la IP de la red dada, cURL usará la interfaz física."
 
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/global.lua:26
 msgid "Global Settings"
-msgstr "Ajustes globales"
+msgstr "Configuración global"
 
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:606
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:615
@@ -802,7 +802,7 @@ msgstr "No hay servicio configurado."
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:56
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/detail.lua:265
 msgid "Timer Settings"
-msgstr "Ajustes del temporizador"
+msgstr "Configuración del temporizador"
 
 #: applications/luci-app-ddns/luasrc/model/cbi/ddns/overview.lua:101
 msgid "To change global settings click here"

--- a/applications/luci-app-firewall/po/es/firewall.po
+++ b/applications/luci-app-firewall/po/es/firewall.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2010-03-30 17:00+0200\n"
-"PO-Revision-Date: 2019-08-01 22:47-0300\n"
+"PO-Revision-Date: 2019-09-17 23:31-0300\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -881,7 +881,7 @@ msgstr "segundo"
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:173
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:265
 msgid "this new zone"
-msgstr ""
+msgstr "Esta nueva zona"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js:197
 #: applications/luci-app-firewall/luasrc/tools/firewall.lua:121

--- a/applications/luci-app-mjpg-streamer/po/es/mjpg-streamer.po
+++ b/applications/luci-app-mjpg-streamer/po/es/mjpg-streamer.po
@@ -3,12 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2019-09-17 23:33-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
-"Last-Translator: \n"
+"X-Generator: Poedit 2.2.3\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
@@ -130,11 +130,13 @@ msgstr "Control led"
 
 #: applications/luci-app-mjpg-streamer/luasrc/model/cbi/mjpg-streamer.lua:222
 msgid "Link newest picture to fixed file name"
-msgstr ""
+msgstr "Vincula la imagen más reciente al nombre de archivo fijo"
 
 #: applications/luci-app-mjpg-streamer/luasrc/model/cbi/mjpg-streamer.lua:222
 msgid "Link the last picture in ringbuffer to fixed named file provided."
 msgstr ""
+"Enlace la última imagen en ringbuffer a un archivo con nombre fijo "
+"proporcionado."
 
 #: applications/luci-app-mjpg-streamer/luasrc/controller/mjpg-streamer.lua:12
 msgid "MJPG-streamer"

--- a/applications/luci-app-mwan3/po/es/mwan3.po
+++ b/applications/luci-app-mwan3/po/es/mwan3.po
@@ -3,12 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2019-09-17 23:36-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
-"Last-Translator: \n"
+"X-Generator: Poedit 2.2.3\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
@@ -778,7 +778,7 @@ msgstr "Intervalo de actualización"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/ruleconfig.lua:37
 msgid "View the content of /etc/protocols for protocol description"
-msgstr "Ver el contenido de /etc/protocol para la descripción del protocolo."
+msgstr "Ver el contenido de /etc/protocol para la descripción del protocolo"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interface.lua:19
 msgid "WARNING: %d interfaces are configured exceeding the maximum of %d!"
@@ -854,7 +854,7 @@ msgstr "agujero negro (caída)"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:241
 msgid "connected (mwan3)"
-msgstr ""
+msgstr "conectado (mwan3)"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:82
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:30
@@ -864,15 +864,15 @@ msgstr "predeterminado (usar tabla de enrutamiento principal)"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:242
 msgid "disconnected (mwan3)"
-msgstr ""
+msgstr "desconectado (mwan3)"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:240
 msgid "ifdown (netifd)"
-msgstr ""
+msgstr "Interfaz abajo (netifd)"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua:239
 msgid "ifup (netifd)"
-msgstr ""
+msgstr "Interfaz arriba (netifd)"
 
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policy.lua:84
 #: applications/luci-app-mwan3/luasrc/model/cbi/mwan/policyconfig.lua:28

--- a/applications/luci-app-ntpc/po/es/ntpc.po
+++ b/applications/luci-app-ntpc/po/es/ntpc.po
@@ -1,21 +1,21 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2010-04-14 13:24+0200\n"
-"PO-Revision-Date: 2012-11-25 11:14+0200\n"
-"Last-Translator: José Vicente <josevteg@gmail.com>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2019-09-17 23:38-0300\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Pootle 2.0.6\n"
+"X-Generator: Poedit 2.2.3\n"
+"Language-Team: \n"
 
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpc.lua:21
 msgid "Clock Adjustment"
-msgstr "Ajuste del Reloj"
+msgstr "Configuración del reloj"
 
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpc.lua:17
 msgid "Count of time measurements"
@@ -34,7 +34,7 @@ msgstr "General"
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpc.lua:34
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpcmini.lua:23
 msgid "Hostname"
-msgstr "Nombre de la máquina"
+msgstr "Nombre de host"
 
 #: applications/luci-app-ntpc/luasrc/model/cbi/ntpc/ntpc.lua:25
 msgid "Offset frequency"

--- a/applications/luci-app-simple-adblock/po/es/simple-adblock.po
+++ b/applications/luci-app-simple-adblock/po/es/simple-adblock.po
@@ -3,7 +3,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2019-08-01 22:58-0300\n"
+"PO-Revision-Date: 2019-09-17 22:46-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -14,11 +14,11 @@ msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:191
 msgid "Add IPv6 entries"
-msgstr ""
+msgstr "Añadir entradas IPv6"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:189
 msgid "Add IPv6 entries to block-list."
-msgstr ""
+msgstr "Añadir entradas IPv6 a la lista de bloqueo."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:178
 msgid "Advanced Configuration"
@@ -36,6 +36,8 @@ msgstr "Permitir caracteres no ASCII en el archivo DNSMASQ"
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
 msgstr ""
+"Intente crear un caché comprimido de la lista de bloqueo en la memoria "
+"persistente."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:149
 msgid "Basic Configuration"
@@ -64,26 +66,27 @@ msgstr "Configuración"
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:151
 msgid "Controls system log and console output verbosity."
 msgstr ""
+"Controla el registro del sistema y la verbosidad de salida de la consola."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:204
 msgid "Curl download retry"
-msgstr ""
+msgstr "Intento de descarga de Curl"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:180
 msgid "DNS Service"
-msgstr ""
+msgstr "Servicio de DNS"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:183
 msgid "DNSMASQ Additional Hosts"
-msgstr ""
+msgstr "Hosts adicionales de DNSMASQ"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:184
 msgid "DNSMASQ Config"
-msgstr ""
+msgstr "Config de DNSMASQ"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:185
 msgid "DNSMASQ Servers File"
-msgstr ""
+msgstr "Archivo de servidores DNSMASQ"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:196
 msgid "Delay (in seconds) for on-boot start"
@@ -95,7 +98,7 @@ msgstr "Deshabilitar depuración"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:190
 msgid "Do not add IPv6 entries"
-msgstr ""
+msgstr "No añadir entradas IPv6"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:214
 msgid "Do not allow Non-ASCII"
@@ -124,7 +127,7 @@ msgstr "Habilitar/Iniciar"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:223
 msgid "Enables debug output to /tmp/simple-adblock.log."
-msgstr ""
+msgstr "Habilita la salida de depuración a /tmp/simple-adblock.log."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:157
 msgid "Force Router DNS"
@@ -137,24 +140,28 @@ msgstr "Forzar el servidor DNS del enrutador a todos los dispositivos locales"
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:157
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
+"Fuerza el uso de DNS del enrutador en dispositivos locales, también "
+"conocido como secuestro de DNS."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:189
 msgid "IPv6 Support"
-msgstr ""
+msgstr "Soporte de IPv6"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:204
 msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
 msgstr ""
+"Si curl está instalado y detectado, volvería a intentar descargar esto "
+"muchas veces en tiempo de espera/falla."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
 msgid "Individual domains to be blacklisted."
-msgstr ""
+msgstr "Dominios individuales para ser incluidos en la lista negra."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:231
 msgid "Individual domains to be whitelisted."
-msgstr ""
+msgstr "Dominios individuales para ser incluidos en la lista blanca."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:94
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:98
@@ -170,6 +177,8 @@ msgid ""
 "Launch all lists downloads and processing simultaneously, reducing service "
 "start time."
 msgstr ""
+"Inicie todas las descargas y el procesamiento de listas simultáneamente, "
+"reduciendo el tiempo de inicio del servicio."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:158
 msgid "Let local devices use their own DNS servers if set"
@@ -196,6 +205,8 @@ msgstr "Configuración de verbosidad de salida"
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:180
 msgid "Pick the DNS resolution option to create the adblock list for, see the"
 msgstr ""
+"Elija la opción de resolución DNS para crear la lista de bloqueos de "
+"anuncios, consulte el"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:168
 msgid "Pick the LED not already used in"
@@ -203,7 +214,7 @@ msgstr "Elige el LED que no se haya usado en"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
 msgid "README"
-msgstr ""
+msgstr "LÉEME"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:120
 msgid "Reload"
@@ -211,7 +222,7 @@ msgstr "Recargar"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:196
 msgid "Run service after set delay on boot."
-msgstr ""
+msgstr "Ejecute el servicio después de la demora establecida en el arranque."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:76
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:79
@@ -237,7 +248,7 @@ msgstr "Simple AdBlock"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:46
 msgid "Simple AdBlock Settings"
-msgstr "Ajustes de Simple AdBlock "
+msgstr "Configuración de Simple AdBlock "
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:208
 msgid "Simultaneous processing"
@@ -250,6 +261,8 @@ msgstr "Alguna salida"
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:200
 msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
+"Detenga la descarga si está detenida durante un número determinado de "
+"segundos."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:104
 msgid "Stop/Disable"
@@ -277,19 +290,19 @@ msgstr "Tarea"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:246
 msgid "URLs to lists of domains to be blacklisted."
-msgstr ""
+msgstr "URL a listas de dominios que se incluirán en la lista negra."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:241
 msgid "URLs to lists of domains to be whitelisted."
-msgstr ""
+msgstr "URL a listas de dominios que se incluirán en la lista blanca."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:251
 msgid "URLs to lists of hosts to be blacklisted."
-msgstr ""
+msgstr "URL a listas de hosts que se incluirán en la lista negra."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
 msgid "Unbound AdBlock List"
-msgstr ""
+msgstr "Lista de AdBlock Unbound"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:210
 msgid "Use simultaneous processing"
@@ -313,7 +326,7 @@ msgstr "Dominios en lista blanca"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
 msgid "for details."
-msgstr ""
+msgstr "para detalles."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:172
 msgid "none"

--- a/applications/luci-app-travelmate/po/es/travelmate.po
+++ b/applications/luci-app-travelmate/po/es/travelmate.po
@@ -3,7 +3,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2019-08-01 23:10-0300\n"
+"PO-Revision-Date: 2019-09-17 22:49-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,7 +23,7 @@ msgstr "Acción"
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:74
 msgid "Add Open Uplinks"
-msgstr ""
+msgstr "Añadir enlaces ascendentes abiertos"
 
 #: applications/luci-app-travelmate/luasrc/view/travelmate/wifi_scan.htm:80
 msgid "Add Uplink"
@@ -52,7 +52,7 @@ msgstr "Autenticación"
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua:143
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua:136
 msgid "Auto Login Script"
-msgstr ""
+msgstr "Script de inicio de sesión automático"
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua:72
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua:89
@@ -66,6 +66,8 @@ msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
+"Agregue automáticamente enlaces ascendentes abiertos como portales cautivos "
+"de hotel a su configuración inalámbrica."
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:112
 msgid ""
@@ -184,7 +186,7 @@ msgstr "Editar este enlace"
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:54
 msgid "Enable Travelmate"
-msgstr "Habilitar Travelmate"
+msgstr "Habilitar"
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:103
 msgid "Enable Verbose Debug Logging"
@@ -207,6 +209,8 @@ msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
+"Referencia de script externo que se llamará para inicios de sesión cautivos "
+"automatizados del portal."
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:100
 msgid "Extra Options"
@@ -251,7 +255,7 @@ msgstr "Forzar TKIP"
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua:63
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua:79
 msgid "Force TKIP and CCMP (AES)"
-msgstr "Forzar TKIP and CCMP (AES)"
+msgstr "Forzar TKIP y CCMP (AES)"
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:136
 msgid ""

--- a/applications/luci-app-vpnbypass/po/es/vpnbypass.po
+++ b/applications/luci-app-vpnbypass/po/es/vpnbypass.po
@@ -3,12 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2019-09-17 22:51-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
-"Last-Translator: \n"
+"X-Generator: Poedit 2.2.3\n"
+"Last-Translator: Franco Castillo <castillofrancodamin@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
@@ -24,7 +24,7 @@ msgstr ""
 
 #: applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua:14
 msgid "Enable/Start"
-msgstr ""
+msgstr "Habilitar/Iniciar"
 
 #: applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua:53
 msgid "Local IP Addresses to Bypass"
@@ -72,19 +72,19 @@ msgstr "Puertos remotos para activar VPN Bypass"
 
 #: applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua:5
 msgid "Service Status"
-msgstr ""
+msgstr "Estado del servicio"
 
 #: applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua:13
 msgid "Service is disabled/stopped"
-msgstr ""
+msgstr "El servicio está deshabilitado/detenido"
 
 #: applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua:17
 msgid "Service is enabled/started"
-msgstr ""
+msgstr "El servicio está habilitado/iniciado"
 
 #: applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua:18
 msgid "Stop/Disable"
-msgstr ""
+msgstr "Detener/Deshabilitar"
 
 #: applications/luci-app-vpnbypass/luasrc/controller/vpnbypass.lua:5
 #: applications/luci-app-vpnbypass/luasrc/controller/vpnbypass.lua:7
@@ -93,7 +93,7 @@ msgstr "VPN Bypass"
 
 #: applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua:36
 msgid "VPN Bypass Rules"
-msgstr ""
+msgstr "Reglas de VPN Bypass"
 
 #: applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua:3
 msgid "VPN Bypass Settings"

--- a/applications/luci-app-wifischedule/po/es/wifischedule.po
+++ b/applications/luci-app-wifischedule/po/es/wifischedule.po
@@ -3,12 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2019-09-17 22:54-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
-"Last-Translator: \n"
+"X-Generator: Poedit 2.2.3\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
@@ -139,7 +139,7 @@ msgstr "Miércoles"
 #: applications/luci-app-wifischedule/luasrc/controller/wifischedule/wifi_schedule.lua:26
 #: applications/luci-app-wifischedule/luasrc/model/cbi/wifischedule/wifi_schedule.lua:39
 msgid "Wifi Schedule"
-msgstr "Programar WiFi"
+msgstr "Horario de WiFi"
 
 #: applications/luci-app-wifischedule/luasrc/controller/wifischedule/wifi_schedule.lua:35
 msgid "Wifi Schedule Logfile"

--- a/applications/luci-app-wireguard/po/es/wireguard.po
+++ b/applications/luci-app-wireguard/po/es/wireguard.po
@@ -3,7 +3,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2019-08-01 21:49-0300\n"
+"PO-Revision-Date: 2019-09-17 22:55-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -55,7 +55,7 @@ msgstr "Último Handshake"
 
 #: applications/luci-app-wireguard/luasrc/view/wireguard.htm:125
 msgid "Listen Port"
-msgstr "Escuchar puerto"
+msgstr "Puerto"
 
 #: applications/luci-app-wireguard/luasrc/view/wireguard.htm:81
 msgid "Never"

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -3,14 +3,14 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-06-10 03:41+0200\n"
-"PO-Revision-Date: 2019-09-12 16:33-0300\n"
+"PO-Revision-Date: 2019-09-17 22:08-0300\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.2.3\n"
 "Language-Team: \n"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:857
@@ -245,7 +245,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:252
 msgid "<abbr title=\"maximal\">Max.</abbr> concurrent queries"
-msgstr "<abbr title=\"maximal\">Máx.</abbr> consultas simultáneas"
+msgstr "Máx. consultas simultáneas"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:42
 msgid ""
@@ -405,11 +405,11 @@ msgstr "Añadir dirección IPv6..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:47
 msgid "Add LED action"
-msgstr ""
+msgstr "Agregar acción LED"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:215
 msgid "Add VLAN"
-msgstr ""
+msgstr "Añadir VLAN"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
@@ -1128,7 +1128,7 @@ msgstr "Comando OK"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:41
 msgid "Command failed"
-msgstr ""
+msgstr "Comando fallido"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:64
 msgid "Comment"
@@ -1202,7 +1202,7 @@ msgstr "Conexiones"
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:30
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:66
 msgid "Contents have been saved."
-msgstr ""
+msgstr "Los contenidos han sido guardados."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:618
 msgid "Continue"
@@ -1960,7 +1960,7 @@ msgstr "Expandir hosts"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:195
 msgid "Expecting an hexadecimal assignment hint"
-msgstr ""
+msgstr "Esperando una pista de asignación hexadecimal"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:59
 msgid "Expecting: %s"
@@ -2025,7 +2025,7 @@ msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:45
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
-msgstr ""
+msgstr "Error al ejecutar la acción \"/etc/init.d/%s%s\": %s"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
 msgid "File"
@@ -2768,7 +2768,7 @@ msgstr "Configuración de la interfaz"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:103
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:99
 msgid "Interface has %d pending changes"
-msgstr "La interfaz %d tiene cambios pendientes"
+msgstr "La interfaz tiene %d cambios pendientes"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:57
 msgid "Interface is marked for deletion"
@@ -5781,7 +5781,7 @@ msgstr "No se puede resolver el nombre de host del par"
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:33
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:68
 msgid "Unable to save contents: %s"
-msgstr ""
+msgstr "No se puede guardar el contenido: %s"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:132
 msgid "Unavailable Seconds (UAS)"


### PR DESCRIPTION
Update of the Spanish translation of luci-base and some LuCI applications.

* luci-base
* adblock
* advanced-reboot
* aria2
* banip
* ddns
* firewall
* mjpg-streamer
* mwan3
* ntpc
* simple-adblock
* travelmate
* vpnbypass
* wifischedule
* wireguard

Signed-off-by: Franco Castillo <castillofrancodamian@gmail.com>