### PR TITLE
luci-base: show manufacturer in leases overview page

### DIFF
--- a/contrib/package/ouidb/Makefile
+++ b/contrib/package/ouidb/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2019 TDT AG <development@tdt.de> 
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ouidb
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/jfisbein/ouidb-json.git
+PKG_SOURCE_DATE:=2019-09-18
+PKG_SOURCE_VERSION:=c45622bbcc29644a03202ce6ac0a618e8af417c3
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.gz
+PKG_MIRROR_HASH:=13d59c76a3cee23a6183da4bec57591bb9e0689dedfba1c9350830cfe9ca2945
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+
+PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ouidb
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=OUI Database
+endef
+
+define Package/ouidb/description
+A json version of the OUI Database published at https://linuxnet.ca/ieee/oui/
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) ./script/* $(PKG_BUILD_DIR)/
+endef
+
+define Build/Compile
+	$(STAGING_DIR_HOST)/bin/$(PYTHON) $(PKG_BUILD_DIR)/convert.py \
+		$(PKG_BUILD_DIR)/ouidb.json > $(PKG_BUILD_DIR)/ouidb-mini.json
+endef
+
+define Package/ouidb/install
+	$(INSTALL_DIR) $(1)/usr/share/luci
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ouidb-mini.json \
+		$(1)/usr/share/luci/ouidb.json
+endef
+
+$(eval $(call BuildPackage,ouidb))

--- a/contrib/package/ouidb/script/convert.py
+++ b/contrib/package/ouidb/script/convert.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import json
+import sys
+
+if len(sys.argv) < 2:
+    print('Usage: %s input-file' % sys.argv[0])
+    sys.exit(2)
+
+oui = { }
+
+d = json.load(open(sys.argv[1], 'r'))
+for obj in d:
+    oui[obj.get("prefix")] = obj.get("organization").get("name")
+print(json.dumps(oui))

--- a/modules/luci-base/luasrc/tools/status.lua
+++ b/modules/luci-base/luasrc/tools/status.lua
@@ -104,6 +104,22 @@ local function dhcp_leases_common(family)
 		end
 	end
 
+	-- Load company name from OUI database
+	if family == 4 then
+		local ouidb_file = "/usr/share/luci/ouidb.json"
+		if nixio.fs.access(ouidb_file) then
+			local json  = require("luci.jsonc")
+			ouidb = json.parse(nixio.fs.readfile(ouidb_file) or "")
+			for _, lease in ipairs(rv) do
+				tuble = {}
+				for str in lease["macaddr"]:gmatch("([^:]+)") do
+					table.insert(tuble, str)
+				end
+				lease.company = ouidb[string.format("%s%s%s", tuble[1], tuble[2], tuble[3])]
+			end
+		end
+	end
+
 	return rv
 end
 

--- a/modules/luci-base/luasrc/view/lease_status.htm
+++ b/modules/luci-base/luasrc/view/lease_status.htm
@@ -1,3 +1,9 @@
+<%
+	local fs = require "nixio.fs"
+	local has_ipv6 = fs.access("/proc/net/ipv6_route")
+	local has_oui = fs.access("/usr/share/luci/ouidb.json")
+-%>
+
 <script type="text/javascript">//<![CDATA[
 	XHR.poll(-1, '<%=url('admin/dhcplease_status')%>', null,
 		function(x, st)
@@ -17,13 +23,22 @@
 						timestr = '<em><%:expired%></em>';
 					else
 						timestr = String.format('%t', st[0][i].expires);
-
+					<% if has_oui then -%>
+					rows.push([
+						st[0][i].hostname || '?',
+						st[0][i].ipaddr,
+						st[0][i].macaddr,
+						st[0][i].company,
+						timestr
+					]);
+					<% else -%>
 					rows.push([
 						st[0][i].hostname || '?',
 						st[0][i].ipaddr,
 						st[0][i].macaddr,
 						timestr
 					]);
+					<% end -%>
 				}
 
 				cbi_update_table(tb, rows, '<em><%:There are no active leases.%></em>');
@@ -71,6 +86,9 @@
 			<div class="th"><%:Hostname%></div>
 			<div class="th"><%:IPv4-Address%></div>
 			<div class="th"><%:MAC-Address%></div>
+			<% if has_oui then -%>
+			<div class="th"><%:Company%></div>
+			<% end -%>
 			<div class="th"><%:Leasetime remaining%></div>
 		</div>
 		<div class="tr placeholder">
@@ -79,12 +97,7 @@
 	</div>
 </div>
 
-<%
-	local fs = require "nixio.fs"
-	local has_ipv6 = fs.access("/proc/net/ipv6_route")
-
-	if has_ipv6 then
--%>
+<% if has_ipv6 then -%>
 	<div class="cbi-section" style="display:none">
 		<h3><%:Active DHCPv6 Leases%></h3>
 		<div class="table" id="lease6_status_table">


### PR DESCRIPTION
This pull-request will add the feature, which was requested in the issue #2065.

**This works for now only for ipv4.**

I have added a new package for luci (ouidb) to lookup the company name with the oui part of the mac. I have also added the possibily, that the ouidb is not required for small devices. So if ouidb file is not installed then it will not shown in then status page.

To minify the oui database, I have added a python convert script to remove the unneeded information.
Only the Company name and the oui are written to the ouidb.

Size difference

- With all information 6.3MB
- With oui and manufacture information  0.9MB
