### PR TITLE
luci-base: update Japanese translation

### DIFF
--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Camp addicional --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Escolliu, si us plau --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personalitzat --"
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr "Càrrega d'1 minut:"
 msgid "15 Minute Load:"
 msgstr "Càrrega de 15 minuts:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Càrrega de 5 minuts:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -171,7 +172,7 @@ msgstr ""
 "Es consultaran els servidors <abbr title=\"Domain Name System\">DNS</abbr> "
 "segons l'ordre del fitxer de resolució"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -207,7 +208,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configuració dels <abbr title=\"Light Emitting Diode\">LED</abbr>s"
 
@@ -252,7 +253,7 @@ msgstr ""
 "Avís: cal reiniciar manualment el servei cron si el fitxer crontab estava "
 "buit abans d'editar-lo."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -333,8 +334,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Concentrador d'accés"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Punt d'accés"
 
@@ -365,17 +366,17 @@ msgstr "Arrendaments DHCP actius"
 msgid "Active DHCPv6 Leases"
 msgstr "Arrendaments DHCPv6 actius"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -406,10 +407,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -423,7 +427,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Afegeix una interfície nova..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -472,8 +476,8 @@ msgstr "Administració"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -483,11 +487,11 @@ msgstr "Paràmetres avançats"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -513,25 +517,25 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Permetre l'autenticació <abbr title=\"Secure Shell\">SSH</abbr> amb "
 "contrasenya"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Permet-les totes menys les llistades"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Permet només les llistades"
 
@@ -539,17 +543,17 @@ msgstr "Permet només les llistades"
 msgid "Allow localhost"
 msgstr "Permetre el localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Permetre a màquines remotes de connectar-se als ports reenviats de l'SSH "
 "local"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Accés d'administrador amb contrasenya"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Permetre l'accés de l'usurari <em>root</em> amb contrasenya"
 
@@ -558,7 +562,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr "Permet respostes del rang 127.0.0.0/8, p.e. per serveis RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -566,7 +570,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -645,7 +649,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -664,11 +668,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Qualsevol zona"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -692,7 +696,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Estacions associades"
@@ -706,7 +710,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Autenticació"
 
@@ -801,7 +805,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -819,7 +823,7 @@ msgstr "Enrere a la configuració"
 msgid "Backup"
 msgstr "Còpia de seguretat"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Còpia de seguretat i microprogramari"
 
@@ -836,7 +840,7 @@ msgstr "Adreça mal especificada!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -874,7 +878,7 @@ msgstr "Velocitat de bits"
 msgid "Bogus NX Domain Override"
 msgstr "Substitució dels dominis NX falsos"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Pont"
@@ -892,7 +896,7 @@ msgstr "Número d'unitat de pont"
 msgid "Bring up on boot"
 msgstr "Aixecar a l'engegada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -917,13 +921,13 @@ msgstr "Ús de CPU (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -946,13 +950,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Cadena"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Canvis"
 
@@ -960,23 +958,19 @@ msgstr "Canvis"
 msgid "Changes applied."
 msgstr "Canvis aplicats."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Canvia la paraula clau de l'administrador per accedir al dispositiu"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Canal"
@@ -989,7 +983,7 @@ msgstr "Comprovació"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -1002,7 +996,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1014,7 +1008,7 @@ msgstr ""
 "ompliu el camp <em>crea</em> per definir una nova zona i adjuntar-hi la "
 "interfície."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1022,7 +1016,7 @@ msgstr ""
 "Trieu les xarxes que voleu adjuntar a la interfície sense fil o ompliu el "
 "camp <em>crea</em> per definir una xarxa nova."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Xifra"
 
@@ -1044,9 +1038,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Client"
 
@@ -1055,8 +1049,8 @@ msgstr "Client"
 msgid "Client ID to send when requesting DHCP"
 msgstr "ID de client a enviar en les sol·licituds DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1079,7 +1073,7 @@ msgstr "Tanca la llista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1106,7 +1100,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1114,7 +1108,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1130,11 +1124,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1142,7 +1136,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Confirmació"
 
@@ -1175,7 +1169,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1186,12 +1180,12 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Codi de País"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Crea / Assigna zona de tallafocs"
 
@@ -1199,11 +1193,11 @@ msgstr "Crea / Assigna zona de tallafocs"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Crític"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Nivell de registre del Cron"
 
@@ -1238,15 +1232,15 @@ msgstr ""
 "Personalitza el comportament dels <abbr title=\"Light Emitting Diode\">LED</"
 "abbr>s del dispositiu, si és possible."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1259,7 +1253,7 @@ msgstr "Servidor DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP i DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1332,7 +1326,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1344,14 +1338,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Depuració"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "%d per defecte"
 
@@ -1389,47 +1383,47 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Suprimeix aquesta xarxa"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Descripció"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Disseny"
 
@@ -1460,7 +1454,7 @@ msgstr ""
 msgid "Device"
 msgstr "Dispositiu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Configuració de dispositiu"
 
@@ -1477,7 +1471,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1495,12 +1489,12 @@ msgstr "Diagnòstics"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Directori"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Inhabilita"
 
@@ -1516,14 +1510,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1535,11 +1530,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Inhabilitat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1558,21 +1549,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Optimització de distància"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distància al membre de la xarxa més allunyat en metres."
 
@@ -1600,15 +1589,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1648,15 +1637,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Instància de Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1688,17 +1677,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Mètode EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Edita"
 
@@ -1708,7 +1697,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Edita aquesta xarxa"
 
@@ -1716,12 +1705,12 @@ msgstr "Edita aquesta xarxa"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Emergència"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Habilita"
 
@@ -1756,7 +1745,7 @@ msgstr "Habilita negociació IPv6 en la enllaç PPP"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Habilita el passatge de trames enormes"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Habilita el client NTP"
 
@@ -1772,11 +1761,11 @@ msgstr "Habilita el servidor TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Habilita la funcionalitat VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1800,7 +1789,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1822,7 +1811,7 @@ msgstr "Habilitat"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1843,17 +1832,17 @@ msgstr "Mode d'encapsulació"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Encriptació"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1865,7 +1854,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Esborrant..."
 
@@ -1879,7 +1868,7 @@ msgstr "Esborrant..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Error"
 
@@ -1887,12 +1876,12 @@ msgstr "Error"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
@@ -1926,23 +1915,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Servidor de registre del sistema extern"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Port del servidor de registre del sistema extern"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "Protocol del servidor de registre del sistema extern"
 
@@ -1950,19 +1939,23 @@ msgstr "Protocol del servidor de registre del sistema extern"
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1970,15 +1963,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Fitxer"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2023,7 +2016,7 @@ msgstr "Acaba"
 msgid "Firewall"
 msgstr "Tallafocs"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2063,7 +2056,7 @@ msgstr "Escriu una imatge nova a la memòria flaix"
 msgid "Flash operations"
 msgstr "Operacions a la memòria flaix"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Escrivint a la memòria flaix..."
 
@@ -2071,11 +2064,11 @@ msgstr "Escrivint a la memòria flaix..."
 msgid "Force"
 msgstr "Força"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Força el CCMP (AES)"
 
@@ -2083,11 +2076,11 @@ msgstr "Força el CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Força el DHCP en aquesta xarxa encara que es detecti altre servidor."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Força el TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Força el TKIP i el CCMP (AES)"
 
@@ -2119,7 +2112,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Reenvia el trànsit difós"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2127,7 +2120,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Mode de reenviament"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Llindar de fragmentació"
 
@@ -2136,7 +2129,7 @@ msgstr "Llindar de fragmentació"
 msgid "Free"
 msgstr "Lliure"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2158,19 +2151,19 @@ msgstr "Només GPRS"
 msgid "Gateway"
 msgstr "Passarel·la"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Ports de passarel·la"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2178,8 +2171,8 @@ msgstr "Ajusts generals"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
@@ -2187,7 +2180,7 @@ msgstr ""
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2195,7 +2188,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Genera l'arxiu"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 "La contrasenya i la confirmació de contrasenya no es coincideixen. La "
@@ -2216,8 +2209,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Vés a la configuració de contrasenya"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2247,7 +2240,7 @@ msgstr "Penja"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2255,7 +2248,7 @@ msgstr ""
 "Ací pots configurar els aspectes bàsics del teu dispositiu, com el nom de la "
 "màquina o el fus horari."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "No mostris l'<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
@@ -2267,7 +2260,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "Nom de màquina"
 
@@ -2292,7 +2285,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Nom de màquina"
 
@@ -2313,7 +2306,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2534,7 +2527,7 @@ msgstr "IPv6-sobre-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-sobre-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identitat"
 
@@ -2646,7 +2639,7 @@ msgstr "Temps d'espera d'inactivitat"
 msgid "Inbound:"
 msgstr "Entrant:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Informació"
 
@@ -2684,7 +2677,7 @@ msgstr "Instal·la extensions de protocol"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfície"
 
@@ -2692,7 +2685,7 @@ msgstr "Interfície"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Configuració d'interfície"
 
@@ -2722,7 +2715,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2752,7 +2745,7 @@ msgstr "Error de servidor intern"
 msgid "Invalid"
 msgstr "Invàlid"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2772,7 +2765,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2780,7 +2773,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Usuari i/o contrasenya invàlids! Si us plau prova-ho de nou."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2800,15 +2793,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "Es requereix JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Uneix-te a la xarxa"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2825,15 +2818,15 @@ msgstr "Registre del nucli"
 msgid "Kernel Version"
 msgstr "Versió del nucli"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Clau"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Clau #%d"
 
@@ -2877,11 +2870,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Etiqueta"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Llengua"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Llengua i estil"
 
@@ -2921,7 +2914,7 @@ msgstr "Deixeu-ho en blanc per autodetectar"
 msgid "Leave empty to use the current WAN address"
 msgstr "Deixeu-ho en blanc per utilitzar l'adreça WAN actual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Llegenda:"
 
@@ -2963,7 +2956,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2972,7 +2965,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2997,11 +2990,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Habilita el servei en totes les interfícies o, si no se n'especifica cap, en "
@@ -3026,11 +3019,7 @@ msgstr "Càrrega mitjana"
 msgid "Loading"
 msgstr "Carregant"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3070,7 +3059,7 @@ msgid "Local Startup"
 msgstr "Inici local"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Hora local"
 
@@ -3102,7 +3091,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Localitza les peticions"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Nivell de sortida de registre"
 
@@ -3110,7 +3099,7 @@ msgstr "Nivell de sortida de registre"
 msgid "Log queries"
 msgstr "Registra les peticions"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Registre"
 
@@ -3141,22 +3130,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "Adreça MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filtre d'adreces MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Filtre MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Llista MAC"
 
@@ -3184,7 +3173,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3204,7 +3193,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3212,7 +3201,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3238,7 +3227,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3251,7 +3240,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3263,11 +3252,11 @@ msgstr "Memòria"
 msgid "Memory usage (%)"
 msgstr "Ús de Memòria (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3278,7 +3267,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Mètrica"
 
@@ -3290,7 +3279,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3298,8 +3287,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Mode"
@@ -3330,16 +3319,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Temps d'espera d'inici de mòdem"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3352,7 +3341,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr "Punt de muntatge"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3402,7 +3391,7 @@ msgstr "Baixa"
 msgid "Move up"
 msgstr "Puja"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3427,11 +3416,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Candidats de servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3439,7 +3428,7 @@ msgstr "Candidats de servidor NTP"
 msgid "Name"
 msgstr "Nom"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Nom de la nova xarxa"
 
@@ -3449,8 +3438,8 @@ msgstr "Navegació"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3483,7 +3472,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Següent"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3492,7 +3481,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Cap servidor DHCP configurat en aquesta interfície"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3504,7 +3493,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3535,11 +3524,12 @@ msgstr "Sense memòria cau negativa"
 msgid "No password set!"
 msgstr "No hi ha cap contrasenya establerta!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3584,7 +3574,7 @@ msgstr ""
 msgid "None"
 msgstr "Cap"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3614,7 +3604,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Avís"
 
@@ -3626,7 +3616,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3692,24 +3682,24 @@ msgstr "Obre una llista..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Opció canviada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Opció treta"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3723,41 +3713,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3817,7 +3807,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3839,7 +3829,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3884,7 +3874,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3939,29 +3929,29 @@ msgid "Part of zone %q"
 msgstr "Part de la zona %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Contrasenya"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Autenticació per contrasenya"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Contrasenya de la clau privada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3969,31 +3959,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Ruta als Certificats CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Ruta a la clau privada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4020,7 +4010,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4040,7 +4030,7 @@ msgstr "Executa un reinici"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4080,7 +4070,7 @@ msgstr "Si us plau entra el teu nom d'usuari i contrasenya."
 msgid "Policy"
 msgstr "Política"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4116,7 +4106,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4135,11 +4125,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Evita la comunicació client a client"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4170,7 +4160,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protocol"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Habilita el servidor NTP"
 
@@ -4178,15 +4168,15 @@ msgstr "Habilita el servidor NTP"
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4213,11 +4203,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4225,11 +4215,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Llindar RTS/CTS"
 
@@ -4245,31 +4235,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Velocitat RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4319,7 +4309,7 @@ msgstr "Trànsit en temps real"
 msgid "Realtime Wireless"
 msgstr "Dispositiu sense fils en temps real"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4327,7 +4317,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reinicia"
@@ -4345,7 +4335,7 @@ msgstr "Arranca de nou el sistema operatiu del teu dispositiu"
 msgid "Receive"
 msgstr "Recepció"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4385,11 +4375,11 @@ msgstr "Adreça IPv4 remota"
 msgid "Remote IPv4 address or FQDN"
 msgstr "Adreça IPv4 remota o FQDN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Treu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Reemplaça la configuració sense fil"
 
@@ -4405,7 +4395,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4413,42 +4403,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "Alguns ISP ho requereixen, per exemple el Charter amb DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4460,31 +4450,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4535,10 +4525,8 @@ msgstr "Restauració de la configuració"
 msgid "Restore backup"
 msgstr "Restaura còpia de seguretat"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Mostra/amaga la contrasenya"
 
@@ -4546,15 +4534,15 @@ msgstr "Mostra/amaga la contrasenya"
 msgid "Revert"
 msgstr "Reverteix"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4570,7 +4558,7 @@ msgstr "Directori arrel dels fitxers servits per TFTP"
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4586,8 +4574,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Contrasenya de l'encaminador"
 
@@ -4629,8 +4617,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Accés SSH"
 
@@ -4646,14 +4634,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "Claus SSH"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4662,19 +4650,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Desa"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Desa i aplica"
@@ -4687,24 +4673,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Escaneja"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Tasques programades"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Secció afegida"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Secció treta"
 
@@ -4719,9 +4701,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4790,7 +4772,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4810,12 +4792,12 @@ msgstr "Atura aquesta interfície"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Senyal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4835,7 +4817,7 @@ msgstr "Mida"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4852,7 +4834,7 @@ msgstr "Salta al contingut"
 msgid "Skip to navigation"
 msgstr "Salta a la navegació"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4890,10 +4872,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "Especifica el directori a que el dispositiu està adjuntat"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Especifica el port d'escolta d'aquesta instància del <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4906,7 +4884,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4929,7 +4907,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Especifiqueu el clau de xifració secret aquí."
 
@@ -4943,16 +4921,16 @@ msgstr "Inici"
 msgid "Start priority"
 msgstr "Prioritat d'inici"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Arrencada"
 
@@ -4972,7 +4950,7 @@ msgstr "Leases estàtics"
 msgid "Static Routes"
 msgstr "Rutes estàtiques"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4985,13 +4963,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Estat"
@@ -5006,12 +4984,12 @@ msgstr "Atura"
 msgid "Strict order"
 msgstr "Ordre estricte"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Envia"
 
@@ -5049,7 +5027,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5064,11 +5042,11 @@ msgstr "Protocol de commutador"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5078,7 +5056,7 @@ msgstr "Sincronitza amb el navegador"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5089,11 +5067,11 @@ msgstr "Sistema"
 msgid "System Log"
 msgstr "Registre del sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Propietats del sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Mida de la memòria intermèdia per al registre del sistema"
 
@@ -5159,7 +5137,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5175,7 +5153,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5230,11 +5208,11 @@ msgstr "Les següents regles estan actualment actives en aquest sistema."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5265,7 +5243,7 @@ msgstr "La longitud del prefix IPv6 en bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5279,7 +5257,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5287,7 +5265,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5295,7 +5273,7 @@ msgstr ""
 "El sistema està esborrant la partició de configuració i es reiniciarà quan "
 "termini."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5309,7 +5287,7 @@ msgstr ""
 "connectar-te de nou a l'encaminador, depenent de la configuració que hi "
 "tinguis."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5330,7 +5308,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "No hi ha arrendaments actius."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5349,7 +5327,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5434,22 +5412,22 @@ msgstr ""
 "Aquesta pàgina ofereix una vista general de les connexions de xarxa actives "
 "actualment."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Aquesta secció encara no conté cap valor"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Sincronització de l'hora"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Zona horària"
 
@@ -5508,7 +5486,7 @@ msgstr "Mode d'activació"
 msgid "Tunnel ID"
 msgstr "ID del túnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interfície del túnel"
@@ -5601,12 +5579,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5615,7 +5593,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5626,11 +5604,12 @@ msgstr "Sense gestionar"
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Canvis sense desar"
 
@@ -5671,15 +5650,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Puja un arxiu..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5817,11 +5796,11 @@ msgstr ""
 msgid "Used"
 msgstr "Usat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5901,32 +5880,32 @@ msgstr "Verifica"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Sistema obert WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Clau compartit WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Contrasenya WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Mode WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Contrasenya WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5942,7 +5921,7 @@ msgstr "Esperant que s'apliquin els canvis..."
 msgid "Waiting for command to complete..."
 msgstr "Esperant que s'acabi l'ordre..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5950,8 +5929,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr "Esperant el dispositiu..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Advertència"
 
@@ -5959,11 +5938,11 @@ msgstr "Advertència"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5975,7 +5954,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5986,13 +5965,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Sense fils"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adaptador sense fils"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6002,7 +5981,7 @@ msgstr "Xarxa sense fils"
 msgid "Wireless Overview"
 msgstr "Resum sense fils"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Seguretat sense fils"
 
@@ -6022,11 +6001,11 @@ msgstr "El dispositiu sense fils està inhabilitat"
 msgid "Wireless is not associated"
 msgstr "El dispositiu sense fils està sense associar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "La xarxa sense fil està inhabilitada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "La xarxa sense fils està habilitada"
 
@@ -6034,11 +6013,11 @@ msgstr "La xarxa sense fils està habilitada"
 msgid "Write received DNS requests to syslog"
 msgstr "Escriure les peticions DNS rebudes al registre del sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Escriure el registre del sistema al fitxer"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6070,19 +6049,19 @@ msgstr ""
 "Has d'activar el JavaScript al teu navegador o LuCI no funcionarà "
 "correctament."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6093,7 +6072,7 @@ msgstr "qualsevol"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6152,7 +6131,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "inhabilita"
 
@@ -6253,7 +6232,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "fitxer <abbr title=\"Domain Name System\">DNS</abbr> local"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6272,7 +6255,7 @@ msgstr "cap enllaç"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "cap"
 
@@ -6283,8 +6266,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6298,6 +6281,10 @@ msgstr "parat"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "engegat"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6316,7 +6303,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6330,8 +6317,8 @@ msgstr ""
 msgid "routed"
 msgstr "encaminat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6352,11 +6339,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "etiquetat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6375,7 +6366,7 @@ msgstr "desconegut"
 msgid "unlimited"
 msgstr "il·limitat"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6556,6 +6547,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6566,6 +6561,13 @@ msgstr "sí"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Enrere"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Ports de passarel·la"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr ""
+#~ "Especifica el port d'escolta d'aquesta instància del <em>Dropbear</em>"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Commutador %q (%s)"

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -2153,7 +2153,7 @@ msgstr "Passarel·la"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Ports de passarel·la"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6561,9 +6561,6 @@ msgstr "sí"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Enrere"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Ports de passarel·la"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr ""

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -15,11 +15,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -61,19 +62,19 @@ msgid "-- Additional Field --"
 msgstr "-- Doplňující pole --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Prosím vyberte --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- vlastní --"
@@ -96,7 +97,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -108,7 +109,7 @@ msgstr "Zatížení za 1 minutu:"
 msgid "15 Minute Load:"
 msgstr "Zatížení za 15 minut:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -121,35 +122,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Zatížení za 5 minut:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -169,7 +170,7 @@ msgstr ""
 "<abbr title=\"Domain Name System\">DNS</abbr> servery budou dotazovány podle "
 "pořadí resolvfile"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -204,7 +205,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Konfigurace"
 
@@ -247,7 +248,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -328,8 +329,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Přístupový koncentrátor"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Přístupový bod"
 
@@ -364,17 +365,17 @@ msgstr "Aktivní propůjčené DHCP adresy (leases)"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktivní propůjčené DHCPv6 adresy (leases)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -405,10 +406,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -421,7 +425,7 @@ msgstr "Přidat lokální koncovku k doménovým jménům ze souboru hosts"
 msgid "Add new interface..."
 msgstr "Přidat rozhraní..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -470,8 +474,8 @@ msgstr "Správa"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -481,11 +485,11 @@ msgstr "Pokročilé nastavení"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Upozornění"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -511,23 +515,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Povolit <abbr title=\"Secure Shell\">SSH</abbr> autentizaci heslem"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Povolit vše mimo uvedené"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Povolit pouze uvedené"
 
@@ -535,17 +539,17 @@ msgstr "Povolit pouze uvedené"
 msgid "Allow localhost"
 msgstr "Povolit localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Povolit vzdáleným hostitelům připojování k místním portům přesměrovaným "
 "pomocí SSH"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Povolit přihlašovaní root účtu pomocí hesla"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Povolit <em>root</em> účtu přihlášení bez nastaveného hesla"
 
@@ -554,7 +558,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr "Povolit upstream odpovědi na 127.0.0.0/8 rozsah, např. pro RBL služby"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -562,7 +566,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -641,7 +645,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -660,11 +664,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Libovolná zóna"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -688,7 +692,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Připojení klienti"
@@ -702,7 +706,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Autentizace"
 
@@ -797,7 +801,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -815,7 +819,7 @@ msgstr "Zpět ke konfiguraci"
 msgid "Backup"
 msgstr "Zálohovat"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Zálohovat / nahrát firmware"
 
@@ -832,7 +836,7 @@ msgstr "Zadána neplatná adresa!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -870,7 +874,7 @@ msgstr "Přenosová rychlost"
 msgid "Bogus NX Domain Override"
 msgstr "Přepíše falešnou hodnotu NX Domény"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Síťový most"
@@ -888,7 +892,7 @@ msgstr "Číslo síťového mostu"
 msgid "Bring up on boot"
 msgstr "Zapnout po startu"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -913,13 +917,13 @@ msgstr "Vytížení CPU (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Storno"
@@ -942,13 +946,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Řetěz"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Změny"
 
@@ -956,23 +954,19 @@ msgstr "Změny"
 msgid "Changes applied."
 msgstr "Změny aplikovány."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Změní administrátorské heslo pro přístup k zařízení"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Kanál"
@@ -985,7 +979,7 @@ msgstr "Kontrola"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -998,7 +992,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1010,7 +1004,7 @@ msgstr ""
 "zóny a její následné přiřazení danému rozhraní vyplňte pole <em>vytvořit</"
 "em>."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1018,7 +1012,7 @@ msgstr ""
 "Vyberte síť(ě), které chcete připojit k tomuto bezdrátovému rozhraní, nebo "
 "vyplňte pole <em>vytvořit</em> a pojmenujte novou síť."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Šifra"
 
@@ -1039,9 +1033,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Klient"
 
@@ -1050,8 +1044,8 @@ msgstr "Klient"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Klientské ID odesílané v DHCP požadavku"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1076,7 +1070,7 @@ msgstr "Zavřít seznam..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1103,7 +1097,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1111,7 +1105,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1127,11 +1121,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1139,7 +1133,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Ověření"
 
@@ -1172,7 +1166,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1183,12 +1177,12 @@ msgstr ""
 msgid "Country"
 msgstr "Země"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Kód země"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Vytvořit / přiřadit zónu firewallu"
 
@@ -1196,11 +1190,11 @@ msgstr "Vytvořit / přiřadit zónu firewallu"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Kritické"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Úroveň protokolování Cronu"
 
@@ -1235,15 +1229,15 @@ msgstr ""
 "Upraví chování <abbr title=\"Light Emitting Diode\">LED</abbr> diod zařízení "
 "pokud je to možné."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1256,7 +1250,7 @@ msgstr "DHCP server"
 msgid "DHCP and DNS"
 msgstr "DHCP a DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1329,7 +1323,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1341,14 +1335,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Ladění"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Výchozí %d"
 
@@ -1388,47 +1382,47 @@ msgstr ""
 "Další možnosti DHCP, například \"<code>6,192.168.2.1,192.168.2.2</code>\", "
 "které odkazuje na různé DNS servery pro klienty."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Odstranit"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Odstranit tuto síť"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Popis"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Vzhled"
 
@@ -1459,7 +1453,7 @@ msgstr ""
 msgid "Device"
 msgstr "Zařízení"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Nastavení zařízení"
 
@@ -1476,7 +1470,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1494,12 +1488,12 @@ msgstr "Diagnostika"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Adresář"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Zakázat"
 
@@ -1515,14 +1509,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1534,11 +1529,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Zakázáno"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1557,21 +1548,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Optimalizace na vzdálenost"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Vzdálenost nejodlehlejšího člena sítě v metrech."
 
@@ -1601,15 +1590,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Nepřeposílat reverzní dotazy na místní sítě"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1649,15 +1638,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Instance Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1691,17 +1680,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Metoda EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Upravit"
 
@@ -1711,7 +1700,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Upravit tuto síť"
 
@@ -1719,12 +1708,12 @@ msgstr "Upravit tuto síť"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Záchrana"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Povolit"
 
@@ -1759,7 +1748,7 @@ msgstr "Na PPP spoji povolit vyjednání IPv6"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Povolit průchod jumbo rámců"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Povolit NTP klienta"
 
@@ -1775,11 +1764,11 @@ msgstr "Povolit TFTP server"
 msgid "Enable VLAN functionality"
 msgstr "Povolit funkcionalitu VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1803,7 +1792,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "Povolit tento přípojný bod"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1825,7 +1814,7 @@ msgstr "Povoleno"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1846,17 +1835,17 @@ msgstr "Režim zapouzdření"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Šifrování"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1868,7 +1857,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Odstraňování..."
 
@@ -1882,7 +1871,7 @@ msgstr "Odstraňování..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Chyba"
 
@@ -1890,12 +1879,12 @@ msgstr "Chyba"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernetový adaptér"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernetový switch"
@@ -1931,23 +1920,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Externí protokolovací server"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Port externího protokolovacího serveru"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1955,19 +1944,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1975,15 +1968,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Soubor"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2028,7 +2021,7 @@ msgstr "Dokončit"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2068,7 +2061,7 @@ msgstr "Nahrát nový obraz s firmwarem"
 msgid "Flash operations"
 msgstr "Operace nad flash pamětí"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Nahrávám..."
 
@@ -2076,11 +2069,11 @@ msgstr "Nahrávám..."
 msgid "Force"
 msgstr "Vynutit"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Vynutit CCMP (AES)"
 
@@ -2088,11 +2081,11 @@ msgstr "Vynutit CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Na této síti vynutit DHCP i v případě detekování jiného serveru."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Vynutit TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Vynutit TKIP a CCMP (AES)"
 
@@ -2124,7 +2117,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Přeposílat broadcasty"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2132,7 +2125,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Režim přeposílání"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Hranice fragmentace"
 
@@ -2141,7 +2134,7 @@ msgstr "Hranice fragmentace"
 msgid "Free"
 msgstr "Volné"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2163,19 +2156,19 @@ msgstr "Pouze GPRS"
 msgid "Gateway"
 msgstr "Brána"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Porty brány"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2183,8 +2176,8 @@ msgstr "Obecná nastavení"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Obecné nastavení"
 
@@ -2192,7 +2185,7 @@ msgstr "Obecné nastavení"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2200,7 +2193,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Vytvorǐt archív"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Heslo nezměněno z důvodu nesouhlasu nového hesla a ověření hesla!"
 
@@ -2219,8 +2212,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Přejít na nastavení hesla..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2250,7 +2243,7 @@ msgstr "Zavěsit"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2258,7 +2251,7 @@ msgstr ""
 "Nastavení základních vlastností zařízení jako je časová zóna nebo název "
 "zařízení."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Skrývat <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2269,7 +2262,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2295,7 +2288,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Jméno hostitele"
 
@@ -2316,7 +2309,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2537,7 +2530,7 @@ msgstr "IPv6-over-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-over-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identita"
 
@@ -2649,7 +2642,7 @@ msgstr "Časový limit nečinnosti"
 msgid "Inbound:"
 msgstr "Příchozí:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Info"
 
@@ -2687,7 +2680,7 @@ msgstr "Instalovat protokolové rozšíření..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Rozhraní"
 
@@ -2695,7 +2688,7 @@ msgstr "Rozhraní"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Konfigurace rozhraní"
 
@@ -2725,7 +2718,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2756,7 +2749,7 @@ msgstr "Vnitřní chyba serveru"
 msgid "Invalid"
 msgstr "Neplatná vstupní hodnota"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2777,7 +2770,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2785,7 +2778,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Špatné uživatelské jméno a/nebo heslo! Prosím zkuste to znovu."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2805,15 +2798,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "Vyžadován JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Připojit k síti"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Připojit k síti: Vyhledání bezdrátových sítí"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2830,15 +2823,15 @@ msgstr "Záznam jádra"
 msgid "Kernel Version"
 msgstr "Verze jádra"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Klíč"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Klíč #%d"
 
@@ -2882,11 +2875,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Popis"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Jazyk"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Jazyk a styl"
 
@@ -2926,7 +2919,7 @@ msgstr "Ponechte prázdné pro automatickou detekci"
 msgid "Leave empty to use the current WAN address"
 msgstr "Ponecháte-li prázdné, použije stávající WAN adresu"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -2970,7 +2963,7 @@ msgstr ""
 "Seznam <abbr title=\"Domain Name System\">DNS</abbr> serverů, na které "
 "přeposílat požadavky"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2979,7 +2972,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3004,11 +2997,11 @@ msgstr "Seznam hostitelů, kteří udávají falešné hodnoty NX domén"
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Poslouchat pouze na daném rozhraní, nebo pokud není specifikováno, na všech"
@@ -3032,11 +3025,7 @@ msgstr "Zátěž průměrná"
 msgid "Loading"
 msgstr "Načítání"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3076,7 +3065,7 @@ msgid "Local Startup"
 msgstr "Místní startup"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Místní čas"
 
@@ -3114,7 +3103,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Lokalizační dotazy"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Úroveň logování"
 
@@ -3122,7 +3111,7 @@ msgstr "Úroveň logování"
 msgid "Log queries"
 msgstr "Dotazy pro logování"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Logování"
 
@@ -3153,22 +3142,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-Adresa"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filtr MAC adres"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Filtr MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Seznam Mac"
 
@@ -3196,7 +3185,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3216,7 +3205,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3224,7 +3213,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3250,7 +3239,7 @@ msgstr "Nejvyšší počet sekund čekání, než bude modem připraven"
 msgid "Maximum number of leased addresses."
 msgstr "Maximální počet zapůjčených adres."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3263,7 +3252,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3275,11 +3264,11 @@ msgstr "Paměť"
 msgid "Memory usage (%)"
 msgstr "Využití paměti (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3290,7 +3279,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrika"
 
@@ -3302,7 +3291,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3310,8 +3299,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Mód"
@@ -3342,16 +3331,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Časový limit inicializace modemu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Sledování"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3364,7 +3353,7 @@ msgstr "Připojit vstup"
 msgid "Mount Point"
 msgstr "Přípojný bod"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3414,7 +3403,7 @@ msgstr "Přesunout dolů"
 msgid "Move up"
 msgstr "Přesunout nahoru"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3439,11 +3428,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Kandidáti NTP serveru"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3451,7 +3440,7 @@ msgstr "Kandidáti NTP serveru"
 msgid "Name"
 msgstr "Název"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Název nové sítě"
 
@@ -3461,8 +3450,8 @@ msgstr "Navigace"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3495,7 +3484,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Další »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3504,7 +3493,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Pro toto rozhraní není nastaven žádný DHCP server"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3516,7 +3505,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3547,11 +3536,12 @@ msgstr "Žádná negativní mezipaměť"
 msgid "No password set!"
 msgstr "Žádné heslo!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3596,7 +3586,7 @@ msgstr ""
 msgid "None"
 msgstr "Žádný"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normální"
 
@@ -3626,7 +3616,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Oznámení"
 
@@ -3638,7 +3628,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3704,24 +3694,24 @@ msgstr "Otevřít seznam..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Volba změněna"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Volba odstraněna"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3735,41 +3725,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3829,7 +3819,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3853,7 +3843,7 @@ msgstr "Přepsat tabulku, používanou pro vnitřní cesty"
 msgid "Overview"
 msgstr "Přehled"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3898,7 +3888,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3953,29 +3943,29 @@ msgid "Part of zone %q"
 msgstr "Část zóny %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Heslo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Autentizace heslem"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Heslo privátního klíče"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3983,31 +3973,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Cesta k certifikátu CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Cesta k certifikátu klienta"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Cesta k privátnímu klíči"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4034,7 +4024,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4054,7 +4044,7 @@ msgstr "Provést reset"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4094,7 +4084,7 @@ msgstr "Prosím vložte vaše uživatelské jméno a heslo."
 msgid "Policy"
 msgstr "Politika"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4130,7 +4120,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4151,11 +4141,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Zabraňuje komunikaci klient-klient"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4186,7 +4176,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protokol"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Poskytování NTP serveru"
 
@@ -4194,15 +4184,15 @@ msgstr "Poskytování NTP serveru"
 msgid "Provide new network"
 msgstr "Poskytování nové sítě"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4229,11 +4219,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4241,11 +4231,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Práh RTS/CTS"
 
@@ -4261,31 +4251,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "RX Rate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Port pro Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Tajný klíč pro Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Server Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Výběr ověřování portů"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Tajný klíč pro Radius-Authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Server Radius-Authentication"
 
@@ -4335,7 +4325,7 @@ msgstr "Provoz v reálném čase"
 msgid "Realtime Wireless"
 msgstr "Wireless v reálném čase"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4343,7 +4333,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Opětovné nastavení ochrany"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reboot"
@@ -4361,7 +4351,7 @@ msgstr "Rebootuje operační systém vašeho zařízení"
 msgid "Receive"
 msgstr "Přijmout"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4401,11 +4391,11 @@ msgstr "Vzdálená IPv4 adresa"
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Odstranit"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Nahradit bezdrátovou konfiguraci"
 
@@ -4421,7 +4411,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4430,42 +4420,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "Vyžadováno u některých ISP, např. Charter s DocSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4477,31 +4467,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4552,10 +4542,8 @@ msgstr "Obnovit"
 msgid "Restore backup"
 msgstr "Obnovit zálohu"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Odhalit/skrýt heslo"
 
@@ -4563,15 +4551,15 @@ msgstr "Odhalit/skrýt heslo"
 msgid "Revert"
 msgstr "Vrátit zpět"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4587,7 +4575,7 @@ msgstr "Kořenový adresář souborů, přístupných přes TFTP"
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4603,8 +4591,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Heslo routeru"
 
@@ -4645,8 +4633,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Přístup přes SSH"
 
@@ -4662,14 +4650,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH klíče"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4678,19 +4666,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Uložit"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Uložit & použít"
@@ -4703,24 +4689,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Skenovat"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Naplánované úlohy"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Přidána sekce"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Sekce odebrána"
 
@@ -4735,9 +4717,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4808,7 +4790,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4828,12 +4810,12 @@ msgstr "Shodit toho rozhraní"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Signál"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4853,7 +4835,7 @@ msgstr "Velikost"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4870,7 +4852,7 @@ msgstr "Skočit na obsah"
 msgid "Skip to navigation"
 msgstr "Skočit na navigaci"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4911,10 +4893,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Určuje port na kterém bude tato instance <em>Dropbearu</em> naslouchat"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4929,7 +4907,7 @@ msgid ""
 "dead"
 msgstr "Určuje počet sekund, po kterém je hostitel považovám za mrtvého"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4952,7 +4930,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Zde nastavte soukromý šifrovací klíč."
 
@@ -4966,16 +4944,16 @@ msgstr "Start"
 msgid "Start priority"
 msgstr "Priorita spouštění"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Po spuštění"
 
@@ -4995,7 +4973,7 @@ msgstr "Statické zápůjčky"
 msgid "Static Routes"
 msgstr "Statické trasy"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5011,13 +4989,13 @@ msgstr ""
 "jmen DHCP klientům. Jsou také vyžadovány pro nedynamické konfigurace "
 "rozhraní, kde jsou povoleni pouze hosté s odpovídajícím nastavením."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Stav"
@@ -5032,12 +5010,12 @@ msgstr "Stop"
 msgid "Strict order"
 msgstr "Striktní výběr"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Odeslat"
 
@@ -5075,7 +5053,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5090,11 +5068,11 @@ msgstr "Směrovací protokol"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5104,7 +5082,7 @@ msgstr "Synchronizovat s prohlížečem"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5115,11 +5093,11 @@ msgstr "Systém"
 msgid "System Log"
 msgstr "Systémový log"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Vlastnosti systému"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Velikost bufferu systémového logu"
 
@@ -5185,7 +5163,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr "IPv6 prefix přidělený poskytovatelm většinou končí  <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5201,7 +5179,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5255,11 +5233,11 @@ msgstr "Následující pravidla jsou v nyní na tomto systému aktivní."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5289,7 +5267,7 @@ msgstr "Délka IPv6 prefixu v bitech"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5309,7 +5287,7 @@ msgstr ""
 "jeden port pro připojení k vyšší síti (Uplink) jako třeba internet a "
 "zbývající porty pro místní síť."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5317,7 +5295,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5325,7 +5303,7 @@ msgstr ""
 "Systém maže konfigurační oddíl, po skončení procesu bude automaticky "
 "restartován."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5338,7 +5316,7 @@ msgstr ""
 "nastavení, bude možná nutné obnovit adresu vašeho počítače, aby jste se "
 "mohli znovu připojit."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5357,7 +5335,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Nejsou žádné aktivní zápůjčky."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5376,7 +5354,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5458,22 +5436,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "Tato stránka zobrazuje přehled aktivních síťových spojení."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Tato sekce zatím neobsahuje žádné hodnoty"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Synchronizace času"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Časové pásmo"
 
@@ -5531,7 +5509,7 @@ msgstr "Trigger mód"
 msgid "Tunnel ID"
 msgstr "ID tunelu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Rozhraní tunelu"
@@ -5624,12 +5602,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5638,7 +5616,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5649,11 +5627,12 @@ msgstr "Nespravovaný"
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Neuložené změny"
 
@@ -5694,15 +5673,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Nahrát archiv..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5843,11 +5822,11 @@ msgstr ""
 msgid "Used"
 msgstr "Použit"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5927,32 +5906,32 @@ msgstr "Ověřit"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "WEP Open System"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Sdílený klíč WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP heslo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM mód"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA heslo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5968,7 +5947,7 @@ msgstr "Čekání na realizaci změn..."
 msgid "Waiting for command to complete..."
 msgstr "Čekání na dokončení příkazu..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5976,8 +5955,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Varování"
 
@@ -5985,11 +5964,11 @@ msgstr "Varování"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6001,7 +5980,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -6012,13 +5991,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Bezdrátová síť"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Bezdrátový adaptér"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6028,7 +6007,7 @@ msgstr "Bezdrátová síť"
 msgid "Wireless Overview"
 msgstr "Přehled bezdrátových sití"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Zabezpečení bezdrátové sítě"
 
@@ -6048,11 +6027,11 @@ msgstr "Bezdrátová síť vypnuta"
 msgid "Wireless is not associated"
 msgstr "Bezdrátová síť nespojena"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Bezdrátová síť je zakázána"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Bezdrátová síť je povolena"
 
@@ -6060,11 +6039,11 @@ msgstr "Bezdrátová síť je povolena"
 msgid "Write received DNS requests to syslog"
 msgstr "Zapisovat přijaté požadavky DNS do systemového logu"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6094,19 +6073,19 @@ msgid ""
 msgstr ""
 "Aby LuCI fungoval správně, musíte mít v prohlížeči povolený JavaScript."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6117,7 +6096,7 @@ msgstr "libovolný"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6175,7 +6154,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "zakázat"
 
@@ -6276,7 +6255,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "místní <abbr title=\"Domain Name System\">DNS</abbr> soubor"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6295,7 +6278,7 @@ msgstr "žádné spojení"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "žádný"
 
@@ -6306,8 +6289,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6321,6 +6304,10 @@ msgstr "off"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "on"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6339,7 +6326,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6353,8 +6340,8 @@ msgstr ""
 msgid "routed"
 msgstr "směrované"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6375,11 +6362,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "označený"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6398,7 +6389,7 @@ msgstr "neznámý"
 msgid "unlimited"
 msgstr "neomezený"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6579,6 +6570,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6589,6 +6584,13 @@ msgstr "ano"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Zpět"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Porty brány"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr ""
+#~ "Určuje port na kterém bude tato instance <em>Dropbearu</em> naslouchat"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Směrovač číslo %q (%s)"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -2158,7 +2158,7 @@ msgstr "Brána"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Porty brány"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6584,9 +6584,6 @@ msgstr "ano"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Zpět"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Porty brány"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr ""

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -2214,7 +2214,7 @@ msgstr "Gateway"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Gateway-Ports"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6786,9 +6786,6 @@ msgstr "« Zurück"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Deaktiviert (Standard)"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Gateway-Ports"
 
 #~ msgid "Loading SSH keys…"
 #~ msgstr "Lade SSH-Schlüssel…"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr "%d ungültige Felder"
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Zusätzliches Feld --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Bitte auswählen --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- benutzerdefiniert --"
@@ -98,7 +99,7 @@ msgstr "-- UUID vergleichen --"
 msgid "-- please select --"
 msgstr "-- Bitte auswählen --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 "0 = keinen Signal-Schwellwert benutzen, 1 = Treiber-Default nicht ändern"
@@ -111,7 +112,7 @@ msgstr "Systemlast (1 Minute):"
 msgid "15 Minute Load:"
 msgstr "Systemlast (15 Minuten):"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr "vierstellige hexadezimale ID"
 
@@ -124,35 +125,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Systemlast (5 Minuten):"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr "sechstellige hexadezimale ID (ohne Doppelpunkte)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr "802.11r: Schnelle Client-Übergabe"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr "Maximales Timeout für Quelladressprüfungen (SA Query)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr "Wiederholungsintervall für Quelladressprüfungen (SA Query)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr "802.11w: Schutz von Management-Frames aktivieren"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr "802.11w: Maximales Timeout"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr "802.11w: Wiederholungsintervall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -172,7 +173,7 @@ msgstr ""
 "<abbr title=\"Domain Name System\">DNS</abbr>-Server in der Reihenfolge der "
 "Resolv-Datei abfragen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -206,7 +207,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "IPv6-Suffix (hexadezimal)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "LED Konfiguration"
 
@@ -253,7 +254,7 @@ msgstr ""
 "<br/>Hinweis: Der Cron-Dienst muss manuell neu gestartet werden wenn die "
 "Crontab-Datei vor der Bearbeitung leer war."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr "Es existiert bereits ein Verzeichnis mit dem gleichen Namen."
 
@@ -335,8 +336,8 @@ msgstr "Nicht vorhandene Schnittstelle"
 msgid "Access Concentrator"
 msgstr "Access Concentrator"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Access Point"
 
@@ -367,17 +368,17 @@ msgstr "Aktive DHCP-Leases"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktive DHCPv6-Leases"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -408,10 +409,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr "Schlüssel hinzufügen"
 
@@ -424,7 +428,7 @@ msgstr "Lokalen Domainsuffx an Namen aus der Hosts-Datei anhängen"
 msgid "Add new interface..."
 msgstr "Neue Schnittstelle hinzufügen..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr "Peer hinzufügen"
 
@@ -473,8 +477,8 @@ msgstr "Administration"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -484,11 +488,11 @@ msgstr "Erweiterte Einstellungen"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr "Vollständige Sendeleistung (ACTATP)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alarm"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -516,25 +520,25 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr "IPs sequenziell vergeben"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Erlaube Anmeldung per Passwort"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 "Erlaube dem Access-Point die Trennung von Clients mit schlechter "
 "Signalqualität"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Alle außer gelistete erlauben"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "Veraltete 802.11b-Raten erlauben"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Nur gelistete erlauben"
 
@@ -542,15 +546,15 @@ msgstr "Nur gelistete erlauben"
 msgid "Allow localhost"
 msgstr "Erlaube localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr "Entfernten Hosts erlauben zu lokale SSH-Tunnel-Ports zu verbinden"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "\"root\" Login mit Passwort aktivieren"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 "Erlaubt es dem <em>root</em> Benutzer sich mit einem Passwort statt einem "
@@ -563,7 +567,7 @@ msgstr ""
 "Dies erlaubt DNS-Antworten im 127.0.0.0/8 Bereich der z.B. für RBL Dienste "
 "genutzt wird"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "Erlaubte IP-Adressen"
 
@@ -571,7 +575,7 @@ msgstr "Erlaubte IP-Adressen"
 msgid "Always announce default router"
 msgstr "Immer Defaultrouter ankündigen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -655,7 +659,7 @@ msgstr "Angekündigte Suchdomains"
 msgid "Announced DNS servers"
 msgstr "Angekündigte DNS Server"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr "Anonyme Identität"
 
@@ -674,13 +678,13 @@ msgstr "Automatische Swap-Aktivierung"
 msgid "Any zone"
 msgstr "Beliebige Zone"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 "Anforderung zur Anwendung der Änderungen mit Status <code>%h</code> "
 "fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr "Ungeprüft übernehmen"
 
@@ -708,7 +712,7 @@ msgstr ""
 "Der Schnittstelle zugewiesene Partitionen des Adressraums werden anhand "
 "dieser hexadezimalen ID gewählt."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Assoziierte Clients"
@@ -722,7 +726,7 @@ msgstr "Assoziierungen"
 msgid "Auth Group"
 msgstr "Berechtigungsgruppe"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Authentifizierung"
 
@@ -817,7 +821,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -835,7 +839,7 @@ msgstr "Zurück zur Konfiguration"
 msgid "Backup"
 msgstr "Sichern"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Backup / Firmware Update"
 
@@ -852,7 +856,7 @@ msgstr "Ungültige Adresse angegeben!"
 msgid "Band"
 msgstr "Frequenztyp"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr "Beacon-Intervall"
 
@@ -893,7 +897,7 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Ungültige \"NX-Domain\" Antworten ignorieren"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bridge"
@@ -911,7 +915,7 @@ msgstr "Geräteindex der Brücke"
 msgid "Bring up on boot"
 msgstr "Während des Bootvorgangs starten"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr "Durchsuchen…"
 
@@ -938,13 +942,13 @@ msgstr "CPU-Nutzung (%)"
 msgid "Call failed"
 msgstr "Anruf fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -967,13 +971,7 @@ msgstr "Achtung: Systemupgrade wird erzwungen"
 msgid "Chain"
 msgstr "Kette"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr "Login-Passwort ändern"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Änderungen"
 
@@ -981,23 +979,19 @@ msgstr "Änderungen"
 msgid "Changes applied."
 msgstr "Änderungen angewendet."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "Änderungen wurden verworfen."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Ändert das Administratorpasswort für den Zugriff auf dieses Gerät"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr "Ändere Passwort…"
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Kanal"
@@ -1010,7 +1004,7 @@ msgstr "Prüfen"
 msgid "Check filesystems before mount"
 msgstr "Dateisysteme prüfen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 "Diese Option setzen um existierende Netzwerke auf dem Radio zu löschen."
@@ -1024,7 +1018,7 @@ msgid "Choose mtdblock"
 msgstr "Wähle \"mtdblock\" Datei"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1036,7 +1030,7 @@ msgstr ""
 "oder das <em>erzeugen</em> Feld ausfüllen um eine neue Zone direkt anzulegen "
 "und zuzuweisen."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1044,7 +1038,7 @@ msgstr ""
 "Wählt die Netzwerke die dieser WLAN-Schnittstelle zugeordnet werden. Das "
 "<em>erstelle</em>-Feld ausfüllen um ein neues Netzwerk zu erzeugen."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Verschlüsselungsalgorithmus"
 
@@ -1069,9 +1063,9 @@ msgstr ""
 "herunterzuladen. (Hinweis: Diese Funktionalität ist nur für Experten "
 "gedacht!)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Client"
 
@@ -1080,8 +1074,8 @@ msgstr "Client"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Zu sendende Client-ID bei DHCP Anfragen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr "Schließen"
 
@@ -1106,7 +1100,7 @@ msgstr "Schließe Liste..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1133,7 +1127,7 @@ msgstr ""
 msgid "Comment"
 msgstr "Kommentar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1145,7 +1139,7 @@ msgstr ""
 "Kompatibilitätsprobleme verursachen und die Zuverlässigkeit von "
 "Schlüsselerneuerungen in ausgelasteten Umgebungen verringern."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1161,11 +1155,11 @@ msgstr "Konfiguration fehlgeschlagen"
 msgid "Configuration files will be kept"
 msgstr "Konfigurationsdateien werden beibehalten"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "Die Konfiguration wurde angewendet."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "Die Konfiguration wurde zurückgerollt!"
 
@@ -1173,7 +1167,7 @@ msgstr "Die Konfiguration wurde zurückgerollt!"
 msgid "Confirm disconnect"
 msgstr "Verbindungstrennung bestätigen"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Bestätigung"
 
@@ -1206,7 +1200,7 @@ msgstr ""
 msgid "Continue"
 msgstr "Fortfahren"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1221,12 +1215,12 @@ msgstr ""
 msgid "Country"
 msgstr "Land"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Ländercode"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Firewallzone anlegen / zuweisen"
 
@@ -1234,11 +1228,11 @@ msgstr "Firewallzone anlegen / zuweisen"
 msgid "Create interface"
 msgstr "Schnittstelle anlegen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Kritisch"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Cron Protokoll-Level"
 
@@ -1274,15 +1268,15 @@ msgid ""
 "\">LED</abbr>s if possible."
 msgstr "Passt das Verhalten der Geräte-LEDs an - wenn dies möglich ist."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1295,7 +1289,7 @@ msgstr "DHCP-Server"
 msgid "DHCP and DNS"
 msgstr "DHCP und DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1368,7 +1362,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr "DSL Leitungsmodus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1380,14 +1374,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr "Datenrate"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Debug"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Standard %d"
 
@@ -1427,47 +1421,47 @@ msgstr ""
 "Definiert zusätzliche DHCP-Optionen, z.B. \"<code>6,192.168.2.1,192.168.2.2</"
 "code>\" um einen anderen DNS-Server an Clients zu verteilen."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Löschen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr "Schlüssel löschen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr "Löscherlaubnis verweigert"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr "Löschanforderung fehlgeschlagen: %d %s"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Dieses Netzwerk löschen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Beschreibung"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr "Abwählen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Design"
 
@@ -1498,7 +1492,7 @@ msgstr "Ziel-Zone"
 msgid "Device"
 msgstr "Gerät"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Gerätekonfiguration"
 
@@ -1515,7 +1509,7 @@ msgstr "Das Gerät startet neu..."
 msgid "Device is restarting…"
 msgstr "Netzwerkadapter startet neu…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Das Gerät ist nicht erreichbar!"
 
@@ -1533,12 +1527,12 @@ msgstr "Diagnosen"
 msgid "Dial number"
 msgstr "Einwahlnummer"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Verzeichnis"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Deaktivieren"
 
@@ -1554,14 +1548,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Verschlüsselung deaktivieren"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr "Inaktivitäts-Proben deaktivieren"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "Dieses Netzwerk deaktivieren"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1573,11 +1568,7 @@ msgstr "Dieses Netzwerk deaktivieren"
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Deaktiviert (Standard)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr "Trennung bei schlechtem Antwortverhalten"
 
@@ -1596,21 +1587,19 @@ msgstr "Trennen"
 msgid "Disconnection attempt failed"
 msgstr "Verbindungstrennung fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Distanzoptimierung"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distanz zum am weitesten entfernten Funkpartner in Metern."
 
@@ -1643,16 +1632,16 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Keine Rückwärtsauflösungen für lokale Netzwerke weiterleiten"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Soll \"%s\" wirklich gelöscht werden?"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 "Soll der untenstehende SSH-Schlüssel wirklich vom System entfernt werden?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Soll das Verzeichnis \"%s\" wirklich rekursiv gelöscht werden?"
 
@@ -1690,15 +1679,15 @@ msgstr "Mtdblock-Datei herunterladen"
 msgid "Downstream SNR offset"
 msgstr "Downstream SNR-Offset"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr "Ziehen zum Umsortieren"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Dropbear Instanz"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1731,17 +1720,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr "EA-Bitlänge"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP-Methode"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -1753,7 +1742,7 @@ msgstr ""
 "Um die Syntaxfehler zu beheben, bitte die obige unformatierte Konfiguration "
 "anpassen und \"Speichern\" klicken um die Seite neu zu laden."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Dieses Netzwerk bearbeiten"
 
@@ -1761,12 +1750,12 @@ msgstr "Dieses Netzwerk bearbeiten"
 msgid "Edit wireless network"
 msgstr "Drahtlosnetzwerk bearbeiten"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Notfall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Aktivieren"
 
@@ -1803,7 +1792,7 @@ msgstr "Aushandeln von IPv6-Adressen auf der PPP-Verbindung aktivieren"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Aktiviere Jumbo Frame Durchleitung"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Aktiviere NTP-Client"
 
@@ -1819,11 +1808,11 @@ msgstr "TFTP-Server aktivieren"
 msgid "Enable VLAN functionality"
 msgstr "VLAN-Funktionalität aktivieren"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "WPS-via-Knopfdruck aktivieren, erfordert WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "Key Reinstallation (KRACK) Gegenmaßnahmen aktivieren"
 
@@ -1847,7 +1836,7 @@ msgstr "Das DF-Bit (Nicht fragmentieren) auf gekapselten Paketen setzen."
 msgid "Enable this mount"
 msgstr "Diesen Mountpunkt aktivieren"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Dieses Netzwerk aktivieren"
 
@@ -1869,7 +1858,7 @@ msgstr "Aktiviert"
 msgid "Enables IGMP snooping on this bridge"
 msgstr "Aktiviert die automatische IGMP-Erkennung auf dieser Netzwerkbrücke"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1892,17 +1881,17 @@ msgstr "Kapselung"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Verschlüsselung"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr "Entfernter Server"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr "Entfernter Port"
 
@@ -1914,7 +1903,7 @@ msgstr "Eigenen Wert angeben"
 msgid "Enter custom values"
 msgstr "Eigene Werte angeben"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Lösche..."
 
@@ -1928,7 +1917,7 @@ msgstr "Lösche..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Fehler"
 
@@ -1936,12 +1925,12 @@ msgstr "Fehler"
 msgid "Errored seconds (ES)"
 msgstr "Fehlersekunden (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Netzwerkschnittstelle"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Netzwerk Switch"
@@ -1978,23 +1967,23 @@ msgstr ""
 msgid "External"
 msgstr "Extern"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr "Externe R0-Key-Holder-List"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr "Externe R1-Key-Holder-List"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Externer Protokollserver IP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Externer Protokollserver Port"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "Externes Protokollserver Protokoll"
 
@@ -2002,19 +1991,23 @@ msgstr "Externes Protokollserver Protokoll"
 msgid "Extra SSH command options"
 msgstr "Zusätzliche SSH-Kommando-Optionen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr "FT-über-DS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr "FT-drahtlos"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr "FT Protokoll"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "Konnte nicht innerhalb von %d Sekunden bestätigen, warte auf Zurückrollen "
@@ -2024,15 +2017,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Datei"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr "Datei nicht verfügbar"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr "Dateiname"
 
@@ -2080,7 +2073,7 @@ msgstr "Fertigstellen"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr "Firewall-Markierung"
 
@@ -2120,7 +2113,7 @@ msgstr "Neues Firmware Image schreiben"
 msgid "Flash operations"
 msgstr "Flash-Operationen"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Firmware wird installiert..."
 
@@ -2128,11 +2121,11 @@ msgstr "Firmware wird installiert..."
 msgid "Force"
 msgstr "Start erzwingen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "40MHz-Modus forcieren"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "CCMP (AES) erzwingen"
 
@@ -2142,11 +2135,11 @@ msgstr ""
 "Aktiviere DHCP-Server für dieses Netzwerk, selbst wenn ein anderer aktiver "
 "Server erkannt wurde."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Erzwinge TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Erzwinge TKIP und CCMP (AES)"
 
@@ -2178,7 +2171,7 @@ msgstr "Fehlerkorrektursekunden (FECS)"
 msgid "Forward broadcast traffic"
 msgstr "Broadcasts weiterleiten"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr "Mesh-Nachbar-Traffic weiterleiten"
 
@@ -2186,7 +2179,7 @@ msgstr "Mesh-Nachbar-Traffic weiterleiten"
 msgid "Forwarding mode"
 msgstr "Weiterleitungstyp"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Fragmentierungsschwelle"
 
@@ -2195,7 +2188,7 @@ msgstr "Fragmentierungsschwelle"
 msgid "Free"
 msgstr "Frei"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2219,19 +2212,19 @@ msgstr "Nur GPRS"
 msgid "Gateway"
 msgstr "Gateway"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr "Gateway-Adresse ist ungültig"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Gateway-Ports"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2239,8 +2232,8 @@ msgstr "Allgemeine Einstellungen"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Allgemeine Einstellungen"
 
@@ -2248,7 +2241,7 @@ msgstr "Allgemeine Einstellungen"
 msgid "Generate Config"
 msgstr "Konfiguration generieren"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr "PMK lokal generieren"
 
@@ -2256,7 +2249,7 @@ msgstr "PMK lokal generieren"
 msgid "Generate archive"
 msgstr "Sicherung erstellen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 "Die angegebenen Passwörter stimmen nicht überein, das Systempasswort wurde "
@@ -2277,8 +2270,8 @@ msgstr "Globale Netzwerkeinstellungen"
 msgid "Go to password configuration..."
 msgstr "Zur Passwortkonfiguration..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2308,7 +2301,7 @@ msgstr "Auflegen"
 msgid "Header Error Code Errors (HEC)"
 msgstr "Anzahl Header-Error-Code-Fehler (HEC)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2316,7 +2309,7 @@ msgstr ""
 "An dieser Stelle können Grundeinstellungen des Systems wie Hostname oder "
 "Zeitzone vorgenommen werden."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "ESSID verstecken"
 
@@ -2327,7 +2320,7 @@ msgstr "Leere Chains ausblenden"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2352,7 +2345,7 @@ msgstr "\"Host-Uniq\"-Bezeichner"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Hostname"
 
@@ -2373,7 +2366,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr "IKE-DH-Gruppe"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "IP-Adressen"
 
@@ -2594,7 +2587,7 @@ msgstr "IPv6-über-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-über-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identität"
 
@@ -2711,7 +2704,7 @@ msgstr "Timeout bei Inaktivität"
 msgid "Inbound:"
 msgstr "Eingehend:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Info"
 
@@ -2751,7 +2744,7 @@ msgstr "Installiere Protokoll-Erweiterungen"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Schnittstelle"
 
@@ -2760,7 +2753,7 @@ msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 "Das Gerät der Schnittstelle %q wurde automatisch von %q auf %q geändert."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Schnittstellenkonfiguration"
 
@@ -2790,7 +2783,7 @@ msgstr "Netzwerkadapter startet..."
 msgid "Interface is stopping..."
 msgstr "Netzwerkadapter stoppt..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "Schnittstellenname"
 
@@ -2820,7 +2813,7 @@ msgstr "Interner Serverfehler"
 msgid "Invalid"
 msgstr "Ungültige Eingabe"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr "Ungültige Base64-Zeichenkette"
 
@@ -2840,7 +2833,7 @@ msgstr "Ungültiges Argument"
 msgid "Invalid command"
 msgstr "Ungültiges Kommando"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr "Ungültiger Hexadezimalwert"
 
@@ -2849,7 +2842,7 @@ msgid "Invalid username and/or password! Please try again."
 msgstr ""
 "Ungültiger Benutzername oder ungültiges Passwort! Bitte erneut versuchen. "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "Clients isolieren"
 
@@ -2869,15 +2862,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "JavaScript benötigt!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Netzwerk beitreten"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Netzwerk beitreten: Suche nach Netzwerken"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "Trete Netzwerk %q bei"
 
@@ -2894,15 +2887,15 @@ msgstr "Kernelprotokoll"
 msgid "Kernel Version"
 msgstr "Kernel Version"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Schlüssel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Schlüssel Nr. %d"
 
@@ -2946,11 +2939,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Label"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Sprache"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Sprache und Aussehen"
 
@@ -2990,7 +2983,7 @@ msgstr "Zur automatischen Erkennung leer lassen"
 msgid "Leave empty to use the current WAN address"
 msgstr "Leer lassen um die aktuelle WAN-Adresse zu verwenden"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Legende:"
 
@@ -3036,7 +3029,7 @@ msgstr ""
 "Liste von <abbr title=\"Domain Name System\">DNS</abbr>-Servern an welche "
 "Requests weitergeleitet werden"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -3051,7 +3044,7 @@ msgstr ""
 "werden kann, mit der sich der Client wärend der anfänglichen "
 "Mobilitätsdomänen-Assoziation verbunden hat."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3082,11 +3075,11 @@ msgstr "Liste von Servern die falsche \"NX Domain\" Antworten liefern"
 msgid "Listen Interfaces"
 msgstr "Aktive Schnittstellen"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "Aktive Ports"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Nur auf die gegebene Schnittstelle reagieren, nutze alle wenn nicht "
@@ -3111,11 +3104,7 @@ msgstr "Durchschnittslast"
 msgid "Loading"
 msgstr "Lade"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr "Lade SSH-Schlüssel…"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr "Lade Verzeichniseinträge…"
 
@@ -3155,7 +3144,7 @@ msgid "Local Startup"
 msgstr "Lokales Startskript"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Lokale Zeit"
 
@@ -3195,7 +3184,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Lokalisiere Anfragen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Protokolllevel"
 
@@ -3203,7 +3192,7 @@ msgstr "Protokolllevel"
 msgid "Log queries"
 msgstr "Schreibe Abfragelog"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Protokollierung"
 
@@ -3234,22 +3223,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-Adresse"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "MAC-Adressfilter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-Filter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC-Adressliste"
 
@@ -3277,7 +3266,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3297,7 +3286,7 @@ msgstr "Das Root-Dateisystem muss mit folgenden Kommandsos vorbereitet werden:"
 msgid "Manual"
 msgstr "Manuell"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3305,7 +3294,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr "Maximal erreichbare Datenrate (ATTNDR)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr "Maximal erlaubter Inaktivitätszeitraum"
 
@@ -3331,7 +3320,7 @@ msgstr "Maximale Zeit die gewartet wird bis das Modem bereit ist (in Sekunden)"
 msgid "Maximum number of leased addresses."
 msgstr "Maximal zulässige Anzahl von vergeben DHCP-Adressen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr "Maximale Sendeleistung"
 
@@ -3344,7 +3333,7 @@ msgstr "Maximale Sendeleistung"
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr "Mittel"
 
@@ -3356,11 +3345,11 @@ msgstr "Hauptspeicher"
 msgid "Memory usage (%)"
 msgstr "Speichernutzung (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr "Mesh-ID"
 
@@ -3371,7 +3360,7 @@ msgstr "Methode nicht gefunden"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrik"
 
@@ -3383,7 +3372,7 @@ msgstr "Spiegel-Monitor-Port"
 msgid "Mirror source port"
 msgstr "Spiegel-Quell-Port"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr "Mobilitätsbereich"
 
@@ -3391,8 +3380,8 @@ msgstr "Mobilitätsbereich"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Modus"
@@ -3423,16 +3412,16 @@ msgstr "Modem-Informationsabfrage fehlgeschlagen"
 msgid "Modem init timeout"
 msgstr "Wartezeit für Modeminitialisierung"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr "Mehr Zeichen"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr "Mehr…"
 
@@ -3445,7 +3434,7 @@ msgstr "Mount-Eintrag"
 msgid "Mount Point"
 msgstr "Einhängepunkt"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3495,7 +3484,7 @@ msgstr "Nach unten schieben"
 msgid "Move up"
 msgstr "Nach oben schieben"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3520,11 +3509,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "NTP Server Kandidaten"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3532,7 +3521,7 @@ msgstr "NTP Server Kandidaten"
 msgid "Name"
 msgstr "Name"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Name des neuen Netzwerkes"
 
@@ -3542,8 +3531,8 @@ msgstr "Navigation"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3576,7 +3565,7 @@ msgstr "Name der neuen Schnittstelle…"
 msgid "Next »"
 msgstr "Weiter »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Nein"
@@ -3585,7 +3574,7 @@ msgstr "Nein"
 msgid "No DHCP Server configured for this interface"
 msgstr "Kein DHCP Server auf dieser Schnittstelle eingerichtet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr "Keine Verschlüsselung"
 
@@ -3597,7 +3586,7 @@ msgstr "Kein NAT-T"
 msgid "No data received"
 msgstr "Keine Daten empfangen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr "Keine Einträge in diesem Verzeichnis"
 
@@ -3628,11 +3617,12 @@ msgstr "Kein Negativ-Cache"
 msgid "No password set!"
 msgstr "Kein Passwort gesetzt!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr "Noch keine Peers definiert."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr "Bisher keine SSH-Schlüssel hinterlegt."
 
@@ -3677,7 +3667,7 @@ msgstr "An Schnittstellen binden"
 msgid "None"
 msgstr "keine"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3707,7 +3697,7 @@ msgstr "Beim Hochfahren nicht starten"
 msgid "Not supported"
 msgstr "Nicht unterstützt"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Notiz"
 
@@ -3721,7 +3711,7 @@ msgstr ""
 "Anzahl der zwischengespeicherten DNS-Einträge. Maximum sind 10000 Einträge, "
 "\"0\" deaktiviert die Zwischenspeicherung."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr "Für Kompression benutze parallele Prozessanzahl"
 
@@ -3787,24 +3777,24 @@ msgstr "Liste öffnen..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "Betriebsfrequenz"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Option geändert"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Option entfernt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "Optional"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3824,7 +3814,7 @@ msgstr ""
 "Server empfangen wird, kombiniert das System das Suffix mit dem Präfix um "
 "eine IPv6-Adresse (z.B. 'a:b:c:d::1') für die Schnittstelle zu formen."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
@@ -3832,15 +3822,15 @@ msgstr ""
 "Optional. Base64-kodierter, vorhab ausgetauschter Schlüssel um eine weitere "
 "Ebene an symmetrischer Verschlüsselung für erhöhte Sicherheit hinzuzufügen."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Optional. Routen für erlaubte IP-Adressen erzeugen."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr "Optionale Beschreibung des entfernten VPN-Partners."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
@@ -3848,15 +3838,15 @@ msgstr ""
 "Optional. Hostname oder Adresse des Verbindungspartners. Namen werden vor "
 "dem Verbindungsaufbau aufgelöst."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr "Optional. Maximale MTU für Tunnelschnittstellen."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr "Optional. Port-Nummer des Verbindungspartners."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
@@ -3865,7 +3855,7 @@ msgstr ""
 "(deaktiviert). Der empfohlene Wert für Geräte hinter einem NAT sind 25 "
 "Sekunden."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 "Optional. Benutzte UDP-Port-Nummer für ausgehende und eingehende Pakete."
@@ -3926,7 +3916,7 @@ msgstr "TOS-Wert überschreiben"
 msgid "Override TTL"
 msgstr "TTL-Wert überschreiben"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "Standard Schnittstellennamen überschreiben"
 
@@ -3950,7 +3940,7 @@ msgstr "Überschreibt die benutzte Tabelle für interne Routen"
 msgid "Overview"
 msgstr "Übersicht"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Existierende Datei \"%s\" überschreiben?"
 
@@ -3995,7 +3985,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr "PIN-Code abgelehnt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -4050,29 +4040,29 @@ msgid "Part of zone %q"
 msgstr "Teil von Zone %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Passwort"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Passwortanmeldung"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Passwort des privaten Schlüssels"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "Password des inneren, privaten Schlüssels"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr "Passwortstärke"
 
@@ -4080,31 +4070,31 @@ msgstr "Passwortstärke"
 msgid "Password2"
 msgstr "Passwort Bestätigung"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr "Schlüssel einfügen oder Schlüsseldatei hereinziehen…"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Pfad zum CA-Zertifikat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Pfad zu Client-Zertifikat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Pfad zum Privaten Schlüssel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "Pfad zum inneren CA-Zertifikat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "Pfad zum inneren Client-Zertifikat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "Pfad zum inneren, privaten Schlüssel"
 
@@ -4131,7 +4121,7 @@ msgstr "Entfernte IP-Adresse"
 msgid "Peer address is missing"
 msgstr "Entfernte IP-Adresse fehlt"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr "Verbindungspartner"
 
@@ -4151,7 +4141,7 @@ msgstr "Reset durchführen"
 msgid "Permission denied"
 msgstr "Zugriff verweigert"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr "Persistentes Keep-Alive"
 
@@ -4191,7 +4181,7 @@ msgstr "Bitte Benutzernamen und Passwort eingeben."
 msgid "Policy"
 msgstr "Standardregel"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4227,7 +4217,7 @@ msgstr "UMTS bevorzugen"
 msgid "Prefix Delegated"
 msgstr "Delegiertes Präfix"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr "Gemeinsamer Schlüssel"
 
@@ -4248,11 +4238,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr "Verhindert das Binden an diese Schnittstellen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Unterbindet Client-Client-Verkehr"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "Privater Schlüssel"
 
@@ -4283,7 +4273,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "NTP-Server anbieten"
 
@@ -4291,15 +4281,15 @@ msgstr "NTP-Server anbieten"
 msgid "Provide new network"
 msgstr "Neues Netzwerk anbieten"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "Öffentlicher Schlüssel"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4334,11 +4324,11 @@ msgid ""
 "servers"
 msgstr "Alle verfügbaren übergeordneten DNS-Server abfragen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr "R0-Schlüsselgültigkeit"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr "R1-Schlüsselinhaber"
 
@@ -4346,11 +4336,11 @@ msgstr "R1-Schlüsselinhaber"
 msgid "RFC3947 NAT-T mode"
 msgstr "RFC3947 \"NAT-T\"-Modus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr "RSSI-Schwellwert für Assoziationen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS-Schwelle"
 
@@ -4367,31 +4357,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "RX-Rate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr "RX-Rate / TX-Rate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Radius-Accounting-Port"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Radius-Accounting-Secret"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Radius-Accounting-Server"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Radius-Authentication-Port"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Radius-Authentication-Secret"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Radius-Authentication-Server"
 
@@ -4444,7 +4434,7 @@ msgstr "Echtzeitverkehr"
 msgid "Realtime Wireless"
 msgstr "Echtzeit-WLAN-Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr "Reassoziierungsfrist"
 
@@ -4452,7 +4442,7 @@ msgstr "Reassoziierungsfrist"
 msgid "Rebind protection"
 msgstr "DNS-Rebind-Schutz"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Neu Starten"
@@ -4470,7 +4460,7 @@ msgstr "Startet das Betriebssystem des Routers neu."
 msgid "Receive"
 msgstr "Empfangen"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr "Empfohlen. IP-Adresse der WireGuard-Schnittstelle."
 
@@ -4510,11 +4500,11 @@ msgstr "Entfernte IPv4-Adresse"
 msgid "Remote IPv4 address or FQDN"
 msgstr "Entfernte IPv4-Adresse oder Hostname"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Entfernen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Drahtloskonfiguration ersetzen"
 
@@ -4530,7 +4520,7 @@ msgstr "IPv6-Präfix dieser Länge anfordern"
 msgid "Request timeout"
 msgstr "Anfrage-Timeout"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "Benötigt"
 
@@ -4539,16 +4529,16 @@ msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 "Wird von bestimmten Internet-Providern benötigt, z.B. Charter mit DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr "Benötigt. Base64-kodierter privater Schlüssel für diese Schnittstelle"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 "Benötigt. Base64-kodierter öffentlicher Schlüssel für diese Schnittstelle"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
@@ -4558,27 +4548,27 @@ msgstr ""
 "Tunnels nutzen darf. Entspricht üblicherweise der Tunnel-IP-Adresse des "
 "Verbindungspartners und den Netzwerken, die dieser durch den Tunnel routet."
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr "Benötigt \"hostapd\""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr "Benötigt \"hostapd\" mit EAP-Support"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr "Benötigt \"hostapd\" mit OWE-Support"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr "Benötigt \"hostapd\" mit SAE-Support"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4594,31 +4584,31 @@ msgstr ""
 "Setzt DNSSEC-Unterstützung im DNS-Zielserver vorraus; überprüft ob "
 "unsignierte Antworten wirklich von unsignierten Domains kommen."
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr "Benötigt \"wpa-supplicant\""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr "Benötigt \"wpa-supplicant\" mit EAP-Support"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr "Benötigt \"wpa-supplicant\" mit OWE-Support"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "Benötigt \"wpa-supplicant\" mit SAE-Support"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4669,10 +4659,8 @@ msgstr "Wiederherstellen"
 msgid "Restore backup"
 msgstr "Sicherung wiederherstellen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Passwort zeigen/verstecken"
 
@@ -4680,15 +4668,15 @@ msgstr "Passwort zeigen/verstecken"
 msgid "Revert"
 msgstr "Verwerfen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "Änderungen verwerfen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Anforderung zum Verwerfen mit Status <code>%h</code> fehlgeschlagen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "Verwerfe Konfigurationsänderungen..."
 
@@ -4704,7 +4692,7 @@ msgstr "Wurzelverzeichnis für über TFTP ausgelieferte Dateien "
 msgid "Root preparation"
 msgstr "Wurzelverzeichnis erzeugen"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr "Erlaubte IP-Addressen routen"
 
@@ -4720,8 +4708,8 @@ msgstr "Routen-Typ"
 msgid "Router Advertisement-Service"
 msgstr "Router-Advertisement-Dienst"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Routerpasswort"
 
@@ -4763,8 +4751,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH-Zugriff"
 
@@ -4780,14 +4768,14 @@ msgstr "SSH-Server-Port"
 msgid "SSH username"
 msgstr "SSH Benutzername"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH-Schlüssel"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4796,19 +4784,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Speichern"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Speichern & Anwenden"
@@ -4821,24 +4807,20 @@ msgstr "Speichere mtdblock"
 msgid "Save mtdblock contents"
 msgstr "Inhalte von mtdblock-Partitionen speichern"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr "Speichere Schlüssel…"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Geplante Aufgaben"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Sektion hinzugefügt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Sektion entfernt"
 
@@ -4856,9 +4838,9 @@ msgstr ""
 "wenn die Formatüberprüfung fehlschlägt. Diese Option nur benutzen wenn das "
 "Abbild korrekt und für dieses Gerät bestimmt ist!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr "Datei auswählen…"
 
@@ -4932,7 +4914,7 @@ msgstr "schwerwiegende Fehlersekunden (SES)"
 msgid "Short GI"
 msgstr "kurzes Guardintervall"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr "Kurze Präambel"
 
@@ -4952,12 +4934,12 @@ msgstr "Diese Schnittstelle herunterfahren"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr "Signal / Rauschen"
 
@@ -4977,7 +4959,7 @@ msgstr "Größe"
 msgid "Size of DNS query cache"
 msgstr "Größe des DNS-Caches"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr "Größe der ZRAM-Gerätedatei in Megabytes."
 
@@ -4994,7 +4976,7 @@ msgstr "Zum Inhalt springen"
 msgid "Skip to navigation"
 msgstr "Zur Navigation springen"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Software-VLAN"
@@ -5036,10 +5018,6 @@ msgstr "Quelladresse"
 msgid "Specifies the directory the device is attached to"
 msgstr "Nennt das Verzeichnis, an welches das Gerät angebunden ist"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Gibt den Server-Port dieser <em>Dropbear</em>-Instanz an"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -5056,7 +5034,7 @@ msgstr ""
 "Spezifiziert die maximale Anzahl an Sekunde nach denen Hoss als tot erachtet "
 "werden"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -5086,7 +5064,7 @@ msgstr ""
 "Setzt eine spezifische MTU (Maximum Transmission Unit) abweichend von den "
 "standardmäßigen 1280 Bytes."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Geben Sie hier den geheimen Netzwerkschlüssel an"
 
@@ -5100,16 +5078,16 @@ msgstr "Start"
 msgid "Start priority"
 msgstr "Startpriorität"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "Starte Anwendung der Konfigurationsänderungen..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "Starte WLAN Scan..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Systemstart"
 
@@ -5129,7 +5107,7 @@ msgstr "Statische Einträge"
 msgid "Static Routes"
 msgstr "Statische Routen"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5146,13 +5124,13 @@ msgstr ""
 "Konfigurationen benötigt auf denen lediglich Hosts mit zugehörigem "
 "statischem Lease-Eintrag bedient werden."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr "Client-Inaktivitäts-Limit"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -5167,12 +5145,12 @@ msgstr "Stoppen"
 msgid "Strict order"
 msgstr "Strikte Reihenfolge"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr "Stark"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Absenden"
 
@@ -5213,7 +5191,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Switch-Port-Maske"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Switch-VLAN"
@@ -5228,11 +5206,11 @@ msgstr "Wechsle Protokoll"
 msgid "Switch to CIDR list notation"
 msgstr "Auf CIDR-Listen-Notation wechseln"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr "Symbolischer Link"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr "Mit NTP-Server synchronisieren"
 
@@ -5242,7 +5220,7 @@ msgstr "Mit Browser synchronisieren"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5253,11 +5231,11 @@ msgstr "System"
 msgid "System Log"
 msgstr "Systemprotokoll"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Systemeigenschaften"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Größe des Systemprotokoll-Puffers"
 
@@ -5329,7 +5307,7 @@ msgstr ""
 "Vom Provider zugewiesenes IPv6-Präfix, endet normalerweise mit <code>::</"
 "code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5347,7 +5325,7 @@ msgstr ""
 "Die Konfigurationsdatei konnte aufgrund der folgenden Fehler nicht geladen "
 "werden:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5407,11 +5385,11 @@ msgstr "Die folgenden Regeln sind zur Zeit auf dem System aktiv."
 msgid "The gateway address must not be a local IP address"
 msgstr "Das Gateway darf keine lokale IP-Addresse des Routers sein"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr "Der angegebene öffentliche SSH-Schlüssel wurde bereits hinzugefügt."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5445,7 +5423,7 @@ msgstr "Länge des IPv6-Präfix in Bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "Die lokale IPv4-Adresse über die der Tunnel aufgebaut wird (optional)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr "Der Netzwerkname wird bereits verwendet"
 
@@ -5467,7 +5445,7 @@ msgstr ""
 "Schnittstellen bilden ein <abbr title=\"Virtual Local Area Network\">VLAN</"
 "abbr> für das lokale Netzwerk."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 "Der ausgewählte \"%s\" Betriebsmodus ist nicht kompatibel mit %s-"
@@ -5478,7 +5456,7 @@ msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 "Das mitgesendete Sicherheits-Token ist ungültig oder bereits abgelaufen!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5486,7 +5464,7 @@ msgstr ""
 "Die Einstellungen werden nun gelöscht! Anschließend wird ein Neustart des "
 "Systems durchgeführt."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5499,7 +5477,7 @@ msgstr ""
 "Konfiguration ist es notwendig, dass Sie auf Ihrem Computer eine neue IP-"
 "Adresse beziehen müssen um auf das Gerät zugreifen zu können."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "Das Systempasswort wurde erfolgreich geändert."
 
@@ -5520,7 +5498,7 @@ msgstr "Es gibt keine aktiven Leases"
 msgid "There are no active leases."
 msgstr "Es gibt z.Z. keine aktiven Leases."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr "Es gibt keine anzuwendenden Änderungen"
 
@@ -5539,7 +5517,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "IPv4-Adresse des Relais"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 "Dieser Authentifizierungstyp ist nicht mit der ausgewählten EAP-Methode "
@@ -5636,22 +5614,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "Diese Seite gibt eine Übersicht über aktive Netzwerkverbindungen."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Diese Sektion enthält noch keine Einträge"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Zeitsynchronisation"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr "Zeitintervall für die neubestimmung des Gruppenschlüssels"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Zeitzone"
 
@@ -5711,7 +5689,7 @@ msgstr "Auslösmechanismus"
 msgid "Tunnel ID"
 msgstr "Tunnel-ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Tunnelschnittstelle"
@@ -5804,12 +5782,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Nicht verfügbare Sekunden (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Protokollfehler: %s"
@@ -5818,7 +5796,7 @@ msgstr "Protokollfehler: %s"
 msgid "Unknown error code"
 msgstr "Unbekannter Fehlercode"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5829,11 +5807,12 @@ msgstr "Ignoriert"
 msgid "Unmount"
 msgstr "Aushängen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr "Unbenannter Schlüssel"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Ungespeicherte Änderungen"
 
@@ -5874,15 +5853,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Backup wiederherstellen..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr "Datei hochladen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr "Datei hochladen…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr "Upload-Anfrage fehlgeschlagen: %s"
 
@@ -6027,11 +6006,11 @@ msgstr ""
 msgid "Used"
 msgstr "Belegt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Benutzer Schlüsselindex"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -6113,32 +6092,32 @@ msgstr "Verifizieren"
 msgid "Virtual dynamic interface"
 msgstr "Virtuelle dynamisches Schnittstelle"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "WEP Open System"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "WEP Shared Key"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP Schlüssel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM Modus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA Schlüssel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6154,7 +6133,7 @@ msgstr "Änderungen werden angewandt..."
 msgid "Waiting for command to complete..."
 msgstr "Der Befehl wird ausgeführt..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr "Warte auf das Anwenden der Konfiguration… %d Sek."
 
@@ -6162,8 +6141,8 @@ msgstr "Warte auf das Anwenden der Konfiguration… %d Sek."
 msgid "Waiting for device..."
 msgstr "Warte auf Gerät..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Warnung"
 
@@ -6173,11 +6152,11 @@ msgstr ""
 "Achtung: Es gibt ungespeicherte Änderungen die bei einem Neustart verloren "
 "gehen!"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr "Schwach"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6192,7 +6171,7 @@ msgstr ""
 msgid "Width"
 msgstr "Breite"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -6203,13 +6182,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "WLAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "WLAN-Gerät"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6219,7 +6198,7 @@ msgstr "Drahtlosnetzwerk"
 msgid "Wireless Overview"
 msgstr "Drahtlosübersicht"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "WLAN-Verschlüsselung"
 
@@ -6239,11 +6218,11 @@ msgstr "W-LAN ist deaktiviert"
 msgid "Wireless is not associated"
 msgstr "W-LAN ist nicht assoziiert"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Das WLAN-Netzwerk ist deaktiviert"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Das WLAN-Netzwerk ist aktiviert"
 
@@ -6251,11 +6230,11 @@ msgstr "Das WLAN-Netzwerk ist aktiviert"
 msgid "Write received DNS requests to syslog"
 msgstr "Empfangene DNS-Anfragen in das Systemprotokoll schreiben"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Systemprotokoll in Datei schreiben"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Ja"
@@ -6289,19 +6268,19 @@ msgstr ""
 "Im Browser muss JavaScript aktiviert sein oder LuCI wird nicht richtig "
 "funktionieren."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr "ZRAM Kompressionsalgorithmus"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr "ZRAM Kompressionsprozesse"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr "ZRAM Einstellungen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr "ZRAM Größe"
 
@@ -6312,7 +6291,7 @@ msgstr "beliebig"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6370,7 +6349,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "deaktivieren"
 
@@ -6469,7 +6448,11 @@ msgstr "Schlüssel mit exakt 5 oder 13 Zeichen"
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "Lokale DNS-Datei"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "Minuten"
 
@@ -6488,7 +6471,7 @@ msgstr "nicht verbunden"
 msgid "non-empty value"
 msgstr "nicht-leeren Wert"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "keine"
 
@@ -6499,8 +6482,8 @@ msgid "not present"
 msgstr "nicht vorhanden"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6514,6 +6497,10 @@ msgstr "aus"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "ein"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6532,7 +6519,7 @@ msgstr "positiven Dezimalwert"
 msgid "positive integer value"
 msgstr "positive Ganzzahl"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "zufällig"
 
@@ -6546,8 +6533,8 @@ msgstr "Relay-Modus"
 msgid "routed"
 msgstr "routed"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr "Sekunden"
 
@@ -6568,11 +6555,15 @@ msgstr "nur zustandlos"
 msgid "stateless + stateful"
 msgstr "zustandslos + zustandsorientiert"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "tagged"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr "Zeiteinheiten (TUs / 1024 ms) [1000-65535]"
 
@@ -6591,7 +6582,7 @@ msgstr "unbekannt"
 msgid "unlimited"
 msgstr "unbegrenzt"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6772,6 +6763,10 @@ msgstr "Wert mit mindestens %d Zeichen"
 msgid "value with at most %d characters"
 msgstr "Wert mit maximal %d Zeichen"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6782,6 +6777,27 @@ msgstr "ja"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Zurück"
+
+#~ msgid "Change login password"
+#~ msgstr "Login-Passwort ändern"
+
+#~ msgid "Changing password…"
+#~ msgstr "Ändere Passwort…"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Deaktiviert (Standard)"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Gateway-Ports"
+
+#~ msgid "Loading SSH keys…"
+#~ msgstr "Lade SSH-Schlüssel…"
+
+#~ msgid "Saving keys…"
+#~ msgstr "Speichere Schlüssel…"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Gibt den Server-Port dieser <em>Dropbear</em>-Instanz an"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Switch %q (%s)"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -2172,7 +2172,7 @@ msgstr "Πύλη"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Θύρες πύλης"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6564,9 +6564,6 @@ msgstr "ναι"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Πίσω"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Θύρες πύλης"
 
 #, fuzzy
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Επιπλέον Πεδίο --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Παρακαλώ επιλέξτε --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- προσαρμοσμένο --"
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr "Φορτίο 1 λεπτού:"
 msgid "15 Minute Load:"
 msgstr "Φορτίο 15 λεπτών:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Φορτίο 5 λεπτών:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -171,7 +172,7 @@ msgstr ""
 "Οι <abbr title=\"Σύστημα Ονόματος Τομέα\">DNS</abbr> εξυπηρετητές θα "
 "ερωτηθούν με την σειρά εμφάνισης στο αρχείο resolvfile"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -207,7 +208,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Παραμετροποίηση <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
@@ -250,7 +251,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -331,8 +332,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Συγκεντρωτής Πρόσβασης "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Σημείο Πρόσβασης"
 
@@ -365,17 +366,17 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -406,10 +407,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -423,7 +427,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Προσθήκη νέας διεπαφής..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -472,8 +476,8 @@ msgstr "Διαχείριση"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -483,11 +487,11 @@ msgstr "Προχωρημένες Ρυθμίσεις"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Ειδοποίηση"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -513,25 +517,25 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Επιτρέπει την εξουσιοδότηση <abbr title=\"Secure Shell\">SSH</abbr> με "
 "κωδικό πρόσβασης"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Να επιτρέπονται όλες, εκτός από αυτές στη λίστα"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Να επιτρέπονται μόνο αυτές στην λίστα"
 
@@ -539,17 +543,17 @@ msgstr "Να επιτρέπονται μόνο αυτές στην λίστα"
 msgid "Allow localhost"
 msgstr "Να επιτρέπεται το localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Να επιτρέπεται σε απομακρυσμένα συστήματα να συνδέονται σε τοπικά "
 "προωθημένες SSH θύρες"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Να επιτρέπονται root συνδέσεις με κωδικό πρόσβασης"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 "Να επιτρέπεται στον χρήστη <em>root</em> να συνδέετε με κωδικό πρόσβασης"
@@ -561,7 +565,7 @@ msgstr ""
 "Να επιτρέπονται απαντήσεις από ανώτερο επίπεδο εντός του εύρους 127.0.0.0/8, "
 "π.χ. για υπηρεσίες RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -569,7 +573,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -648,7 +652,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -667,11 +671,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Οιαδήποτε ζώνη"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -695,7 +699,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Συνδεδεμένοι Σταθμοί"
@@ -709,7 +713,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Εξουσιοδότηση"
 
@@ -804,7 +808,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -822,7 +826,7 @@ msgstr "Πίσω προς παραμετροποίηση"
 msgid "Backup"
 msgstr "Αποθήκευση"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Αντίγραφο ασφαλείας / Εγγραφή FLASH Υλικολογισμικό"
 
@@ -840,7 +844,7 @@ msgstr "Μη έγκυρη διεύθυνση!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -879,7 +883,7 @@ msgstr "Ρυθμός δεδομένων"
 msgid "Bogus NX Domain Override"
 msgstr "Παράκαμψη Ψευδούς Τομέα NX"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Γέφυρα"
@@ -897,7 +901,7 @@ msgstr "Αριθμός μονάδας γέφυρας"
 msgid "Bring up on boot"
 msgstr "Ανέβασμα κατά την εκκίνηση"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -922,13 +926,13 @@ msgstr "Χρήση CPU (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Ακύρωση"
@@ -951,13 +955,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Αλυσίδα"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Αλλαγές"
 
@@ -965,23 +963,19 @@ msgstr "Αλλαγές"
 msgid "Changes applied."
 msgstr "Αλλαγές εφαρμόστηκαν."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Αλλάζει τον κωδικό διαχειριστή για πρόσβαση στη συσκευή"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Κανάλι"
@@ -994,7 +988,7 @@ msgstr "Έλεγχος"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -1007,7 +1001,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1019,13 +1013,13 @@ msgstr ""
 "από την συσχετισμένη ζώνη ή συμπληρώστε το <em>δημιουργία</em> πεδίο για να "
 "προσδιορίσετε μία νέα ζώνη και να προσαρτήσετε την διεπαφή σε αυτό."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1047,9 +1041,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Πελάτης"
 
@@ -1058,8 +1052,8 @@ msgstr "Πελάτης"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Αναγνωριστικό πελάτη που αποστέλλετε κατά την αίτηση DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1085,7 +1079,7 @@ msgstr "Κλείσιμο λίστας..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1112,7 +1106,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1120,7 +1114,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1136,11 +1130,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1148,7 +1142,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Επιβεβαίωση"
 
@@ -1181,7 +1175,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1192,12 +1186,12 @@ msgstr ""
 msgid "Country"
 msgstr "Χώρα"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Κωδικός Χώρας"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Δημιουργία / Ανάθεση ζώνης τείχους προστασίας"
 
@@ -1205,11 +1199,11 @@ msgstr "Δημιουργία / Ανάθεση ζώνης τείχους προσ
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Επίπεδο Καταγραφής Cron"
 
@@ -1244,15 +1238,15 @@ msgstr ""
 "Ρυθμίζει, αν είναι δυνατόν, την συμπεριφορά των <abbr title=\"Light Emitting "
 "Diode\">LED</abbr> της συσκευής."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1265,7 +1259,7 @@ msgstr "Εξυπηρετητής DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP και DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1338,7 +1332,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1350,14 +1344,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Αποσφαλμάτωση"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Προεπιλογή %d"
 
@@ -1397,47 +1391,47 @@ msgstr ""
 "Ορίστε επιπλέον επιλογές DHCP, που διαφημίζουν διαφορετικούς εξυπηρετητές "
 "DNS στους πελάτες, για παράδειγμα \"<code>6,192.168.2.1,192.168.2.2</code>\"."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Διαγραφή αυτού του δικτύου"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Εμφάνιση"
 
@@ -1468,7 +1462,7 @@ msgstr ""
 msgid "Device"
 msgstr "Συσκευή"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Παραμετροποίηση Συσκευής"
 
@@ -1485,7 +1479,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1503,12 +1497,12 @@ msgstr "Διαγνωστικά"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Κατάλογος"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Απενεργοποίηση"
 
@@ -1524,14 +1518,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1543,11 +1538,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Απενεργοποιημένο"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1566,21 +1557,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Βελτιστοποίηση Απόστασης"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Απόσταση σε μέτρα από το πιο απομακρυσμένο μέλος του δικτύου."
 
@@ -1612,15 +1601,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1660,15 +1649,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1703,17 +1692,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Μέθοδος EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Επεξεργασία"
 
@@ -1723,7 +1712,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Επεξεργασία αυτού του δικτύου"
 
@@ -1731,12 +1720,12 @@ msgstr "Επεξεργασία αυτού του δικτύου"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Έκτακτη ανάγκη"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Ενεργοποίηση"
 
@@ -1771,7 +1760,7 @@ msgstr "Ενεργοποίηση διαπραγμάτευσης IPv6 πάνω σ
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Ενεργοποίηση διέλευσης Jumbo Frame"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1787,11 +1776,11 @@ msgstr "Ενεργοποίηση εξυπηρετητή TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Ενεργοποίηση λειτουργίας VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1815,7 +1804,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "Ενεργοποίηση αυτής της προσάρτησης"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1837,7 +1826,7 @@ msgstr "Ενεργοποιημένο"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1858,17 +1847,17 @@ msgstr "Λειτουργία ενθυλάκωσης"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Κρυπτογράφηση"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1880,7 +1869,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Διαγράφεται..."
 
@@ -1894,7 +1883,7 @@ msgstr "Διαγράφεται..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Σφάλμα"
 
@@ -1902,12 +1891,12 @@ msgstr "Σφάλμα"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Προσαρμογέας Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet Switch"
@@ -1944,23 +1933,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Εξωτερικός εξυπηρετητής καταγραφής συστήματος"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1968,19 +1957,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1988,15 +1981,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Αρχείο"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2041,7 +2034,7 @@ msgstr "Τέλος"
 msgid "Firewall"
 msgstr "Τείχος Προστασίας"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2081,7 +2074,7 @@ msgstr "Φλασάρισμα νέας εικόνας υλικολογισμικ�
 msgid "Flash operations"
 msgstr "Λειτουργίες φλασάρισματος"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Φλασάρεται..."
 
@@ -2089,11 +2082,11 @@ msgstr "Φλασάρεται..."
 msgid "Force"
 msgstr "Επιβολή"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Επιβολή CCMP (AES)"
 
@@ -2102,11 +2095,11 @@ msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 "Επιβολή DHCP σε αυτό το δίκτυο ακόμα κι αν έχει εντοπιστεί άλλος εξυπηρετητής"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Επιβολή TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Επιβολή TKIP και CCMP (AES)"
 
@@ -2138,7 +2131,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Προώθηση κίνησης broadcast"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2146,7 +2139,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Μέθοδος προώθησης"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Όριο Κατακερµατισµού"
 
@@ -2155,7 +2148,7 @@ msgstr "Όριο Κατακερµατισµού"
 msgid "Free"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2177,19 +2170,19 @@ msgstr ""
 msgid "Gateway"
 msgstr "Πύλη"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Θύρες πύλης"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2197,8 +2190,8 @@ msgstr "Γενικές Ρυθμίσεις"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
@@ -2206,7 +2199,7 @@ msgstr ""
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2214,7 +2207,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2233,8 +2226,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2264,7 +2257,7 @@ msgstr "Κρέμασμα"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2272,7 +2265,7 @@ msgstr ""
 "Εδώ μπορείτε να παραμετροποιήσετε βασικές πλευρές της συσκευής σας όπως το "
 "όνομα υπολογιστή ή τη ζώνη ώρας."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Κρυφό <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2283,7 +2276,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2309,7 +2302,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Όνομα Υπολογιστή"
 
@@ -2330,7 +2323,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2551,7 +2544,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Ταυτότητα"
 
@@ -2667,7 +2660,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Πληροφορίες"
 
@@ -2705,7 +2698,7 @@ msgstr "Εγκατάσταση επεκτάσεων πρωτοκόλλου..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Διεπαφή"
 
@@ -2713,7 +2706,7 @@ msgstr "Διεπαφή"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Παραμετροποίηση Διεπαφής"
 
@@ -2743,7 +2736,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2773,7 +2766,7 @@ msgstr ""
 msgid "Invalid"
 msgstr "Άκυρη τιμή εισόδου"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2793,7 +2786,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2801,7 +2794,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Άκυρο όνομα χρήστη και/ή κωδικός πρόσβασης! Παρακαλώ προσπαθήστε ξανά."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2821,15 +2814,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "Απαιτείται JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2846,15 +2839,15 @@ msgstr "Καταγραφή Πυρήνα"
 msgid "Kernel Version"
 msgstr "Έκδοση Πυρήνα"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Κλειδί"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Κλειδί #%d"
 
@@ -2898,11 +2891,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Ετικέτα"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Γλώσσα"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr ""
 
@@ -2942,7 +2935,7 @@ msgstr "Αφήστε το κενό για να γίνει αυτόματη αν�
 msgid "Leave empty to use the current WAN address"
 msgstr "Αφήστε το κενό για να γίνει χρήση της τρέχουσας διεύθυνσης WAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Υπόμνημα:"
 
@@ -2984,7 +2977,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2993,7 +2986,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3018,11 +3011,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -3045,11 +3038,7 @@ msgstr "Μέσος όρος φόρτου"
 msgid "Loading"
 msgstr "Φόρτωση"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3089,7 +3078,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Τοπική Ώρα"
 
@@ -3121,7 +3110,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Τοπικά ερωτήματα"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Επίπεδο εξόδου αρχείων καταγραφής"
 
@@ -3129,7 +3118,7 @@ msgstr "Επίπεδο εξόδου αρχείων καταγραφής"
 msgid "Log queries"
 msgstr "Καταγραφή ερωτημάτων"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Καταγραφή"
 
@@ -3160,22 +3149,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-Διεύθυνση"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Φίλτρο MAC Διευθύνσεων"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-Φίλτρο"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Λίστα MAC"
 
@@ -3203,7 +3192,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3223,7 +3212,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3231,7 +3220,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3258,7 +3247,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr "Μέγιστος αριθμός διευθύνσεων lease"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3271,7 +3260,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3283,11 +3272,11 @@ msgstr "Μνήμη"
 msgid "Memory usage (%)"
 msgstr "Χρήση Μνήμης (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3298,7 +3287,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Μέτρο"
 
@@ -3310,7 +3299,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3318,8 +3307,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Λειτουργία"
@@ -3350,16 +3339,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Παρακολούθηση"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3373,7 +3362,7 @@ msgstr "Προσάρτηση"
 msgid "Mount Point"
 msgstr "Σημείο Προσάρτησης"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3423,7 +3412,7 @@ msgstr "Μετακίνηση κάτω"
 msgid "Move up"
 msgstr "Μετακίνηση πάνω"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3448,11 +3437,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3460,7 +3449,7 @@ msgstr ""
 msgid "Name"
 msgstr "Όνομα"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Όνομα νέου δικτύου"
 
@@ -3470,8 +3459,8 @@ msgstr "Πλοήγηση"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3504,7 +3493,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Επόμενο »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3513,7 +3502,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Δεν υπάρχει ρυθμισμένος DHCP εξυπηρετητής για αυτή τη διεπαφή"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3525,7 +3514,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3556,11 +3545,12 @@ msgstr ""
 msgid "No password set!"
 msgstr "Δεν έχει οριστεί κωδικός πρόσβασης!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3605,7 +3595,7 @@ msgstr ""
 msgid "None"
 msgstr "Κανένα"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Φυσιολογικό"
 
@@ -3635,7 +3625,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Επισήμανση"
 
@@ -3647,7 +3637,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3713,24 +3703,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Η επιλογή άλλαξε"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Η επιλογή αφαιρέθηκε"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3744,41 +3734,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3838,7 +3828,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3860,7 +3850,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Επισκόπηση"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3905,7 +3895,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3960,29 +3950,29 @@ msgid "Part of zone %q"
 msgstr "Μέρος της ζώνης %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Κωδικός Πρόσβασης"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Εξουσιοδότηση με κωδικό πρόσβασης"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Κωδικός Πρόσβασης του Ιδιωτικού Κλειδιού"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3990,31 +3980,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Διαδρομή για Πιστοποιητικό CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Διαδρομή για Πιστοποιητικό-Πελάτη"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Διαδρομή για Ιδιωτικό Κλειδί"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4041,7 +4031,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4061,7 +4051,7 @@ msgstr "Διενέργεια αρχικοποίησης"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4101,7 +4091,7 @@ msgstr "Παρακαλώ εισάγετε όνομα χρήστη και κωδ�
 msgid "Policy"
 msgstr "Πολιτική"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Θύρα"
 
@@ -4137,7 +4127,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4156,12 +4146,12 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 #, fuzzy
 msgid "Prevents client-to-client communication"
 msgstr "Αποτρέπει την επικοινωνία μεταξύ πελατών"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4192,7 +4182,7 @@ msgstr "Πρωτ."
 msgid "Protocol"
 msgstr "Πρωτόκολλο"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4200,15 +4190,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Ψευδό Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4235,11 +4225,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4247,11 +4237,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Όριο RTS/CTS"
 
@@ -4267,31 +4257,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4341,7 +4331,7 @@ msgstr "Κίνηση πραγματικού χρόνου"
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4349,7 +4339,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Επανεκκίνηση"
@@ -4367,7 +4357,7 @@ msgstr "Επανεκκίνηση του λειτουργικού συστήμα�
 msgid "Receive"
 msgstr "Λήψη"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4407,11 +4397,11 @@ msgstr "Απομακρυσμένη διεύθυνση IPv4"
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Αφαίρεση"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Αντικατάσταση ρυθμίσεων ασύρματης σύνδεσης"
 
@@ -4427,7 +4417,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4435,42 +4425,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4482,31 +4472,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4557,10 +4547,8 @@ msgstr "Επαναφορά Αντίγραφου Ασφαλείας"
 msgid "Restore backup"
 msgstr "Επαναφορά αντιγράφου ασφαλείας"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr ""
 
@@ -4568,15 +4556,15 @@ msgstr ""
 msgid "Revert"
 msgstr "Αναίρεση"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4592,7 +4580,7 @@ msgstr "Κατάλογος Root για αρχεία που σερβίροντα�
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4608,8 +4596,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Κωδικός Πρόσβασης Δρομολογητή"
 
@@ -4652,8 +4640,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Πρόσβαση SSH"
 
@@ -4669,14 +4657,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "Κλειδιά SSH"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4685,19 +4673,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Αποθήκευση & Εφαρμογή"
@@ -4710,24 +4696,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Σάρωση"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Προγραμματισμένες Εργασίες"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr ""
 
@@ -4742,9 +4724,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4813,7 +4795,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4833,12 +4815,12 @@ msgstr "Απενεργοποίηση αυτής της διεπαφής"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Σήμα"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4858,7 +4840,7 @@ msgstr "Μέγεθος"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4875,7 +4857,7 @@ msgstr "Παράκαμψη σε περιεχόμενο"
 msgid "Skip to navigation"
 msgstr "Παράκαμψη σε πλοήγηση"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4913,12 +4895,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-#, fuzzy
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-"Προσδιορίζει την θύρα ακρόασης αυτού του στιγμιοτύπου <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4931,7 +4907,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4954,7 +4930,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Ορίστε το κρυφό κλειδί κρυπτογράφησης."
 
@@ -4968,16 +4944,16 @@ msgstr "Αρχή"
 msgid "Start priority"
 msgstr "Προτεραιότητα εκκίνησης"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Εκκίνηση"
 
@@ -4997,7 +4973,7 @@ msgstr "Στατικά Leases"
 msgid "Static Routes"
 msgstr "Στατικές Διαδρομές"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5010,13 +4986,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Κατάσταση"
@@ -5031,12 +5007,12 @@ msgstr ""
 msgid "Strict order"
 msgstr "Αυστηρή σειρά"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Υποβολή"
 
@@ -5074,7 +5050,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5089,11 +5065,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5103,7 +5079,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5114,11 +5090,11 @@ msgstr "Σύστημα"
 msgid "System Log"
 msgstr "Καταγραφή Συστήματος"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Ιδιότητες Συστήματος"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5184,7 +5160,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5200,7 +5176,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5251,11 +5227,11 @@ msgstr "Οι παρακάτω κανόνες είναι αυτή τη στιγμ
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5285,7 +5261,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5299,7 +5275,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5307,13 +5283,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5326,7 +5302,7 @@ msgstr ""
 "είναι πιθανό να χρειαστεί να ανανεώσετε την διεύθυνση του υπολογιστή σας για "
 "να αποκτήσετε ξανά πρόσβαση στη συσκευή."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5347,7 +5323,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Δεν υπάρχουν ενεργά leases."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5364,7 +5340,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5445,22 +5421,22 @@ msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Αυτή η σελίδα δίνει μία εικόνα για τις τρέχουσες ενεργές συνδέσεις δικτύου."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Αυτό το τμήμα δεν περιέχει τιμές ακόμη"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Ζώνη ώρας"
 
@@ -5519,7 +5495,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Διεπαφή Τούνελ"
@@ -5612,12 +5588,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Άγνωστο"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5626,7 +5602,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5637,11 +5613,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Μη-αποθηκευμένες Αλλαγές"
 
@@ -5679,15 +5656,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5825,11 +5802,11 @@ msgstr ""
 msgid "Used"
 msgstr "Σε χρήση"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Χρησιμοποιούμενη Υποδοχή Κλειδιού"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5909,32 +5886,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Μοιραζόμενο κλειδί WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Κωδική φράση WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Υποστήριξη WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Κωδική φράση WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5948,7 +5925,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5956,8 +5933,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
@@ -5965,11 +5942,11 @@ msgstr "Προειδοποίηση"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5981,7 +5958,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5992,13 +5969,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Ασύρματο"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Ασύρματος Προσαρμογέας"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6008,7 +5985,7 @@ msgstr "Ασύρματο Δίκτυο"
 msgid "Wireless Overview"
 msgstr "Επισκόπηση Ασύρματου Δικτύου"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Ασφάλεια Ασύρματου Δικτύου"
 
@@ -6028,11 +6005,11 @@ msgstr "Το ασύρματο δίκτυο είναι απενεργοποιημ
 msgid "Wireless is not associated"
 msgstr "Το ασύρματο δίκτυο μη συνδεδεμένο"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Το ασύρματο δίκτυο είναι ανενεργό"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Το ασύρματο δίκτυο είναι ενεργό"
 
@@ -6040,11 +6017,11 @@ msgstr "Το ασύρματο δίκτυο είναι ενεργό"
 msgid "Write received DNS requests to syslog"
 msgstr "Καταγραφή των ληφθέντων DNS αιτήσεων στο syslog"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6074,19 +6051,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6097,7 +6074,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6157,7 +6134,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "ανενεργό"
 
@@ -6258,7 +6235,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "τοπικό αρχείο <abbr title=\"Domain Name System\">DNS</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6277,7 +6258,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "κανένα"
 
@@ -6288,8 +6269,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6303,6 +6284,10 @@ msgstr "κλειστό"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "ανοιχτό"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6321,7 +6306,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6335,8 +6320,8 @@ msgstr ""
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6357,11 +6342,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6380,7 +6369,7 @@ msgstr ""
 msgid "unlimited"
 msgstr "απεριόριστα"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6561,6 +6550,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6571,6 +6564,14 @@ msgstr "ναι"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Πίσω"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Θύρες πύλης"
+
+#, fuzzy
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr ""
+#~ "Προσδιορίζει την θύρα ακρόασης αυτού του στιγμιοτύπου <em>Dropbear</em>"
 
 #~ msgid "Antenna 1"
 #~ msgstr "Κεραία 1"

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Additional Field --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Please choose --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- custom --"
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr "1 Minute Load:"
 msgid "15 Minute Load:"
 msgstr "15 Minute Load:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "5 Minute Load:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -171,7 +172,7 @@ msgstr ""
 "<abbr title=\"Domain Name System\">DNS</abbr> servers will be queried in the "
 "order of the resolvfile"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -207,7 +208,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 
@@ -250,7 +251,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -331,8 +332,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Access Concentrator"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Access Point"
 
@@ -363,17 +364,17 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -404,10 +405,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -420,7 +424,7 @@ msgstr "Add local domain suffix to names served from hosts files"
 msgid "Add new interface..."
 msgstr "Add new interface..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -469,8 +473,8 @@ msgstr "Administration"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -480,11 +484,11 @@ msgstr "Advanced Settings"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alert"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -510,23 +514,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Allow all except listed"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Allow listed only"
 
@@ -534,15 +538,15 @@ msgstr "Allow listed only"
 msgid "Allow localhost"
 msgstr "Allow localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr "Allow remote hosts to connect to local SSH forwarded ports"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Allow root logins with password"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Allow the <em>root</em> user to login with password"
 
@@ -552,7 +556,7 @@ msgid ""
 msgstr ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -560,7 +564,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -639,7 +643,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -658,11 +662,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Any zone"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -686,7 +690,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Associated Stations"
@@ -700,7 +704,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Authentication"
 
@@ -795,7 +799,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -813,7 +817,7 @@ msgstr "Back to configuration"
 msgid "Backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Backup / Flash Firmware"
 
@@ -830,7 +834,7 @@ msgstr "Bad address specified!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -868,7 +872,7 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Bogus NX Domain Override"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bridge"
@@ -886,7 +890,7 @@ msgstr "Bridge unit number"
 msgid "Bring up on boot"
 msgstr "Bring up on boot"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -911,13 +915,13 @@ msgstr "CPU usage (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancel"
@@ -940,13 +944,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Chain"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Changes"
 
@@ -954,23 +952,19 @@ msgstr "Changes"
 msgid "Changes applied."
 msgstr "Changes applied."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Changes the administrator password for accessing the device"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Channel"
@@ -983,7 +977,7 @@ msgstr "Check"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -996,7 +990,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1008,13 +1002,13 @@ msgstr ""
 "fill out the <em>create</em> field to define a new zone and attach the "
 "interface to it."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Cipher"
 
@@ -1036,9 +1030,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Client"
 
@@ -1047,8 +1041,8 @@ msgstr "Client"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Client ID to send when requesting DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1073,7 +1067,7 @@ msgstr "Close list..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1100,7 +1094,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1108,7 +1102,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1124,11 +1118,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1136,7 +1130,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Confirmation"
 
@@ -1169,7 +1163,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1180,12 +1174,12 @@ msgstr ""
 msgid "Country"
 msgstr "Country"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Country Code"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Create / Assign firewall-zone"
 
@@ -1193,11 +1187,11 @@ msgstr "Create / Assign firewall-zone"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Critical"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Cron Log Level"
 
@@ -1232,15 +1226,15 @@ msgstr ""
 "Customizes the behaviour of the device <abbr title=\"Light Emitting Diode"
 "\">LED</abbr>s if possible."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1253,7 +1247,7 @@ msgstr "DHCP Server"
 msgid "DHCP and DNS"
 msgstr "DHCP and DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1326,7 +1320,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1338,14 +1332,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Debug"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Default %d"
 
@@ -1386,47 +1380,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" which advertises different DNS "
 "servers to clients."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Delete"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Delete this network"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Description"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Design"
 
@@ -1457,7 +1451,7 @@ msgstr ""
 msgid "Device"
 msgstr "Device"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Device Configuration"
 
@@ -1474,7 +1468,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1492,12 +1486,12 @@ msgstr "Diagnostics"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Directory"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr ""
 
@@ -1511,14 +1505,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1530,11 +1525,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Disabled"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1553,21 +1544,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Distance Optimization"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distance to farthest network member in meters."
 
@@ -1595,15 +1584,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1643,15 +1632,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1683,17 +1672,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP-Method"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Edit"
 
@@ -1703,7 +1692,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr ""
 
@@ -1711,12 +1700,12 @@ msgstr ""
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr ""
 
@@ -1751,7 +1740,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1767,11 +1756,11 @@ msgstr ""
 msgid "Enable VLAN functionality"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1795,7 +1784,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1817,7 +1806,7 @@ msgstr "Enabled"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1838,17 +1827,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Encryption"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1860,7 +1849,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr ""
 
@@ -1874,7 +1863,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Error"
 
@@ -1882,12 +1871,12 @@ msgstr "Error"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet Adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet Switch"
@@ -1921,23 +1910,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1945,19 +1934,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1965,15 +1958,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2018,7 +2011,7 @@ msgstr ""
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2058,7 +2051,7 @@ msgstr ""
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2066,11 +2059,11 @@ msgstr ""
 msgid "Force"
 msgstr "Force"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr ""
 
@@ -2078,11 +2071,11 @@ msgstr ""
 msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
@@ -2114,7 +2107,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2122,7 +2115,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Fragmentation Threshold"
 
@@ -2131,7 +2124,7 @@ msgstr "Fragmentation Threshold"
 msgid "Free"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2153,19 +2146,19 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2173,8 +2166,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "General Setup"
 
@@ -2182,7 +2175,7 @@ msgstr "General Setup"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2190,7 +2183,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2209,8 +2202,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2240,7 +2233,7 @@ msgstr "Hang Up"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2248,7 +2241,7 @@ msgstr ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2259,7 +2252,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2284,7 +2277,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Hostname"
 
@@ -2305,7 +2298,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2526,7 +2519,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identity"
 
@@ -2637,7 +2630,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr ""
 
@@ -2675,7 +2668,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
 
@@ -2683,7 +2676,7 @@ msgstr "Interface"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr ""
 
@@ -2713,7 +2706,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2743,7 +2736,7 @@ msgstr ""
 msgid "Invalid"
 msgstr "Invalid input value"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2763,7 +2756,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2771,7 +2764,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Invalid username and/or password! Please try again."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2791,15 +2784,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Join Network"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2816,15 +2809,15 @@ msgstr "Kernel Log"
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Key"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2868,11 +2861,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Language"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr ""
 
@@ -2912,7 +2905,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2954,7 +2947,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2963,7 +2956,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2988,11 +2981,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -3015,11 +3008,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3059,7 +3048,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Local Time"
 
@@ -3091,7 +3080,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Localise queries"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3099,7 +3088,7 @@ msgstr ""
 msgid "Log queries"
 msgstr "Log queries"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3130,22 +3119,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "MAC-Address Filter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-Filter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC-List"
 
@@ -3173,7 +3162,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3193,7 +3182,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3201,7 +3190,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3227,7 +3216,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3240,7 +3229,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3252,11 +3241,11 @@ msgstr "Memory"
 msgid "Memory usage (%)"
 msgstr "Memory usage (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3267,7 +3256,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metric"
 
@@ -3279,7 +3268,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3287,8 +3276,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Mode"
@@ -3319,16 +3308,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3341,7 +3330,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr "Mount Point"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3391,7 +3380,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3416,11 +3405,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3428,7 +3417,7 @@ msgstr ""
 msgid "Name"
 msgstr "Name"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Name of the new network"
 
@@ -3438,8 +3427,8 @@ msgstr "Navigation"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3472,7 +3461,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3481,7 +3470,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3493,7 +3482,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3524,11 +3513,12 @@ msgstr ""
 msgid "No password set!"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3573,7 +3563,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr ""
 
@@ -3603,7 +3593,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr ""
 
@@ -3615,7 +3605,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3681,24 +3671,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3712,41 +3702,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3806,7 +3796,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3828,7 +3818,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Overview"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3873,7 +3863,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3928,29 +3918,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Password"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Password authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Password of Private Key"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3958,31 +3948,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Path to CA-Certificate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Path to Private Key"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4009,7 +3999,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4029,7 +4019,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4069,7 +4059,7 @@ msgstr "Please enter your username and password."
 msgid "Policy"
 msgstr "Policy"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4105,7 +4095,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4124,11 +4114,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Prevents client-to-client communication"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4159,7 +4149,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protocol"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4167,15 +4157,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4202,11 +4192,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4214,11 +4204,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS Threshold"
 
@@ -4234,31 +4224,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4308,7 +4298,7 @@ msgstr ""
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4316,7 +4306,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reboot"
@@ -4334,7 +4324,7 @@ msgstr "Reboots the operating system of your device"
 msgid "Receive"
 msgstr "Receive"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4374,11 +4364,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Remove"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4394,7 +4384,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4402,42 +4392,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4449,31 +4439,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4524,10 +4514,8 @@ msgstr ""
 msgid "Restore backup"
 msgstr "Restore backup"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr ""
 
@@ -4535,15 +4523,15 @@ msgstr ""
 msgid "Revert"
 msgstr "Revert"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4559,7 +4547,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4575,8 +4563,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr ""
 
@@ -4618,8 +4606,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr ""
 
@@ -4635,14 +4623,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4651,19 +4639,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Save"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Save & Apply"
@@ -4676,24 +4662,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Scheduled Tasks"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr ""
 
@@ -4708,9 +4690,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4779,7 +4761,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4799,12 +4781,12 @@ msgstr ""
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4824,7 +4806,7 @@ msgstr "Size"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4841,7 +4823,7 @@ msgstr "Skip to content"
 msgid "Skip to navigation"
 msgstr "Skip to navigation"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4879,10 +4861,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4895,7 +4873,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4918,7 +4896,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4932,16 +4910,16 @@ msgstr "Start"
 msgid "Start priority"
 msgstr "Start priority"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr ""
 
@@ -4961,7 +4939,7 @@ msgstr "Static Leases"
 msgid "Static Routes"
 msgstr "Static Routes"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4974,13 +4952,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -4995,12 +4973,12 @@ msgstr "Stop"
 msgid "Strict order"
 msgstr "Strict order"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Submit"
 
@@ -5038,7 +5016,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5053,11 +5031,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5067,7 +5045,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5078,11 +5056,11 @@ msgstr "System"
 msgid "System Log"
 msgstr "System Log"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5148,7 +5126,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5162,7 +5140,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5213,11 +5191,11 @@ msgstr "The following rules are currently active on this system."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5247,7 +5225,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5261,7 +5239,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5269,13 +5247,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5288,7 +5266,7 @@ msgstr ""
 "address of your computer to reach the device again, depending on your "
 "settings."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5309,7 +5287,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5326,7 +5304,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5404,22 +5382,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "This page gives an overview over currently active network connections."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "This section contains no values yet"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Timezone"
 
@@ -5477,7 +5455,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5570,12 +5548,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5584,7 +5562,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5595,11 +5573,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Unsaved Changes"
 
@@ -5637,15 +5616,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5783,11 +5762,11 @@ msgstr ""
 msgid "Used"
 msgstr "Used"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5867,32 +5846,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM Mode"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5908,7 +5887,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5916,8 +5895,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr ""
 
@@ -5925,11 +5904,11 @@ msgstr ""
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5941,7 +5920,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5952,13 +5931,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Wireless Adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5968,7 +5947,7 @@ msgstr "Wireless Network"
 msgid "Wireless Overview"
 msgstr "Wireless Overview"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Wireless Security"
 
@@ -5988,11 +5967,11 @@ msgstr ""
 msgid "Wireless is not associated"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr ""
 
@@ -6000,11 +5979,11 @@ msgstr ""
 msgid "Write received DNS requests to syslog"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6033,19 +6012,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6056,7 +6035,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6114,7 +6093,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "disable"
 
@@ -6215,7 +6194,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6234,7 +6217,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "none"
 
@@ -6245,8 +6228,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6259,6 +6242,10 @@ msgstr ""
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:205
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
@@ -6278,7 +6265,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6292,8 +6279,8 @@ msgstr ""
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6314,11 +6301,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6337,7 +6328,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6516,6 +6507,10 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:441
 msgid "value with at most %d characters"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -2215,7 +2215,7 @@ msgstr "Puerta de enlace"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Puertos del gateway"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6767,9 +6767,6 @@ msgstr "« Volver"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Deshabilitado (predeterminado)"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Puertos del gateway"
 
 #~ msgid "Loading SSH keys…"
 #~ msgstr "Cargando claves SSH..."

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr "%.1f dB"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr "%d campo(s) inválido(s)"
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Campo adicional --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Por favor elija --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- Personalizado --"
@@ -98,7 +99,7 @@ msgstr "-- Emparejar por uuid --"
 msgid "-- please select --"
 msgstr "-- Por favor seleccione --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 "0 = Sin utilizar el umbral RSSI, 1 = No cambiar el valor predeterminado del "
@@ -112,7 +113,7 @@ msgstr "Carga a 1 minuto:"
 msgid "15 Minute Load:"
 msgstr "Carga a 15 minutos:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr "ID hexadecimal de 4 caracteres"
 
@@ -125,35 +126,35 @@ msgstr "464XLAT (CLAT)"
 msgid "5 Minute Load:"
 msgstr "Carga a 5 minutos:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr "Identificador de 6 octetos como una cadena hexadecimal, sin dos puntos"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr "Habilitar 802.11r (FT)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr "Consulta tiempo de espera máximo de Asociación SA de 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr "Consulta tiempo de espera de reintento de Asociación SA de 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr "Protección de marco de gestión de 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr "Tiempo de espera máximo de 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr "Tiempo de espera de reintento de 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -173,7 +174,7 @@ msgstr ""
 "Los servidores de <abbr title=\"Domain Name System\">DNS</abbr> se consultan "
 "en el orden en que aparecen en el archivo resolv"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -210,7 +211,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configuración de <abbr title=\"Light Emitting Diode\">LEDs</abbr>"
 
@@ -255,7 +256,7 @@ msgstr ""
 "<br/>Nota: debe reiniciar manualmente el servicio cron si el archivo crontab "
 "estaba vacío antes de editar."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr "Ya existe un directorio con el mismo nombre."
 
@@ -338,8 +339,8 @@ msgstr "Interfaz ausente"
 msgid "Access Concentrator"
 msgstr "Concentrador de acceso"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "AP"
 
@@ -370,17 +371,17 @@ msgstr "Clientes DHCP activos"
 msgid "Active DHCPv6 Leases"
 msgstr "Clientes DHCPv6 activos"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -411,10 +412,13 @@ msgstr "Agregar acción LED"
 msgid "Add VLAN"
 msgstr "Añadir VLAN"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr "Añadir clave"
 
@@ -429,7 +433,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Añadir nueva interfaz..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr "Añadir par"
 
@@ -478,8 +482,8 @@ msgstr "Administración"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -489,11 +493,11 @@ msgstr "Configuración avanzada"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr "Potencia de transmisión agregada (ACTATP)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -521,26 +525,26 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr "Asignar IPs secuencialmente"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Permitir autenticación de contraseña via <abbr title=\"Secure Shell\">SSH</"
 "abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 "Permitir que el modo AP desconecte los clientes por una condición de ACK bajo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Permitir a todos excepto a los de la lista"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "Permitir tasas de 802.11b heredadas"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Permitir a los pertenecientes en la lista"
 
@@ -548,17 +552,17 @@ msgstr "Permitir a los pertenecientes en la lista"
 msgid "Allow localhost"
 msgstr "Permitir host local"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Permitir que los hosts remotos se conecten a los puertos reenviados SSH "
 "locales"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Permitir conexiones a root con contraseña"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Permitir al usuario <em>root</em> conectar con contraseña"
 
@@ -568,7 +572,7 @@ msgid ""
 msgstr ""
 "Permitir respuestas en el rango 127.0.0.0/8, por ejemplo para servicios RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "IPs permitidas"
 
@@ -576,7 +580,7 @@ msgstr "IPs permitidas"
 msgid "Always announce default router"
 msgstr "Siempre anunciar el enrutador predeterminado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -659,7 +663,7 @@ msgstr "Dominios DNS anunciados"
 msgid "Announced DNS servers"
 msgstr "Servidores DNS anunciados"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr "Identidad anónima"
 
@@ -678,11 +682,11 @@ msgstr "Swap anónimo"
 msgid "Any zone"
 msgstr "Cualquier zona"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Solicitud de aplicar fallida con estado <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr "Aplicar sin restricción"
 
@@ -710,7 +714,7 @@ msgstr ""
 "Asigna partes de prefijo utilizando este ID de subprefijo hexadecimal para "
 "esta interfaz."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Dispositivos conectados"
@@ -724,7 +728,7 @@ msgstr "Dispositivos"
 msgid "Auth Group"
 msgstr "Grupo de autenticaciones"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Autenticación"
 
@@ -821,7 +825,7 @@ msgstr "BR / DMR / AFTR"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -839,7 +843,7 @@ msgstr "Volver a la configuración"
 msgid "Backup"
 msgstr "Copia de seguridad"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Copia de seguridad / Grabar firmware"
 
@@ -856,7 +860,7 @@ msgstr "¡Dirección no válida!"
 msgid "Band"
 msgstr "Banda"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr "Intervalo de baliza"
 
@@ -897,7 +901,7 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Ignorar dominio falso NX"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Puente"
@@ -915,7 +919,7 @@ msgstr "Número de unidad del puente"
 msgid "Bring up on boot"
 msgstr "Iniciar en el arranque"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr "Explorar..."
 
@@ -941,13 +945,13 @@ msgstr "Uso de CPU (%)"
 msgid "Call failed"
 msgstr "Llamada fallida"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancelar"
@@ -970,13 +974,7 @@ msgstr "Precaución: la actualización del sistema será forzada"
 msgid "Chain"
 msgstr "Cadena"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr "Cambiar contraseña de inicio de sesión"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Cambios"
 
@@ -984,23 +982,19 @@ msgstr "Cambios"
 msgid "Changes applied."
 msgstr "Cambios aplicados."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "Se revirtieron los cambios."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Cambie la contraseña del administrador para acceder al dispositivo"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr "Cambiando contraseña..."
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Canal"
@@ -1013,7 +1007,7 @@ msgstr "Comprobar"
 msgid "Check filesystems before mount"
 msgstr "Comprobar los sistemas de archivos antes de montar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "Marque esta opción para eliminar las redes existentes de esta radio."
 
@@ -1026,7 +1020,7 @@ msgid "Choose mtdblock"
 msgstr "Elegir mtdblock"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1038,7 +1032,7 @@ msgstr ""
 "rellene el campo <em>crear</em> para definir una zona nueva a la que "
 "asignarla."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1046,7 +1040,7 @@ msgstr ""
 "Elija la red o redes a las que quiere unir esta interfaz WiFi o rellene el "
 "campo <em>crear</em> para definir una red nueva."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Cifrado"
 
@@ -1070,9 +1064,9 @@ msgstr ""
 "Haga clic en \"Guardar mtdblock\" para descargar el archivo mtdblock "
 "especificado. (NOTA: ¡ESTA FUNCIÓN ES PARA PROFESIONALES!)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Cliente"
 
@@ -1081,8 +1075,8 @@ msgstr "Cliente"
 msgid "Client ID to send when requesting DHCP"
 msgstr "ID de cliente que se enviará al solicitar DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr "Cerrar"
 
@@ -1107,7 +1101,7 @@ msgstr "Cerrar lista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1134,7 +1128,7 @@ msgstr "Comando fallido"
 msgid "Comment"
 msgstr "Comentario"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1147,7 +1141,7 @@ msgstr ""
 "interoperabilidad y reducir la robustez de la negociación de claves, "
 "especialmente en entornos con una gran carga de tráfico."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1163,11 +1157,11 @@ msgstr "Configuración fallida"
 msgid "Configuration files will be kept"
 msgstr "Los archivos de configuración se mantendrán"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "Se ha aplicado la configuración."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "¡La configuración ha sido revertida!"
 
@@ -1175,7 +1169,7 @@ msgstr "¡La configuración ha sido revertida!"
 msgid "Confirm disconnect"
 msgstr "Confirmar desconexión"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Confirmación"
 
@@ -1208,7 +1202,7 @@ msgstr "Los contenidos han sido guardados."
 msgid "Continue"
 msgstr "Continuar"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1223,12 +1217,12 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Código de país"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Crear / Asignar zona de firewall"
 
@@ -1236,11 +1230,11 @@ msgstr "Crear / Asignar zona de firewall"
 msgid "Create interface"
 msgstr "Crear interfaz"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Crítico"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Nivel de registro de cron"
 
@@ -1277,15 +1271,15 @@ msgstr ""
 "Personaliza el comportamiento de los <abbr title=\"Light Emitting Diode"
 "\">LED</abbr>s del dispositivo, si es posible."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr "Cliente DAE"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr "Puerto DAE"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr "Secreto DAE"
 
@@ -1298,7 +1292,7 @@ msgstr "Servidor DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP y DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1371,7 +1365,7 @@ msgstr "Estado DSL"
 msgid "DSL line mode"
 msgstr "Modo de línea DSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr "Intervalo DTIM"
 
@@ -1383,14 +1377,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr "Velocidad de datos"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Depuración"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "%d por defecto"
 
@@ -1431,47 +1425,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" que publica diferentes servidores "
 "DNS a los clientes."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Eliminar"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr "Eliminar clave"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr "Eliminar permiso denegado"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr "Error al eliminar la solicitud: %d %s"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Eliminar esta red"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr "Intervalo de mensaje de indicación de tráfico de entrega"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Descripción"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr "Deseleccionar"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Diseño"
 
@@ -1502,7 +1496,7 @@ msgstr "Zona de destino"
 msgid "Device"
 msgstr "Dispositivo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Configuración del dispositivo"
 
@@ -1519,7 +1513,7 @@ msgstr "El dispositivo se está reiniciando..."
 msgid "Device is restarting…"
 msgstr "El dispositivo se está reiniciando"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Dispositivo inalcanzable!"
 
@@ -1537,12 +1531,12 @@ msgstr "Diagnósticos"
 msgid "Dial number"
 msgstr "Marcar el número"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Directorio"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Deshabilitar"
 
@@ -1558,14 +1552,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Deshabilitar encriptación"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr "Deshabilitar el sondeo de inactividad"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "Deshabilitar esta red"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1577,11 +1572,7 @@ msgstr "Deshabilitar esta red"
 msgid "Disabled"
 msgstr "Deshabilitado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Deshabilitado (predeterminado)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr "Desasociarse en un reconocimiento bajo"
 
@@ -1600,21 +1591,19 @@ msgstr "Desconectar"
 msgid "Disconnection attempt failed"
 msgstr "Intento de desconexión fallido"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Optimización de distancia"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distancia en metros al miembro mas lejano de la red."
 
@@ -1644,15 +1633,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "No reenviar búsquedas inversas para redes locales"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "¿Realmente quieres eliminar \"%s\" ?"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr "¿Realmente quiere eliminar la siguiente clave SSH?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "¿Realmente desea eliminar recursivamente el directorio \"%s\" ?"
 
@@ -1692,15 +1681,15 @@ msgstr "Descargar mtdblock"
 msgid "Downstream SNR offset"
 msgstr "Desplazamiento SNR en sentido descendente"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr "Arrastrar para reordenar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Instancia Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1734,17 +1723,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr "Longitud de bits EA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Editar"
 
@@ -1756,7 +1745,7 @@ msgstr ""
 "Edite los datos de configuración sin procesar anteriores para corregir "
 "cualquier error y presione \"Guardar\" para volver a cargar la página."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Editar esta red"
 
@@ -1764,12 +1753,12 @@ msgstr "Editar esta red"
 msgid "Edit wireless network"
 msgstr "Editar red WiFi"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Emergencia"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Habilitar"
 
@@ -1806,7 +1795,7 @@ msgstr "Habilitar negociación IPv6 en el enlace PPP"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Habilitar paso de tramas jumbo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Habilitar cliente NTP"
 
@@ -1822,11 +1811,11 @@ msgstr "Habilitar servidor TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Habilitar funcionalidad VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "Habilitar botón WPS, requiere WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "Habilitar las medidas correctivas de reinstalación de claves (KRACK)"
 
@@ -1851,7 +1840,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "Habilitar este punto de montaje"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Habilitar esta red"
 
@@ -1873,7 +1862,7 @@ msgstr "Habilitado"
 msgid "Enables IGMP snooping on this bridge"
 msgstr "Habilita el protocolo IGMP Snooping en este puente"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1896,17 +1885,17 @@ msgstr "Modo de encapsulado"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Encriptación"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr "Punto final de Host"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr "Punto final del puerto"
 
@@ -1918,7 +1907,7 @@ msgstr "Ingrese valor personalizado"
 msgid "Enter custom values"
 msgstr "Ingrese valores personalizados"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Borrando..."
 
@@ -1932,7 +1921,7 @@ msgstr "Borrando..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Error"
 
@@ -1940,12 +1929,12 @@ msgstr "Error"
 msgid "Errored seconds (ES)"
 msgstr "Segundos errados (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptador ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch ethernet"
@@ -1981,23 +1970,23 @@ msgstr ""
 msgid "External"
 msgstr "Externo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr "Lista de soporte de clave externa R0"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr "Lista de soporte de clave externa R1"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Servidor externo de registro del sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Puerto del servidor externo de registro del sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "Protocolo de servidor de registro de sistema externo"
 
@@ -2005,19 +1994,23 @@ msgstr "Protocolo de servidor de registro de sistema externo"
 msgid "Extra SSH command options"
 msgstr "Opciones de comando SSH adicionales"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr "FT sobre DS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr "FT sobre The Air"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr "Protocolo FT"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "Error al confirmar aplicar dentro de %ds. Esperando a que se reviertan los "
@@ -2027,15 +2020,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "Error al ejecutar la acción \"/etc/init.d/%s%s\": %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Archivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr "Archivo no accesible"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr "Nombre de archivo"
 
@@ -2083,7 +2076,7 @@ msgstr "Terminar"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr "Marca de Firewall"
 
@@ -2123,7 +2116,7 @@ msgstr "Grabar nueva imagen de firmware"
 msgid "Flash operations"
 msgstr "Operaciones de grabado"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Grabando..."
 
@@ -2131,11 +2124,11 @@ msgstr "Grabando..."
 msgid "Force"
 msgstr "Forzar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "Forzar modo 40MHz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Forzar CCMP (AES)"
 
@@ -2143,11 +2136,11 @@ msgstr "Forzar CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Forzar DHCP en esta red aunque se detecte otro servidor."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Forzar TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forzar TKIP y CCMP (AES)"
 
@@ -2179,7 +2172,7 @@ msgstr "Segundos de corrección de errores de reenvío (FECS)"
 msgid "Forward broadcast traffic"
 msgstr "Reenviar tráfico de difusión"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr "Reenviar tráfico de pares de malla"
 
@@ -2187,7 +2180,7 @@ msgstr "Reenviar tráfico de pares de malla"
 msgid "Forwarding mode"
 msgstr "Modo de reenvío"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Umbral de fragmentación"
 
@@ -2196,7 +2189,7 @@ msgstr "Umbral de fragmentación"
 msgid "Free"
 msgstr "Libre"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2220,19 +2213,19 @@ msgstr "Sólo GPRS"
 msgid "Gateway"
 msgstr "Puerta de enlace"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr "La dirección de la puerta de enlace es inválida"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Puertos del gateway"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2240,8 +2233,8 @@ msgstr "Configuración general"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configuración general"
 
@@ -2249,7 +2242,7 @@ msgstr "Configuración general"
 msgid "Generate Config"
 msgstr "Generar Config"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr "Generar PMK localmente"
 
@@ -2257,7 +2250,7 @@ msgstr "Generar PMK localmente"
 msgid "Generate archive"
 msgstr "Generar archivo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 "La confirmación y la contraseña no coinciden. ¡No se ha cambiado la "
@@ -2278,8 +2271,8 @@ msgstr "Opciones globales de red"
 msgid "Go to password configuration..."
 msgstr "Ir a la configuración de la contraseña..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2309,7 +2302,7 @@ msgstr "Suspender"
 msgid "Header Error Code Errors (HEC)"
 msgstr "Errores de código de error de encabezado (HEC)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2317,7 +2310,7 @@ msgstr ""
 "Aquí puede configurar los aspectos básicos de su dispositivo, como el nombre "
 "del host o la zona horaria."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Ocultar <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2328,7 +2321,7 @@ msgstr "Ocultar cadenas vacias"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "Host"
 
@@ -2353,7 +2346,7 @@ msgstr "Contenido de la etiqueta Host-Uniq"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Nombre del host"
 
@@ -2374,7 +2367,7 @@ msgstr "Híbrido"
 msgid "IKE DH Group"
 msgstr "Grupo IKE DH"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "Direcciones IP"
 
@@ -2595,7 +2588,7 @@ msgstr "IPv6-sobre-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-sobre-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identidad"
 
@@ -2715,7 +2708,7 @@ msgstr "Espera de inactividad"
 msgid "Inbound:"
 msgstr "Entrante:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Información"
 
@@ -2753,7 +2746,7 @@ msgstr "Instalar extensiones de protocolo..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfaz"
 
@@ -2761,7 +2754,7 @@ msgstr "Interfaz"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr "La interfaz %q del dispositivo migra automáticamente de %q a %q."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Configuración de la interfaz"
 
@@ -2791,7 +2784,7 @@ msgstr "La interfaz se está iniciando..."
 msgid "Interface is stopping..."
 msgstr "La interfaz se está deteniendo..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "Nombre de interfaz"
 
@@ -2821,7 +2814,7 @@ msgstr "Error interno del servidor"
 msgid "Invalid"
 msgstr "Inválido"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr "Cadena de clave Base64 inválida"
 
@@ -2841,7 +2834,7 @@ msgstr "Argumento inválido"
 msgid "Invalid command"
 msgstr "Comando inválido"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr "Valor hexadecimal inválido"
 
@@ -2849,7 +2842,7 @@ msgstr "Valor hexadecimal inválido"
 msgid "Invalid username and/or password! Please try again."
 msgstr "¡Nombre de usuario y/o contraseña no válido/s!. Por favor reintente."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "Aislar clientes"
 
@@ -2868,15 +2861,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "¡Se necesita JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Conectar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Conectarse a una red: Búsqueda de redes WiFi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "Conectarse a: %q"
 
@@ -2893,15 +2886,15 @@ msgstr "Registro del Kernel"
 msgid "Kernel Version"
 msgstr "Versión del Kernel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Clave"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Clave #%d"
 
@@ -2945,11 +2938,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Etiqueta"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Idioma"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Idioma y Estilo"
 
@@ -2989,7 +2982,7 @@ msgstr "Deje vacío para autodetectar"
 msgid "Leave empty to use the current WAN address"
 msgstr "Deje vacío para usar la dirección WAN actual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Registro de cambios:"
 
@@ -3035,7 +3028,7 @@ msgstr ""
 "Lista de servidores <abbr title=\"Domain Name System\">DNS</abbr> a los que "
 "enviar solicitudes"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -3049,7 +3042,7 @@ msgstr ""
 "dirección MAC de destino cuando se solicita la clave PMK-R1 del R0KH que el "
 "STA usó durante la Asociación de dominio de movilidad inicial."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3080,11 +3073,11 @@ msgstr "Lista de dispositivos que proporcionan resultados de dominio NX falsos"
 msgid "Listen Interfaces"
 msgstr "Interfaces de escucha"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "Puerto"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr "Escucha solo en la interfaz dada o, si no se especifica, en todas"
 
@@ -3107,11 +3100,7 @@ msgstr "Carga media"
 msgid "Loading"
 msgstr "Cargando"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr "Cargando claves SSH..."
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr "Cargando el contenido del directorio..."
 
@@ -3151,7 +3140,7 @@ msgid "Local Startup"
 msgstr "Arranque local"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Hora local"
 
@@ -3189,7 +3178,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Localizar consultas"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Nivel de registro"
 
@@ -3197,7 +3186,7 @@ msgstr "Nivel de registro"
 msgid "Log queries"
 msgstr "Registrar consultas"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Registro"
 
@@ -3228,22 +3217,22 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "Dirección MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filtro por dirección MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Filtro por dirección MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Lista de direcciones MAC"
 
@@ -3271,7 +3260,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3293,7 +3282,7 @@ msgstr ""
 msgid "Manual"
 msgstr "Manual"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr "AP"
 
@@ -3301,7 +3290,7 @@ msgstr "AP"
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr "Max. velocidad de datos alcanzable (ATTNDR)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr "Máximo permitido de intervalo de escucha"
 
@@ -3327,7 +3316,7 @@ msgstr "Segundos máximos de espera a que el módem esté activo"
 msgid "Maximum number of leased addresses."
 msgstr "Máximo de conexiones activas."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr "Máxima potencia de transmisión"
 
@@ -3340,7 +3329,7 @@ msgstr "Máxima potencia de transmisión"
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr "Medio"
 
@@ -3352,11 +3341,11 @@ msgstr "Memoria"
 msgid "Memory usage (%)"
 msgstr "Uso de RAM (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr "Malla"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr "ID de malla"
 
@@ -3367,7 +3356,7 @@ msgstr "Método no encontrado"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Métrica"
 
@@ -3379,7 +3368,7 @@ msgstr "Puerto monitor de espejo"
 msgid "Mirror source port"
 msgstr "Puerto fuente de espejo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr "Dominio de movilidad"
 
@@ -3387,8 +3376,8 @@ msgstr "Dominio de movilidad"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Modo"
@@ -3419,16 +3408,16 @@ msgstr "Error en la consulta de información del módem"
 msgid "Modem init timeout"
 msgstr "Espera de inicialización del modem"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr "Más caracteres"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr "Más…"
 
@@ -3441,7 +3430,7 @@ msgstr "Entrada de montaje"
 msgid "Mount Point"
 msgstr "Punto de montaje"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3491,7 +3480,7 @@ msgstr "Bajar"
 msgid "Move up"
 msgstr "Subir"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3516,11 +3505,11 @@ msgstr "NDP-Proxy"
 msgid "NT Domain"
 msgstr "Dominio NT"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Servidores NTP a consultar"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3528,7 +3517,7 @@ msgstr "Servidores NTP a consultar"
 msgid "Name"
 msgstr "Nombre"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Nombre de la nueva red"
 
@@ -3538,8 +3527,8 @@ msgstr "Navegación"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3572,7 +3561,7 @@ msgstr "Nuevo nombre de interfaz..."
 msgid "Next »"
 msgstr "Siguiente »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "No"
@@ -3581,7 +3570,7 @@ msgstr "No"
 msgid "No DHCP Server configured for this interface"
 msgstr "No se ha configurado un servidor DHCP para esta interfaz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr "Sin encriptación"
 
@@ -3593,7 +3582,7 @@ msgstr "Sin NAT-T"
 msgid "No data received"
 msgstr "Sin datos recibidos"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr "No hay entradas en este directorio"
 
@@ -3624,11 +3613,12 @@ msgstr "Sin caché negativa"
 msgid "No password set!"
 msgstr "¡Sin contraseña!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr "Sin pares definidos"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr "No hay claves públicas presentes todavía."
 
@@ -3673,7 +3663,7 @@ msgstr "Sin comodín"
 msgid "None"
 msgstr "Ninguno"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3703,7 +3693,7 @@ msgstr "No se inició en el arranque"
 msgid "Not supported"
 msgstr "No soportado"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Aviso"
 
@@ -3717,7 +3707,7 @@ msgstr ""
 "Número de entradas de DNS en caché (el máximo es 10000, 0 es sin "
 "almacenamiento en caché)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr "Número de hilos paralelos utilizados para la compresión"
 
@@ -3783,24 +3773,24 @@ msgstr "Abrir lista..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr "OpenConnect (CISCO AnyConnect)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "Frecuencia de operación"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Opción cambiada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Opción removida"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "Opcional"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3820,7 +3810,7 @@ msgstr ""
 "servidor delegante, use el sufijo (como '::1') para formar la dirección IPv6 "
 "('a:b:c:d::1') para la interfaz."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
@@ -3829,30 +3819,30 @@ msgstr ""
 "adicional de criptografía de clave simétrica para la resistencia post-"
 "cuántica."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Opcional. Crear rutas para IPs permitidas para este par."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr "Opcional. Descripción del par."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 "Opcional. Host de pares. Los nombres se resuelven antes de abrir la interfaz."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr "Opcional. Unidad máxima de transmisión de la interfaz del túnel."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr "Opcional. Puerto de pares."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
@@ -3861,7 +3851,7 @@ msgstr ""
 "0 (deshabilitado). El valor recomendado si este dispositivo está detrás de "
 "un NAT es 25."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Opcional. Puerto UDP utilizado para paquetes salientes y entrantes."
 
@@ -3921,7 +3911,7 @@ msgstr "Reemplazar TOS"
 msgid "Override TTL"
 msgstr "Reemplazar TTL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "Reemplaza el nombre de interfaz predeterminado"
 
@@ -3945,7 +3935,7 @@ msgstr "Anular la tabla utilizada para rutas internas"
 msgid "Overview"
 msgstr "Descripción general"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Sobrescribir archivo \"%s\" existente?"
 
@@ -3990,7 +3980,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr "Código PIN rechazado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr "PMK R1 Push"
 
@@ -4045,29 +4035,29 @@ msgid "Part of zone %q"
 msgstr "Parte de zona %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Contraseña"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Autentificación de contraseña"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Contraseña de la Clave Privada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "Contraseña de clave privada interna"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr "Seguridad de la contraseña"
 
@@ -4075,31 +4065,31 @@ msgstr "Seguridad de la contraseña"
 msgid "Password2"
 msgstr "Contraseña2"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr "Pegar o arrastrar archivo de clave SSH..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Ruta al Certificado CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Camino al certificado de cliente"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Ruta a la Clave Privada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "Ruta al certificado interno de CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "Ruta al certificado del cliente interno"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "Ruta a la clave privada interna"
 
@@ -4126,7 +4116,7 @@ msgstr "Dirección IP del par para asignar"
 msgid "Peer address is missing"
 msgstr "Falta la dirección del compañero"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr "Pares"
 
@@ -4146,7 +4136,7 @@ msgstr "Realizar restablecimiento"
 msgid "Permission denied"
 msgstr "Permiso denegado"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr "Mantener vivo persistente"
 
@@ -4186,7 +4176,7 @@ msgstr "Por favor, introduzca su nombre de usuario y contraseña."
 msgid "Policy"
 msgstr "Política"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Puerto"
 
@@ -4222,7 +4212,7 @@ msgstr "Preferir UMTS"
 msgid "Prefix Delegated"
 msgstr "Prefijo delegado"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr "Clave precompartida"
 
@@ -4243,11 +4233,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr "Evita escuchar en estas interfaces."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Impide la comunicación entre los clientes"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "Clave privada"
 
@@ -4278,7 +4268,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Dar servicio NTP"
 
@@ -4286,15 +4276,15 @@ msgstr "Dar servicio NTP"
 msgid "Provide new network"
 msgstr "Introduzca una nueva red"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "Clave pública"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4330,11 +4320,11 @@ msgstr ""
 "Consulta todos los servidores <abbr title=\"Domain Name System\">DNS</abbr> "
 "disponibles en el enlace"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr "Tiempo de vida de la clave R0"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr "Llavero R1"
 
@@ -4342,11 +4332,11 @@ msgstr "Llavero R1"
 msgid "RFC3947 NAT-T mode"
 msgstr "RFC3947 modo NAT-T"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr "Umbral RSSI para unirse"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Umbral RTS/CTS"
 
@@ -4362,31 +4352,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Tasa RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr "Tasa RX / Tasa TX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Puerto de contabilidad Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Secreto de contabilidad Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Servidor de contabilidad Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Puerto de autentificación Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Secreto de autentificación Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Servidor de autentificación Radius"
 
@@ -4441,7 +4431,7 @@ msgstr "Tráfico en tiempo real"
 msgid "Realtime Wireless"
 msgstr "Red WiFi en tiempo real"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr "Fecha límite de reasociación"
 
@@ -4449,7 +4439,7 @@ msgstr "Fecha límite de reasociación"
 msgid "Rebind protection"
 msgstr "Protección contra reasociación"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reiniciar"
@@ -4467,7 +4457,7 @@ msgstr "Reiniciar el sistema operativo de su dispositivo"
 msgid "Receive"
 msgstr "Recibir"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr "Recomendado. Direcciones IP de la interfaz de WireGuard."
 
@@ -4507,11 +4497,11 @@ msgstr "Dirección IPv4 remota"
 msgid "Remote IPv4 address or FQDN"
 msgstr "Dirección IPv4 remota o FQDN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Remover"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Cambiar la configuración WiFi"
 
@@ -4527,7 +4517,7 @@ msgstr "Solicitud IPv6-prefijo de longitud"
 msgid "Request timeout"
 msgstr "Tiempo de espera de solicitud terminada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "Requerido"
 
@@ -4535,15 +4525,15 @@ msgstr "Requerido"
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "Requerido para ciertos ISPs, por ejemplo Charter con DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr "Requerido. Clave privada codificada en base64 para esta interfaz."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr "Requerido. Base64 codificada clave pública de igual."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
@@ -4553,27 +4543,27 @@ msgstr ""
 "túnel. Por lo general, las direcciones IP del túnel del par y las redes que "
 "el mismo enruta a través del túnel."
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr "Requiere hostapd"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr "Requiere hostapd con soporte EAP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr "Requiere hostapd con soporte OWE"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr "Requiere hostapd con soporte SAE"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4589,31 +4579,31 @@ msgstr ""
 "Requiere upstream soporta DNSSEC; Verifique que las respuestas de los "
 "dominios no firmados realmente provengan de dominios no firmados"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr "Requiere wpa-supplicant"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr "Requiere wpa-supplicant con soporte EAP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr "Requiere wpa-supplicant con soporte OWE"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "Requiere wpa-supplicant con soporte SAE"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4664,10 +4654,8 @@ msgstr "Restaurar"
 msgid "Restore backup"
 msgstr "Restaurar copia de seguridad"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Mostrar/ocultar contraseña"
 
@@ -4675,15 +4663,15 @@ msgstr "Mostrar/ocultar contraseña"
 msgid "Revert"
 msgstr "Revertir"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "Revertir cambios"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Error al revertir la solicitud con el estado <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "Revirtiendo configuración..."
 
@@ -4699,7 +4687,7 @@ msgstr "Directorio raíz para los archivos servidos por TFTP"
 msgid "Root preparation"
 msgstr "Preparación de la raíz"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr "Ruta permitida IPs"
 
@@ -4715,8 +4703,8 @@ msgstr "Tipo de ruta"
 msgid "Router Advertisement-Service"
 msgstr "Servicio de anuncio de enrutador"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Contraseña del router"
 
@@ -4758,8 +4746,8 @@ msgstr "SHA256"
 msgid "SNR"
 msgstr "SNR"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Acceso SSH"
 
@@ -4775,14 +4763,14 @@ msgstr "Puerto del servidor SSH"
 msgid "SSH username"
 msgstr "Nombre de usuario SSH"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "Claves SSH"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4791,19 +4779,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Guardar"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Guardar y aplicar"
@@ -4816,24 +4802,20 @@ msgstr "Guardar mtdblock"
 msgid "Save mtdblock contents"
 msgstr "Guardar contenidos mtdblock"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr "Guardando llaves..."
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Escanear"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Tareas programadas"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Sección añadida"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Sección removida"
 
@@ -4851,9 +4833,9 @@ msgstr ""
 "la verificación del formato de la imagen. ¡Úselo solo si está seguro de que "
 "el firmware es correcto y está diseñado para su dispositivo!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr "Seleccionar archivo..."
 
@@ -4927,7 +4909,7 @@ msgstr "Segundos con errores graves (SES)"
 msgid "Short GI"
 msgstr "GI corto"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr "Preámbulo corto"
 
@@ -4947,12 +4929,12 @@ msgstr "Apagar esta interfaz"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Señal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr "Señal / Ruido"
 
@@ -4972,7 +4954,7 @@ msgstr "Tamaño"
 msgid "Size of DNS query cache"
 msgstr "Tamaño de la caché de consultas DNS"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr "Tamaño del dispositivo ZRam en megabytes"
 
@@ -4989,7 +4971,7 @@ msgstr "Saltar al contenido"
 msgid "Skip to navigation"
 msgstr "Saltar a navegación"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Software VLAN"
@@ -5030,11 +5012,6 @@ msgstr "Dirección de la fuente"
 msgid "Specifies the directory the device is attached to"
 msgstr "Especifica el directorio al que está enlazado el dispositivo"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-"Especifica los puertos de escucha de esta instancia de <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -5051,7 +5028,7 @@ msgstr ""
 "Especifica la cantidad de segundos a transcurrir hasta suponer muerto un "
 "dispositivo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -5081,7 +5058,7 @@ msgstr ""
 "Especifique una MTU (Unidad de transmisión máxima) distinta de la "
 "predeterminada (1280 bytes)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Especifique la clave de encriptación."
 
@@ -5095,16 +5072,16 @@ msgstr "Iniciar"
 msgid "Start priority"
 msgstr "Prioridad de inicio"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "Iniciando aplicar configuración..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "Iniciando escaneo de WiFi..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Arranque"
 
@@ -5124,7 +5101,7 @@ msgstr "Direcciones estáticas"
 msgid "Static Routes"
 msgstr "Rutas estáticas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5141,13 +5118,13 @@ msgstr ""
 "necesarias para configuraciones de interfaces no dinámicas en las que a cada "
 "dispositivo siempre se le quiere dar la misma dirección IP."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr "Límite de inactividad de la estación"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Estado"
@@ -5162,12 +5139,12 @@ msgstr "Detener"
 msgid "Strict order"
 msgstr "Orden estricto"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr "Fuerte"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Enviar"
 
@@ -5207,7 +5184,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Máscara de puerto de Switch"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Switch VLAN"
@@ -5222,11 +5199,11 @@ msgstr "Intercambiar protocolo"
 msgid "Switch to CIDR list notation"
 msgstr "Cambiar a la notación de lista CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr "Enlace simbólico"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr "Sincronizar con el servidor NTP"
 
@@ -5236,7 +5213,7 @@ msgstr "Sincronizar con el navegador"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5247,11 +5224,11 @@ msgstr "Sistema"
 msgid "System Log"
 msgstr "Registro del sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Propiedades del sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Tamaño del buffer de registro del sistema"
 
@@ -5323,7 +5300,7 @@ msgid ""
 msgstr ""
 "El prefijo IPv6 asignado por el proveedor, suele termina con <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5340,7 +5317,7 @@ msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 "El archivo de configuración no se pudo cargar debido al siguiente error:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5403,11 +5380,11 @@ msgstr "Las siguientes reglas están actualmente activas en este sistema."
 msgid "The gateway address must not be a local IP address"
 msgstr "La dirección de la puerta de enlace no debe ser una dirección IP local"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr "La clave pública SSH dada ya se ha agregado."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5440,7 +5417,7 @@ msgstr "Longitud del prefijo IPv6 en bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "La dirección IPv4 local sobre la que se crea el túnel (opcional)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr "El nombre de la red ya está en uso."
 
@@ -5460,7 +5437,7 @@ msgstr ""
 "segmentos de red. Es común que exista un puerto por defecto para subida "
 "hacia una red mayor como internet y el resto se dediquen a la red local."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr "El modo %s seleccionado es incompatible con el cifrado %s"
 
@@ -5468,7 +5445,7 @@ msgstr "El modo %s seleccionado es incompatible con el cifrado %s"
 msgid "The submitted security token is invalid or already expired!"
 msgstr "¡El token de seguridad enviado no es válido o ya está vencido!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5476,7 +5453,7 @@ msgstr ""
 "El sistema está borrando la partición de configuración y se reiniciará "
 "cuando termine."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5487,7 +5464,7 @@ msgstr ""
 "Espere unos minutos antes de reconectar. Es posible que tenga que renovar la "
 "conexión de su ordenador para poder acceder de nuevo al dispositivo."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "La contraseña del sistema se ha cambiado correctamente."
 
@@ -5508,7 +5485,7 @@ msgstr "No hay direcciones activas"
 msgid "There are no active leases."
 msgstr "Sin conexiones activas."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr "No hay cambios para aplicar."
 
@@ -5527,7 +5504,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "Dirección IPv4 del relé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr "Este tipo de autenticación no es aplicable al método EAP seleccionado."
 
@@ -5620,22 +5597,22 @@ msgstr "Procesos del sistema que se están ejecutando actualmente y su estado."
 msgid "This page gives an overview over currently active network connections."
 msgstr "Conexiones de red activas."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "No hay reglas definidas"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Sincronización horaria"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr "Intervalo de tiempo para reprogramar GTK"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Zona horaria"
 
@@ -5694,7 +5671,7 @@ msgstr "Modo de disparador"
 msgid "Tunnel ID"
 msgstr "ID de túnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interfaz de túnel"
@@ -5787,12 +5764,12 @@ msgstr "No se puede guardar el contenido: %s"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Segundos no disponibles (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Error desconocido (%s)"
@@ -5801,7 +5778,7 @@ msgstr "Error desconocido (%s)"
 msgid "Unknown error code"
 msgstr "Código de error desconocido"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5812,11 +5789,12 @@ msgstr "No administrado"
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr "Clave sin nombre"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Cambios sin aplicar"
 
@@ -5857,15 +5835,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Subir archivo..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr "Subir archivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr "Subir archivo..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr "Error al cargar la solicitud: %s"
 
@@ -6010,11 +5988,11 @@ msgstr ""
 msgid "Used"
 msgstr "Usado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Espacio de clave usado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -6096,32 +6074,32 @@ msgstr "Verificar"
 msgid "Virtual dynamic interface"
 msgstr "Interfaz dinámica virtual"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Sistema abierto WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Clave compartida WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Contraseña WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Habilitar WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Contraseña WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6137,7 +6115,7 @@ msgstr "Esperando a que se apliquen los cambios..."
 msgid "Waiting for command to complete..."
 msgstr "Esperando a que termine el comando..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr "Esperando a que se aplique la configuración… %ds"
 
@@ -6145,8 +6123,8 @@ msgstr "Esperando a que se aplique la configuración… %ds"
 msgid "Waiting for device..."
 msgstr "Esperando al dispositivo..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Aviso"
 
@@ -6154,11 +6132,11 @@ msgstr "Aviso"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr "Advertencia: ¡Hay cambios no aplicados que se perderán al reiniciar!"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr "Débil"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6173,7 +6151,7 @@ msgstr ""
 msgid "Width"
 msgstr "Ancho de banda"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr "WireGuard VPN"
@@ -6184,13 +6162,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "WiFi"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adaptador WiFi"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6200,7 +6178,7 @@ msgstr "Red WiFi"
 msgid "Wireless Overview"
 msgstr "Visión general de WiFi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Seguridad WiFi"
 
@@ -6220,11 +6198,11 @@ msgstr "Red WiFi deshabilitada"
 msgid "Wireless is not associated"
 msgstr "Red WiFi no asociada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Red WiFi deshabilitada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Red WiFi habilitada"
 
@@ -6232,11 +6210,11 @@ msgstr "Red WiFi habilitada"
 msgid "Write received DNS requests to syslog"
 msgstr "Escribe las peticiones de DNS recibidas en el registro del sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Escribe el registro del sistema al archivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Si"
@@ -6269,19 +6247,19 @@ msgid ""
 msgstr ""
 "Debe habilitar JavaScript en su navegador o LuCI no funcionará correctamente."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr "Algoritmo de compresión ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr "Streams de compresión ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr "Configuración de ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr "Tamaño de ZRam"
 
@@ -6292,7 +6270,7 @@ msgstr "Cualquiera"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6350,7 +6328,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "Deshabilitar"
 
@@ -6451,7 +6429,11 @@ msgstr "clave de 5 o 13 caracteres"
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "Archivo <abbr title=\"Domain Name System\">DNS</abbr> local"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "Minutos"
 
@@ -6470,7 +6452,7 @@ msgstr "Sin enlace"
 msgid "non-empty value"
 msgstr "valor no vacío"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "ninguno"
 
@@ -6481,8 +6463,8 @@ msgid "not present"
 msgstr "No presente"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6496,6 +6478,10 @@ msgstr "Apagado"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "Encendido"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6514,7 +6500,7 @@ msgstr "valor decimal positivo"
 msgid "positive integer value"
 msgstr "valor entero positivo"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "Aleatorio"
 
@@ -6528,8 +6514,8 @@ msgstr "Modo relé"
 msgid "routed"
 msgstr "Enrutado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr "Seg"
 
@@ -6550,11 +6536,15 @@ msgstr "Sin estado"
 msgid "stateless + stateful"
 msgstr "Sin estado + Con estado"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "Etiquetado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr "Unidades de tiempo (TUs / 1.024 ms) [1000-65535]"
 
@@ -6573,7 +6563,7 @@ msgstr "Desconocido"
 msgid "unlimited"
 msgstr "Ilimitado"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6754,6 +6744,10 @@ msgstr "valor con al menos %d caracteres"
 msgid "value with at most %d characters"
 msgstr "valor con un máximo de %d caracteres"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6764,6 +6758,28 @@ msgstr "Si"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Volver"
+
+#~ msgid "Change login password"
+#~ msgstr "Cambiar contraseña de inicio de sesión"
+
+#~ msgid "Changing password…"
+#~ msgstr "Cambiando contraseña..."
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Deshabilitado (predeterminado)"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Puertos del gateway"
+
+#~ msgid "Loading SSH keys…"
+#~ msgstr "Cargando claves SSH..."
+
+#~ msgid "Saving keys…"
+#~ msgstr "Guardando llaves..."
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr ""
+#~ "Especifica los puertos de escucha de esta instancia de <em>Dropbear</em>"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Switch %q (%s)"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -2177,7 +2177,7 @@ msgstr "Passerelle"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Ports de la passerelle"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6629,9 +6629,6 @@ msgstr "oui"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Retour"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Ports de la passerelle"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Indique le port d'écoute de cette instance <em>Dropbear</em>"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Champ Supplémentaire --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Choisir --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- autre --"
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr "Charge sur 1 minute :"
 msgid "15 Minute Load:"
 msgstr "Charge sur 15 minutes :"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Charge sur 5 minutes :"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -171,7 +172,7 @@ msgstr ""
 "Les serveurs <abbr title=\"Domain Name System\">DNS</abbr> seront<br/"
 ">interrogés dans l'ordre du fichier de résolution"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -207,7 +208,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr ""
 "Configuration des <abbr title=\"Diode Électro-Luminescente\">DEL</abbr>s"
@@ -251,7 +252,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -336,8 +337,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Concentrateur d'accès"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Point d'accès"
 
@@ -368,17 +369,17 @@ msgstr "Bails DHCP actifs"
 msgid "Active DHCPv6 Leases"
 msgstr "Bails DHCPv6 actifs"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -409,10 +410,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -426,7 +430,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Ajout d'une nouvelle interface..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -475,8 +479,8 @@ msgstr "Administration"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -486,11 +490,11 @@ msgstr "Paramètres avancés"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alerte"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -516,25 +520,25 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Autoriser l'authentification <abbr title=\"Secure Shell\">SSH</abbr> par mot "
 "de passe"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Autoriser tout sauf ce qui est listé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Autoriser seulement ce qui est listé"
 
@@ -542,17 +546,17 @@ msgstr "Autoriser seulement ce qui est listé"
 msgid "Allow localhost"
 msgstr "Autoriser l'hôte local"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Permettre à des hôtes distants de se conecter à des ports SSH locaux "
 "correspondants (« forwarded »)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Autoriser les connexions administrateur avec mot de passe"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 "Autoriser l'utilisateur <em>root</em> à se connecter avec un mot de passe"
@@ -564,7 +568,7 @@ msgstr ""
 "Autorise les réponses de l'amont dans la plage 127.0.0.0/8, par ex. pour les "
 "services RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -572,7 +576,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -651,7 +655,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -670,11 +674,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "N'importe quelle zone"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -698,7 +702,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Équipements associés"
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Authentification"
 
@@ -807,7 +811,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -825,7 +829,7 @@ msgstr "Retour à la configuration"
 msgid "Backup"
 msgstr "Sauvegarder"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Sauvegarde / Mise à jour du micrologiciel"
 
@@ -842,7 +846,7 @@ msgstr "Adresse spécifiée incorrecte!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -880,7 +884,7 @@ msgstr "Débit"
 msgid "Bogus NX Domain Override"
 msgstr "Contourne les «  NX Domain » bogués"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Pont"
@@ -898,7 +902,7 @@ msgstr "Numéro d'unité du pont"
 msgid "Bring up on boot"
 msgstr "L'activer au démarrage"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -923,13 +927,13 @@ msgstr "Utilisation CPU (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Annuler"
@@ -952,13 +956,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Chaîne"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Changements"
 
@@ -966,23 +964,19 @@ msgstr "Changements"
 msgid "Changes applied."
 msgstr "Changements appliqués."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Change le mot de passe administrateur pour accéder à l'équipement"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Canal"
@@ -995,7 +989,7 @@ msgstr "Vérification"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -1008,7 +1002,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1020,7 +1014,7 @@ msgstr ""
 "zone associée, ou remplissez le champ <em>créer</em> pour définir une "
 "nouvelle zone et y inclure cette interface."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1029,7 +1023,7 @@ msgstr ""
 "sans-fil ou remplissez le <em>créer</em>  champ pour définir un nouveau "
 "réseau. "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Code de chiffrement"
 
@@ -1051,9 +1045,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Client"
 
@@ -1062,8 +1056,8 @@ msgstr "Client"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Identifiant client à envoyer dans les requêtes DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1088,7 +1082,7 @@ msgstr "Fermer la liste…"
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1115,7 +1109,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1123,7 +1117,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1139,11 +1133,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1151,7 +1145,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Confirmation"
 
@@ -1184,7 +1178,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1195,12 +1189,12 @@ msgstr ""
 msgid "Country"
 msgstr "Pays"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Code pays"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Créer / Assigner une zone du pare-feu"
 
@@ -1208,11 +1202,11 @@ msgstr "Créer / Assigner une zone du pare-feu"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Critique"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Niveau de journalisation de Cron"
 
@@ -1247,15 +1241,15 @@ msgstr ""
 "Personnaliser le comportement des <abbr title=\"Diode Électro-Luminescente"
 "\">DEL</abbr>s si possible."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1268,7 +1262,7 @@ msgstr "Serveur DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP et DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1341,7 +1335,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1353,14 +1347,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Deboguage"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "%d par défaut"
 
@@ -1401,47 +1395,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" qui publie différents serveurs "
 "DNS à ses clients."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Effacer"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Supprimer ce réseau"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Description"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Apparence"
 
@@ -1472,7 +1466,7 @@ msgstr ""
 msgid "Device"
 msgstr "Équipement"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Configuration de l'équipement"
 
@@ -1489,7 +1483,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1507,12 +1501,12 @@ msgstr "Diagnostics"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Répertoire"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Désactiver"
 
@@ -1528,14 +1522,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1547,11 +1542,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1570,21 +1561,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Optimisation de la distance"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distance au membre du réseau le plus éloigné, en mètres."
 
@@ -1617,15 +1606,15 @@ msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 "Ne pas transmettre les requêtes de recherche inverse pour les réseaux locaux"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1665,15 +1654,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Session Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1707,17 +1696,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Méthode EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Éditer"
 
@@ -1727,7 +1716,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Éditer ce réseau"
 
@@ -1735,12 +1724,12 @@ msgstr "Éditer ce réseau"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Urgence"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Activer"
 
@@ -1775,7 +1764,7 @@ msgstr "Activer la négociation IPv6 sur le lien PPP"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Activer la circulation de très grandes trames (Jumbo)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Activer client NTP"
 
@@ -1791,11 +1780,11 @@ msgstr "Activer le serveur TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Acviter la gestion des VLANs"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1819,7 +1808,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "Activer ce montage"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1841,7 +1830,7 @@ msgstr "Activé"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1864,17 +1853,17 @@ msgstr "Mode encapsulé"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Chiffrement"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1886,7 +1875,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Effacement…"
 
@@ -1900,7 +1889,7 @@ msgstr "Effacement…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Erreur"
 
@@ -1908,12 +1897,12 @@ msgstr "Erreur"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Module Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Commutateur Ethernet"
@@ -1950,23 +1939,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Serveur distant de journaux système"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Port du serveur distant de journaux système"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1974,19 +1963,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1994,15 +1987,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Fichier"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2047,7 +2040,7 @@ msgstr "Terminer"
 msgid "Firewall"
 msgstr "Pare-feu"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2087,7 +2080,7 @@ msgstr "Écrire l'image du nouveau micrologiciel"
 msgid "Flash operations"
 msgstr "Opérations d'écriture"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Écriture…"
 
@@ -2095,11 +2088,11 @@ msgstr "Écriture…"
 msgid "Force"
 msgstr "Forcer"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Forcer CCMP (AES)"
 
@@ -2107,11 +2100,11 @@ msgstr "Forcer CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Force le DHCP sur ce réseau même si un autre serveur est détecté."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Forcer TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forcer TKIP et CCMP (AES)"
 
@@ -2143,7 +2136,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Transmettre le trafic de diffusion"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2151,7 +2144,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Mode de transmission"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Seuil de fragmentation"
 
@@ -2160,7 +2153,7 @@ msgstr "Seuil de fragmentation"
 msgid "Free"
 msgstr "Libre"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2182,19 +2175,19 @@ msgstr "seulement GPRS"
 msgid "Gateway"
 msgstr "Passerelle"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Ports de la passerelle"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2202,8 +2195,8 @@ msgstr "Paramètres généraux"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configuration générale"
 
@@ -2211,7 +2204,7 @@ msgstr "Configuration générale"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2219,7 +2212,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Construire l'archive"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 "La confirmation du nouveau mot de passe ne correspond pas, changement "
@@ -2240,8 +2233,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Aller à la configuration du mot de passe…"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2271,7 +2264,7 @@ msgstr "Signal (HUP)"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2279,7 +2272,7 @@ msgstr ""
 "Ici, vous pouvez configurer les aspects basiques de votre routeur comme son "
 "nom ou son fuseau horaire."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Cacher le ESSID"
 
@@ -2290,7 +2283,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2315,7 +2308,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Nom d'hôte"
 
@@ -2336,7 +2329,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2557,7 +2550,7 @@ msgstr "IPv6 sur IPv4 (6ème)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6 sur IPv4 (6 vers 4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identité"
 
@@ -2671,7 +2664,7 @@ msgstr "Délai d'inactivité"
 msgid "Inbound:"
 msgstr "Intérieur :"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Info"
 
@@ -2709,7 +2702,7 @@ msgstr "Installation des extensions de protocole…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
 
@@ -2717,7 +2710,7 @@ msgstr "Interface"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Configuration de l'interface"
 
@@ -2747,7 +2740,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2777,7 +2770,7 @@ msgstr "Erreur Serveur Interne"
 msgid "Invalid"
 msgstr "Erreur : donnée entrée invalide"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2800,7 +2793,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2808,7 +2801,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Nom d'utilisateur et/ou mot de passe invalides ! Réessayez !"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2829,15 +2822,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "Nécessite un Script Java !"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Rejoindre un réseau"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Rejoindre un réseau : recherche des réseaux sans-fil"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2854,15 +2847,15 @@ msgstr "Journal du noyau"
 msgid "Kernel Version"
 msgstr "Version du noyau"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Clé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Clé n° %d"
 
@@ -2906,11 +2899,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Étiquette"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Langue"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Langue et apparence"
 
@@ -2950,7 +2943,7 @@ msgstr "Laisser vide pour l'auto-détection"
 msgid "Leave empty to use the current WAN address"
 msgstr "Laisser vide pour utiliser l'adresse WAN actuelle"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Légende :"
 
@@ -2994,7 +2987,7 @@ msgstr ""
 "Liste des serveurs auquels sont transmis les requêtes <abbr title=\"Domain "
 "Name System\">DNS</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -3003,7 +2996,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3029,11 +3022,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr "Écouter seulement sur l'interface spécifié, sinon sur toutes"
 
@@ -3056,11 +3049,7 @@ msgstr "Charge moyenne"
 msgid "Loading"
 msgstr "Chargement"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3100,7 +3089,7 @@ msgid "Local Startup"
 msgstr "Démarrage local"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Heure Locale"
 
@@ -3139,7 +3128,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Localiser les requêtes"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Niveau de journalisation"
 
@@ -3147,7 +3136,7 @@ msgstr "Niveau de journalisation"
 msgid "Log queries"
 msgstr "Journaliser les requêtes"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Journalisation"
 
@@ -3180,22 +3169,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "Adresse MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filtrage par adresses MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Filtrage par adresses MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Liste des adresses MAC"
 
@@ -3223,7 +3212,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3243,7 +3232,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3251,7 +3240,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3277,7 +3266,7 @@ msgstr "Délai d'attente maximum que le modem soit prêt"
 msgid "Maximum number of leased addresses."
 msgstr "Nombre maximum d'adresses allouées."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3290,7 +3279,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3302,11 +3291,11 @@ msgstr "Mémoire"
 msgid "Memory usage (%)"
 msgstr "Utilisation Mémoire (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3317,7 +3306,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrique"
 
@@ -3329,7 +3318,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3337,8 +3326,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Mode"
@@ -3369,16 +3358,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Délai max. d'initialisation du modem"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3391,7 +3380,7 @@ msgstr "Montage"
 msgid "Mount Point"
 msgstr "Point de montage"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3441,7 +3430,7 @@ msgstr "Descendre"
 msgid "Move up"
 msgstr "Monter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3466,11 +3455,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Serveurs NTP candidats"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3478,7 +3467,7 @@ msgstr "Serveurs NTP candidats"
 msgid "Name"
 msgstr "Nom"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Nom du nouveau réseau"
 
@@ -3488,8 +3477,8 @@ msgstr "Navigation"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3522,7 +3511,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Prochain »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3531,7 +3520,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Aucun serveur DHCP configuré sur cette interface"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3543,7 +3532,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3574,11 +3563,12 @@ msgstr "Pas de cache négatif"
 msgid "No password set!"
 msgstr "Pas de mot de passe positionné !"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3623,7 +3613,7 @@ msgstr ""
 msgid "None"
 msgstr "Vide"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3653,7 +3643,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Note"
 
@@ -3665,7 +3655,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3731,24 +3721,24 @@ msgstr "Ouvrir la liste…"
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Option modifiée"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Option retirée"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3762,41 +3752,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3856,7 +3846,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3880,7 +3870,7 @@ msgstr "Modifier la table utilisée pour les routes internes"
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3925,7 +3915,7 @@ msgstr "code PIN"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3980,29 +3970,29 @@ msgid "Part of zone %q"
 msgstr "Fait partie de la zone %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Mot de passe"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Authentification par mot de passe"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Mot de passe de la clé privée"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -4010,31 +4000,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Chemin de la CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Chemin du certificat-client"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Chemin de la clé privée"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4061,7 +4051,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4081,7 +4071,7 @@ msgstr "Réinitialiser"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4121,7 +4111,7 @@ msgstr "Saisissez votre nom d'utilisateur et mot de passe."
 msgid "Policy"
 msgstr "Politique"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4157,7 +4147,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4178,11 +4168,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Empêche la communication directe entre clients"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4213,7 +4203,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protocole"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Fournir serveur NTP"
 
@@ -4221,15 +4211,15 @@ msgstr "Fournir serveur NTP"
 msgid "Provide new network"
 msgstr "Donner un nouveau réseau"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4256,11 +4246,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4268,11 +4258,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Seuil RTS/CTS"
 
@@ -4288,31 +4278,31 @@ msgstr "Reçu"
 msgid "RX Rate"
 msgstr "Débit en réception"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Port de la comptabilisation Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Secret de la comptabilisation Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Serveur de la comptabilisation Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Port de l'authentification Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Secret de l'authentification Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Serveur de l'authentification Radius"
 
@@ -4360,7 +4350,7 @@ msgstr "Trafic temps-réel"
 msgid "Realtime Wireless"
 msgstr "Qualité de réception actuelle"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4368,7 +4358,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Protection contre l'attaque « rebind »"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Redémarrage"
@@ -4386,7 +4376,7 @@ msgstr "Redémarrage du système d'exploitation de votre équipement"
 msgid "Receive"
 msgstr "Reçoit"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4426,11 +4416,11 @@ msgstr "Adresse IPv4 distante"
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Désinstaller"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Remplacer la configuration sans-fil"
 
@@ -4446,7 +4436,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4454,42 +4444,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "Nécessaire avec certains FAIs, par ex. : Charter avec DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4501,31 +4491,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4576,10 +4566,8 @@ msgstr "Restaurer"
 msgid "Restore backup"
 msgstr "Restaurer une sauvegarde"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Montrer/cacher le mot de passe"
 
@@ -4587,15 +4575,15 @@ msgstr "Montrer/cacher le mot de passe"
 msgid "Revert"
 msgstr "Revenir"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4611,7 +4599,7 @@ msgstr "Répertoire racine des fichiers fournis par TFTP"
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4627,8 +4615,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Mot de passe du routeur"
 
@@ -4671,8 +4659,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Accès SSH"
 
@@ -4688,14 +4676,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "Clés SSH"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4704,19 +4692,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Sauvegarder et Appliquer"
@@ -4729,24 +4715,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Tâches Régulières"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Section ajoutée"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Section retirée"
 
@@ -4761,9 +4743,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4834,7 +4816,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4854,12 +4836,12 @@ msgstr "Arrêter cet interface"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4879,7 +4861,7 @@ msgstr "Taille"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4896,7 +4878,7 @@ msgstr "Skip to content"
 msgid "Skip to navigation"
 msgstr "Skip to navigation"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4938,10 +4920,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "Indique le répertoire auquel le périphérique est rattaché"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Indique le port d'écoute de cette instance <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4956,7 +4934,7 @@ msgid ""
 "dead"
 msgstr "Indique le délai après quoi les hôtes seront supposés disparus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4979,7 +4957,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Spécifiez ici la clé secrète de chiffrage."
 
@@ -4993,16 +4971,16 @@ msgstr "Démarrer"
 msgid "Start priority"
 msgstr "Priorité de démarrage"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Démarrage"
 
@@ -5022,7 +5000,7 @@ msgstr "Baux Statiques"
 msgid "Static Routes"
 msgstr "Routes statiques"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5039,13 +5017,13 @@ msgstr ""
 "interfaces sans configuration dynamique où l'on fournit un bail aux seuls "
 "hôtes configurés."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -5060,12 +5038,12 @@ msgstr "Arrêter"
 msgid "Strict order"
 msgstr "Ordre stricte"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Soumettre"
 
@@ -5103,7 +5081,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5118,11 +5096,11 @@ msgstr "Protocole du commutateur"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5132,7 +5110,7 @@ msgstr "Synchro avec le navigateur"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5143,11 +5121,11 @@ msgstr "Système"
 msgid "System Log"
 msgstr "Journal système"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Propriétés système"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Taille du tampon du journal système"
 
@@ -5215,7 +5193,7 @@ msgstr ""
 "Le préfixe IPv6 attribué par le fournisseur, se termine généralement par "
 "<code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5231,7 +5209,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5283,11 +5261,11 @@ msgstr "Les règles suivantes sont actuellement actives sur ce système."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5319,7 +5297,7 @@ msgstr "La longueur du préfixe IPv6 en bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5340,7 +5318,7 @@ msgstr ""
 "un port d'uplink pour une connexion vers un réseau plus vaste, comme "
 "internet et les autres ports sont réservés au réseau local."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5348,7 +5326,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5356,7 +5334,7 @@ msgstr ""
 "Le système est en train d'effacer la partition de configuration et "
 "redémarrera tout seul une fois cela fini."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5369,7 +5347,7 @@ msgstr ""
 "address of your computer to reach the device again, depending on your "
 "settings."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5390,7 +5368,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Il n'y a aucun bail actif."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5410,7 +5388,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "L'adresse IPv4 du relais"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5499,22 +5477,22 @@ msgstr ""
 "Cette page donne une vue d'ensemble des connexions réseaux actuellement "
 "actives."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Cette section ne contient pas encore de valeur"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Synchronisation de l'heure"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Fuseau horaire"
 
@@ -5573,7 +5551,7 @@ msgstr "Mode de déclenchement"
 msgid "Tunnel ID"
 msgstr "ID du tunnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interface du tunnel"
@@ -5666,12 +5644,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5680,7 +5658,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5691,11 +5669,12 @@ msgstr "non-géré"
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Changements non appliqués"
 
@@ -5737,15 +5716,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Envoi de l'archive…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5887,11 +5866,11 @@ msgstr ""
 msgid "Used"
 msgstr "Utilisé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Clé utilisée"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5971,32 +5950,32 @@ msgstr "Vérifier"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Système ouvert WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Clé partagée WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Mot de passe WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Mode WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Mot de passe WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6012,7 +5991,7 @@ msgstr "En attente de l'application des changements..."
 msgid "Waiting for command to complete..."
 msgstr "En attente de la fin de la commande..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -6020,8 +5999,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Attention"
 
@@ -6029,11 +6008,11 @@ msgstr "Attention"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6045,7 +6024,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -6056,13 +6035,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Sans-fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Module Wi-Fi"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6072,7 +6051,7 @@ msgstr "Réseau sans-fil"
 msgid "Wireless Overview"
 msgstr "Présentation des réseaux sans-fil"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Sécurité des réseaux sans-fil"
 
@@ -6092,11 +6071,11 @@ msgstr "Le Wi-Fi est désactivé"
 msgid "Wireless is not associated"
 msgstr "Le Wi-Fi est non associé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Le réseau Wi-Fi est désactivé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Le réseau Wi-Fi est activé"
 
@@ -6104,11 +6083,11 @@ msgstr "Le réseau Wi-Fi est activé"
 msgid "Write received DNS requests to syslog"
 msgstr "Écrire les requêtes DNS reçues dans syslog"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6140,19 +6119,19 @@ msgstr ""
 "Vous devez activer JavaScript dans votre navigateur pour que LuCI fonctionne "
 "correctement."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6163,7 +6142,7 @@ msgstr "n'importe lequel"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6222,7 +6201,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "désactiver"
 
@@ -6321,7 +6300,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "fichier de résolution local"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6340,7 +6323,7 @@ msgstr "pas de lien"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "aucun"
 
@@ -6351,8 +6334,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6366,6 +6349,10 @@ msgstr "Arrêté"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "Actif"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6384,7 +6371,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6398,8 +6385,8 @@ msgstr ""
 msgid "routed"
 msgstr "routé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6420,11 +6407,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "marqué"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6443,7 +6434,7 @@ msgstr "inconnu"
 msgid "unlimited"
 msgstr "non limité"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6624,6 +6615,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6634,6 +6629,12 @@ msgstr "oui"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Retour"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Ports de la passerelle"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Indique le port d'écoute de cette instance <em>Dropbear</em>"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Commutateur %q (%s)"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -15,11 +15,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -61,19 +62,19 @@ msgid "-- Additional Field --"
 msgstr "-- שדה נוסף --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- נא לבחור --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- מותאם אישית --"
@@ -96,7 +97,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -108,7 +109,7 @@ msgstr "עומס במשך דקה:"
 msgid "15 Minute Load:"
 msgstr "עומס במשך רבע שעה:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -121,35 +122,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "עומס במשך 5 דקות:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr ""
 
@@ -167,7 +168,7 @@ msgid ""
 "order of the resolvfile"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -202,7 +203,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "הגדרות <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
@@ -241,7 +242,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -324,8 +325,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "מרכז גישות"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "נקודת גישה"
 
@@ -357,18 +358,18 @@ msgid "Active DHCPv6 Leases"
 msgstr "הרשאות DHCPv6 פעילות"
 
 # צריך אימות של מישהו שמבין יותר במושגים האלו אם צריך בכלל לתרגם את זה או להשאיר כמו שזה
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 #, fuzzy
 msgid "Ad-Hoc"
 msgstr "אד-הוק"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -399,10 +400,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -416,7 +420,7 @@ msgstr "הוסף דומיין מקומי לשמות המוגשים מהקבצי�
 msgid "Add new interface..."
 msgstr "הוסף ממשק חדש..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -466,8 +470,8 @@ msgstr "מנהלה"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -477,12 +481,12 @@ msgstr "הגדרות מתקדמות"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 #, fuzzy
 msgid "Alert"
 msgstr "אזעקה"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -508,24 +512,24 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 #, fuzzy
 msgid "Allow all except listed"
 msgstr "אפשר הכל חוץ מהרשומים"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "אפשר רשומים בלבד"
 
@@ -534,15 +538,15 @@ msgstr "אפשר רשומים בלבד"
 msgid "Allow localhost"
 msgstr "אפשר localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 
@@ -551,7 +555,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -559,7 +563,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -638,7 +642,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -659,11 +663,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "כל תחום"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -687,7 +691,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "תחנות קשורות"
@@ -701,7 +705,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "אימות"
 
@@ -796,7 +800,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -814,7 +818,7 @@ msgstr "חזרה להגדרות"
 msgid "Backup"
 msgstr "גיבוי"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "גיבוי / קושחת פלאש"
 
@@ -831,7 +835,7 @@ msgstr "פורטה כתובת לא תקינה"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -869,7 +873,7 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "גשר"
@@ -888,7 +892,7 @@ msgstr "מס' יח' גשר"
 msgid "Bring up on boot"
 msgstr "הבא באיתחול"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -913,13 +917,13 @@ msgstr "שימוש מעבד (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "בטל"
@@ -942,13 +946,7 @@ msgstr ""
 msgid "Chain"
 msgstr "שרשרת"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "שינויים"
 
@@ -956,23 +954,19 @@ msgstr "שינויים"
 msgid "Changes applied."
 msgstr "השינויים הוחלו"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "משנה את סיסמת המנהל לגישה למכשיר"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "ערוץ"
@@ -985,7 +979,7 @@ msgstr "לבדוק"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -998,7 +992,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1006,13 +1000,13 @@ msgid ""
 "interface to it."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1032,9 +1026,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr ""
 
@@ -1043,8 +1037,8 @@ msgstr ""
 msgid "Client ID to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1067,7 +1061,7 @@ msgstr "סגור רשימה..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1094,7 +1088,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1102,7 +1096,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1118,11 +1112,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1130,7 +1124,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "אישור"
 
@@ -1163,7 +1157,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1174,12 +1168,12 @@ msgstr ""
 msgid "Country"
 msgstr "מדינה"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "קוד מדינה"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "צור / הקצה תחום-חומת אש"
 
@@ -1187,11 +1181,11 @@ msgstr "צור / הקצה תחום-חומת אש"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "קריטי"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr ""
 
@@ -1226,15 +1220,15 @@ msgstr ""
 "מתאים את הגדרות ה-<abbr title=\"Light Emitting Diode\">LED</abbr>-ים במכשיר "
 "(אם אפשרי)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1247,7 +1241,7 @@ msgstr "שרת DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP ו- DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1320,7 +1314,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1332,14 +1326,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr ""
 
@@ -1379,47 +1373,47 @@ msgstr ""
 "הגדר אפשרויות DHCP נוספות, למשל \"<code>6,192.168.2.1,192.168.2.2</code>\" "
 "אשר מציגות שרתי DNS שונים ללקוח"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "למחוק"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "מחק רשת זו"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "תיאור"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "עיצוב"
 
@@ -1450,7 +1444,7 @@ msgstr ""
 msgid "Device"
 msgstr "מכשיר"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "הגדרות מכשיר"
 
@@ -1467,7 +1461,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1485,12 +1479,12 @@ msgstr "אבחון"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr ""
 
@@ -1504,14 +1498,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1523,11 +1518,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1546,21 +1537,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "מרחק לנק' הרשת הרחוקה ביותר במטרים"
 
@@ -1584,15 +1573,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1630,15 +1619,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1669,17 +1658,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "ערוך"
 
@@ -1689,7 +1678,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "ערוך רשת זו"
 
@@ -1697,12 +1686,12 @@ msgstr "ערוך רשת זו"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "מצב חרום"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "אפשר"
 
@@ -1737,7 +1726,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1753,11 +1742,11 @@ msgstr "אפשר שרת TFTP"
 msgid "Enable VLAN functionality"
 msgstr "אפשר תפקוד VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1781,7 +1770,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1803,7 +1792,7 @@ msgstr "אפשר"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1824,17 +1813,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "הצפנה"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1846,7 +1835,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "מוחק..."
 
@@ -1860,7 +1849,7 @@ msgstr "מוחק..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "שגיאה"
 
@@ -1868,12 +1857,12 @@ msgstr "שגיאה"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1907,23 +1896,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1931,19 +1920,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1951,15 +1944,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2004,7 +1997,7 @@ msgstr ""
 msgid "Firewall"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2044,7 +2037,7 @@ msgstr ""
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2052,11 +2045,11 @@ msgstr ""
 msgid "Force"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr ""
 
@@ -2064,11 +2057,11 @@ msgstr ""
 msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
@@ -2100,7 +2093,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2108,7 +2101,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr ""
 
@@ -2117,7 +2110,7 @@ msgstr ""
 msgid "Free"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2139,19 +2132,19 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2159,8 +2152,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
@@ -2168,7 +2161,7 @@ msgstr ""
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2176,7 +2169,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2195,8 +2188,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2226,13 +2219,13 @@ msgstr ""
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -2243,7 +2236,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2268,7 +2261,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr ""
 
@@ -2289,7 +2282,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2510,7 +2503,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr ""
 
@@ -2616,7 +2609,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr ""
 
@@ -2654,7 +2647,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
 
@@ -2662,7 +2655,7 @@ msgstr ""
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr ""
 
@@ -2692,7 +2685,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2722,7 +2715,7 @@ msgstr ""
 msgid "Invalid"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2742,7 +2735,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2750,7 +2743,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "שם משתמש ו/או סיסמה שגויים! אנא נסה שנית."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2767,15 +2760,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2792,15 +2785,15 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2844,11 +2837,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr ""
 
@@ -2888,7 +2881,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2930,7 +2923,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2939,7 +2932,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2964,11 +2957,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -2991,11 +2984,7 @@ msgstr "עומס ממוצע"
 msgid "Loading"
 msgstr "טוען"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3035,7 +3024,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr ""
 
@@ -3067,7 +3056,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3075,7 +3064,7 @@ msgstr ""
 msgid "Log queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3106,22 +3095,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr ""
 
@@ -3149,7 +3138,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3169,7 +3158,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3177,7 +3166,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3203,7 +3192,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3216,7 +3205,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3228,11 +3217,11 @@ msgstr ""
 msgid "Memory usage (%)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3243,7 +3232,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
 
@@ -3255,7 +3244,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3263,8 +3252,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr ""
@@ -3295,16 +3284,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3317,7 +3306,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3365,7 +3354,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr ""
 
@@ -3390,11 +3379,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3402,7 +3391,7 @@ msgstr ""
 msgid "Name"
 msgstr "שם"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr ""
 
@@ -3412,8 +3401,8 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3446,7 +3435,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3455,7 +3444,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3467,7 +3456,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3498,11 +3487,12 @@ msgstr ""
 msgid "No password set!"
 msgstr "לא הוגדרה סיסמה!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3547,7 +3537,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr ""
 
@@ -3577,7 +3567,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr ""
 
@@ -3589,7 +3579,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3655,24 +3645,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3686,41 +3676,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3780,7 +3770,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3802,7 +3792,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3847,7 +3837,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3902,29 +3892,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3932,31 +3922,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "נתיב למפתח הפרטי"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3983,7 +3973,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4003,7 +3993,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4043,7 +4033,7 @@ msgstr "אנא הזן את שם המשתמש והסיסמה שלך:"
 msgid "Policy"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr ""
 
@@ -4079,7 +4069,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4098,11 +4088,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4133,7 +4123,7 @@ msgstr ""
 msgid "Protocol"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4141,15 +4131,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4176,11 +4166,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4188,11 +4178,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr ""
 
@@ -4208,31 +4198,31 @@ msgstr ""
 msgid "RX Rate"
 msgstr "קצב קליטה"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4280,7 +4270,7 @@ msgstr ""
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4288,7 +4278,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr ""
@@ -4306,7 +4296,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4346,11 +4336,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4366,7 +4356,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4374,42 +4364,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4421,31 +4411,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4496,10 +4486,8 @@ msgstr "שחזור"
 msgid "Restore backup"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr ""
 
@@ -4507,15 +4495,15 @@ msgstr ""
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4531,7 +4519,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4547,8 +4535,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr ""
 
@@ -4588,8 +4576,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr ""
 
@@ -4605,14 +4593,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr ""
@@ -4621,19 +4609,17 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4646,24 +4632,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr ""
 
@@ -4678,9 +4660,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4749,7 +4731,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4769,12 +4751,12 @@ msgstr ""
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4794,7 +4776,7 @@ msgstr ""
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4811,7 +4793,7 @@ msgstr "דלג אל התוכן"
 msgid "Skip to navigation"
 msgstr "דלג אל הניווט"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4851,10 +4833,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4867,7 +4845,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4890,7 +4868,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4904,16 +4882,16 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "אתחול"
 
@@ -4933,7 +4911,7 @@ msgstr "הקצאות סטטיות"
 msgid "Static Routes"
 msgstr "ניתובים סטטיים"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4949,13 +4927,13 @@ msgstr ""
 "הן נחוצות גם עבור הגדרות ממשק שאינן דינאמיות, בהן מטופלות רק ישויות בעלות "
 "הקצאה מתאימה."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "מצב"
@@ -4970,12 +4948,12 @@ msgstr "עצור"
 msgid "Strict order"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "שלח"
 
@@ -5013,7 +4991,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5028,11 +5006,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5042,7 +5020,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5053,11 +5031,11 @@ msgstr ""
 msgid "System Log"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5123,7 +5101,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5137,7 +5115,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5183,11 +5161,11 @@ msgstr "החוקים הבאים מאופשרים כרגע במערכת זו."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5217,7 +5195,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5231,7 +5209,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5239,13 +5217,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5253,7 +5231,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5272,7 +5250,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5289,7 +5267,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5363,22 +5341,22 @@ msgstr "רשימה זו מציגה סקירה של תהליכי המערכת ה�
 msgid "This page gives an overview over currently active network connections."
 msgstr "דף זה מציג סקירה של חיבורי הרשת הפעילים כרגע."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "אזור זה עדיין לא מכיל ערכים."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "סנכרון זמן"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "אזור זמן"
 
@@ -5434,7 +5412,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5527,12 +5505,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5541,7 +5519,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5552,11 +5530,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5594,15 +5573,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5740,11 +5719,11 @@ msgstr ""
 msgid "Used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5824,32 +5803,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "סיסמת WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "סיסמת WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5863,7 +5842,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5871,8 +5850,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "אזהרה"
 
@@ -5880,11 +5859,11 @@ msgstr "אזהרה"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5896,7 +5875,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5907,13 +5886,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5923,7 +5902,7 @@ msgstr ""
 msgid "Wireless Overview"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr ""
 
@@ -5943,11 +5922,11 @@ msgstr ""
 msgid "Wireless is not associated"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "רשת אלחוטית מנוטרלת"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "רשת אלחוטית מאופשרת"
 
@@ -5955,11 +5934,11 @@ msgstr "רשת אלחוטית מאופשרת"
 msgid "Write received DNS requests to syslog"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -5985,19 +5964,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr "אתה חייב להפעיל את JavaScript בדפדפן שלך; אחרת, LuCI לא יפעל כראוי."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6008,7 +5987,7 @@ msgstr "כלשהו"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6066,7 +6045,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "בטל"
 
@@ -6165,7 +6144,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6184,7 +6167,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "ללא"
 
@@ -6195,8 +6178,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6210,6 +6193,10 @@ msgstr "כבוי"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "פועל"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6228,7 +6215,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6242,8 +6229,8 @@ msgstr ""
 msgid "routed"
 msgstr "מנותב"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6264,11 +6251,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "מתויג"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6287,7 +6278,7 @@ msgstr ""
 msgid "unlimited"
 msgstr "ללא הגבלה"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6466,6 +6457,10 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:441
 msgid "value with at most %d characters"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -15,11 +15,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -61,19 +62,19 @@ msgid "-- Additional Field --"
 msgstr "-- További mező --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Kérem válasszon --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- egyéni --"
@@ -96,7 +97,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -108,7 +109,7 @@ msgstr "Terhelés (utolsó 1 perc):"
 msgid "15 Minute Load:"
 msgstr "Terhelés (utolsó 15 perc):"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -121,35 +122,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Terhelés (utolsó 5 perc):"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -169,7 +170,7 @@ msgstr ""
 "<abbr title=\"Domain Name System\">DNS</abbr> szerverek a resolv fájl "
 "sorrendjében"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -205,7 +206,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> konfiguráció"
 
@@ -248,7 +249,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -329,8 +330,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Elérési központ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Hozzáférési pont"
 
@@ -363,17 +364,17 @@ msgstr "Aktív DHCP bérletek"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktív DHCPv6 bérletek"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -404,10 +405,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -421,7 +425,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Új interfész hozzáadása..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -470,8 +474,8 @@ msgstr "Adminisztráció"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -481,11 +485,11 @@ msgstr "Haladó beállítások"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Riasztás"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -511,24 +515,24 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "<abbr title=\"Secure Shell\">SSH</abbr> jelszó hitelesítés engedélyezése"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Összes engedélyezése a felsoroltakon kívül"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Csak a felsoroltak engedélyezése"
 
@@ -536,17 +540,17 @@ msgstr "Csak a felsoroltak engedélyezése"
 msgid "Allow localhost"
 msgstr "Lolcalhost engedélyezése"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Távoli hostok csatlakozásának engedélyezése a helyi SSH továbbított "
 "portokhoz."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "root jelszavas bejelentkezésének engedélyezése"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Engedélyezi a <em>root</em> felhasználó jelszavas bejelentkezését"
 
@@ -557,7 +561,7 @@ msgstr ""
 "A 127.0.0.0/8-as tartományba eső DNS válaszok engedélyezése (pl. RBL "
 "szervizek)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -565,7 +569,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -644,7 +648,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -663,11 +667,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Bármelyik zóna"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -691,7 +695,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Kapcsolódó kliensek"
@@ -705,7 +709,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Hitelesítés"
 
@@ -800,7 +804,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -818,7 +822,7 @@ msgstr "Vissza a beállításokhoz"
 msgid "Backup"
 msgstr "Mentés"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Mentés / Firmware frissítés"
 
@@ -835,7 +839,7 @@ msgstr "Hibás címet adott meg!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -874,7 +878,7 @@ msgstr "Bitráta"
 msgid "Bogus NX Domain Override"
 msgstr "Hamis NX tartomány felülbírálása"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Híd"
@@ -892,7 +896,7 @@ msgstr "Híd eszközszám"
 msgid "Bring up on boot"
 msgstr "Hozza fel a rendszer indításakor"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -917,13 +921,13 @@ msgstr "Processzor használat (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Mégsem"
@@ -946,13 +950,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Lánc"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Módosítások"
 
@@ -960,24 +958,20 @@ msgstr "Módosítások"
 msgid "Changes applied."
 msgstr "A módosítások alkalmazva."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr ""
 "Itt módosíthatja az eszköz eléréséhez szükséges adminisztrátori jelszót"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Csatorna"
@@ -990,7 +984,7 @@ msgstr "Ellenőrzés"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -1003,7 +997,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1015,7 +1009,7 @@ msgstr ""
 "zónából történő eltávolításához, vagy töltse ki az <em>új</em> mezőt új zóna "
 "megadásához és csatlakoztassa az interfészt ahhoz."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1024,7 +1018,7 @@ msgstr ""
 "vezetéknélküli interfészhez, vagy töltse ki az <em>új</em> mezőt egy új "
 "hálózat definiálásához."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Titkosító"
 
@@ -1046,9 +1040,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Ügyfél"
 
@@ -1057,8 +1051,8 @@ msgstr "Ügyfél"
 msgid "Client ID to send when requesting DHCP"
 msgstr "DHCP kérés során küldendő kliens azonosító"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1083,7 +1077,7 @@ msgstr "Lista bezárása..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1110,7 +1104,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1118,7 +1112,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1134,11 +1128,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1146,7 +1140,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Megerősítés"
 
@@ -1179,7 +1173,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1190,12 +1184,12 @@ msgstr ""
 msgid "Country"
 msgstr "Ország"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Országkód"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Tűzfal zóna készítés / hozzárendelés"
 
@@ -1203,11 +1197,11 @@ msgstr "Tűzfal zóna készítés / hozzárendelés"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Kritikus"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Cron naplózási szint"
 
@@ -1242,15 +1236,15 @@ msgstr ""
 "Az eszköz <abbr title=\"Light Emitting Diode\">LED</abbr>-jei működésének "
 "testreszabása."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1263,7 +1257,7 @@ msgstr "DHCP kiszolgáló"
 msgid "DHCP and DNS"
 msgstr "DHCP és DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1336,7 +1330,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1348,14 +1342,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Hibakeresés"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Alapértelmezés %d"
 
@@ -1395,47 +1389,47 @@ msgstr ""
 "Adjon meg további DHCP opciókat, például \"<code>6,192.168.2.1,192.168.2.2</"
 "code>\", mely különböző DNS kiszolgálókat hirdet az ügyfelek részére."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Törlés"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Hálózat törlése"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Leírás"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Megjelenés"
 
@@ -1466,7 +1460,7 @@ msgstr ""
 msgid "Device"
 msgstr "Eszköz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Eszköz beállítások"
 
@@ -1483,7 +1477,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1501,12 +1495,12 @@ msgstr "Diagnosztika"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Könyvtár"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Letiltás"
 
@@ -1522,14 +1516,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1541,11 +1536,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Letiltva"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1564,21 +1555,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Távolság optimalizáció"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "A hálózat legtávolabbi tagjának távolsága méterben."
 
@@ -1608,15 +1597,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Ne továbbítson fordított keresési kéréseket a helyi hálózathoz"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1656,15 +1645,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Dropbear példány"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1700,17 +1689,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP metódus"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Szerkesztés"
 
@@ -1720,7 +1709,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Hálózat szerkesztése"
 
@@ -1728,12 +1717,12 @@ msgstr "Hálózat szerkesztése"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Vészhelyzet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Engedélyezés"
 
@@ -1768,7 +1757,7 @@ msgstr "IPv6 egyeztetés engedélyezése a PPP linken"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Óriás keretek átengedésének engedélyezése"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "NTP-kliens engedélyezése"
 
@@ -1784,11 +1773,11 @@ msgstr "TFTP kiszolgáló engedélyezése"
 msgid "Enable VLAN functionality"
 msgstr "VLAN funkció engedélyezése"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1812,7 +1801,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "A csatolás engedélyezése"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1834,7 +1823,7 @@ msgstr "Engedélyezve"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1855,17 +1844,17 @@ msgstr "Beágyazási mód"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Titkosítás"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1877,7 +1866,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Törlés..."
 
@@ -1891,7 +1880,7 @@ msgstr "Törlés..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Hiba"
 
@@ -1899,12 +1888,12 @@ msgstr "Hiba"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet switch"
@@ -1939,23 +1928,23 @@ msgstr "A bérelt címek lejárati ideje, a minimális érték 2 perc."
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Külső rendszernapló kiszolgáló"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Külső rendszernapló kiszolgáló port"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1963,19 +1952,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1983,15 +1976,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Fájl"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2036,7 +2029,7 @@ msgstr "Befejezés"
 msgid "Firewall"
 msgstr "Tűzfal"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2076,7 +2069,7 @@ msgstr "Új firmware image flash-elése"
 msgid "Flash operations"
 msgstr "Flash műveletek"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Flash-elés..."
 
@@ -2084,11 +2077,11 @@ msgstr "Flash-elés..."
 msgid "Force"
 msgstr "Kényszerítés"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "CCMP (AES) kényszerítése"
 
@@ -2098,11 +2091,11 @@ msgstr ""
 "DHCP kényszerítése ezen a hálózaton még akkor is ha van másik szerver "
 "észlelve."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "TKIP kényszerítése"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "TKIP és CCMP (AES) kényszerítése"
 
@@ -2134,7 +2127,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Broadcast forgalom továbbítás"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2142,7 +2135,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Továbbítás módja"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Töredezettségi küszöb"
 
@@ -2151,7 +2144,7 @@ msgstr "Töredezettségi küszöb"
 msgid "Free"
 msgstr "Szabad"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2173,19 +2166,19 @@ msgstr "Csak GPRS"
 msgid "Gateway"
 msgstr "Átjáró"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Átjáró portok"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2193,8 +2186,8 @@ msgstr "Általános beállítások"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Általános beállítások"
 
@@ -2202,7 +2195,7 @@ msgstr "Általános beállítások"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2210,7 +2203,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Archívum készítése"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "A megadott jelszavak nem egyeznek, a jelszó nem lett megváltoztatva!"
 
@@ -2229,8 +2222,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Ugrás a jelszó beállításhoz..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2260,7 +2253,7 @@ msgstr "Befejezés"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2268,7 +2261,7 @@ msgstr ""
 "Itt állíthatja be az eszköz alapvető tulajdonságait, mint például a gépnév "
 "vagy az időzóna."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr> elrejtése"
 
@@ -2279,7 +2272,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2304,7 +2297,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Gépnév"
 
@@ -2325,7 +2318,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2546,7 +2539,7 @@ msgstr "IPv6 IPv4 felett (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6 IPv4 felett (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identitás"
 
@@ -2661,7 +2654,7 @@ msgstr "Inaktivitási időtúllépés"
 msgid "Inbound:"
 msgstr "Bejövő"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Információk"
 
@@ -2699,7 +2692,7 @@ msgstr "Protokoll kiterjesztések telepítése..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfész"
 
@@ -2707,7 +2700,7 @@ msgstr "Interfész"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Interfész beállítások"
 
@@ -2737,7 +2730,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2767,7 +2760,7 @@ msgstr "Belső szerverhiba"
 msgid "Invalid"
 msgstr "Érvénytelen"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2790,7 +2783,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2798,7 +2791,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Érvénytelen felhasználói név és/vagy jelszó! Kérem próbálja újra!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2818,15 +2811,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "JavaScript szükséges!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Csatlakozás a hálózathoz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Csatlakozás a hálózathoz: vezetéknélküli hálózatok keresése"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2843,15 +2836,15 @@ msgstr "Kernel napló"
 msgid "Kernel Version"
 msgstr "Kernel verzió"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Kulcs"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Kulcs #%d"
 
@@ -2895,11 +2888,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Címke"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Nyelv"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Nyelv és megjelenés"
 
@@ -2939,7 +2932,7 @@ msgstr "Automatikus észleléshez hagyja üresen"
 msgid "Leave empty to use the current WAN address"
 msgstr "A jelenlegi WAN cím használatához hagyja üresen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Jelmagyarázat:"
 
@@ -2983,7 +2976,7 @@ msgstr ""
 "<abbr title=\"Domain Name System\">DNS</abbr> szerverek listája, ahová a "
 "kérések továbbításra kerülnek"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2992,7 +2985,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3017,11 +3010,11 @@ msgstr "A hamis NX tartomány eredményeket szolgáltató gépek listája"
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Csak a megadott interfészen hallgat, vagy az összesen, amennyiben nem adja "
@@ -3046,11 +3039,7 @@ msgstr "Átlagos terhelés"
 msgid "Loading"
 msgstr "Betöltés"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3090,7 +3079,7 @@ msgid "Local Startup"
 msgstr "Helyi indítóscript"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Helyi idő"
 
@@ -3130,7 +3119,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Lekérdezések lokalizációja"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Napló kimeneti szintje"
 
@@ -3138,7 +3127,7 @@ msgstr "Napló kimeneti szintje"
 msgid "Log queries"
 msgstr "Kérések naplózása"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Naplózás"
 
@@ -3169,22 +3158,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-cím"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "MAC-cím szűrő"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-szűrő"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC-lista"
 
@@ -3212,7 +3201,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3232,7 +3221,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3240,7 +3229,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3266,7 +3255,7 @@ msgstr "Maximális várakozási idő a modem kész állapotára (másodpercben)"
 msgid "Maximum number of leased addresses."
 msgstr "DHCP címek maximális száma"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3279,7 +3268,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3291,11 +3280,11 @@ msgstr "Memória"
 msgid "Memory usage (%)"
 msgstr "Memória használat (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3306,7 +3295,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrika"
 
@@ -3318,7 +3307,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3326,8 +3315,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Mód"
@@ -3358,16 +3347,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Modem inicializálás időtúllépés"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Ellenőrzés"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3380,7 +3369,7 @@ msgstr "Csatolási bejegyzés"
 msgid "Mount Point"
 msgstr "Csatolási pont"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3430,7 +3419,7 @@ msgstr "Mozgatás lefelé"
 msgid "Move up"
 msgstr "Mozgatás felfelé"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS azonosító"
 
@@ -3455,11 +3444,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Kijelölt NTP kiszolgálók"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3467,7 +3456,7 @@ msgstr "Kijelölt NTP kiszolgálók"
 msgid "Name"
 msgstr "Név"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Az új hálózat neve"
 
@@ -3477,8 +3466,8 @@ msgstr "Navigáció"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3511,7 +3500,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Következő »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3520,7 +3509,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Ehhez az interfészhez nincs DHCP kiszolgáló beállítva"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3532,7 +3521,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3563,11 +3552,12 @@ msgstr "Nincs negatív gyorsítótár"
 msgid "No password set!"
 msgstr "Nincs jelszó!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3612,7 +3602,7 @@ msgstr ""
 msgid "None"
 msgstr "Nincs"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normál"
 
@@ -3642,7 +3632,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Megjegyzés"
 
@@ -3654,7 +3644,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3720,24 +3710,24 @@ msgstr "Lista megnyitása..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Beállítás módosítva"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Beállítás eltávolítva"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3751,41 +3741,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3845,7 +3835,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3869,7 +3859,7 @@ msgstr "A belső útvonalakhoz használt tábla felülbírálása"
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3914,7 +3904,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3969,29 +3959,29 @@ msgid "Part of zone %q"
 msgstr "A %q zóna része"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Jelszó"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Jelszó hitelesítés"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "A privát kulcsh jelszava"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3999,31 +3989,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "CA tanúsítvány elérési útja"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Kliens tanúsítvány elérési útja"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "A privát kulcs elérési útja"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4050,7 +4040,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4070,7 +4060,7 @@ msgstr "Visszaállítás végrehajtása"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4110,7 +4100,7 @@ msgstr "Adja meg a felhasználónevét és a jelszavát."
 msgid "Policy"
 msgstr "Szabály"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4146,7 +4136,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4167,11 +4157,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Ügyfél-ügyfél közötti kommunikáció megakadályozása"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4202,7 +4192,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "NTP kiszolgáló"
 
@@ -4210,15 +4200,15 @@ msgstr "NTP kiszolgáló"
 msgid "Provide new network"
 msgstr "Új hálózat nyújtása"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Ál Ad-hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4245,11 +4235,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4257,11 +4247,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS küszöbérték"
 
@@ -4277,31 +4267,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "RX sebesség"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Radius-Naplózási-Port"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Radius-Naplózás-Kulcs"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Radius-Naplózás-Kiszolgáló"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Radius-Hitelesítés-Port"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Radius-Hitelesítés-Kulcs"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Radius-Hitelesítés-Kiszolgáló"
 
@@ -4351,7 +4341,7 @@ msgstr "Valósidejű forgalom"
 msgid "Realtime Wireless"
 msgstr "Valósidejű vezetéknélküli adatok"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4359,7 +4349,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Rebind elleni védelem"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Újraindítás"
@@ -4377,7 +4367,7 @@ msgstr "Újraindítja az eszköz operációs rendszerét"
 msgid "Receive"
 msgstr "Fogadás"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4417,11 +4407,11 @@ msgstr "Távoli IPv4 cím"
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Eltávolítás"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Vezetéknélküli beállítások lecserélése"
 
@@ -4437,7 +4427,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4446,42 +4436,42 @@ msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 "Szükséges bizonyos internetszolgáltatók esetén, pl. Charter 'DOCSIS 3'-al"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4493,31 +4483,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4568,10 +4558,8 @@ msgstr "Visszaállítás"
 msgid "Restore backup"
 msgstr "Biztonsági mentés visszaállítása"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Jelszó mutatása/elrejtése"
 
@@ -4579,15 +4567,15 @@ msgstr "Jelszó mutatása/elrejtése"
 msgid "Revert"
 msgstr "Visszavonás"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4603,7 +4591,7 @@ msgstr "TFTP-n keresztül megosztott fájlok gyökérkönyvtára"
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4619,8 +4607,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Router jelszó"
 
@@ -4662,8 +4650,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH hozzáférés"
 
@@ -4679,14 +4667,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH kulcsok"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4695,19 +4683,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Mentés"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Mentés & Alkalmazás"
@@ -4720,24 +4706,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Felderítés"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Ütemezett feladatok"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Szakasz hozzáadva"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Szakasz eltávolítva"
 
@@ -4752,9 +4734,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4825,7 +4807,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4845,12 +4827,12 @@ msgstr "Interfész leállítása"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Jel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4870,7 +4852,7 @@ msgstr "Méret"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4887,7 +4869,7 @@ msgstr "Ugrás a tartalomhoz"
 msgid "Skip to navigation"
 msgstr "Ugrás a navigációhoz"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4928,10 +4910,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "Megadja az eszköz csatlakozási könyvtárát."
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Megadja a <em>Dropbear</em> példány portját"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4947,7 +4925,7 @@ msgid ""
 msgstr ""
 "Megadja a másodpercek számát, amik után a host nem elérhetőnek tekinthető"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4970,7 +4948,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Itt adja meg a titkosító kulcsot."
 
@@ -4984,16 +4962,16 @@ msgstr "Indítás"
 msgid "Start priority"
 msgstr "Indítás prioritása"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Rendszerindítás"
 
@@ -5013,7 +4991,7 @@ msgstr "Statikus bérletek"
 msgid "Static Routes"
 msgstr "Statikus útvonalak"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5030,13 +5008,13 @@ msgstr ""
 "szükségesek, ahol a csak a megfelelő bérlettel rendelkező hosztok kerülnek "
 "kiszolgálásra."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Állapot"
@@ -5051,12 +5029,12 @@ msgstr "Leállítás"
 msgid "Strict order"
 msgstr "Kötött sorrend"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Elküldés"
 
@@ -5094,7 +5072,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5109,11 +5087,11 @@ msgstr "Protokoll csere"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5123,7 +5101,7 @@ msgstr "Szinkronizálás a böngészővel"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5134,11 +5112,11 @@ msgstr "Rendszer"
 msgid "System Log"
 msgstr "Rendszernapló"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Rendszer tulajdonságok"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Rendszer napló puffer méret"
 
@@ -5205,7 +5183,7 @@ msgid ""
 msgstr ""
 "A szolgáltatóhoz rendelt IPv6 előtag, általában így végződik: <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5221,7 +5199,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5276,11 +5254,11 @@ msgstr "Jelenleg a következő szabályok aktívak a rendszeren."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5311,7 +5289,7 @@ msgstr "Az IPv6 előtag hossza bitekben"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5332,7 +5310,7 @@ msgstr ""
 "hálózathoz (pl. az internet) való kapcsolódásra és a többi port a helyi "
 "hálózathoz."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5340,13 +5318,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "A rendszer most törli a konfigurációs partíciót majd újraindul."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5359,7 +5337,7 @@ msgstr ""
 "eléréséhez a beállításaitól függően szükséges lehet a számítógépe IP-címének "
 "megújítása."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5380,7 +5358,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Nincsenek aktív bérletek."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5400,7 +5378,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "Az átjátszó IPV4 címe"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5488,22 +5466,22 @@ msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Ez a lap a rendszerben jelenleg aktív hálózati kapcsolatokról ad áttekintést."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Ez a szakasz még nem tartalmaz értékeket"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Idő szinkronizálás"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Időzóna"
 
@@ -5562,7 +5540,7 @@ msgstr "Trigger mód"
 msgid "Tunnel ID"
 msgstr "Tunnel azonosító"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Tunnel interfész"
@@ -5655,12 +5633,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5669,7 +5647,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5680,11 +5658,12 @@ msgstr "Nem kezelt"
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "El nem mentett módosítások"
 
@@ -5725,15 +5704,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Archívum feltöltése..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5875,11 +5854,11 @@ msgstr ""
 msgid "Used"
 msgstr "Használt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Használt kulcsindex"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5959,32 +5938,32 @@ msgstr "Ellenőrzés"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "WEP nyílt rendszer"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "WEP megosztott kulcs"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP jelmondat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM mód"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA jelmondat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6000,7 +5979,7 @@ msgstr "Várakozás a változtatások alkalmazására..."
 msgid "Waiting for command to complete..."
 msgstr "Várakozás a parancs befejezésére..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -6008,8 +5987,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
@@ -6017,11 +5996,11 @@ msgstr "Figyelmeztetés"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6033,7 +6012,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -6044,13 +6023,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Vezetéknélküli rész"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Vezetéknélküli adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6060,7 +6039,7 @@ msgstr "Vezetéknélküli hálózat"
 msgid "Wireless Overview"
 msgstr "Vezetéknélküli rész áttekintés"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Vezetéknélküli biztonság"
 
@@ -6080,11 +6059,11 @@ msgstr "Vezetéknélküli hálózat le van tiltva"
 msgid "Wireless is not associated"
 msgstr "Vezetéknélküli hálózat nincs kapcsolódva"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Vezetéknélküli hálózat letiltva"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Vezetéknélküli hálózat engedélyezve"
 
@@ -6092,11 +6071,11 @@ msgstr "Vezetéknélküli hálózat engedélyezve"
 msgid "Write received DNS requests to syslog"
 msgstr "A kapott DNS kéréseket írja a rendszernaplóba"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6128,19 +6107,19 @@ msgstr ""
 "Engélyezze a Java Szkripteket a böngészőjében, mert anélkül a LuCI nem fog "
 "megfelelően működni."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6151,7 +6130,7 @@ msgstr "bármelyik"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6209,7 +6188,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "letiltás"
 
@@ -6310,7 +6289,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "helyi <abbr title=\"Domain Name System\">DNS</abbr> fájl"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6329,7 +6312,7 @@ msgstr "nincs link"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "nincs"
 
@@ -6340,8 +6323,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6355,6 +6338,10 @@ msgstr "ki"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "be"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6373,7 +6360,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6387,8 +6374,8 @@ msgstr ""
 msgid "routed"
 msgstr "irányított"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6409,11 +6396,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "cimkézett"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6432,7 +6423,7 @@ msgstr "ismeretlen"
 msgid "unlimited"
 msgstr "korlátlan"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6613,6 +6604,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6623,6 +6618,12 @@ msgstr "igen"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Vissza"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Átjáró portok"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Megadja a <em>Dropbear</em> példány portját"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Kapcsoló %q (%s)"

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -2168,7 +2168,7 @@ msgstr "Átjáró"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Átjáró portok"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6618,9 +6618,6 @@ msgstr "igen"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Vissza"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Átjáró portok"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Megadja a <em>Dropbear</em> példány portját"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Campo aggiuntivo --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Per favore scegli --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personalizzato --"
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr "Carico in 1 minuto:"
 msgid "15 Minute Load:"
 msgstr "Carico in 15 minut:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Carico in 5 minuti:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr ""
 "<abbr title=\"Servizio basilare di impostazione Identificatore\">BSSID</abbr>"
@@ -172,7 +173,7 @@ msgstr ""
 "<abbr title=\"Sistema Nome Dominio\">DNS</abbr> I server che verranno "
 "interrogati nell'ordine del resolv file"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "<abbr title=\"Impostazione Identificatore Servizio Esteso\">ESSID</abbr>"
@@ -210,7 +211,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configurazione <abbr title=\"Diodo ad Emissione di Luce\">LED</abbr>"
 
@@ -255,7 +256,7 @@ msgstr ""
 "<br/>Nota: devi riavviare manualmente il servizio cron se il file crontab "
 "era vuoto prima delle modifiche."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -336,8 +337,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Accesso Concentratore"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Punto di Accesso"
 
@@ -372,17 +373,17 @@ msgstr "Contratti attivi DHCP"
 msgid "Active DHCPv6 Leases"
 msgstr "Contratti attivi DHCPv6"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -413,10 +414,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -430,7 +434,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Aggiungi nuova interfaccia..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -479,8 +483,8 @@ msgstr "Amministrazione"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -490,11 +494,11 @@ msgstr "Opzioni Avanzate"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Allerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -520,25 +524,25 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Permetti autenticazione <abbr title=\"Secure Shell\">SSH</abbr> tramite "
 "password"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Consenti tutti tranne quelli nell'elenco"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Consenti solo quelli nell'elenco"
 
@@ -546,16 +550,16 @@ msgstr "Consenti solo quelli nell'elenco"
 msgid "Allow localhost"
 msgstr "Permetti localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Permetti agli host remoti di connettersi tramite ssh reindirizzando le porte"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Permetti l'accesso a root con password"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Abilita l'utente root con l'accesso via password"
 
@@ -566,7 +570,7 @@ msgstr ""
 "Permetti le risposte upstream nell'intervallo 127.0.0.0/8, per esempio nei "
 "servizi RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -574,7 +578,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -653,7 +657,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -672,11 +676,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Qualsiasi Zona"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -700,7 +704,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Dispositivi Wi-Fi connessi"
@@ -714,7 +718,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Autenticazione PEAP"
 
@@ -809,7 +813,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -827,7 +831,7 @@ msgstr "Indietro alla configurazione"
 msgid "Backup"
 msgstr "Copia di Sicurezza"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Copia di Sicurezza / Flash Firmware"
 
@@ -844,7 +848,7 @@ msgstr "E' stato specificato un indirizzo errato!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -882,7 +886,7 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Ignora Dominio Bogus NX"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Ponte"
@@ -900,7 +904,7 @@ msgstr "Numero Unità Ponte"
 msgid "Bring up on boot"
 msgstr "Attivare all'avvio"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -925,13 +929,13 @@ msgstr "Uso CPU (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Annulla"
@@ -954,13 +958,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Catena"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Modifiche"
 
@@ -968,23 +966,19 @@ msgstr "Modifiche"
 msgid "Changes applied."
 msgstr "Modifiche applicate."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Cambia la password di amministratore per accedere al dispositivo"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Canale"
@@ -997,7 +991,7 @@ msgstr "Verifica"
 msgid "Check filesystems before mount"
 msgstr "Controlla i filesystem prima di montare"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "Marca questa opzione per cancellare le reti esistenti da questa radio."
 
@@ -1010,7 +1004,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1022,7 +1016,7 @@ msgstr ""
 "associata o compilare il campo <em>crea</em> per definire una nuova zona e "
 "collegare l'interfaccia ad esso."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1030,7 +1024,7 @@ msgstr ""
 "Scegliere la/le rete/reti a cui vuoi collegare questa interfaccia wireless o "
 "riempire il campo <em>crea<em> per definire una nuova rete."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Cifratura"
 
@@ -1052,9 +1046,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Cliente"
 
@@ -1063,8 +1057,8 @@ msgstr "Cliente"
 msgid "Client ID to send when requesting DHCP"
 msgstr "ID Cliente da inviare all'interno della richiesta DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1089,7 +1083,7 @@ msgstr "Scegliere dall'elenco..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1116,7 +1110,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1124,7 +1118,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1140,11 +1134,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1152,7 +1146,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Conferma"
 
@@ -1185,7 +1179,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1196,12 +1190,12 @@ msgstr ""
 msgid "Country"
 msgstr "Nazione"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Codice Nazione"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Crea / Assegna zona firewall"
 
@@ -1209,11 +1203,11 @@ msgstr "Crea / Assegna zona firewall"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Critico"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Livello di log del Cron"
 
@@ -1248,15 +1242,15 @@ msgstr ""
 "Personalizza la configurazione dei <abbr title=\"Light Emitting Diode\">LED</"
 "abbr> del sistema se possibile."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1269,7 +1263,7 @@ msgstr "Server DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP e DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1342,7 +1336,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1354,14 +1348,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Debug"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Predefinito %d"
 
@@ -1402,47 +1396,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" fornisce differenti server DNS ai "
 "client."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Elimina"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Rimuovi questa rete"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Descrizione"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Tema"
 
@@ -1473,7 +1467,7 @@ msgstr ""
 msgid "Device"
 msgstr "Dispositivo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Configurazione del dispositivo"
 
@@ -1490,7 +1484,7 @@ msgstr "Dispositivo in riavvio..."
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Dispositivo irraggiungibile"
 
@@ -1508,12 +1502,12 @@ msgstr "Diagnostica"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Cartella"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Disabilita"
 
@@ -1529,14 +1523,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Disabilita Crittografia"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1548,11 +1543,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Disabilitato"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Disabilitato (default)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1571,21 +1562,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Ottimizzazione distanza"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distanza del membro più lontano della rete in metri."
 
@@ -1614,15 +1603,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Non proseguire con le ricerche inverse per le reti locali."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1662,15 +1651,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Instanza di Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1704,17 +1693,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Metodo EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Modifica"
 
@@ -1724,7 +1713,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Modifica questa rete"
 
@@ -1732,12 +1721,12 @@ msgstr "Modifica questa rete"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Emergenza"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Abilita"
 
@@ -1772,7 +1761,7 @@ msgstr "Attiva la negoziazione IPv6 sul collegamento PPP"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Abilita Jumbo Frame passthrough"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Attiva il cliente NTP"
 
@@ -1788,11 +1777,11 @@ msgstr "Abilita il server TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Abilita la funzionalità VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "Abilita pulsante WPS, richiede WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1816,7 +1805,7 @@ msgstr "Abilita l'opzione DF (non Frammentare) dei pacchetti incapsulati"
 msgid "Enable this mount"
 msgstr "Abilita questo mount"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1838,7 +1827,7 @@ msgstr "Abilitato"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1859,17 +1848,17 @@ msgstr "Modalità di incapsulamento"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Crittografia"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1881,7 +1870,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Cancellazione..."
 
@@ -1895,7 +1884,7 @@ msgstr "Cancellazione..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Errore"
 
@@ -1903,12 +1892,12 @@ msgstr "Errore"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Scheda di Rete"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch di Rete"
@@ -1944,23 +1933,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Server Log di Sistema esterno"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Porta Server Log di Sistema esterno"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1968,19 +1957,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1988,15 +1981,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "File"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2041,7 +2034,7 @@ msgstr "Fine"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2081,7 +2074,7 @@ msgstr "Flash immagine nuovo firmware"
 msgid "Flash operations"
 msgstr "Operazioni Flash"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Flashing..."
 
@@ -2089,11 +2082,11 @@ msgstr "Flashing..."
 msgid "Force"
 msgstr "Forza"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Forza CCMP (AES)"
 
@@ -2101,11 +2094,11 @@ msgstr "Forza CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Forza DHCP su questa rete, anche se un altro server viene rilevato."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Forza TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forza TKIP e CCMP (AES)"
 
@@ -2137,7 +2130,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Inoltra il traffico broadcast"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2145,7 +2138,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Modalità di Inoltro"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Soglia di frammentazione"
 
@@ -2154,7 +2147,7 @@ msgstr "Soglia di frammentazione"
 msgid "Free"
 msgstr "Disponibile"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2176,19 +2169,19 @@ msgstr "Solo GPRS"
 msgid "Gateway"
 msgstr "Gateway"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Porte Gateway"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2196,8 +2189,8 @@ msgstr "Opzioni Generali"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Impostazioni Generali"
 
@@ -2205,7 +2198,7 @@ msgstr "Impostazioni Generali"
 msgid "Generate Config"
 msgstr "Genera Configurazione"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2213,7 +2206,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Genera Archivio"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 "La conferma della password assegnata non ha prodotto risultati, la password "
@@ -2234,8 +2227,8 @@ msgstr "Opzioni rete globale"
 msgid "Go to password configuration..."
 msgstr "Vai alla configurazione della password..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2265,7 +2258,7 @@ msgstr "Hangup"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2273,7 +2266,7 @@ msgstr ""
 "Qui puoi configurare gli aspetti base del tuo dispositivo come l&#39;"
 "hostname o il fuso orario."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Nascondi <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2284,7 +2277,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2310,7 +2303,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Hostname"
 
@@ -2331,7 +2324,7 @@ msgstr "Ibrido"
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "Indirizzi IP"
 
@@ -2552,7 +2545,7 @@ msgstr "IPv6-su-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-su-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identità PEAP"
 
@@ -2669,7 +2662,7 @@ msgstr "Tempo di Inattività"
 msgid "Inbound:"
 msgstr "In entrata:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Informazioni"
 
@@ -2707,7 +2700,7 @@ msgstr "Installa le estensioni del protocollo..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfaccia"
 
@@ -2715,7 +2708,7 @@ msgstr "Interfaccia"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Configurazione Interfaccia"
 
@@ -2745,7 +2738,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "Nome Interfaccia"
 
@@ -2775,7 +2768,7 @@ msgstr "Errore del Server Interno"
 msgid "Invalid"
 msgstr "Valore immesso non valido"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2795,7 +2788,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2803,7 +2796,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Username o password non validi! Per favore riprova."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "Isola Clienti"
 
@@ -2823,15 +2816,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "Richiesto JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Aggiungi Rete"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Aggiunta Rete: Rilevamento Wireless"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2848,15 +2841,15 @@ msgstr "Registro del Kernel"
 msgid "Kernel Version"
 msgstr "Versione del Kernel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Chiave"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Chiave #%d"
 
@@ -2900,11 +2893,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Etichetta"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Lingua"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Lingua e Stile"
 
@@ -2944,7 +2937,7 @@ msgstr "Lasciare vuoto per l'autorilevamento"
 msgid "Leave empty to use the current WAN address"
 msgstr "Lasciare vuoto per usare l'indirizzo WAN attuale"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -2988,7 +2981,7 @@ msgstr ""
 "Elenco di Server <abbr title=\"Sistema Nome Dimio\">DNS</abbr>a cui "
 "inoltrare le richieste in"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2997,7 +2990,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3022,11 +3015,11 @@ msgstr "Elenco degli host che forniscono falsi risultati di dominio NX"
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr "Ascolta solo l'interfaccia data o, se non specificato, su tutte"
 
@@ -3049,11 +3042,7 @@ msgstr "Carico Medio"
 msgid "Loading"
 msgstr "Caricamento"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3093,7 +3082,7 @@ msgid "Local Startup"
 msgstr "Avvio Locale"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Ora locale"
 
@@ -3131,7 +3120,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Localizza richieste"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Livello di dettaglio registro"
 
@@ -3139,7 +3128,7 @@ msgstr "Livello di dettaglio registro"
 msgid "Log queries"
 msgstr "Logga richieste"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Logging"
 
@@ -3170,22 +3159,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filtro indirizzo MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Filtro MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Lista MAC"
 
@@ -3213,7 +3202,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3233,7 +3222,7 @@ msgstr ""
 msgid "Manual"
 msgstr "Manuale"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3241,7 +3230,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3267,7 +3256,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr "Numero massimo indirizzi in contratto"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3280,7 +3269,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3292,11 +3281,11 @@ msgstr "Memoria"
 msgid "Memory usage (%)"
 msgstr "Uso Memoria (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3307,7 +3296,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrica"
 
@@ -3319,7 +3308,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3327,8 +3316,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Modalità"
@@ -3359,16 +3348,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3381,7 +3370,7 @@ msgstr "Voce di Mount"
 msgid "Mount Point"
 msgstr "Punto di Mount"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3431,7 +3420,7 @@ msgstr "Muovi giù"
 msgid "Move up"
 msgstr "Muovi su"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "ID della NAS"
 
@@ -3456,11 +3445,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Candidati server NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3468,7 +3457,7 @@ msgstr "Candidati server NTP"
 msgid "Name"
 msgstr "Nome"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Nome della nuova rete"
 
@@ -3478,8 +3467,8 @@ msgstr "Navigazione"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3512,7 +3501,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Prossimo »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3521,7 +3510,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Nessun Server DHCP configurato per questa interfaccia"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3533,7 +3522,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3564,11 +3553,12 @@ msgstr ""
 msgid "No password set!"
 msgstr "Nessuna password immessa!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3613,7 +3603,7 @@ msgstr ""
 msgid "None"
 msgstr "Nessuno"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normale"
 
@@ -3643,7 +3633,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Notifica"
 
@@ -3655,7 +3645,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3721,24 +3711,24 @@ msgstr "Apri lista..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Opzione cambiata"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Opzione cancellata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3752,41 +3742,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3846,7 +3836,7 @@ msgstr "Sovrascrivi TOS"
 msgid "Override TTL"
 msgstr "Sovrascrivi TTL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "Sovrascrivi nome interfaccia di default"
 
@@ -3870,7 +3860,7 @@ msgstr "Sovrascrivi la tabella usata per le route interne"
 msgid "Overview"
 msgstr "Riassunto"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3915,7 +3905,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3970,29 +3960,29 @@ msgid "Part of zone %q"
 msgstr "Parte della zona %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Password"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Password di authenticazione"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Password della chiave privata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -4000,31 +3990,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Percorso al certificato CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Percorso alla chiave privata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4051,7 +4041,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4071,7 +4061,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4111,7 +4101,7 @@ msgstr "Per favore inserisci il tuo username e la password."
 msgid "Policy"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Porta"
 
@@ -4147,7 +4137,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4166,11 +4156,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Impedisci la comunicazione fra Client"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4201,7 +4191,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protocollo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Fornisci server NTP"
 
@@ -4209,15 +4199,15 @@ msgstr "Fornisci server NTP"
 msgid "Provide new network"
 msgstr "Fornisci nuova rete"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "Chiave Pubblica"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4244,11 +4234,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4256,11 +4246,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Soglia RTS/CTS"
 
@@ -4276,31 +4266,31 @@ msgstr ""
 msgid "RX Rate"
 msgstr "Velocità RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4350,7 +4340,7 @@ msgstr "Traffico in Tempo Reale"
 msgid "Realtime Wireless"
 msgstr "Wireless in Tempo Reale"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4358,7 +4348,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Riavvia"
@@ -4376,7 +4366,7 @@ msgstr "Riavvia il sistema operativo del tuo dispositivo"
 msgid "Receive"
 msgstr "Ricezione"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4416,11 +4406,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Sostituisci configurazione wireless"
 
@@ -4436,7 +4426,7 @@ msgstr "Richiede prefisso-IPv6 di lunghezza"
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "Richiesto"
 
@@ -4444,42 +4434,42 @@ msgstr "Richiesto"
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4491,31 +4481,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4566,10 +4556,8 @@ msgstr "Ripristina"
 msgid "Restore backup"
 msgstr "Ripristina backup"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Rivela/nascondi password"
 
@@ -4577,15 +4565,15 @@ msgstr "Rivela/nascondi password"
 msgid "Revert"
 msgstr "Ripristina"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4601,7 +4589,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4617,8 +4605,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr ""
 
@@ -4660,8 +4648,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr ""
 
@@ -4677,14 +4665,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr ""
@@ -4693,19 +4681,17 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Salva"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salva & applica"
@@ -4718,24 +4704,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Operazioni programmate"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Sezione aggiunta"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Sezione rimossa"
 
@@ -4750,9 +4732,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4821,7 +4803,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4841,12 +4823,12 @@ msgstr ""
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Segnale"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4866,7 +4848,7 @@ msgstr "Dimensione"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4883,7 +4865,7 @@ msgstr "Salta a contenuto"
 msgid "Skip to navigation"
 msgstr "Salta a navigazione"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4925,10 +4907,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "Specifica la cartella a cui è collegato il dispositivo in"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Specifica la porta di ascolto di questa istanza <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4945,7 +4923,7 @@ msgstr ""
 "Specifica la quantità massima di secondi dopo di che si presume che gli host "
 "siano morti."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4968,7 +4946,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Specificare la chiave di cifratura qui."
 
@@ -4982,16 +4960,16 @@ msgstr "Inizio"
 msgid "Start priority"
 msgstr "Priorità di avvio"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Avvio"
 
@@ -5011,7 +4989,7 @@ msgstr "Contratti statici"
 msgid "Static Routes"
 msgstr "Instradamenti Statici"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5028,13 +5006,13 @@ msgstr ""
 "di configurazione non dinamici, dove solo gli host col contratto "
 "corrispondente vengono serviti."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Stato"
@@ -5049,12 +5027,12 @@ msgstr "Ferma"
 msgid "Strict order"
 msgstr "Ordine severo"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Invia"
 
@@ -5092,7 +5070,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5107,11 +5085,11 @@ msgstr "Cambia protocollo"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5121,7 +5099,7 @@ msgstr "Sincronizza con il browser"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5132,11 +5110,11 @@ msgstr "Sistema"
 msgid "System Log"
 msgstr "Registro di Sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Proprietà di Sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Dimensione Buffer Log di Sistema"
 
@@ -5204,7 +5182,7 @@ msgstr ""
 "Il prefisso IPv6 assegnati dal provider, si conclude di solito con <code>::</"
 "code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5218,7 +5196,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5268,11 +5246,11 @@ msgstr "Le seguenti regole sono al momento attive su questo sistema."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5302,7 +5280,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5316,7 +5294,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5324,13 +5302,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5343,7 +5321,7 @@ msgstr ""
 "address of your computer to reach the device again, depending on your "
 "settings."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5364,7 +5342,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Non ci sono contratti attivi."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5381,7 +5359,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5461,22 +5439,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "Questa pagina ti da una riassunto delle connessioni al momento attive."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Questa sezione non contiene ancora valori"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Sincronizzazione Orario"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Fuso orario"
 
@@ -5534,7 +5512,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5627,12 +5605,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5641,7 +5619,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5652,11 +5630,12 @@ msgstr "Non gestito"
 msgid "Unmount"
 msgstr "Smonta"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Modifiche non salvate"
 
@@ -5697,15 +5676,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Carica archivio..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5849,11 +5828,11 @@ msgstr ""
 msgid "Used"
 msgstr "Usato"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Slot Chiave Usata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5933,32 +5912,32 @@ msgstr "Verifica"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Sistema Aperto WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Chiave Condivisa WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "frase di accesso WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Modalità WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "frase di accesso WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5974,7 +5953,7 @@ msgstr "In attesa delle modifiche da applicare ..."
 msgid "Waiting for command to complete..."
 msgstr "In attesa del comando da completare..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5982,8 +5961,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Avviso"
 
@@ -5991,11 +5970,11 @@ msgstr "Avviso"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6007,7 +5986,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -6018,13 +5997,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Dispositivo Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6034,7 +6013,7 @@ msgstr "Rete Wireless"
 msgid "Wireless Overview"
 msgstr "Panoramica Wireless"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Sicurezza Wireless"
 
@@ -6054,11 +6033,11 @@ msgstr "La rete Wireless è disattivata"
 msgid "Wireless is not associated"
 msgstr "La rete Wireless è non associata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "La rete Wireless è disattivata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "La rete wireless è attivata"
 
@@ -6066,11 +6045,11 @@ msgstr "La rete wireless è attivata"
 msgid "Write received DNS requests to syslog"
 msgstr "Scrittura delle richiesta DNS ricevute nel syslog"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Scrivi registro di sistema su file"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6103,19 +6082,19 @@ msgstr ""
 "È necessario attivare JavaScript nel tuo browser o LuCI non funzionerà "
 "correttamente."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6126,7 +6105,7 @@ msgstr "qualsiasi"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6184,7 +6163,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "disabilita"
 
@@ -6285,7 +6264,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "File <abbr title=\"Sistema Nome Dominio\">DNS</abbr> locale"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6304,7 +6287,7 @@ msgstr "Nessun collegamento"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "nessuna"
 
@@ -6315,8 +6298,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6330,6 +6313,10 @@ msgstr "spento"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "acceso"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6348,7 +6335,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6362,8 +6349,8 @@ msgstr ""
 msgid "routed"
 msgstr "instradato"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6384,11 +6371,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "etichettato"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6407,7 +6398,7 @@ msgstr "sconosciuto"
 msgid "unlimited"
 msgstr "illimitato"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6588,6 +6579,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6598,6 +6593,15 @@ msgstr "Sì"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Indietro"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Disabilitato (default)"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Porte Gateway"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Specifica la porta di ascolto di questa istanza <em>Dropbear</em>"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Switch %q (%s)"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -2171,7 +2171,7 @@ msgstr "Gateway"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Porte Gateway"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6596,9 +6596,6 @@ msgstr "« Indietro"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Disabilitato (default)"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Porte Gateway"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Specifica la porta di ascolto di questa istanza <em>Dropbear</em>"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -2194,7 +2194,7 @@ msgstr "ゲートウェイ"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "ゲートウェイ ポート"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6702,9 +6702,6 @@ msgstr "« 戻る"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "無効（デフォルト）"
-
-#~ msgid "Gateway ports"
-#~ msgstr "ゲートウェイ ポート"
 
 #~ msgid "Loading SSH keys…"
 #~ msgstr "SSH 鍵をロード中…"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-06-10 03:40+0200\n"
-"PO-Revision-Date: 2019-09-15 20:03+0900\n"
+"PO-Revision-Date: 2019-09-21 17:09+0900\n"
 "Last-Translator: INAGAKI Hiroshi <musashino.open@gmail.com>\n"
 "Language-Team: \n"
 "Language: ja\n"
@@ -409,7 +409,7 @@ msgstr "VLAN を追加"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
 msgid "Add instance"
-msgstr ""
+msgstr "インスタンスを追加"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
@@ -1991,7 +1991,7 @@ msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
 msgid "Failed to change the system password."
-msgstr ""
+msgstr "システム パスワードの変更に失敗しました。"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
@@ -6366,7 +6366,7 @@ msgstr "ローカル <abbr title=\"Domain Name System\">DNS</abbr>ファイル"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
 msgid "medium security"
-msgstr ""
+msgstr "セキュリティ: 中"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
@@ -6416,7 +6416,7 @@ msgstr "オン"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
 msgid "open network"
-msgstr ""
+msgstr "オープン ネットワーク"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6473,7 +6473,7 @@ msgstr "ステートレス + ステートフル"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
 msgid "strong security"
-msgstr ""
+msgstr "セキュリティ: 強"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
@@ -6681,7 +6681,7 @@ msgstr "%d 文字以下の値"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
 msgid "weak security"
-msgstr ""
+msgstr "セキュリティ: 弱"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
@@ -6693,21 +6693,3 @@ msgstr "はい"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 戻る"
-
-#~ msgid "Change login password"
-#~ msgstr "ログイン パスワードの変更"
-
-#~ msgid "Changing password…"
-#~ msgstr "パスワードを変更中…"
-
-#~ msgid "Disabled (default)"
-#~ msgstr "無効（デフォルト）"
-
-#~ msgid "Loading SSH keys…"
-#~ msgstr "SSH 鍵をロード中…"
-
-#~ msgid "Saving keys…"
-#~ msgstr "公開鍵を保存中…"
-
-#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-#~ msgstr "<em>Dropbear</em> の待ち受けポートを設定してください。"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr "%.1f dB"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr "%d ビット"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr "無効な入力欄: %d 個"
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- 追加項目 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- 選択してください --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- 手動設定 --"
@@ -98,7 +99,7 @@ msgstr "-- UUID を指定 --"
 msgid "-- please select --"
 msgstr "-- 選択してください --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr "0: RSSI しきい値を使用しない, 1: ドライバのデフォルトを使用する"
 
@@ -110,7 +111,7 @@ msgstr "過去1分の負荷:"
 msgid "15 Minute Load:"
 msgstr "過去15分の負荷:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr "4 文字かつ 16 進数の ID"
 
@@ -123,35 +124,35 @@ msgstr "464XLAT (CLAT)"
 msgid "5 Minute Load:"
 msgstr "過去5分の負荷:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr "802.11r 高速ローミング"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr "802.11w アソシエーションSAクエリの最大タイムアウト時間です。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr "802.11w アソシエーションSAクエリの再試行タイムアウト時間です。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr "802.11w 管理フレーム保護"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr "802.11w 最大タイムアウト"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr "802.11w 再試行タイムアウト"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -171,7 +172,7 @@ msgstr ""
 "リゾルバファイルの順番に、<abbr title=\"Domain Name System\">DNS</abbr>サー"
 "バーに問い合わせを行います"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -208,7 +209,7 @@ msgstr ""
 "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-サフィックス (16進数)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 設定"
 
@@ -253,7 +254,7 @@ msgstr ""
 "<br />注意: 編集前の crontab ファイルが空の場合、手動で cron サービスの再起動"
 "を行う必要があります。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr "同名のディレクトリが既に存在します。"
 
@@ -331,8 +332,8 @@ msgstr "存在しないインターフェース"
 msgid "Access Concentrator"
 msgstr "Access Concentrator"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "アクセスポイント"
 
@@ -365,17 +366,17 @@ msgstr "アクティブなDHCPリース"
 msgid "Active DHCPv6 Leases"
 msgstr "アクティブなDHCPv6リース"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "アドホック"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -406,10 +407,13 @@ msgstr "LED の動作を追加"
 msgid "Add VLAN"
 msgstr "VLAN を追加"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr "公開鍵を追加"
 
@@ -424,7 +428,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "インターフェースの新規作成..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr "ピアを追加"
 
@@ -473,8 +477,8 @@ msgstr "管理画面"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -484,11 +488,11 @@ msgstr "詳細設定"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "警告"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -515,23 +519,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr "連続 IP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "<abbr title=\"Secure Shell\">SSH</abbr> パスワード認証を許可します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr "AP モード動作時に、低 ACK（確認応答）状態の STA の切断を許可します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "リスト内の端末からのアクセスを禁止"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "レガシー 802.11b レートを許可"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "リスト内の端末からのアクセスを許可"
 
@@ -539,16 +543,16 @@ msgstr "リスト内の端末からのアクセスを許可"
 msgid "Allow localhost"
 msgstr "ローカルホストを許可する"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "リモートホストがSSH転送されたローカルのポートに接続することを許可します。"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "パスワードでの root ログインを許可"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "パスワードを使用した <em>root</em> 権限でのログインを許可します。"
 
@@ -559,7 +563,7 @@ msgstr ""
 "上位サーバーからの特定範囲内 (127.0.0.0/8) の応答を許可します。例: RBL サービ"
 "スのため"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "許可されるIP"
 
@@ -567,7 +571,7 @@ msgstr "許可されるIP"
 msgid "Always announce default router"
 msgstr "常にデフォルト ルーターを通知する"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -650,7 +654,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -669,11 +673,11 @@ msgstr "アノニマス スワップ"
 msgid "Any zone"
 msgstr "全てのゾーン"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "適用リクエストはステータス <code>%h</code> で失敗しました"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr "チェック無しの適用"
 
@@ -701,7 +705,7 @@ msgstr ""
 "このサブ プレフィクス ID（16進数）を使用するプレフィクス領域を、このインター"
 "フェースに割り当てます。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "アソシエーション済み端末"
@@ -715,7 +719,7 @@ msgstr "アソシエーション数"
 msgid "Auth Group"
 msgstr "認証グループ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "認証"
 
@@ -810,7 +814,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -828,7 +832,7 @@ msgstr "設定へ戻る"
 msgid "Backup"
 msgstr "バックアップ"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "バックアップ / ファームウェア更新"
 
@@ -845,7 +849,7 @@ msgstr "無効なアドレスです!"
 msgid "Band"
 msgstr "バンド"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr "ビーコン間隔"
 
@@ -885,7 +889,7 @@ msgstr "ビットレート"
 msgid "Bogus NX Domain Override"
 msgstr "偽の NX ドメイン オーバーライド"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "ブリッジ"
@@ -903,7 +907,7 @@ msgstr "ブリッジ ユニット番号"
 msgid "Bring up on boot"
 msgstr "デフォルトで起動する"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr "参照..."
 
@@ -928,13 +932,13 @@ msgstr "CPU使用率 (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "キャンセル"
@@ -957,13 +961,7 @@ msgstr "注意: システムは強制的にアップグレードされます"
 msgid "Chain"
 msgstr "チェイン"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr "ログイン パスワードの変更"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "変更"
 
@@ -971,23 +969,19 @@ msgstr "変更"
 msgid "Changes applied."
 msgstr "変更が適用されました。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "変更は取り消されました。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "デバイスの管理者パスワードを変更します"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr "パスワードを変更中…"
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "チャネル"
@@ -1000,7 +994,7 @@ msgstr "チェック"
 msgid "Check filesystems before mount"
 msgstr "マウント前にファイルシステムをチェックする"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 "この無線から既存のネットワークを削除する場合、このオプションを有効にします。"
@@ -1014,7 +1008,7 @@ msgid "Choose mtdblock"
 msgstr "mtdblock を選択"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1026,7 +1020,7 @@ msgstr ""
 "フィールドにゾーン名を入力すると、新しくゾーンを作成し、このインターフェース"
 "に設定します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1034,7 +1028,7 @@ msgstr ""
 "無線インターフェースをアタッチするネットワークを選択してください。または、"
 "<em>作成</em>欄を選択すると新しいネットワークを作成します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "暗号化方式"
 
@@ -1058,9 +1052,9 @@ msgstr ""
 "指定した mtdblock ファイルをダウンロードするには、 \"mtdblock を保存\" をク"
 "リックしてください。（注: この機能はプロフェッショナル向けです！）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "クライアント"
 
@@ -1069,8 +1063,8 @@ msgstr "クライアント"
 msgid "Client ID to send when requesting DHCP"
 msgstr "DHCPリクエスト時に送信するクライアントID"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr "閉じる"
 
@@ -1095,7 +1089,7 @@ msgstr "リストを閉じる"
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1122,7 +1116,7 @@ msgstr "コマンド失敗"
 msgid "Comment"
 msgstr "コメント"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1134,7 +1128,7 @@ msgstr ""
 "この回避策は、相互運用性の問題や、特に高負荷のトラフィック環境下におけるキー "
 "ネゴシエーションの信頼性低下の原因となることがあります。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1150,11 +1144,11 @@ msgstr "設定が失敗しました"
 msgid "Configuration files will be kept"
 msgstr "設定ファイルは保持されます"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "設定が適用されました。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "設定はロールバックされました！"
 
@@ -1162,7 +1156,7 @@ msgstr "設定はロールバックされました！"
 msgid "Confirm disconnect"
 msgstr "切断の確認"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "確認"
 
@@ -1195,7 +1189,7 @@ msgstr "内容が保存されました。"
 msgid "Continue"
 msgstr "続行"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1209,12 +1203,12 @@ msgstr ""
 msgid "Country"
 msgstr "国"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "国コード"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "ファイアウォール ゾーンの作成 / 割り当て"
 
@@ -1222,11 +1216,11 @@ msgstr "ファイアウォール ゾーンの作成 / 割り当て"
 msgid "Create interface"
 msgstr "インターフェースを作成"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "重大"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Cronのログ出力レベル"
 
@@ -1263,15 +1257,15 @@ msgstr ""
 "<abbr title=\"Light Emitting Diode\">LED</abbr> デバイスの挙動をカスタマイズ"
 "します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1284,7 +1278,7 @@ msgstr "DHCPサーバー"
 msgid "DHCP and DNS"
 msgstr "DHCP 及び DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1357,7 +1351,7 @@ msgstr "DSL ステータス"
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr "DTIM インターバル"
 
@@ -1369,14 +1363,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "デバッグ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "標準設定 %d"
 
@@ -1416,47 +1410,47 @@ msgstr ""
 "追加のDHCPオプションを設定します。（例：\"<code>6,192.168.2.1,192.168.2.2</"
 "code>\" と設定することで、クライアントに指定のDNSサーバーを通知します。）"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "削除"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr "公開鍵を削除"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr "削除パーミッションが拒否されました"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr "削除リクエスト失敗: %d %s"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "ネットワークを削除します"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr "Delivery Traffic Indication Message インターバル"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "詳細"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "デザイン"
 
@@ -1487,7 +1481,7 @@ msgstr "宛先ゾーン"
 msgid "Device"
 msgstr "デバイス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "デバイス設定"
 
@@ -1504,7 +1498,7 @@ msgstr "デバイスを再起動中です..."
 msgid "Device is restarting…"
 msgstr "デバイスを再起動中..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "デバイスに到達できません"
 
@@ -1522,12 +1516,12 @@ msgstr "診断機能"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "ディレクトリ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "無効"
 
@@ -1543,14 +1537,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "暗号化を無効にする"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr "非アクティブ状態ポーリングを無効化"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "このネットワークを無効にします"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1562,11 +1557,7 @@ msgstr "このネットワークを無効にします"
 msgid "Disabled"
 msgstr "無効"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "無効（デフォルト）"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr "低 Acknowledgement 時のアソシエーション解除"
 
@@ -1585,21 +1576,19 @@ msgstr "切断"
 msgid "Disconnection attempt failed"
 msgstr "切断の試行が失敗しました"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "閉じる"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "距離の最適化"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "最も遠い端末との距離(メートル)を設定してください。"
 
@@ -1628,15 +1617,15 @@ msgstr "パブリック DNSサーバーが返答できなかったリクエス�
 msgid "Do not forward reverse lookups for local networks"
 msgstr "ローカル ネットワークへの逆引きを転送しません"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "本当に \"%s\" を削除しますか？"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr "本当に以下の SSH 公開鍵を削除しますか？"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "本当にディレクトリ \"%s\" を再帰的に削除しますか？"
 
@@ -1676,15 +1665,15 @@ msgstr "mtdblock のダウンロード"
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr "ドラッグして並び替え"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Dropbear設定"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1718,17 +1707,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr "EA ビット長"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP メソッド"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "編集"
 
@@ -1740,7 +1729,7 @@ msgstr ""
 "上記の設定データを直接編集してエラーを修正し、 \"保存\" ボタンを押してこの"
 "ページをリロードします。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "ネットワークを編集"
 
@@ -1748,12 +1737,12 @@ msgstr "ネットワークを編集"
 msgid "Edit wireless network"
 msgstr "無線ネットワークの編集"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "緊急"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "有効"
 
@@ -1790,7 +1779,7 @@ msgstr "PPPリンクのIPv6 ネゴシエーションを有効にする"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "ジャンボフレーム パススルーを有効にする"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "NTPクライアント機能を有効にする"
 
@@ -1806,11 +1795,11 @@ msgstr "TFTPサーバーを有効にする"
 msgid "Enable VLAN functionality"
 msgstr "VLAN機能を有効にする"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "WPS プッシュボタンを有効化するには、WPA(2)-PSKが必要です。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "Key Reinstallation (KRACK) 対策の有効化"
 
@@ -1834,7 +1823,7 @@ msgstr "カプセル化されたパケットの DF (Don't Fragment) フラグを
 msgid "Enable this mount"
 msgstr "マウント設定を有効にする"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "このネットワークを有効にします"
 
@@ -1856,7 +1845,7 @@ msgstr "有効"
 msgid "Enables IGMP snooping on this bridge"
 msgstr "ブリッジの IGMP スヌーピングを有効にします"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1879,17 +1868,17 @@ msgstr "カプセル化モード"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "暗号化モード"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr "エンドポイント ホスト"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr "エンドポイント ポート"
 
@@ -1901,7 +1890,7 @@ msgstr "カスタム値を入力"
 msgid "Enter custom values"
 msgstr "カスタム値を入力"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "消去中..."
 
@@ -1915,7 +1904,7 @@ msgstr "消去中..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "エラー"
 
@@ -1923,12 +1912,12 @@ msgstr "エラー"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "イーサネットアダプタ"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "イーサネットスイッチ"
@@ -1964,23 +1953,23 @@ msgstr ""
 msgid "External"
 msgstr "外部"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "外部システムログ サーバー"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "外部システムログ・サーバー ポート"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "外部システムログ・サーバー プロトコル"
 
@@ -1988,19 +1977,23 @@ msgstr "外部システムログ・サーバー プロトコル"
 msgid "Extra SSH command options"
 msgstr "拡張 SSHコマンドオプション"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "%d 秒以内の適用を確認できませんでした。ロールバック中です..."
 
@@ -2008,15 +2001,15 @@ msgstr "%d 秒以内の適用を確認できませんでした。ロールバッ
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr "\"/etc/init.d/%s %s\" の実行に失敗しました: %s"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "ファイル"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr "ファイル名"
 
@@ -2063,7 +2056,7 @@ msgstr "終了"
 msgid "Firewall"
 msgstr "ファイアウォール"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2103,7 +2096,7 @@ msgstr "ファームウェアの更新"
 msgid "Flash operations"
 msgstr "更新機能"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "更新中..."
 
@@ -2111,11 +2104,11 @@ msgstr "更新中..."
 msgid "Force"
 msgstr "強制"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "強制 40MHz モード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "CCMP (AES) を使用"
 
@@ -2124,11 +2117,11 @@ msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 "別のDHCPサーバーが検出された場合でも、DHCPサーバー機能を強制的に起動します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "TKIP を使用"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "TKIP 及びCCMP (AES) を使用"
 
@@ -2160,7 +2153,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "ブロードキャスト トラフィックを転送する"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2168,7 +2161,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "転送モード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "フラグメンテーションしきい値"
 
@@ -2177,7 +2170,7 @@ msgstr "フラグメンテーションしきい値"
 msgid "Free"
 msgstr "空き"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2199,19 +2192,19 @@ msgstr "GPRSのみ"
 msgid "Gateway"
 msgstr "ゲートウェイ"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr "無効なゲートウェイ アドレスです"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "ゲートウェイ ポート"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2219,8 +2212,8 @@ msgstr "一般設定"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "一般設定"
 
@@ -2228,7 +2221,7 @@ msgstr "一般設定"
 msgid "Generate Config"
 msgstr "コンフィグ生成"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2236,7 +2229,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "バックアップ アーカイブを生成"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "入力されたパスワードが一致しません。パスワードは変更されませんでした!"
 
@@ -2255,8 +2248,8 @@ msgstr "グローバル ネットワークオプション"
 msgid "Go to password configuration..."
 msgstr "パスワード設定へ移動..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2286,14 +2279,14 @@ msgstr "再起動"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr ""
 "このページではホスト名やタイムゾーンなどの基本的な設定を行うことが出来ます。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>の隠匿"
 
@@ -2304,7 +2297,7 @@ msgstr "空のチェインを非表示"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "ホスト"
 
@@ -2330,7 +2323,7 @@ msgstr "Host-Uniq タグ"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "ホスト名"
 
@@ -2351,7 +2344,7 @@ msgstr "ハイブリッド"
 msgid "IKE DH Group"
 msgstr "IKE DHグループ"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "IPアドレス"
 
@@ -2572,7 +2565,7 @@ msgstr "IPv6-over-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-over-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "識別子"
 
@@ -2688,7 +2681,7 @@ msgstr "未使用時タイムアウト"
 msgid "Inbound:"
 msgstr "受信:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "情報"
 
@@ -2728,7 +2721,7 @@ msgstr "プロトコル拡張機能をインストールします..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "インターフェース"
 
@@ -2737,7 +2730,7 @@ msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 "インターフェース %q のデバイスは、 %q から %q へ自動的に移行されました。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "インターフェース設定"
 
@@ -2767,7 +2760,7 @@ msgstr "インターフェースを開始中..."
 msgid "Interface is stopping..."
 msgstr "インターフェースを停止中..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "インターフェース名"
 
@@ -2797,7 +2790,7 @@ msgstr "内部サーバー エラー"
 msgid "Invalid"
 msgstr "入力値が不正です"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr "無効な Base64 キー文字列"
 
@@ -2817,7 +2810,7 @@ msgstr "無効な引数"
 msgid "Invalid command"
 msgstr "無効なコマンド"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr "無効な 16 進数値"
 
@@ -2826,7 +2819,7 @@ msgid "Invalid username and/or password! Please try again."
 msgstr ""
 "ユーザー名かパスワード、もしくは両方が不正です！もう一度入力してください。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "クライアント間の分離"
 
@@ -2845,15 +2838,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "JavaScriptを有効にしてください!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "ネットワークに接続する"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "ネットワークに接続する: 無線LANスキャン"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "ネットワークに接続: %q"
 
@@ -2870,15 +2863,15 @@ msgstr "カーネル ログ"
 msgid "Kernel Version"
 msgstr "カーネル バージョン"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "暗号キー"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "キー #%d"
 
@@ -2922,11 +2915,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "ラベル"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "言語"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "言語とスタイル"
 
@@ -2966,7 +2959,7 @@ msgstr "空欄の場合、自動検知を行います"
 msgid "Leave empty to use the current WAN address"
 msgstr "空欄の場合、現在のWANアドレスを使用します"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "凡例:"
 
@@ -3012,7 +3005,7 @@ msgstr ""
 "問い合わせを転送する<abbr title=\"Domain Name System\">DNS</abbr> サーバーの"
 "リストを設定します"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -3021,7 +3014,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3046,11 +3039,11 @@ msgstr "NX ドメインの偽の結果として返されるホストのリスト
 msgid "Listen Interfaces"
 msgstr "待ち受けインターフェース"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "待ち受けポート"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "指定されたインターフェースでのみ待ち受けを行います。設定しない場合はすべての"
@@ -3075,11 +3068,7 @@ msgstr "システム平均負荷"
 msgid "Loading"
 msgstr "ロード中"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr "SSH 鍵をロード中…"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr "ディレクトリ内を読み込み中..."
 
@@ -3119,7 +3108,7 @@ msgid "Local Startup"
 msgstr "ローカル スタートアップ"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "時刻"
 
@@ -3157,7 +3146,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "ローカライズクエリ"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "ログ出力レベル"
 
@@ -3165,7 +3154,7 @@ msgstr "ログ出力レベル"
 msgid "Log queries"
 msgstr "ログ クエリ"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "ログ"
 
@@ -3197,22 +3186,22 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-アドレス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "MAC-アドレス フィルタ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-フィルタ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC-リスト"
 
@@ -3240,7 +3229,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3261,7 +3250,7 @@ msgstr ""
 msgid "Manual"
 msgstr "手動"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr "マスター"
 
@@ -3269,7 +3258,7 @@ msgstr "マスター"
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr "許容される最大 Listen 間隔"
 
@@ -3295,7 +3284,7 @@ msgstr "モデムが準備完了状態になるまでの最大待ち時間"
 msgid "Maximum number of leased addresses."
 msgstr "リースされるアドレスの最大数です。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr "最大送信出力"
 
@@ -3308,7 +3297,7 @@ msgstr "最大送信出力"
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr "中"
 
@@ -3320,11 +3309,11 @@ msgstr "メモリー"
 msgid "Memory usage (%)"
 msgstr "メモリ使用率 (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr "メッシュ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr "メッシュ ID"
 
@@ -3335,7 +3324,7 @@ msgstr "メソッドが見つかりません"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "メトリック"
 
@@ -3347,7 +3336,7 @@ msgstr "ミラー監視ポート"
 msgid "Mirror source port"
 msgstr "ミラー元ポート"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr "モビリティ ドメイン"
 
@@ -3355,8 +3344,8 @@ msgstr "モビリティ ドメイン"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "モード"
@@ -3387,16 +3376,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "モデム初期化タイムアウト"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "モニター"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr "文字数不足"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr "さらに表示…"
 
@@ -3409,7 +3398,7 @@ msgstr "マウント機能"
 msgid "Mount Point"
 msgstr "マウントポイント"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3459,7 +3448,7 @@ msgstr "下へ移動"
 msgid "Move up"
 msgstr "上へ移動"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3484,11 +3473,11 @@ msgstr "NDP-プロキシ"
 msgid "NT Domain"
 msgstr "NT ドメイン"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "NTPサーバー候補"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3496,7 +3485,7 @@ msgstr "NTPサーバー候補"
 msgid "Name"
 msgstr "名前"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "新しいネットワークの名前"
 
@@ -3506,8 +3495,8 @@ msgstr "ナビゲーション"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3540,7 +3529,7 @@ msgstr "新規インターフェース名"
 msgid "Next »"
 msgstr "次 »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "いいえ"
@@ -3549,7 +3538,7 @@ msgstr "いいえ"
 msgid "No DHCP Server configured for this interface"
 msgstr "このインターフェースにはDHCPサーバーが設定されていません"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr "暗号化無し"
 
@@ -3561,7 +3550,7 @@ msgstr "NAT-Tを使用しない"
 msgid "No data received"
 msgstr "受信データ無し"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr "ディレクトリ内にエントリーがありません"
 
@@ -3592,11 +3581,12 @@ msgstr "ネガティブキャッシュを行なわない"
 msgid "No password set!"
 msgstr "パスワードが設定されていません!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr "まだ公開鍵はありません。"
 
@@ -3641,7 +3631,7 @@ msgstr "非ワイルドカード"
 msgid "None"
 msgstr "なし"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "標準"
 
@@ -3671,7 +3661,7 @@ msgstr "システム起動時に開始されません"
 msgid "Not supported"
 msgstr "サポートされていません"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "注意"
 
@@ -3685,7 +3675,7 @@ msgstr ""
 "キャッシュされる DNS エントリーの数です。（最大 10000 件。 0の場合はキャッ"
 "シュしません）"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr "圧縮に使用される、並列スレッド数です。"
 
@@ -3751,24 +3741,24 @@ msgstr "リストを開く..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr "OpenConnect (CISCO AnyConnect)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "動作周波数"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "変更されるオプション"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "削除されるオプション"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "オプション"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3786,21 +3776,21 @@ msgstr ""
 "ス（例: '::1'）を指定します。（オプション）　使用できる値: 'eui64', "
 "'random', または '::1' や '::1:2' のような固定値"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
@@ -3808,15 +3798,15 @@ msgstr ""
 "ピアのホストです。名前はインターフェースの起動前に解決されます。（オプショ"
 "ン）"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr "トンネル インターフェースのMaximum Transmission Unit（オプション）"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr "ピアのポート（オプション）"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
@@ -3824,7 +3814,7 @@ msgstr ""
 "キープアライブ メッセージの送信間隔（秒）です。既定値: ０。このデバイスがNAT"
 "以下に存在する場合の推奨値は25です。（オプション）"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "発信パケットと受信パケットに使用されるUDPポート（オプション）"
 
@@ -3884,7 +3874,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "デフォルトのインターフェース名を上書きします。"
 
@@ -3908,7 +3898,7 @@ msgstr "内部ルートに使用されるテーブルを上書きします。"
 msgid "Overview"
 msgstr "概要"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "既存のファイル \"%s\" を上書きしますか？"
 
@@ -3953,7 +3943,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr "PIN コードが拒否されました"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -4008,29 +3998,29 @@ msgid "Part of zone %q"
 msgstr "ゾーン %q の一部"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "パスワード"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "パスワード認証"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "秘密鍵のパスワード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "秘密鍵のパスワード"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr "パスワード強度"
 
@@ -4038,31 +4028,31 @@ msgstr "パスワード強度"
 msgid "Password2"
 msgstr "パスワード2"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr "貼付けまたは SSH 鍵ファイルをドラッグ…"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "CA証明書のパス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "クライアント証明書のパス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "秘密鍵のパス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "CA 証明書のパス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "クライアント証明書のパス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "秘密鍵のパス"
 
@@ -4089,7 +4079,7 @@ msgstr "割り当てるピア IP アドレス"
 msgid "Peer address is missing"
 msgstr "ピアのアドレスがありません"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr "ピア"
 
@@ -4109,7 +4099,7 @@ msgstr "設定リセットを実行"
 msgid "Permission denied"
 msgstr "パーミッション拒否"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr "永続的なキープアライブ"
 
@@ -4149,7 +4139,7 @@ msgstr "ユーザー名とパスワードを入力してください。"
 msgid "Policy"
 msgstr "ポリシー"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "ポート"
 
@@ -4185,7 +4175,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr "委任されたプレフィクス (PD)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr "事前共有鍵"
 
@@ -4206,11 +4196,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr "これらのインターフェースでの待ち受けを停止します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "クライアント同士の通信を制限します"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "秘密鍵"
 
@@ -4241,7 +4231,7 @@ msgstr "プロトコル"
 msgid "Protocol"
 msgstr "プロトコル"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "NTPサーバー機能を有効にする"
 
@@ -4249,15 +4239,15 @@ msgstr "NTPサーバー機能を有効にする"
 msgid "Provide new network"
 msgstr "新しいネットワークを設定します"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "擬似アドホック (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "公開鍵"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4290,11 +4280,11 @@ msgstr ""
 "アップストリームの利用可能な全 <abbr title=\"Domain Name System\">DNS</abbr> "
 "サーバを問い合わせます"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4302,11 +4292,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr "RFC3947 NAT-Tモード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr "ネットワーク参加の RSSI しきい値"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTSしきい値"
 
@@ -4322,31 +4312,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "受信レート"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr "受信レート / 送信レート"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Radiusアカウントサーバー ポート番号"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Radiusアカウント秘密鍵"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Radiusアカウントサーバー"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Radius認証サーバー ポート番号"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Radius認証秘密鍵"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Radius認証サーバー"
 
@@ -4401,7 +4391,7 @@ msgstr "リアルタイム・トラフィック"
 msgid "Realtime Wireless"
 msgstr "リアルタイム・無線LAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr "再アソシエーション制限時間"
 
@@ -4409,7 +4399,7 @@ msgstr "再アソシエーション制限時間"
 msgid "Rebind protection"
 msgstr "DNSリバインディング・プロテクション"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "再起動"
@@ -4427,7 +4417,7 @@ msgstr "デバイスのオペレーティングシステムを再起動します
 msgid "Receive"
 msgstr "受信"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr "WireGuard インターフェースのIPアドレスです。（推奨）"
 
@@ -4467,11 +4457,11 @@ msgstr "リモート IPv4アドレス"
 msgid "Remote IPv4 address or FQDN"
 msgstr "リモート IPv4アドレス または FQDN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "削除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "無線設定を置換する"
 
@@ -4487,7 +4477,7 @@ msgstr "リクエストするIPv6-プレフィクス長"
 msgid "Request timeout"
 msgstr "リクエスト タイムアウト"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "必須"
 
@@ -4495,42 +4485,42 @@ msgstr "必須"
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "DOCSIS 3.0を使用するいくつかのISPでは必要になります"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr "このインターフェースに使用するBase64-エンコード 秘密鍵（必須）"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr "hostapd が必要"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr "EAP サポートを含む hostapd が必要"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr "OWE サポートを含む hostapd が必要"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr "SAE サポートを含む hostapd が必要"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4546,31 +4536,31 @@ msgstr ""
 "未署名のドメイン レスポンスが、本当にその未署名のドメインから来たものであるか"
 "検証します。上位サーバが DNSSEC をサポートしている必要があります。"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr "wpa-supplicant が必要"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr "EAP サポートを含む wpa-supplicant が必要"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr "OWE サポートを含む wpa-supplicant が必要"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "SAE サポートを含む wpa-supplicant が必要"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4621,10 +4611,8 @@ msgstr "復元"
 msgid "Restore backup"
 msgstr "バックアップから復元する"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "パスワードを表示する/隠す"
 
@@ -4632,15 +4620,15 @@ msgstr "パスワードを表示する/隠す"
 msgid "Revert"
 msgstr "元に戻す"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "変更の取り消し"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "取り消しのリクエストはステータス <code>%h</code> で失敗しました"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "設定を元に戻しています..."
 
@@ -4656,7 +4644,7 @@ msgstr "TFTP経由でファイルを取り扱う際のルートディレクト�
 msgid "Root preparation"
 msgstr "ルートの準備"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4672,8 +4660,8 @@ msgstr "ルート タイプ"
 msgid "Router Advertisement-Service"
 msgstr "ルーター アドバタイズメント-サービス"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "ルーター パスワード"
 
@@ -4715,8 +4703,8 @@ msgstr "SHA256"
 msgid "SNR"
 msgstr "SNR"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH アクセス"
 
@@ -4732,14 +4720,14 @@ msgstr "SSH サーバーポート"
 msgid "SSH username"
 msgstr "SSH ユーザー名"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH キー"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4748,19 +4736,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "スワップ"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "保存"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存 & 適用"
@@ -4773,24 +4759,20 @@ msgstr "mtdblock を保存"
 msgid "Save mtdblock contents"
 msgstr "mtdblock の保存"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr "公開鍵を保存中…"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "スキャン"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "スケジュールタスク"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "追加されるセクション"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "削除されるセクション"
 
@@ -4808,9 +4790,9 @@ msgstr ""
 "を選択してください。ファームウェアが正しいこと、デバイスに適していることを確"
 "認できている場合にのみ使用してください！"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr "ファイルを選択..."
 
@@ -4881,7 +4863,7 @@ msgstr ""
 msgid "Short GI"
 msgstr "Short GI"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr "Short Preamble"
 
@@ -4901,12 +4883,12 @@ msgstr "インターフェースを終了します"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "信号強度"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr "信号強度 / ノイズ"
 
@@ -4926,7 +4908,7 @@ msgstr "サイズ"
 msgid "Size of DNS query cache"
 msgstr "DNS クエリ キャッシュのサイズ"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr "ZRam デバイスのサイズ (MB) です。"
 
@@ -4943,7 +4925,7 @@ msgstr "コンテンツへ移動"
 msgid "Skip to navigation"
 msgstr "ナビゲーションへ移動"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "ソフトウェア VLAN"
@@ -4984,10 +4966,6 @@ msgstr "アクセス元アドレス"
 msgid "Specifies the directory the device is attached to"
 msgstr "デバイスが接続するディレクトリを設定します"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "<em>Dropbear</em> の待ち受けポートを設定してください。"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -5001,7 +4979,7 @@ msgid ""
 "dead"
 msgstr "ホストが死亡しているとみなされるまでの秒数を指定します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -5030,7 +5008,7 @@ msgstr ""
 "デフォルト値 (1280 bytes) 以外の MTU (Maximum Transmission Unit) を指定しま"
 "す。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "暗号鍵を設定します。"
 
@@ -5044,16 +5022,16 @@ msgstr "開始"
 msgid "Start priority"
 msgstr "優先順位"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "設定の適用を開始しています..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "無線LANのスキャンを開始しています..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "スタートアップ"
 
@@ -5073,7 +5051,7 @@ msgstr "静的リース"
 msgid "Static Routes"
 msgstr "静的ルーティング"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5089,13 +5067,13 @@ msgstr ""
 "名をアサインします。また、クライアントは対応するリースを使用するホストがその1"
 "台のみで、かつ静的なインターフェース設定にする必要があります。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr "非アクティブなステーションの制限"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "ステータス"
@@ -5110,12 +5088,12 @@ msgstr "停止"
 msgid "Strict order"
 msgstr "問い合わせの制限"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr "強"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "送信"
 
@@ -5155,7 +5133,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "スイッチポート マスク"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "スイッチ VLAN"
@@ -5170,11 +5148,11 @@ msgstr "プロトコルの切り替え"
 msgid "Switch to CIDR list notation"
 msgstr "CIDR リスト表記へ切替"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr "シンボリックリンク"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr "NTP サーバーと同期"
 
@@ -5184,7 +5162,7 @@ msgstr "ブラウザの時刻と同期"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5195,11 +5173,11 @@ msgstr "システム"
 msgid "System Log"
 msgstr "システムログ"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "システム プロパティ"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "システムログ バッファサイズ"
 
@@ -5267,7 +5245,7 @@ msgstr ""
 "プロバイダに割り当てられる IPv6 プレフィクスです。通常、 <code>::</code> で終"
 "わります。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5283,7 +5261,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "設定ファイルは以下のエラーにより読み込めませんでした:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5343,11 +5321,11 @@ msgstr "このシステムでは、現在以下のルールが有効になって
 msgid "The gateway address must not be a local IP address"
 msgstr "ゲートウェイ アドレスは非ローカル IP アドレスでなければなりません"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr "入力された SSH 公開鍵は既に追加されています。"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5380,7 +5358,7 @@ msgstr "IPv6 プレフィクスの長さ (bit) です。"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr "ネットワーク名は既に使用されています"
 
@@ -5400,7 +5378,7 @@ msgstr ""
 "位のネットワークへの接続に使用するアップリンク ポートと、ローカル ネットワー"
 "ク用のその他のポートが存在します。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr "選択された %s モードは、 %s 暗号化と非互換です"
 
@@ -5408,13 +5386,13 @@ msgstr "選択された %s モードは、 %s 暗号化と非互換です"
 msgid "The submitted security token is invalid or already expired!"
 msgstr "送信されたセキュリティ トークンは無効もしくは期限切れです！"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "システムは設定領域を消去中です。完了後、自動的に再起動します。"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5426,7 +5404,7 @@ msgstr ""
 "わる可能性があるため、再接続時にあなたのコンピュータのIPアドレスを変更しなけ"
 "ればならない場合があります。"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "システム パスワードの変更に成功しました。"
 
@@ -5448,7 +5426,7 @@ msgstr "アクティブなリースはありません"
 msgid "There are no active leases."
 msgstr "リース中のIPアドレスはありません。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr "適用する変更はありません"
 
@@ -5467,7 +5445,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "リレーの IPv4 アドレス"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr "この認証タイプは、選択された EAP メソッドに適用できません。"
 
@@ -5557,22 +5535,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "このページでは、現在アクティブなネットワーク接続を表示します。"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "このセクションは未設定です。"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "時刻設定"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr "Group Temporal Key (GTK) 再生成間隔"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "タイムゾーン"
 
@@ -5630,7 +5608,7 @@ msgstr "トリガーモード"
 msgid "Tunnel ID"
 msgstr "トンネル ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "トンネルインターフェース"
@@ -5723,12 +5701,12 @@ msgstr "内容を保存できません: %s"
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "不明"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "不明なエラー (%s)"
@@ -5737,7 +5715,7 @@ msgstr "不明なエラー (%s)"
 msgid "Unknown error code"
 msgstr "不明なエラーコード"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5748,11 +5726,12 @@ msgstr "Unmanaged"
 msgid "Unmount"
 msgstr "アンマウント"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr "名称未設定の公開鍵"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "保存されていない変更"
 
@@ -5794,15 +5773,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "アーカイブをアップロード..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr "ファイルのアップロード"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr "ファイルをアップロード…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr "アップロード リクエスト失敗: %s"
 
@@ -5946,11 +5925,11 @@ msgstr ""
 msgid "Used"
 msgstr "使用"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "使用するキースロット"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -6030,32 +6009,32 @@ msgstr "確認"
 msgid "Virtual dynamic interface"
 msgstr "仮想ダイナミックインターフェース"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "WEP オープンシステム"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "WEP 共有キー"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP 暗号フレーズ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM モード"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA 暗号フレーズ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6072,7 +6051,7 @@ msgstr "変更を適用中です..."
 msgid "Waiting for command to complete..."
 msgstr "コマンド実行中です..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr "設定を適用中です… %d 秒"
 
@@ -6080,8 +6059,8 @@ msgstr "設定を適用中です… %d 秒"
 msgid "Waiting for device..."
 msgstr "デバイスを起動中です..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "警告"
 
@@ -6089,11 +6068,11 @@ msgstr "警告"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr "警告: 再起動すると消えてしまう、保存されていない設定があります！"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr "弱"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6108,7 +6087,7 @@ msgstr ""
 msgid "Width"
 msgstr "帯域幅"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr "WireGuard VPN"
@@ -6119,13 +6098,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "無線"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "無線アダプタ"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6135,7 +6114,7 @@ msgstr "無線ネットワーク"
 msgid "Wireless Overview"
 msgstr "無線LANデバイス一覧"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "無線LANセキュリティ"
 
@@ -6155,11 +6134,11 @@ msgstr "無線LAN機能は無効になっています"
 msgid "Wireless is not associated"
 msgstr "無線LAN機能がアソシエーションされていません"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "無線LAN機能は無効になっています"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "無線LAN機能は有効になっています"
 
@@ -6167,11 +6146,11 @@ msgstr "無線LAN機能は有効になっています"
 msgid "Write received DNS requests to syslog"
 msgstr "受信したDNSリクエストをsyslogへ記録します"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "システムログをファイルに書き込む"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "はい"
@@ -6203,19 +6182,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr "JavaScriptを有効にしない場合、LuCIは正しく動作しません。"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr "ZRam 圧縮アルゴリズム"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr "ZRam 圧縮ストリーム"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr "ZRam 設定"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr "ZRam サイズ"
 
@@ -6226,7 +6205,7 @@ msgstr "全て"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6284,7 +6263,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "無効"
 
@@ -6385,7 +6364,11 @@ msgstr "5 文字または 13 文字のキー"
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "ローカル <abbr title=\"Domain Name System\">DNS</abbr>ファイル"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "分"
 
@@ -6404,7 +6387,7 @@ msgstr "リンクなし"
 msgid "non-empty value"
 msgstr "空ではない値"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "なし"
 
@@ -6415,8 +6398,8 @@ msgid "not present"
 msgstr "存在しません"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6430,6 +6413,10 @@ msgstr "オフ"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "オン"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6448,7 +6435,7 @@ msgstr "正の値（10進数）"
 msgid "positive integer value"
 msgstr "正の整数値"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "ランダム"
 
@@ -6462,8 +6449,8 @@ msgstr "リレー モード"
 msgid "routed"
 msgstr "routed"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr "秒"
 
@@ -6484,11 +6471,15 @@ msgstr "ステートレス"
 msgid "stateless + stateful"
 msgstr "ステートレス + ステートフル"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "tagged"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6507,7 +6498,7 @@ msgstr "不明"
 msgid "unlimited"
 msgstr "無期限"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6688,6 +6679,10 @@ msgstr " %d 文字以上の値"
 msgid "value with at most %d characters"
 msgstr "%d 文字以下の値"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6698,3 +6693,24 @@ msgstr "はい"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 戻る"
+
+#~ msgid "Change login password"
+#~ msgstr "ログイン パスワードの変更"
+
+#~ msgid "Changing password…"
+#~ msgstr "パスワードを変更中…"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "無効（デフォルト）"
+
+#~ msgid "Gateway ports"
+#~ msgstr "ゲートウェイ ポート"
+
+#~ msgid "Loading SSH keys…"
+#~ msgstr "SSH 鍵をロード中…"
+
+#~ msgid "Saving keys…"
+#~ msgstr "公開鍵を保存中…"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "<em>Dropbear</em> の待ち受けポートを設定してください。"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr ""
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr "1 분 부하:"
 msgid "15 Minute Load:"
 msgstr "15 분 부하:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "5 분 부하:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr ""
 
@@ -169,7 +170,7 @@ msgid ""
 "order of the resolvfile"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -203,7 +204,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 설정"
 
@@ -246,7 +247,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -324,8 +325,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr ""
 
@@ -358,17 +359,17 @@ msgstr "Active DHCP 임대 목록"
 msgid "Active DHCPv6 Leases"
 msgstr "Active DHCPv6 임대 목록"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -399,10 +400,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -415,7 +419,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "새로운 인터페이스 추가..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -464,8 +468,8 @@ msgstr "관리"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -475,11 +479,11 @@ msgstr "고급 설정"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -505,23 +509,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "<abbr title=\"Secure Shell\">SSH</abbr> 암호 인증을 허용합니다"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr ""
 
@@ -529,15 +533,15 @@ msgstr ""
 msgid "Allow localhost"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "암호를 이용한 root 접근 허용"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "암호를 이용한 <em>root</em> 사용자 접근을 허용합니다"
 
@@ -546,7 +550,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -554,7 +558,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -633,7 +637,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -652,11 +656,11 @@ msgstr ""
 msgid "Any zone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -680,7 +684,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "연결된 station 들"
@@ -694,7 +698,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr ""
 
@@ -789,7 +793,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr ""
@@ -807,7 +811,7 @@ msgstr "설정으로 돌아가기"
 msgid "Backup"
 msgstr "백업"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Firmware 백업 / Flash"
 
@@ -824,7 +828,7 @@ msgstr ""
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -862,7 +866,7 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr ""
@@ -880,7 +884,7 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr "부팅시 활성화"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -905,13 +909,13 @@ msgstr "CPU 사용량 (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr ""
@@ -934,13 +938,7 @@ msgstr ""
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "변경 사항"
 
@@ -948,23 +946,19 @@ msgstr "변경 사항"
 msgid "Changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "장비 접근을 위한 관리자 암호를 변경합니다"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr ""
@@ -977,7 +971,7 @@ msgstr ""
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -990,7 +984,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1002,7 +996,7 @@ msgstr ""
 "운 zone 을 정의하고 인터페이스 연결을 원한다면 <em>create</em> 항목을 입력하"
 "세요."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1010,7 +1004,7 @@ msgstr ""
 "이 무선랜 인터페이스와 연결하고자 하는 네트워크(들)을 선택하세요. 혹은 새로"
 "운 네트워크를 정의할려면 <em>create</em> 을 작성하세요."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1032,9 +1026,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr ""
 
@@ -1043,8 +1037,8 @@ msgstr ""
 msgid "Client ID to send when requesting DHCP"
 msgstr "DHCP 요청시 전송할 Client ID"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1067,7 +1061,7 @@ msgstr "목록 닫기..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1094,7 +1088,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1102,7 +1096,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1118,11 +1112,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1130,7 +1124,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "다시 확인"
 
@@ -1163,7 +1157,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1174,12 +1168,12 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Firewall-zone 생성 / 할당"
 
@@ -1187,11 +1181,11 @@ msgstr "Firewall-zone 생성 / 할당"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr ""
 
@@ -1226,15 +1220,15 @@ msgstr ""
 "원한다면 장치에 부착된 <abbr title=\"Light Emitting Diode\">LED</abbr> 들의 "
 "행동을 마음대로 변경할 수 있습니다."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1247,7 +1241,7 @@ msgstr "DHCP 서버"
 msgid "DHCP and DNS"
 msgstr "DHCP 와 DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1320,7 +1314,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1332,14 +1326,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr ""
 
@@ -1380,47 +1374,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" 는 client 에게 다른 DNS 서버를 세"
 "팅하도록 권고할 수 있습니다."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "삭제"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "이 네트워크를 삭제합니다"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "설명"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "디자인"
 
@@ -1451,7 +1445,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "장치 설정"
 
@@ -1468,7 +1462,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1486,12 +1480,12 @@ msgstr "진단"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "비활성화"
 
@@ -1507,14 +1501,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1526,11 +1521,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1549,21 +1540,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr ""
 
@@ -1590,15 +1579,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1636,15 +1625,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1677,17 +1666,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "수정"
 
@@ -1697,7 +1686,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "이 네트워크를 수정합니다"
 
@@ -1705,12 +1694,12 @@ msgstr "이 네트워크를 수정합니다"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "활성화"
 
@@ -1745,7 +1734,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "NTP client 활성화"
 
@@ -1761,11 +1750,11 @@ msgstr "TFTP 서버 활성화"
 msgid "Enable VLAN functionality"
 msgstr "VLAN 기능 활성화"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1789,7 +1778,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1811,7 +1800,7 @@ msgstr "활성화됨"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1832,17 +1821,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "암호화"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1854,7 +1843,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr ""
 
@@ -1868,7 +1857,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr ""
 
@@ -1876,12 +1865,12 @@ msgstr ""
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet 스위치"
@@ -1915,23 +1904,23 @@ msgstr "임대한 주소의 유효 시간.  최소값은  2 분 (<code>2m</code>
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "외부 system log 서버"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "외부 system log 서버 포트"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "외부 system log 서버 프로토콜"
 
@@ -1939,19 +1928,23 @@ msgstr "외부 system log 서버 프로토콜"
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1959,15 +1952,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2012,7 +2005,7 @@ msgstr ""
 msgid "Firewall"
 msgstr "방화벽"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2052,7 +2045,7 @@ msgstr "새로운 firmware 이미지로 flash"
 msgid "Flash operations"
 msgstr "Flash 작업"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2060,11 +2053,11 @@ msgstr ""
 msgid "Force"
 msgstr "강제하기"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr ""
 
@@ -2072,11 +2065,11 @@ msgstr ""
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "다른 DHCP 서버가 탐지되더라도 이 네트워크에 DHCP 를 강제합니다."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
@@ -2108,7 +2101,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2116,7 +2109,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr ""
 
@@ -2125,7 +2118,7 @@ msgstr ""
 msgid "Free"
 msgstr "이용 가능한 양"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2147,19 +2140,19 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2167,8 +2160,8 @@ msgstr "기본 설정"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "기본 설정"
 
@@ -2176,7 +2169,7 @@ msgstr "기본 설정"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2184,7 +2177,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "아카이브 생성"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2203,8 +2196,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "암호 설정 하기"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2234,14 +2227,14 @@ msgstr ""
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr ""
 "여기서 호스트이름이나 시간대와 같은 기본적인 장비 설정을 할 수 있습니다."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr> 숨기기"
 
@@ -2252,7 +2245,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "호스트"
 
@@ -2277,7 +2270,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "호스트이름"
 
@@ -2298,7 +2291,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2519,7 +2512,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr ""
 
@@ -2625,7 +2618,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr ""
 
@@ -2663,7 +2656,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "인터페이스"
 
@@ -2671,7 +2664,7 @@ msgstr "인터페이스"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "인터페이스 설정"
 
@@ -2701,7 +2694,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "인터페이스 이름"
 
@@ -2731,7 +2724,7 @@ msgstr ""
 msgid "Invalid"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2751,7 +2744,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2759,7 +2752,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2776,15 +2769,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "네트워크 연결"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "네트워크 연결: 무선랜 스캔 결과"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "네트워크 연결중: %q"
 
@@ -2801,15 +2794,15 @@ msgstr "Kernel 로그"
 msgid "Kernel Version"
 msgstr "Kernel 버전"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2853,11 +2846,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "언어"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "언어와 스타일"
 
@@ -2897,7 +2890,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2940,7 +2933,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2949,7 +2942,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2974,11 +2967,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "지정한 인터페이스에만 listening 하며 미지정시 모든 인터페이스에 적용됩니다"
@@ -3002,11 +2995,7 @@ msgstr "부하 평균"
 msgid "Loading"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3046,7 +3035,7 @@ msgid "Local Startup"
 msgstr "Local 시작 프로그램"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "지역 시간"
 
@@ -3078,7 +3067,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Log output 레벨"
 
@@ -3086,7 +3075,7 @@ msgstr "Log output 레벨"
 msgid "Log queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3117,22 +3106,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-주소"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "MAC-주소 필터"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-필터"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr ""
 
@@ -3160,7 +3149,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3180,7 +3169,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3188,7 +3177,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3214,7 +3203,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr "임대될 수 있는 주소의 최대 숫자."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3227,7 +3216,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3239,11 +3228,11 @@ msgstr "메모리"
 msgid "Memory usage (%)"
 msgstr "메모리 사용량 (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3254,7 +3243,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
 
@@ -3266,7 +3255,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3274,8 +3263,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr ""
@@ -3306,16 +3295,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3328,7 +3317,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3376,7 +3365,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr ""
 
@@ -3401,11 +3390,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "NTP 서버 목록"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3413,7 +3402,7 @@ msgstr "NTP 서버 목록"
 msgid "Name"
 msgstr "이름"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr ""
 
@@ -3423,8 +3412,8 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3457,7 +3446,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3466,7 +3455,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3478,7 +3467,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3509,11 +3498,12 @@ msgstr ""
 msgid "No password set!"
 msgstr "암호 설정을 해주세요!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3558,7 +3548,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr ""
 
@@ -3588,7 +3578,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr ""
 
@@ -3600,7 +3590,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3666,24 +3656,24 @@ msgstr "목록 열람..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "동작 주파수"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "변경된 option"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "삭제된 option"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3697,41 +3687,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3791,7 +3781,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "기본 인터페이스 이름을 덮어씁니다"
 
@@ -3815,7 +3805,7 @@ msgstr ""
 msgid "Overview"
 msgstr "개요"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3860,7 +3850,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3915,29 +3905,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "암호"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "암호 인증"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3945,31 +3935,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3996,7 +3986,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4016,7 +4006,7 @@ msgstr "Reset 하기"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4056,7 +4046,7 @@ msgstr "사용자이름과 암호를 입력해 주세요."
 msgid "Policy"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "포트"
 
@@ -4092,7 +4082,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4111,11 +4101,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4146,7 +4136,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "프로토콜"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4154,15 +4144,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr "새로운 네트워크를 추가합니다"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4189,11 +4179,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4201,11 +4191,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr ""
 
@@ -4221,31 +4211,31 @@ msgstr ""
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4295,7 +4285,7 @@ msgstr "실시간 트래픽"
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4303,7 +4293,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "재부팅"
@@ -4321,7 +4311,7 @@ msgstr "장치의 운영체제를 재부팅합니다"
 msgid "Receive"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4361,11 +4351,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "제거"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4381,7 +4371,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4389,42 +4379,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "특정 ISP 들에 요구됨.  예: Charter (DOCSIS 3 기반)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4436,31 +4426,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4511,10 +4501,8 @@ msgstr "복구"
 msgid "Restore backup"
 msgstr "백업 복구"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "암호 보이기/숨기기"
 
@@ -4522,15 +4510,15 @@ msgstr "암호 보이기/숨기기"
 msgid "Revert"
 msgstr "변경 취소"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4546,7 +4534,7 @@ msgstr "TFTP 를 통해 제공되는 파일들의 root 디렉토리"
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4562,8 +4550,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "라우터 암호"
 
@@ -4605,8 +4593,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr ""
 
@@ -4622,14 +4610,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4638,19 +4626,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "저장"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "저장 & 적용"
@@ -4663,24 +4649,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Scan 하기"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "작업 관리"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "추가된 section"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "삭제된 section"
 
@@ -4695,9 +4677,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4766,7 +4748,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4786,12 +4768,12 @@ msgstr "이 인터페이스를 정지합니다"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "신호"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4811,7 +4793,7 @@ msgstr "Size"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4828,7 +4810,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4866,10 +4848,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "<em>Dropbear</em> instance 의 listening 포트를 지정합니다"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4882,7 +4860,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4905,7 +4883,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4919,16 +4897,16 @@ msgstr "시작"
 msgid "Start priority"
 msgstr "시작 우선순위"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "시작 프로그램"
 
@@ -4948,7 +4926,7 @@ msgstr "Static Lease 들"
 msgid "Static Routes"
 msgstr "Static Route 경로"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4964,13 +4942,13 @@ msgstr ""
 "할 때 사용됩니다.  이 기능은 또한 지정된 host 에 대해서만 주소 임대를 하도록 "
 "하는 non-dynamic 인터페이스 설정에도 사용됩니다."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "상태"
@@ -4985,12 +4963,12 @@ msgstr "정지"
 msgid "Strict order"
 msgstr "Strict order"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "제출하기"
 
@@ -5028,7 +5006,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "스위치 VLAN"
@@ -5043,11 +5021,11 @@ msgstr "프로토콜 변경"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5057,7 +5035,7 @@ msgstr "브라우저 시간대로 동기화"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5068,11 +5046,11 @@ msgstr "시스템"
 msgid "System Log"
 msgstr "시스템 로그"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "시스템 등록 정보"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "System log 버퍼 크기"
 
@@ -5138,7 +5116,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5152,7 +5130,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5198,11 +5176,11 @@ msgstr "다음의 rule 들이 현재 이 시스템에 적용 중입니다."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5232,7 +5210,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5251,7 +5229,7 @@ msgstr ""
 "segment 들을 분리하는데 사용되기도 합니다. 한 개의 uplink 포트가 인터넷에 연"
 "결되어 있고 나머지 포트들은 local 네트워크로 연결되는 구성에 자주 사용됩니다."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5259,13 +5237,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5273,7 +5251,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5292,7 +5270,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5311,7 +5289,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5391,22 +5369,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "이 페이지는 현재 active 상태인 네트워크 연결을 보여줍니다."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "이 section 은 아직 입력된 값이 없습니다"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "시간 동기화"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "시간대"
 
@@ -5464,7 +5442,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5557,12 +5535,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "알수없음"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5571,7 +5549,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5582,11 +5560,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "적용 안된 변경 사항"
 
@@ -5627,15 +5606,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "아카이브 업로드..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5778,11 +5757,11 @@ msgstr ""
 msgid "Used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5862,32 +5841,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM Mode"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5901,7 +5880,7 @@ msgstr "변경 사항이 적용되기를 기다리는 중입니다..."
 msgid "Waiting for command to complete..."
 msgstr "실행한 명령이 끝나기를 기다리는 중입니다..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5909,8 +5888,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr ""
 
@@ -5918,11 +5897,11 @@ msgstr ""
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5934,7 +5913,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5945,13 +5924,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "무선"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5961,7 +5940,7 @@ msgstr "무선랜 네트워크"
 msgid "Wireless Overview"
 msgstr "무선랜 개요"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "무선랜 보안"
 
@@ -5981,11 +5960,11 @@ msgstr "무선이 비활성화되어"
 msgid "Wireless is not associated"
 msgstr "무선이 연결되어 있지 않습니다"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "무선 네트워크가 꺼져 있음"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "무선 네트워크가 켜져 있음"
 
@@ -5993,11 +5972,11 @@ msgstr "무선 네트워크가 켜져 있음"
 msgid "Write received DNS requests to syslog"
 msgstr "받은 DNS 요청 내용을 systlog 에 기록합니다"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "System log 출력 파일 경로"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6027,19 +6006,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6050,7 +6029,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6108,7 +6087,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr ""
 
@@ -6209,7 +6188,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "local <abbr title=\"Domain Name System\">DNS</abbr> 파일"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6228,7 +6211,7 @@ msgstr "link 없음"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr ""
 
@@ -6239,8 +6222,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6253,6 +6236,10 @@ msgstr ""
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:205
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
@@ -6272,7 +6259,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6286,8 +6273,8 @@ msgstr ""
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6308,11 +6295,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6331,7 +6322,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6512,6 +6503,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6522,6 +6517,9 @@ msgstr ""
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr ""
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "<em>Dropbear</em> instance 의 listening 포트를 지정합니다"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "스위치 %q (%s)"

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Gelanggang Tambahan --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Sila pilih --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- memperibadi --"
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr ""
 msgid "15 Minute Load:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -169,7 +170,7 @@ msgid ""
 "order of the resolvfile"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "<abbr title=\"perkhidmatan set mengenalpasti diperpanjangkan\">ESSID</abbr>"
@@ -204,7 +205,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Konfigurasi lampu LED"
 
@@ -243,7 +244,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -321,8 +322,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Pusat akses"
 
@@ -353,17 +354,17 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -394,10 +395,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -410,7 +414,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -459,8 +463,8 @@ msgstr "Pentadbiran"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -470,11 +474,11 @@ msgstr "Tetapan Lanjutan"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -500,23 +504,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Membenarkan pengesahan kata laluan SSH"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Izinkan semua kecualian yang disenaraikan"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Izinkan senarai saja"
 
@@ -524,15 +528,15 @@ msgstr "Izinkan senarai saja"
 msgid "Allow localhost"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 
@@ -541,7 +545,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -549,7 +553,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -628,7 +632,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -647,11 +651,11 @@ msgstr ""
 msgid "Any zone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -675,7 +679,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Associated Stesen"
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Authentifizierung"
 
@@ -784,7 +788,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr ""
@@ -802,7 +806,7 @@ msgstr ""
 msgid "Backup"
 msgstr "Sandaran"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr ""
 
@@ -819,7 +823,7 @@ msgstr ""
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -854,7 +858,7 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bridge"
@@ -872,7 +876,7 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -897,13 +901,13 @@ msgstr "Penggunaan CPU (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Batal"
@@ -926,13 +930,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Rantai"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Laman"
 
@@ -940,23 +938,19 @@ msgstr "Laman"
 msgid "Changes applied."
 msgstr "Laman diterapkan."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
-msgstr ""
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Saluran"
@@ -969,7 +963,7 @@ msgstr ""
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -982,7 +976,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -990,13 +984,13 @@ msgid ""
 "interface to it."
 msgstr "Pilih zon firewall yang anda ingin tetapkan untuk antar muka ini."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1016,9 +1010,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 #, fuzzy
 msgid "Client"
 msgstr "Pelanggan"
@@ -1028,8 +1022,8 @@ msgstr "Pelanggan"
 msgid "Client ID to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1052,7 +1046,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1079,7 +1073,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1087,7 +1081,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1103,11 +1097,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1115,7 +1109,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Pengesahan"
 
@@ -1148,7 +1142,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1159,12 +1153,12 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Kod negara"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Buat / Menetapkan dinding api-zon"
 
@@ -1172,11 +1166,11 @@ msgstr "Buat / Menetapkan dinding api-zon"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr ""
 
@@ -1209,15 +1203,15 @@ msgid ""
 "\">LED</abbr>s if possible."
 msgstr "Mengkustomisasi perilaku peranti LED jika mungkin."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1230,7 +1224,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1303,7 +1297,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1315,14 +1309,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr ""
 
@@ -1360,47 +1354,47 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Padam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Keterangan"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Disain"
 
@@ -1431,7 +1425,7 @@ msgstr ""
 msgid "Device"
 msgstr "Alat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr ""
 
@@ -1448,7 +1442,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr ""
 
@@ -1485,14 +1479,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1504,11 +1499,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1527,21 +1518,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Jarak Optimasi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Jarak ke rangkaian terjauh ahli dalam meter."
 
@@ -1570,15 +1559,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1616,15 +1605,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1654,17 +1643,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP-Kaedah"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Sunting"
 
@@ -1674,7 +1663,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr ""
 
@@ -1682,12 +1671,12 @@ msgstr ""
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr ""
 
@@ -1722,7 +1711,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1738,11 +1727,11 @@ msgstr ""
 msgid "Enable VLAN functionality"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1766,7 +1755,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1788,7 +1777,7 @@ msgstr ""
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1809,17 +1798,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Enkripsi"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1831,7 +1820,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr ""
 
@@ -1845,7 +1834,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Kesalahan"
 
@@ -1853,12 +1842,12 @@ msgstr "Kesalahan"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet Adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet Beralih"
@@ -1892,23 +1881,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1916,19 +1905,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1936,15 +1929,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -1989,7 +1982,7 @@ msgstr "Selesai"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2029,7 +2022,7 @@ msgstr ""
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2037,11 +2030,11 @@ msgstr ""
 msgid "Force"
 msgstr "Paksa"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr ""
 
@@ -2049,11 +2042,11 @@ msgstr ""
 msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
@@ -2085,7 +2078,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2093,7 +2086,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Fragmentasi Ambang"
 
@@ -2102,7 +2095,7 @@ msgstr "Fragmentasi Ambang"
 msgid "Free"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2124,19 +2117,19 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2144,8 +2137,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Setup Umum"
 
@@ -2153,7 +2146,7 @@ msgstr "Setup Umum"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2161,7 +2154,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2180,8 +2173,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2211,7 +2204,7 @@ msgstr "Menutup"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2219,7 +2212,7 @@ msgstr ""
 "Di sini anda boleh mengkonfigurasi aspek asas peranti anda seperti nama host "
 "atau zon."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Menyembunyikan ESSID"
 
@@ -2230,7 +2223,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2255,7 +2248,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Nama Host"
 
@@ -2276,7 +2269,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2497,7 +2490,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identiti"
 
@@ -2608,7 +2601,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr ""
 
@@ -2646,7 +2639,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
 
@@ -2654,7 +2647,7 @@ msgstr "Interface"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr ""
 
@@ -2684,7 +2677,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2714,7 +2707,7 @@ msgstr ""
 msgid "Invalid"
 msgstr "Tak Sah"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2734,7 +2727,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2742,7 +2735,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Username dan / atau password tak sah! Sila cuba lagi."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2762,16 +2755,16 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 #, fuzzy
 msgid "Join Network"
 msgstr "Gabung Rangkaian"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2788,15 +2781,15 @@ msgstr "Log Kernel"
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Kunci"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2840,11 +2833,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Bahasa"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr ""
 
@@ -2884,7 +2877,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2926,7 +2919,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2935,7 +2928,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2960,11 +2953,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -2987,11 +2980,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3031,7 +3020,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Masa Tempatan"
 
@@ -3063,7 +3052,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Soalan tempatan"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3071,7 +3060,7 @@ msgstr ""
 msgid "Log queries"
 msgstr "Log soalan"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3102,22 +3091,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Penapis alamat MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Penapis MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Senarai MAC"
 
@@ -3145,7 +3134,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3165,7 +3154,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3173,7 +3162,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3199,7 +3188,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3212,7 +3201,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3224,11 +3213,11 @@ msgstr "Memori"
 msgid "Memory usage (%)"
 msgstr "Penggunaan Memori (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3239,7 +3228,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrik"
 
@@ -3251,7 +3240,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3259,8 +3248,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Mode"
@@ -3291,16 +3280,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3313,7 +3302,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr "Mount Point"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3363,7 +3352,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3388,11 +3377,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3400,7 +3389,7 @@ msgstr ""
 msgid "Name"
 msgstr "Nama"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Nama rangkaian baru"
 
@@ -3410,8 +3399,8 @@ msgstr "Navigation"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3444,7 +3433,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Kemudian »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3453,7 +3442,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3465,7 +3454,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3496,11 +3485,12 @@ msgstr ""
 msgid "No password set!"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3545,7 +3535,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr ""
 
@@ -3575,7 +3565,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr ""
 
@@ -3587,7 +3577,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3653,24 +3643,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3684,41 +3674,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3778,7 +3768,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3800,7 +3790,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Keseluruhan"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3845,7 +3835,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3900,29 +3890,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Kata laluan"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Kata laluan pengesahan"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Kata Laluan Kunci Swasta"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3930,31 +3920,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Path ke CA-Sijil"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Path ke Kunci Swasta"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3981,7 +3971,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4001,7 +3991,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4041,7 +4031,7 @@ msgstr "Sila masukkan username dan kata laluan anda."
 msgid "Policy"
 msgstr "Dasar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4077,7 +4067,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4096,11 +4086,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Mencegah komunikasi sesama Pelanggan"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4131,7 +4121,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protokol"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4139,15 +4129,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4174,11 +4164,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4186,11 +4176,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS-Ambang"
 
@@ -4207,31 +4197,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4279,7 +4269,7 @@ msgstr ""
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4287,7 +4277,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reboot"
@@ -4305,7 +4295,7 @@ msgstr "Reboot sistem operasi peranti anda"
 msgid "Receive"
 msgstr "Menerima"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4345,11 +4335,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Menghapuskan"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4365,7 +4355,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4373,42 +4363,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4420,31 +4410,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4495,10 +4485,8 @@ msgstr "Mengembalikan"
 msgid "Restore backup"
 msgstr "Kembalikan sandaran"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr ""
 
@@ -4506,15 +4494,15 @@ msgstr ""
 msgid "Revert"
 msgstr "Kembali"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4530,7 +4518,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4546,8 +4534,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr ""
 
@@ -4589,8 +4577,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr ""
 
@@ -4606,14 +4594,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4622,19 +4610,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Simpan"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Simpan & Melaksanakan"
@@ -4647,24 +4633,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Tugas Jadual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr ""
 
@@ -4679,9 +4661,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4750,7 +4732,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4770,12 +4752,12 @@ msgstr ""
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Isyarat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4795,7 +4777,7 @@ msgstr "Saiz"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4812,7 +4794,7 @@ msgstr "Skip ke kadar"
 msgid "Skip to navigation"
 msgstr "Skip ke navigation"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4850,10 +4832,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4866,7 +4844,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4889,7 +4867,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4903,16 +4881,16 @@ msgstr "Mula"
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr ""
 
@@ -4932,7 +4910,7 @@ msgstr "Statische Einträge"
 msgid "Static Routes"
 msgstr "Laluan Statik"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4945,13 +4923,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -4966,12 +4944,12 @@ msgstr ""
 msgid "Strict order"
 msgstr "Order Ketat"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Menyerahkan"
 
@@ -5009,7 +4987,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5024,11 +5002,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5038,7 +5016,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5049,11 +5027,11 @@ msgstr "Sistem"
 msgid "System Log"
 msgstr "Log Sistem"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5120,7 +5098,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5136,7 +5114,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5186,11 +5164,11 @@ msgstr "Peraturan berikut sedang aktif pada sistem ini."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5220,7 +5198,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5234,7 +5212,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5242,13 +5220,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5261,7 +5239,7 @@ msgstr ""
 "anda perlu mengemas kini alamat komputer anda untuk mencapai peranti lagi, "
 "bergantung pada tetapan anda."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5282,7 +5260,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5299,7 +5277,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5379,22 +5357,22 @@ msgstr ""
 "Laman ini memberikan gambaran lebih dari saat ini sambungan rangkaian yang "
 "aktif."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Bahagian ini belum mengandungi nilai-nilai lagi"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Zon masa"
 
@@ -5449,7 +5427,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5542,12 +5520,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5556,7 +5534,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5567,11 +5545,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Perubahan yang belum disimpan"
 
@@ -5609,15 +5588,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5755,11 +5734,11 @@ msgstr ""
 msgid "Used"
 msgstr "Diguna"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5839,32 +5818,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM Mod"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5880,7 +5859,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5888,8 +5867,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr ""
 
@@ -5897,11 +5876,11 @@ msgstr ""
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5913,7 +5892,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5924,13 +5903,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adapter Wayarles"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5940,7 +5919,7 @@ msgstr "Rangkaian Wayarles"
 msgid "Wireless Overview"
 msgstr "Gambaran keseluruhan Wayarles"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Keselamatan WLAN"
 
@@ -5960,11 +5939,11 @@ msgstr ""
 msgid "Wireless is not associated"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr ""
 
@@ -5972,11 +5951,11 @@ msgstr ""
 msgid "Write received DNS requests to syslog"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6002,19 +5981,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6025,7 +6004,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6083,7 +6062,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "mematikan"
 
@@ -6182,7 +6161,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "Fail DNS tempatan"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6201,7 +6184,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "tidak ada"
 
@@ -6212,8 +6195,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6226,6 +6209,10 @@ msgstr ""
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:205
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
@@ -6245,7 +6232,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6259,8 +6246,8 @@ msgstr ""
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6281,11 +6268,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6304,7 +6295,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6483,6 +6474,10 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:441
 msgid "value with at most %d characters"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -2155,7 +2155,7 @@ msgstr "Gateway"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Gateway porter"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6584,9 +6584,6 @@ msgstr "ja"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Tilbake"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Gateway porter"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Angir den lyttende porten for denne <em>Dropbear</em> instansen"

--- a/modules/luci-base/po/no/base.po
+++ b/modules/luci-base/po/no/base.po
@@ -12,11 +12,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -58,19 +59,19 @@ msgid "-- Additional Field --"
 msgstr "-- Tilleggs Felt --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Vennligst velg --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- egendefinert --"
@@ -93,7 +94,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -105,7 +106,7 @@ msgstr "1 minutts belastning:"
 msgid "15 Minute Load:"
 msgstr "15 minutters belastning:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -118,35 +119,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "5 minutters belastning:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -166,7 +167,7 @@ msgstr ""
 "<abbr title=\"Domain Name System\">DNS</abbr> servere skal følge rekkefølgen "
 "i oppslagsfilen ved spørringer"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -202,7 +203,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Konfigurasjon"
 
@@ -245,7 +246,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -330,8 +331,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Tilgangskonsentrator"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Aksesspunkt"
 
@@ -362,17 +363,17 @@ msgstr "Aktive DHCP Leier"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktive DHCPv6 Leier"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc (Uavhengig)"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -403,10 +404,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -419,7 +423,7 @@ msgstr "Legg det lokale domenesuffikset til navn utgitt fra vertsfiler"
 msgid "Add new interface..."
 msgstr "Legg til grensesnitt..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -468,8 +472,8 @@ msgstr "Administrasjon"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -479,11 +483,11 @@ msgstr "Avanserte Innstillinger"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Varsle"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -509,23 +513,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Tillat <abbr title=\"Secure Shell\">SSH</abbr> passord godkjenning"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Tillat alle unntatt oppførte"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Tillat kun oppførte"
 
@@ -533,15 +537,15 @@ msgstr "Tillat kun oppførte"
 msgid "Allow localhost"
 msgstr "Tillat lokalvert"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr "Tillat eksterne verter å koble til lokale SSH videresendt porter"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Tillat root pålogginger med passord"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Tillat bruker <em>root</em> å logge inn med passord"
 
@@ -550,7 +554,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr "Tillat oppstrøms svar i 127.0.0.0/8 nettet, f.eks for RBL tjenester"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -558,7 +562,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -637,7 +641,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -656,11 +660,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Alle soner"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -684,7 +688,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Tilkoblede Klienter"
@@ -698,7 +702,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Godkjenning"
 
@@ -793,7 +797,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -811,7 +815,7 @@ msgstr "Tilbake til konfigurasjon"
 msgid "Backup"
 msgstr "Sikkerhetskopi"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Sikkerhetskopiering/Firmware oppgradering"
 
@@ -828,7 +832,7 @@ msgstr "Ugyldig adresse oppgitt!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -866,7 +870,7 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Overstyr falske NX Domener"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bro"
@@ -884,7 +888,7 @@ msgstr "Bro enhetsnummer"
 msgid "Bring up on boot"
 msgstr "Slå på ved oppstart"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -909,13 +913,13 @@ msgstr "CPU forbruk (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Avbryt"
@@ -938,13 +942,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Lenke"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Endringer"
 
@@ -952,23 +950,19 @@ msgstr "Endringer"
 msgid "Changes applied."
 msgstr "Endringer utført."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Endrer administrator passordet for tilgang til enheten"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Kanal"
@@ -981,7 +975,7 @@ msgstr "Kontroller"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -994,7 +988,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1006,7 +1000,7 @@ msgstr ""
 "Eller fyll ut <em>Opprett</em> feltet for å definere en ny sone og tilknytte "
 "grensesnittet til det."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1014,7 +1008,7 @@ msgstr ""
 "Velg det eller de nettverk du vil legge til dette trådløse grensesnittet, "
 "eller fyll ut <em>Opprett</em> feltet for å definere et nytt nettverk."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Krypteringsmetode"
 
@@ -1036,9 +1030,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Klient"
 
@@ -1047,8 +1041,8 @@ msgstr "Klient"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Klient ID som sendes ved DHCP spørring"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1073,7 +1067,7 @@ msgstr "Lukk liste..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1100,7 +1094,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1108,7 +1102,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1124,11 +1118,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1136,7 +1130,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Bekreftelse"
 
@@ -1169,7 +1163,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1180,12 +1174,12 @@ msgstr ""
 msgid "Country"
 msgstr "Land"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Landskode"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Opprett/Tildel brannmur sone"
 
@@ -1193,11 +1187,11 @@ msgstr "Opprett/Tildel brannmur sone"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Kritisk"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Cron logg nivå"
 
@@ -1232,15 +1226,15 @@ msgstr ""
 "Tilpasser oppførselen til enhetens <abbr title=\"Light Emitting Diode\">LED</"
 "abbr>s om mulig."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1253,7 +1247,7 @@ msgstr "DHCP Server"
 msgid "DHCP and DNS"
 msgstr "DHCP og DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1326,7 +1320,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1338,14 +1332,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Feilsøking"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Standard %d"
 
@@ -1385,47 +1379,47 @@ msgstr ""
 "Definer flere DHCP valg, f.eks \"<code>192.168.2.1,192.168.2.2</code>\" som "
 "annonserer forskjellige DNS servere til klientene."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Fjern"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Fjern dette nettverket"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Design"
 
@@ -1456,7 +1450,7 @@ msgstr ""
 msgid "Device"
 msgstr "Enhet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Enhet Konfigurasjon"
 
@@ -1473,7 +1467,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1491,12 +1485,12 @@ msgstr "Nettverksdiagnostikk"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Katalog"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Deaktiver"
 
@@ -1512,14 +1506,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1531,11 +1526,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Deaktivert"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1554,21 +1545,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Avstand Optimalisering"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Avstand i meter til det medlem av nettverket som er lengst unna."
 
@@ -1598,15 +1587,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Ikke videresend reverserte oppslag for lokale nettverk"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1646,15 +1635,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Dropbear Instans"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1688,17 +1677,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP-metode"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Endre"
 
@@ -1708,7 +1697,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Endre dette nettverket"
 
@@ -1716,12 +1705,12 @@ msgstr "Endre dette nettverket"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Krisesituasjon"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Aktiver"
 
@@ -1756,7 +1745,7 @@ msgstr "Aktiver IPv6 på PPP lenke"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Aktiver Jumbo Frames gjennomgang"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Aktiver NTP klient"
 
@@ -1772,11 +1761,11 @@ msgstr "Aktiver TFTP server"
 msgid "Enable VLAN functionality"
 msgstr "Aktiver VLAN funksjonalitet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1800,7 +1789,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "Aktiver dette monteringspunktet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1822,7 +1811,7 @@ msgstr "Aktivert"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1843,17 +1832,17 @@ msgstr "Innkapsling modus"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1865,7 +1854,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Sletter..."
 
@@ -1879,7 +1868,7 @@ msgstr "Sletter..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Feil"
 
@@ -1887,12 +1876,12 @@ msgstr "Feil"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet Tilslutning"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet Svitsj"
@@ -1927,23 +1916,23 @@ msgstr "Utløpstid på leide adresser, minimum er 2 minutter (<code>2m</code>)."
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Ekstern systemlogg server"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Ekstern systemlogg server port"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1951,19 +1940,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1971,15 +1964,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2024,7 +2017,7 @@ msgstr "Fullfør"
 msgid "Firewall"
 msgstr "Brannmur"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2064,7 +2057,7 @@ msgstr "Flash nytt firmware image"
 msgid "Flash operations"
 msgstr "Flash operasjoner"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Flasher..."
 
@@ -2072,11 +2065,11 @@ msgstr "Flasher..."
 msgid "Force"
 msgstr "Bruk"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Bruk CCMP (AES)"
 
@@ -2085,11 +2078,11 @@ msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 "Bruk DHCP i dette nettverket, selv om en annen DHCP server er oppdaget."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Bruk TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Bruk TKIP og CCMP (AES)"
 
@@ -2121,7 +2114,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Videresend kringkastingstrafikk"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2129,7 +2122,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Videresending modus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Fragmenterings Terskel"
 
@@ -2138,7 +2131,7 @@ msgstr "Fragmenterings Terskel"
 msgid "Free"
 msgstr "Ledig"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2160,19 +2153,19 @@ msgstr "Kun GPRS"
 msgid "Gateway"
 msgstr "Gateway"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Gateway porter"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2180,8 +2173,8 @@ msgstr "Generelle Innstillinger"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Generelt Oppsett"
 
@@ -2189,7 +2182,7 @@ msgstr "Generelt Oppsett"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2197,7 +2190,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Opprett arkiv"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Det oppgitte passordet var ikke korrekt, passord ble ikke endret!"
 
@@ -2216,8 +2209,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Gå til passord konfigurasjon..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2247,7 +2240,7 @@ msgstr "Slå av"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2255,7 +2248,7 @@ msgstr ""
 "Her kan du konfigurere grunnleggende aspekter av enheten som f.eks. dens "
 "vertsnavn eller tidssone."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Skjul <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2266,7 +2259,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2292,7 +2285,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Vertsnavn"
 
@@ -2313,7 +2306,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2534,7 +2527,7 @@ msgstr "IPv6-over-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-over-IPv4 (6til4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identitet"
 
@@ -2644,7 +2637,7 @@ msgstr "Tidsavbrudd etter innaktivitet"
 msgid "Inbound:"
 msgstr "Innkommende:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Informasjon"
 
@@ -2682,7 +2675,7 @@ msgstr "Installer protokoll utvidelser..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Grensesnitt"
 
@@ -2690,7 +2683,7 @@ msgstr "Grensesnitt"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Grensesnitt Konfigurasjon"
 
@@ -2720,7 +2713,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2750,7 +2743,7 @@ msgstr "Intern server feil"
 msgid "Invalid"
 msgstr "Ugyldig"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2770,7 +2763,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2778,7 +2771,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Ugyldig brukernavn og/eller passord! Vennligst prøv igjen."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2798,15 +2791,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "JavaScript kreves!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Koble til nettverket"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Koble til nettverk: Trådløs Skanning"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2823,15 +2816,15 @@ msgstr "Kjerne Logg"
 msgid "Kernel Version"
 msgstr "Kjerne Versjon"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Nøkkel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Nøkkel #%d"
 
@@ -2875,11 +2868,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Volumnavn"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Språk"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Språk og Utseende"
 
@@ -2919,7 +2912,7 @@ msgstr "La stå tomt for automatisk oppdagelse"
 msgid "Leave empty to use the current WAN address"
 msgstr "La stå tomt for å bruke gjeldene WAN adresse"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Forklaring:"
 
@@ -2963,7 +2956,7 @@ msgstr ""
 "Liste med <abbr title=\"Domain Name System\">DNS</abbr> servere som "
 "forespørsler blir videresendt til"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2972,7 +2965,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2997,11 +2990,11 @@ msgstr "Liste over verter som returneren falske NX domene resultater"
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Lytt kun på det angitte grensesnitt, om ingen er angitt lyttes det på alle"
@@ -3025,11 +3018,7 @@ msgstr "Belastning Gjennomsnitt"
 msgid "Loading"
 msgstr "Laster"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3069,7 +3058,7 @@ msgid "Local Startup"
 msgstr "Lokal Oppstart"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Lokal tid"
 
@@ -3106,7 +3095,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Lokalisere søk"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Logg nivå"
 
@@ -3114,7 +3103,7 @@ msgstr "Logg nivå"
 msgid "Log queries"
 msgstr "Logg spørringer"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Logging"
 
@@ -3145,22 +3134,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-Adresse"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "MAC-Addresse Filter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-Filter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC-Liste"
 
@@ -3188,7 +3177,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3208,7 +3197,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3216,7 +3205,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3242,7 +3231,7 @@ msgstr "Maksimalt antall sekunder å vente på at modemet skal bli klart"
 msgid "Maximum number of leased addresses."
 msgstr "Maksimalt antall utleide adresser."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3255,7 +3244,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3267,11 +3256,11 @@ msgstr "Minne"
 msgid "Memory usage (%)"
 msgstr "Minne forbruk (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3282,7 +3271,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrisk"
 
@@ -3294,7 +3283,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3302,8 +3291,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Modus"
@@ -3334,16 +3323,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "Modem initiering tidsavbrudd"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3356,7 +3345,7 @@ msgstr "Monterings Enhet"
 msgid "Mount Point"
 msgstr "Monterings Punkt"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3406,7 +3395,7 @@ msgstr "Flytt ned"
 msgid "Move up"
 msgstr "Flytt opp"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3431,11 +3420,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "NTP server kandidater"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3443,7 +3432,7 @@ msgstr "NTP server kandidater"
 msgid "Name"
 msgstr "Navn"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Navnet til det nye nettverket"
 
@@ -3453,8 +3442,8 @@ msgstr "Navigasjon"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3487,7 +3476,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Neste »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3496,7 +3485,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Ingen DHCP server er konfigurert for dette grensesnittet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3508,7 +3497,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3539,11 +3528,12 @@ msgstr "Ingen negative cache"
 msgid "No password set!"
 msgstr "Ruteren er ikke passordbeskyttet!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3588,7 +3578,7 @@ msgstr ""
 msgid "None"
 msgstr "Ingen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3618,7 +3608,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Merk"
 
@@ -3630,7 +3620,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3696,24 +3686,24 @@ msgstr "Åpne liste..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Innstilling endret"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Innstilling fjernet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3727,41 +3717,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3821,7 +3811,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3845,7 +3835,7 @@ msgstr "Overstyr tabellen som brukes for interne ruter"
 msgid "Overview"
 msgstr "Oversikt"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3890,7 +3880,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3945,29 +3935,29 @@ msgid "Part of zone %q"
 msgstr "En del av sone %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Passord"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Passord godkjenning"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Passord for privatnøkkel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3975,31 +3965,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Sti til CA-sertifikat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Sti til klient-sertifikat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Sti til privatnøkkel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4026,7 +4016,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4046,7 +4036,7 @@ msgstr "Foreta nullstilling"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4086,7 +4076,7 @@ msgstr "Skriv inn ditt brukernavn og passord."
 msgid "Policy"
 msgstr "Policy"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4122,7 +4112,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4143,11 +4133,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Hindrer klient-til-klient kommunikasjon"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4178,7 +4168,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Funger som NTP Server"
 
@@ -4186,15 +4176,15 @@ msgstr "Funger som NTP Server"
 msgid "Provide new network"
 msgstr "Lag nytt nettverk"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4221,11 +4211,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4233,11 +4223,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS Terskel"
 
@@ -4253,31 +4243,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "RX Rate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Radius-Accounting-Port"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Radius-Accounting-Secret"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Radius-Accounting-Server"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Radius-Authentication-Port"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Radius-Authentication-Secret"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Radius-Authentication-Server"
 
@@ -4327,7 +4317,7 @@ msgstr "Trafikk Sanntid"
 msgid "Realtime Wireless"
 msgstr "Trådløst i sanntid"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4335,7 +4325,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Binde beskyttelse"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Omstart"
@@ -4353,7 +4343,7 @@ msgstr "Omstarter operativsystemet på enheten"
 msgid "Receive"
 msgstr "Motta"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4393,11 +4383,11 @@ msgstr "Ekstern IPv4 adresse"
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Avinstaller"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Erstatt trådløs konfigurasjon"
 
@@ -4413,7 +4403,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4421,42 +4411,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "Er nødvendig for noen nettleverandører, f.eks Charter med DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4468,31 +4458,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4543,10 +4533,8 @@ msgstr "Gjenoppretting"
 msgid "Restore backup"
 msgstr "Gjenopprett sikkerhetskopi"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Vis/Skjul passord"
 
@@ -4554,15 +4542,15 @@ msgstr "Vis/Skjul passord"
 msgid "Revert"
 msgstr "Tilbakestill"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4578,7 +4566,7 @@ msgstr "Rot katalog for filer gitt fra TFTP"
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4594,8 +4582,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Ruter Passord"
 
@@ -4637,8 +4625,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH Tilgang"
 
@@ -4654,14 +4642,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH-Nøkler"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4670,19 +4658,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Lagre"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Lagre & Aktiver"
@@ -4695,24 +4681,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Skann"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Planlagte Oppgaver"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Seksjon lagt til"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Seksjon fjernet"
 
@@ -4727,9 +4709,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4800,7 +4782,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4820,12 +4802,12 @@ msgstr "Slå av dette grensesnittet"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4845,7 +4827,7 @@ msgstr "Størrelse"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4862,7 +4844,7 @@ msgstr "Gå til innhold"
 msgid "Skip to navigation"
 msgstr "Gå til navigasjon"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4903,10 +4885,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "Hvor lagrings enheten blir tilsluttet filsystemet (f.eks. /mnt/sda1)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Angir den lyttende porten for denne <em>Dropbear</em> instansen"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4920,7 +4898,7 @@ msgid ""
 "dead"
 msgstr "Angir maksimalt antall sekunder før verter ansees som frakoblet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4943,7 +4921,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Angi krypteringsnøkkelen her."
 
@@ -4957,16 +4935,16 @@ msgstr "Start"
 msgid "Start priority"
 msgstr "Start prioritet"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Oppstart"
 
@@ -4986,7 +4964,7 @@ msgstr "Statiske Leier"
 msgid "Static Routes"
 msgstr "Statiske Ruter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5002,13 +4980,13 @@ msgstr ""
 "vertsnavn til DHCP klienter. Dette er nødvendig om grensesnittet ikke er "
 "dynamisk konfigurert og kun klienter med dhcp leieavtale får IP."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -5023,12 +5001,12 @@ msgstr "Stop"
 msgid "Strict order"
 msgstr "Streng overholdelse"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Send"
 
@@ -5066,7 +5044,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5081,11 +5059,11 @@ msgstr "Svitsj protokoll"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5095,7 +5073,7 @@ msgstr "Synkroniser med nettleser"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5106,11 +5084,11 @@ msgstr "System"
 msgid "System Log"
 msgstr "System Logg"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "System Egenskaper"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "System logg buffer størrelse"
 
@@ -5177,7 +5155,7 @@ msgid ""
 msgstr ""
 "IPv6 prefikset tilordnet mot leverandør, ender som regel med <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5193,7 +5171,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5247,11 +5225,11 @@ msgstr "Følgende regler er aktiver på systemet."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5281,7 +5259,7 @@ msgstr "Lengden på IPv6 prefikset i bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5301,7 +5279,7 @@ msgstr ""
 "Uplink port for tilkobling til større nettverk som internett og andre porter "
 "til lokalt nettverk."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5309,7 +5287,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5317,7 +5295,7 @@ msgstr ""
 "Systemet sletter konfigurasjonspartisjonen nå, enheten vil bli startet på "
 "nytt når dette er utført."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5329,7 +5307,7 @@ msgstr ""
 "du prøver å koble til igjen. Det kan være nødvendig å fornye ip-adressen til "
 "datamaskinen din for å nå enheten på nytt. (avhengig av innstillingene dine)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5350,7 +5328,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Det er ingen aktive leieavtaler."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5369,7 +5347,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "Dette IPv4 adressen til relayet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5454,22 +5432,22 @@ msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Denne siden gir en oversikt over gjeldende aktive nettverkstilkoblinger."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Denne seksjonen inneholder ennå ingen verdier"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Tidssynkronisering"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Tidssone"
 
@@ -5528,7 +5506,7 @@ msgstr "Utløsende Tilstand"
 msgid "Tunnel ID"
 msgstr "Tunnel ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Tunnel grensesnitt"
@@ -5621,12 +5599,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5635,7 +5613,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5646,11 +5624,12 @@ msgstr "Uhåndtert"
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Ulagrede Endringer"
 
@@ -5691,15 +5670,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Last opp arkiv..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5841,11 +5820,11 @@ msgstr ""
 msgid "Used"
 msgstr "Brukt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Brukte Nøkler"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5925,32 +5904,32 @@ msgstr "Bekreft"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "WEP åpent system"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "WEP delt nøkkel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP passord"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM Modus"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA passord"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5966,7 +5945,7 @@ msgstr "Venter på at endringer utføres..."
 msgid "Waiting for command to complete..."
 msgstr "Venter på at kommando fullføres..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5974,8 +5953,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Advarsel"
 
@@ -5983,11 +5962,11 @@ msgstr "Advarsel"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5999,7 +5978,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -6010,13 +5989,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Trådløs"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Trådløs Tilslutning"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6026,7 +6005,7 @@ msgstr "Trådløst Nettverk"
 msgid "Wireless Overview"
 msgstr "Trådløs Oversikt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Trådløs Sikkerhet"
 
@@ -6046,11 +6025,11 @@ msgstr "Trådløs er deaktiver"
 msgid "Wireless is not associated"
 msgstr "Trådløs er ikke tilknyttet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Trådløst nettverk er deaktivert"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Trådløst nettverk er aktivert"
 
@@ -6058,11 +6037,11 @@ msgstr "Trådløst nettverk er aktivert"
 msgid "Write received DNS requests to syslog"
 msgstr "Skriv mottatte DNS forespørsler til syslog"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6094,19 +6073,19 @@ msgstr ""
 "Du må aktivere JavaScript i nettleseren din ellers vil ikke LuCI fungere "
 "skikkelig."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6117,7 +6096,7 @@ msgstr "enhver"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6175,7 +6154,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "Deaktiver"
 
@@ -6276,7 +6255,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "lokal <abbr title=\"Domain Navn System\">DNS</abbr>-fil"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6295,7 +6278,7 @@ msgstr "ingen forbindelse"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "ingen"
 
@@ -6306,8 +6289,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6321,6 +6304,10 @@ msgstr "av"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "på"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6339,7 +6326,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6353,8 +6340,8 @@ msgstr ""
 msgid "routed"
 msgstr "rutet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6375,11 +6362,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "tagget"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6398,7 +6389,7 @@ msgstr "ukjent"
 msgid "unlimited"
 msgstr "ubegrenset"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6579,6 +6570,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6589,6 +6584,12 @@ msgstr "ja"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Tilbake"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Gateway porter"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Angir den lyttende porten for denne <em>Dropbear</em> instansen"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Svitsj %q (%s)"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -2194,7 +2194,7 @@ msgstr "Brama"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Porty bramy"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6685,9 +6685,6 @@ msgstr "« Wróć"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Wyłączone (domyślnie)"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Porty bramy"
 
 #~ msgid "Loading SSH keys…"
 #~ msgstr "Ładowanie kluczy SSH…"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -18,11 +18,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr "%d nieprawidłowe pole(pola)"
 
@@ -64,19 +65,19 @@ msgid "-- Additional Field --"
 msgstr "-- Dodatkowe pole --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Proszę wybrać --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- własne --"
@@ -99,7 +100,7 @@ msgstr "-- dopasuj po uuid --"
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -111,7 +112,7 @@ msgstr "Obciążenie 1 min.:"
 msgid "15 Minute Load:"
 msgstr "Obciążenie 15 min.:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -124,35 +125,35 @@ msgstr "464XLAT (CLAT)"
 msgid "5 Minute Load:"
 msgstr "Obciążenie 5 min.:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr "Identyfikator 6-oktetowy jako ciąg szesnastkowy - bez dwukropków"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr "802.11w maksymalny czas oczekiwania"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr "802.11w interwał ponawiania prób"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -172,7 +173,7 @@ msgstr ""
 "Nazwa <abbr title=\"Domain Name System\">DNS</abbr> będzie rozwijana przez "
 "kolejne serwery w porządku podanym w resolvfile"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -207,7 +208,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "Sufiks <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>(hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Konfiguracja diod <abbr title=\"Light Emitting Diode\">LED</abbr>"
 
@@ -252,7 +253,7 @@ msgstr ""
 "<br/>Uwaga: musisz ręcznie zrestartować usługę cron, jeśli plik crontab był "
 "pusty przed edycją."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -336,8 +337,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Koncentrator dostępowy (ATM)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Punkt dostępowy"
 
@@ -372,17 +373,17 @@ msgstr "Aktywne dzierżawy DHCP"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktywne dzierżawy DHCPv6"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -413,10 +414,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr "Dodaj klucz"
 
@@ -429,7 +433,7 @@ msgstr "Dodaj lokalny sufiks domeny do nazw urządzeń z pliku hosts"
 msgid "Add new interface..."
 msgstr "Dodaj nowy interfejs..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -479,8 +483,8 @@ msgstr "Zarządzanie"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -490,11 +494,11 @@ msgstr "Ustawienia zaawansowane"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr "Agregacja siły transmisji (ACTATP)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alarm"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -521,23 +525,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr "Przydzielaj adresy IP po kolei"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Pozwól na logowanie <abbr title=\"Secure Shell\">SSH</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr "Pozwól aby tryb AP rozłączał stacje STA w oparciu o niski stan ACK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Pozwól wszystkim oprócz wymienionych"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "Zezwalaj na starsze wersje 802.11b"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Pozwól tylko wymienionym"
 
@@ -545,16 +549,16 @@ msgstr "Pozwól tylko wymienionym"
 msgid "Allow localhost"
 msgstr "Pozwól tylko sobie (localhost)"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Zezwalaj zdalnym hostom na łączenie się z lokalnie przekazywanymi portami SSH"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Zezwól na logowanie roota przy pomocy hasła"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Pozwól użytkownikowi <em>root</em> na logowanie się przy pomocy hasła"
 
@@ -564,7 +568,7 @@ msgid ""
 msgstr ""
 "Pozwól na ruch wychodzący (odpowiedzi) z podsieci 127.0.0.0/8, np. usługi RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "Dozwolone adresy IP"
 
@@ -572,7 +576,7 @@ msgstr "Dozwolone adresy IP"
 msgid "Always announce default router"
 msgstr "Zawsze rozgłaszaj domyślny router"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -655,7 +659,7 @@ msgstr "Rozgłaszaj domeny DNS"
 msgid "Announced DNS servers"
 msgstr "Rozgłaszaj serwery DNS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -674,11 +678,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Dowolna strefa"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Żądanie zatwierdzenia nie powiodło się ze statusem <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -706,7 +710,7 @@ msgstr ""
 "Przypisz cześć prefiksu za pomocą szesnastkowego ID subprefiksu dla tego "
 "interfejsu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Połączone stacje"
@@ -720,7 +724,7 @@ msgstr "Połączeni"
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
@@ -815,7 +819,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -833,7 +837,7 @@ msgstr "Wróć do konfiguracji"
 msgid "Backup"
 msgstr "Kopia zapasowa"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Kopia zapasowa / aktualizacja firmware"
 
@@ -850,7 +854,7 @@ msgstr "Wprowadzono zły adres"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr "Interwał Beaconu"
 
@@ -888,7 +892,7 @@ msgstr "Szybkość transmisji"
 msgid "Bogus NX Domain Override"
 msgstr "Podrób statystyki NXDOMAIN"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Most"
@@ -906,7 +910,7 @@ msgstr "Numer Mostu (urządzenia)"
 msgid "Bring up on boot"
 msgstr "Podnieś przy stracie"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -931,13 +935,13 @@ msgstr "Użycie CPU (%)"
 msgid "Call failed"
 msgstr "Połączenie nieudane"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Anuluj"
@@ -960,13 +964,7 @@ msgstr "Uwaga: Zostanie wymuszone uaktualnienie systemu"
 msgid "Chain"
 msgstr "Łańcuch"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr "Zmień hasło logowania"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Zmiany"
 
@@ -974,23 +972,19 @@ msgstr "Zmiany"
 msgid "Changes applied."
 msgstr "Zmiany zostały zastosowane."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "Zmiany zostały cofnięte."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Zmienia hasło administratora"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr "Zmieniam hasło…"
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Kanał"
@@ -1003,7 +997,7 @@ msgstr "Sprawdź"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -1016,7 +1010,7 @@ msgid "Choose mtdblock"
 msgstr "Wybierz mtdblock"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1028,7 +1022,7 @@ msgstr ""
 "pole <em>utwórz</em> aby zdefiniować nową strefę i przypisać ją do "
 "interfejsu."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1036,7 +1030,7 @@ msgstr ""
 "Wybierz sieć/sieci które chcesz przyłączyć do tego interfejsu "
 "bezprzewodowego lub wypełnij pole <em>utwórz</em> aby utworzyć nową sieć."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Szyfr"
 
@@ -1060,9 +1054,9 @@ msgstr ""
 "Kliknij \"Zapisz mtdblock\", aby pobrać określony plik mtdblock. (UWAGA: TA "
 "FUNKCJA JEST DLA PROFESJONALISTÓW! )"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Klient"
 
@@ -1071,8 +1065,8 @@ msgstr "Klient"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Nazwa (ID) klienta do wysłania podczas negocjacji DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr "Zamknij"
 
@@ -1097,7 +1091,7 @@ msgstr "Zamknij listę..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1124,7 +1118,7 @@ msgstr ""
 msgid "Comment"
 msgstr "Komentarz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1137,7 +1131,7 @@ msgstr ""
 "odporność kluczowych negocjacji, szczególnie w środowiskach o dużym "
 "natężeniu ruchu."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1153,11 +1147,11 @@ msgstr "Konfiguracja nieudana"
 msgid "Configuration files will be kept"
 msgstr "Pliki konfiguracyjne zostaną zachowane"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "Konfiguracja została zastosowana."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "Konfiguracja została wycofana!"
 
@@ -1165,7 +1159,7 @@ msgstr "Konfiguracja została wycofana!"
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Potwierdzenie"
 
@@ -1198,7 +1192,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1209,12 +1203,12 @@ msgstr ""
 msgid "Country"
 msgstr "Kraj"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Kod kraju"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Utwórz / Przypisz strefę firewalla"
 
@@ -1222,11 +1216,11 @@ msgstr "Utwórz / Przypisz strefę firewalla"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Krytyczne"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Poziom logowania Cron`a"
 
@@ -1263,15 +1257,15 @@ msgstr ""
 "Dostosuj zachowanie diod <abbr title=\"Light Emitting Diode\">LED</abbr> "
 "urządzenia jeśli jest to możliwe."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr "DAE-Klient"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr "DAE-Port"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1284,7 +1278,7 @@ msgstr "Serwer DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP i DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1357,7 +1351,7 @@ msgstr "Status DSL"
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr "Interwał DTIM"
 
@@ -1369,14 +1363,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr "Szybkość przesyłania danych"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Debug"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Domyślne %d"
 
@@ -1416,47 +1410,47 @@ msgstr ""
 "Zdefiniuj dodatkowe opcje DHCP, np. \"<code>6,192.168.2.1,192.168.2.2</code>"
 "\" rozgłasza domyślne serwery DNS klientom DHCP."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Usuń"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr "Usuń klucz"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Usuń tą sieć"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr "Interwał komunikatu o wskazaniu dostawy ruchu"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Opis"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Motyw"
 
@@ -1487,7 +1481,7 @@ msgstr ""
 msgid "Device"
 msgstr "Urządzenie"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Konfiguracja urządzenia"
 
@@ -1504,7 +1498,7 @@ msgstr "Urządzenie jest uruchamiane ponownie ..."
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Urządzenie nieosiągalne!"
 
@@ -1522,12 +1516,12 @@ msgstr "Diagnostyka"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Katalog"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Wyłącz"
 
@@ -1543,14 +1537,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Wyłącz szyfrowanie"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "Wyłącz tą sieć"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1562,11 +1557,7 @@ msgstr "Wyłącz tą sieć"
 msgid "Disabled"
 msgstr "Wyłączony"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Wyłączone (domyślnie)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr "Rozłączaj przy niskim stanie ramek ACK"
 
@@ -1585,21 +1576,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr "Próba rozłączenia nie powiodła się"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Optymalizacja odległości"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Odległość do najdalej oddalonego członka sieci w metrach."
 
@@ -1629,15 +1618,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Nie przekazuj odwrotnych lookup`ów do sieci lokalnych"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr "Czy na pewno chcesz usunąć następujący klucz SSH?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1677,15 +1666,15 @@ msgstr "Pobierz mtdblock"
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Usługa Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1720,17 +1709,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Metoda EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Edycja"
 
@@ -1740,7 +1729,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Edytuj tą sieć"
 
@@ -1748,12 +1737,12 @@ msgstr "Edytuj tą sieć"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Zagrożenie"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Włącz"
 
@@ -1790,7 +1779,7 @@ msgstr "Włącz negocjację IPv6 na łączu PPP"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Włącz przechodzenie ramek Jumbo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Włącz klienta NTP"
 
@@ -1806,11 +1795,11 @@ msgstr "Włącz serwer TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Włącz funkcjonalność VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "Włącz przycisk WPS, wymaga WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "Włącz środki zaradcze dotyczące ponownej instalacji kluczy (KRACK)"
 
@@ -1834,7 +1823,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "Włącz ten punkt montowania"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1856,7 +1845,7 @@ msgstr "Włączony"
 msgid "Enables IGMP snooping on this bridge"
 msgstr "Włącz nasłuchiwanie IGMP na tym moście"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1881,17 +1870,17 @@ msgstr "Sposób enkapsulacji"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Szyfrowanie"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1903,7 +1892,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Usuwanie..."
 
@@ -1917,7 +1906,7 @@ msgstr "Usuwanie..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Błąd"
 
@@ -1925,12 +1914,12 @@ msgstr "Błąd"
 msgid "Errored seconds (ES)"
 msgstr "Ilość błędów (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Karta Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
@@ -1966,23 +1955,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Serwer zewnętrzny dla logów systemowych"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Port zewnętrznego serwera logów systemowych"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "Protokół zewnętrznego serwera logów systemowych"
 
@@ -1990,19 +1979,23 @@ msgstr "Protokół zewnętrznego serwera logów systemowych"
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "Nie udało się zatwierdzić w ciągu %ds, czekam na wycofanie…"
 
@@ -2010,15 +2003,15 @@ msgstr "Nie udało się zatwierdzić w ciągu %ds, czekam na wycofanie…"
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Plik"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2063,7 +2056,7 @@ msgstr "Zakończ"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2103,7 +2096,7 @@ msgstr "Wgraj nowy firmware"
 msgid "Flash operations"
 msgstr "Operacje aktualizacji"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Flashowanie..."
 
@@ -2111,11 +2104,11 @@ msgstr "Flashowanie..."
 msgid "Force"
 msgstr "Wymuś"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "Wymuś tryb 40MHz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Wymuś CCMP (AES)"
 
@@ -2124,11 +2117,11 @@ msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 "Wymuś uruchomienie serwera DHCP w tej sieci nawet gdy wykryto inny serwer."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Wymuś TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Wymuś TKIP i CCMP (AES)"
 
@@ -2160,7 +2153,7 @@ msgstr "Próby korekcji błędów (FECS)"
 msgid "Forward broadcast traffic"
 msgstr "Przekazuj broadcast`y"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2168,7 +2161,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Tryb przekazywania"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Próg Fragmentacji"
 
@@ -2177,7 +2170,7 @@ msgstr "Próg Fragmentacji"
 msgid "Free"
 msgstr "Wolna"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2199,19 +2192,19 @@ msgstr "Tylko GPRS"
 msgid "Gateway"
 msgstr "Brama"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr "Adres bramy jest nieprawidłowy"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Porty bramy"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2219,8 +2212,8 @@ msgstr "Ustawienia główne"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Ustawienia podstawowe"
 
@@ -2228,7 +2221,7 @@ msgstr "Ustawienia podstawowe"
 msgid "Generate Config"
 msgstr "Wygeneruj konfigurację"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr "Wygeneruj PMK lokalnie"
 
@@ -2236,7 +2229,7 @@ msgstr "Wygeneruj PMK lokalnie"
 msgid "Generate archive"
 msgstr "Twórz archiwum"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 "Hasło nie zostało zmienione, wpisane poprzednie hasło routera jest "
@@ -2257,8 +2250,8 @@ msgstr "Globalne opcje sieciowe"
 msgid "Go to password configuration..."
 msgstr "Przejdź do konfiguracji hasła..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2288,7 +2281,7 @@ msgstr "Rozłącz"
 msgid "Header Error Code Errors (HEC)"
 msgstr "Błędy kodu nagłówka (HEC)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2296,7 +2289,7 @@ msgstr ""
 "Tutaj możesz skonfigurować podstawowe ustawienia twojego urządzenia, np. "
 "nazwę hosta, strefę czasową."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "Ukryj <abbr title=\"Extended Service Set Identifier (Nazwę sieci)\">ESSID</"
@@ -2309,7 +2302,7 @@ msgstr "Ukryj puste łańcuchy"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2334,7 +2327,7 @@ msgstr "Zawartość znacznika Host-Uniq"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Nazwa hosta"
 
@@ -2355,7 +2348,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2577,7 +2570,7 @@ msgstr "IPv6-przez-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-przez-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Tożsamość"
 
@@ -2692,7 +2685,7 @@ msgstr "Czas bezczynności"
 msgid "Inbound:"
 msgstr "Przychodzący:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Info"
 
@@ -2731,7 +2724,7 @@ msgstr "Instaluj rozszerzenia protokołów..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfejs"
 
@@ -2739,7 +2732,7 @@ msgstr "Interfejs"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Konfiguracja Interfejsu"
 
@@ -2769,7 +2762,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "Nazwa interfejsu"
 
@@ -2799,7 +2792,7 @@ msgstr "Wewnętrzny błąd serwera"
 msgid "Invalid"
 msgstr "Niewłaściwy"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2819,7 +2812,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2827,7 +2820,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Niewłaściwy login i/lub hasło! Spróbuj ponownie."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "Izoluj klientów"
 
@@ -2847,15 +2840,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "JavaScript jest wymagany!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Połącz z siecią"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Przyłącz do sieci: Skanuj sieci Wi-Fi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "Przyłączanie do sieci: %q"
 
@@ -2872,15 +2865,15 @@ msgstr "Log jądra"
 msgid "Kernel Version"
 msgstr "Wersja jądra"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Klucz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Klucz #%d"
 
@@ -2924,11 +2917,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Oznaczenie"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Język"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Wygląd i język"
 
@@ -2968,7 +2961,7 @@ msgstr "Pozostaw puste, aby automatycznie wykryć"
 msgid "Leave empty to use the current WAN address"
 msgstr "Pozostaw puste, aby użyć bieżącego adresu WAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -3013,7 +3006,7 @@ msgstr ""
 "Lista serwerów <abbr title=\"Domain Name System\">DNS</abbr> do których będą "
 "przekazywane zapytania"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -3022,7 +3015,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3047,11 +3040,11 @@ msgstr "Lista hostów które dostarczają zafałszowane wyniki NX domain"
 msgid "Listen Interfaces"
 msgstr "Nasłuchuj interfejs"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "Nasłuchuj port"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Słuchaj tylko na podanym interfejsie, lub jeśli nie podano na wszystkich"
@@ -3075,11 +3068,7 @@ msgstr "Średnie obciążenie"
 msgid "Loading"
 msgstr "Ładowanie"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr "Ładowanie kluczy SSH…"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3119,7 +3108,7 @@ msgid "Local Startup"
 msgstr "Lokalny autostart"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Czas lokalny"
 
@@ -3157,7 +3146,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Zapytania lokalizujące"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Poziom logowania"
 
@@ -3165,7 +3154,7 @@ msgstr "Poziom logowania"
 msgid "Log queries"
 msgstr "Loguj zapytania"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Logowanie"
 
@@ -3196,22 +3185,22 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "Adres MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filtr adresów MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Filtr adresów MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Lista MAC"
 
@@ -3239,7 +3228,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3261,7 +3250,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3269,7 +3258,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr "Max. Osiągalna przepustowość danych (ATTNDR)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3295,7 +3284,7 @@ msgstr "Maksymalny czas podany w sekundach do pełnej gotowości modemu"
 msgid "Maximum number of leased addresses."
 msgstr "Maksymalna liczba dzierżawionych adresów."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3308,7 +3297,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3320,11 +3309,11 @@ msgstr "Pamięć"
 msgid "Memory usage (%)"
 msgstr "Użycie pamięci (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3335,7 +3324,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metryka"
 
@@ -3347,7 +3336,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3355,8 +3344,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Tryb"
@@ -3387,16 +3376,16 @@ msgstr "Zapytanie dotyczące modemu nie powiodło się"
 msgid "Modem init timeout"
 msgstr "Limit czasu inicjacji modemu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3409,7 +3398,7 @@ msgstr "Wpis montowania"
 msgid "Mount Point"
 msgstr "Punkt montowania"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3459,7 +3448,7 @@ msgstr "Przesuń w dół"
 msgid "Move up"
 msgstr "Przesuń w górę"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3484,11 +3473,11 @@ msgstr "Proxy NDP"
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Lista serwerów NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3496,7 +3485,7 @@ msgstr "Lista serwerów NTP"
 msgid "Name"
 msgstr "Nazwa"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Nazwa nowej sieci"
 
@@ -3506,8 +3495,8 @@ msgstr "Nawigacja"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3540,7 +3529,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Następna »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3549,7 +3538,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Brak skonfigurowanego serwera DHCP dla tego interfejsu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3561,7 +3550,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3592,11 +3581,12 @@ msgstr "Brak odwrotnego cache`a"
 msgid "No password set!"
 msgstr "Nie ustawiono hasła!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr "Nie ma jeszcze kluczy publicznych."
 
@@ -3641,7 +3631,7 @@ msgstr "Bez symboli wieloznacznych"
 msgid "None"
 msgstr "Brak"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normalny"
 
@@ -3671,7 +3661,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Spostrzeżenie"
 
@@ -3685,7 +3675,7 @@ msgstr ""
 "Liczba buforowanych wpisów DNS (max wynosi 10000, 0 oznacza brak pamięci "
 "podręcznej)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3751,24 +3741,24 @@ msgstr "Otwórz listę..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "Częstotliwość"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Wartość zmieniona"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Usunięto wartość"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "Opcjonalny"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3786,41 +3776,41 @@ msgstr ""
 "odbierany z serwera delegującego, użyj sufiksa (takiego jak '::1') aby "
 "utworzyć adres IPv6 ('a:b:c:d::1') dla tego interfejsu."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr "Opcjonalny. Opis peera."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3880,7 +3870,7 @@ msgstr "Nadpisz TOS"
 msgid "Override TTL"
 msgstr "Nadpisz TTL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "Nadpisz domyślną nazwę interfejsu"
 
@@ -3904,7 +3894,7 @@ msgstr "Nadpisz tablicę routingu używaną dla wewnętrznych tras routowania"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3949,7 +3939,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr "Kod PIN został odrzucony"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr "PMK R1 Push"
 
@@ -4004,29 +3994,29 @@ msgid "Part of zone %q"
 msgstr "Część strefy %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Hasło"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Uwierzytelnianie hasłem"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Hasło lub klucz prywatny"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "Wewnętrzne hasło klucza prywatnego"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -4034,31 +4024,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr "Wklej lub przeciągnij plik klucza SSH…"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Ścieżka do certyfikatu CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Ścieżka do certyfikatu klienta"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Ścieżka do Klucza Prywatnego"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "Ścieżka do wewnętrznego certyfikatu CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "Ścieżka do wewnętrznego certyfikatu Klienta"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "Ścieżka do wewnętrznego klucza prywatnego "
 
@@ -4085,7 +4075,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr "Brakuje adresu Peera"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4105,7 +4095,7 @@ msgstr "Wykonaj reset"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4145,7 +4135,7 @@ msgstr "Proszę wprowadź swój login i hasło."
 msgid "Policy"
 msgstr "Zasada"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4181,7 +4171,7 @@ msgstr "Preferuj UMTS"
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4202,11 +4192,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr "Zapobiegaj nasłuchiwaniu na tych interfejsach."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Zapobiega komunikacji między klientem a klientem"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "Klucz prywatny"
 
@@ -4237,7 +4227,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protokół"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Włącz serwer NTP"
 
@@ -4245,15 +4235,15 @@ msgstr "Włącz serwer NTP"
 msgid "Provide new network"
 msgstr "Utwórz nową sieć"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "Klucz publiczny"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4286,11 +4276,11 @@ msgstr ""
 "Zapytaj o wszystkie dostępne serwery <abbr title=\"Domain Name System\">DNS</"
 "abbr> "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4298,11 +4288,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Próg RTS/CTS"
 
@@ -4318,31 +4308,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Szybkość RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Port Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Sekret Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Serwer Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Port Radius-Authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Sekret Radius-Authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Serwer Radius-Authentication"
 
@@ -4394,7 +4384,7 @@ msgstr "Ruch w czasie rzeczywistym"
 msgid "Realtime Wireless"
 msgstr "Wi-Fi w czasie rzeczywistym"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr "Termin reasocjacji"
 
@@ -4402,7 +4392,7 @@ msgstr "Termin reasocjacji"
 msgid "Rebind protection"
 msgstr "Przypisz ochronę"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Restart"
@@ -4420,7 +4410,7 @@ msgstr "Uruchamia ponownie system na twoim urządzeniu"
 msgid "Receive"
 msgstr "Odebrane"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4460,11 +4450,11 @@ msgstr "Zdalny adres IPv4"
 msgid "Remote IPv4 address or FQDN"
 msgstr "Zdalny adres IPv4 lub FQDN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Usuń"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Zamień konfigurację WiFi"
 
@@ -4480,7 +4470,7 @@ msgstr "Zażądaj długość prefiksu IPv6"
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "Wymagany"
 
@@ -4488,42 +4478,42 @@ msgstr "Wymagany"
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "Wymagany dla niektórych dostawców internetu, np. Charter z DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4537,31 +4527,31 @@ msgstr ""
 "Wymagane jest wsparcie dla DNSSEC; sprawdzanie, czy niepodpisane odpowiedzi "
 "w domenie rzeczywiście pochodzą z domen bez znaku"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4612,10 +4602,8 @@ msgstr "Przywróć"
 msgid "Restore backup"
 msgstr "Przywróć kopię zapasową"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Odsłoń/Ukryj hasło"
 
@@ -4623,15 +4611,15 @@ msgstr "Odsłoń/Ukryj hasło"
 msgid "Revert"
 msgstr "Przywróć"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "Przywróć zmiany"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Żądanie powrotu nie powiodło się ze statusem <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "Przywracanie konfiguracji…"
 
@@ -4647,7 +4635,7 @@ msgstr "Katalog Root`a dla plików udostępnianych przez TFTP"
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4663,8 +4651,8 @@ msgstr "Typ trasy"
 msgid "Router Advertisement-Service"
 msgstr "Serwis rozgłoszeniowy routera"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Hasło routera"
 
@@ -4707,8 +4695,8 @@ msgstr ""
 msgid "SNR"
 msgstr "SNR"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Dostęp SSH"
 
@@ -4724,14 +4712,14 @@ msgstr "Port serwera SSH"
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "Klucze SSH"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4740,19 +4728,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "SWAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Zapisz"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Zapisz i zastosuj"
@@ -4765,24 +4751,20 @@ msgstr "Zapisz mtdblock"
 msgid "Save mtdblock contents"
 msgstr "Zapisz zawartość mtdblock"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Skanuj"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Zaplanowane Zadania"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Dodano sekcję"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Usunięto sekcję"
 
@@ -4800,9 +4782,9 @@ msgstr ""
 "formatu obrazu nie powiedzie się. Używaj tylko wtedy, gdy masz pewność że "
 "oprogramowanie jest poprawne i jest przeznaczone dla Twojego urządzenia!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4875,7 +4857,7 @@ msgstr "Ilość poważnych błedów (SES)"
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr "Krótki Wstęp"
 
@@ -4895,12 +4877,12 @@ msgstr "Wyłącz ten interfejs"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Sygnał"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4920,7 +4902,7 @@ msgstr "Rozmiar"
 msgid "Size of DNS query cache"
 msgstr "Rozmiar pamięci podręcznej zapytań DNS"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4937,7 +4919,7 @@ msgstr "Pomiń do zawartości"
 msgid "Skip to navigation"
 msgstr "Pomiń do nawigacji"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Programowy VLAN"
@@ -4978,10 +4960,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "Podaje katalog do którego jest podłączone urządzenie"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Określa port nasłuchu dla tej instancji <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4997,7 +4975,7 @@ msgid ""
 msgstr ""
 "Określa maksymalny czas w sekundach przed założeniem, że host jest martwy"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -5020,7 +4998,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Określ tajny klucz szyfrowania."
 
@@ -5034,16 +5012,16 @@ msgstr "Uruchomienie"
 msgid "Start priority"
 msgstr "Priorytet uruchomienia"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "Zatwierdzanie konfiguracji…"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "Rozpoczynanie skanowania..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Autostart"
 
@@ -5063,7 +5041,7 @@ msgstr "Dzierżawy statyczne"
 msgid "Static Routes"
 msgstr "Statyczne ścieżki routingu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5080,13 +5058,13 @@ msgstr ""
 "niedynamicznych konfiguracji interfejsu, gdzie obsługiwane są tylko hosty z "
 "odpowiednim dzierżawami."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr "Station inactivity limit"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -5101,12 +5079,12 @@ msgstr "Stop"
 msgid "Strict order"
 msgstr "Zachowaj kolejność"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Wyślij"
 
@@ -5144,7 +5122,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5159,11 +5137,11 @@ msgstr "Protokół przełącznika"
 msgid "Switch to CIDR list notation"
 msgstr "Przejdź do notacji listy CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5173,7 +5151,7 @@ msgstr "Synchronizuj z przeglądarką"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5184,12 +5162,12 @@ msgstr "System"
 msgid "System Log"
 msgstr "Log systemowy"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Właściwości systemu"
 
 # Wszędzie używane jest "loga" z małej litery.
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Rozmiar bufora loga systemu"
 
@@ -5256,7 +5234,7 @@ msgid ""
 msgstr ""
 "Prefiks IPv6 przypisany do dostawcy, zazwyczaj kończy się <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5272,7 +5250,7 @@ msgstr "Archiwum kopii zapasowej nie wygląda na prawidłowe."
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5327,11 +5305,11 @@ msgstr "Następujące zasady są obecnie aktywne w tym systemie."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr "Podany klucz publiczny SSH został już dodany."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5364,7 +5342,7 @@ msgstr "Długość prefiksu IPv6 w bitach"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "Lokalny adres IPv4, na którym tworzony jest tunel (opcjonalnie)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5385,7 +5363,7 @@ msgstr ""
 "do połączenia z większą siecią, taką jak Internet, a inne porty dla sieci "
 "lokalnej."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5393,14 +5371,14 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr "The submitted security token is invalid or already expired!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 "System usuwa teraz partycję konfiguracji i zrestartuje się po zakończeniu."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5413,7 +5391,7 @@ msgstr ""
 "ustawień może być konieczne odnowienie adresu Twojego komputera, aby dostać "
 "się do urządzenia."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "Hasło systemowe zostało pomyślnie zmienione."
 
@@ -5434,7 +5412,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Brak aktywnych dzierżaw."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5453,7 +5431,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "Ten adres IPv4 przekaźnika"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5542,22 +5520,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "Poniższa strona przedstawia aktualnie aktywne połączenia sieciowe."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Ta sekcja nie zawiera jeszcze żadnych wartości"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Synchronizacja czasu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Strefa czasowa"
 
@@ -5615,7 +5593,7 @@ msgstr "Rodzaj Triggeru"
 msgid "Tunnel ID"
 msgstr "Numer identyfikacyjny tunelu"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interfejs tunelu"
@@ -5708,12 +5686,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Czas niedostępnośći (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Nieznany błąd (%s)"
@@ -5722,7 +5700,7 @@ msgstr "Nieznany błąd (%s)"
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5733,11 +5711,12 @@ msgstr "Niezarządzalny"
 msgid "Unmount"
 msgstr "Odmontuj"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr "Klucz beznazwy"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Niezapisane zmiany"
 
@@ -5779,15 +5758,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Załaduj archiwum..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5930,11 +5909,11 @@ msgstr ""
 msgid "Used"
 msgstr "Użyte"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Użyte gniazdo klucza"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -6014,32 +5993,32 @@ msgstr "Zweryfikuj"
 msgid "Virtual dynamic interface"
 msgstr "Wirtualny interfejs dynamiczny"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Otwarty system WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Współdzielony klucz WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Hasło WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Tryb WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Hasło WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6055,7 +6034,7 @@ msgstr "Trwa wprowadzenie zmian..."
 msgid "Waiting for command to complete..."
 msgstr "Trwa wykonanie polecenia..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -6063,8 +6042,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr "Oczekiwanie na urządzenie..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
@@ -6074,11 +6053,11 @@ msgstr ""
 "Ostrzeżenie: Istnieją niezapisane zmiany, które zostaną utracone po ponownym "
 "uruchomieniu urządzenia!"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6090,7 +6069,7 @@ msgstr ""
 msgid "Width"
 msgstr "Szerokość"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr "WireGuard VPN"
@@ -6101,13 +6080,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "Sieć bezprzewodowa"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adapter bezprzewodowy"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6117,7 +6096,7 @@ msgstr "Sieć bezprzewodowa"
 msgid "Wireless Overview"
 msgstr "Przegląd sieci bezprzewodowych"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Zabezpieczenia sieci bezprzewodowych"
 
@@ -6137,11 +6116,11 @@ msgstr "Sieć bezprzewodowa jest wyłączona"
 msgid "Wireless is not associated"
 msgstr "Sieć bezprzewodowa jest niepołączona"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Sieć bezprzewodowa jest wyłączona"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Sieć bezprzewodowa jest włączona"
 
@@ -6149,11 +6128,11 @@ msgstr "Sieć bezprzewodowa jest włączona"
 msgid "Write received DNS requests to syslog"
 msgstr "Zapisz otrzymane żądania DNS do syslog'a"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Zapisz log systemowy do pliku"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6185,19 +6164,19 @@ msgstr ""
 "Musisz włączyć obsługę JavaScript w swojej przeglądarce, inaczej LuCI nie "
 "będzie działać poprawnie."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr "Alogrytm kompresji ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr "Strumienie kompresji ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr "Ustawienia ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr "Rozmiar ZRam"
 
@@ -6208,7 +6187,7 @@ msgstr "dowolny"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6266,7 +6245,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "wyłącz"
 
@@ -6367,7 +6346,11 @@ msgstr "klucz z 5 lub 13 znakami"
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "lokalny plik <abbr title=\"Domain Name System\">DNS</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "minuty"
 
@@ -6387,7 +6370,7 @@ msgstr "niepowiązane"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "żaden"
 
@@ -6398,8 +6381,8 @@ msgid "not present"
 msgstr "nieobecny"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6413,6 +6396,10 @@ msgstr "wyłączone"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "włączone"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6431,7 +6418,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "losowy"
 
@@ -6445,8 +6432,8 @@ msgstr ""
 msgid "routed"
 msgstr "routowane"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6467,11 +6454,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "otagowane"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr "jednostki czasu (TUs / 1.024 ms) [1000-65535]"
 
@@ -6490,7 +6481,7 @@ msgstr "nieznane"
 msgid "unlimited"
 msgstr "nielimitowane"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6671,6 +6662,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6681,6 +6676,24 @@ msgstr "tak"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Wróć"
+
+#~ msgid "Change login password"
+#~ msgstr "Zmień hasło logowania"
+
+#~ msgid "Changing password…"
+#~ msgstr "Zmieniam hasło…"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Wyłączone (domyślnie)"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Porty bramy"
+
+#~ msgid "Loading SSH keys…"
+#~ msgstr "Ładowanie kluczy SSH…"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Określa port nasłuchu dla tej instancji <em>Dropbear</em>"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Przełącznik %q (%s)"

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -2250,7 +2250,7 @@ msgstr "Roteador"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Acesso remoto a portas encaminhadas"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6816,9 +6816,6 @@ msgstr "« Voltar"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Desabilitado (padrão)"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Acesso remoto a portas encaminhadas"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Especifica a porta de escuta deste <em>Dropbear</em>"

--- a/modules/luci-base/po/pt-br/base.po
+++ b/modules/luci-base/po/pt-br/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr "%.1f dB"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Campo Adicional --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Por favor, escolha --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personalizado --"
@@ -100,7 +101,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr "-- por favor, selecione --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -112,7 +113,7 @@ msgstr "Carga 1 Minuto:"
 msgid "15 Minute Load:"
 msgstr "Carga 15 Minutos:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr "Identificador hexadecimal de 4 caracteres"
 
@@ -125,37 +126,37 @@ msgstr "464XLAT (CLAT)"
 msgid "5 Minute Load:"
 msgstr "Carga 5 Minutos:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 "Identificador de 6 octetos como uma cadeia hexadecimal - sem dois pontos"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr "802.11r Fast Transition"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr "Tempo de expiração máximo da consulta da Associação SA do 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 "Tempo de expiração de tentativa de consulta da Associação SA do 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr "Proteção do Quadro de Gerenciamento do 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr "Estouro de tempo máximo do 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr "Estouro de tempo da nova tentativa do 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr ""
 "<abbr title=\"Identificador de Conjunto Básico de Serviços\">BSSID</abbr>"
@@ -178,7 +179,7 @@ msgstr ""
 "O servidor <abbr title=\"Sistema de Nomes de Domínios\">DNS</abbr> irá "
 "consultar na ordem do arquivo resolvfile"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "<abbr title=\"Identificador de Conjunto de Serviços Estendidos\">ESSID</abbr>"
@@ -218,7 +219,7 @@ msgstr ""
 "6\">IPv6</abbr>-Suffix (hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configuração do <abbr title=\"Diodo Emissor de Luz\">LED</abbr>"
 
@@ -263,7 +264,7 @@ msgstr ""
 "<br/>Nota: você precisa reiniciar manualmente o serviço da cron se o arquivo "
 "crontab estava vazio antes da edição."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -352,8 +353,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Concentrador de Acesso"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Ponto de Acceso (AP)"
 
@@ -386,17 +387,17 @@ msgstr "Alocações DHCP ativas"
 msgid "Active DHCPv6 Leases"
 msgstr "Alocações DHCPv6 ativas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -427,10 +428,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -443,7 +447,7 @@ msgstr "Adiciona um sufixo de domínio local para equipamentos conhecidos"
 msgid "Add new interface..."
 msgstr "Adiciona uma nova interface..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -492,8 +496,8 @@ msgstr "Administração"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -505,11 +509,11 @@ msgstr ""
 "Potência de Transmissão Agregada (<abbr title=\"Aggregate Transmit Power"
 "\">ACTATP</abbr>)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -537,26 +541,26 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr "Alocar endereços IP sequencialmente"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Permitir autenticação <abbr title=\"Shell Seguro\">SSH</abbr> por senha"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 "Permitir, em modo AP, a desconexão de estações baseada na baixa qualidade "
 "das confirmações (ACK)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Permitir todos, exceto os listados"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "Permitir taxas legadas do 802.11b"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Permitir somente os listados"
 
@@ -564,17 +568,17 @@ msgstr "Permitir somente os listados"
 msgid "Allow localhost"
 msgstr "Permitir computador local"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Permitir que equipamentos remotos conectem à portas locais encaminhadas por "
 "SSH"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Permite autenticação do root com senha"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Permite que o usuário <em>root</em> se autentique utilizando senha"
 
@@ -585,7 +589,7 @@ msgstr ""
 "Permite respostas que apontem para 127.0.0.0/8 de servidores externos, por "
 "exemplo, para os serviços RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "Endereços IP autorizados"
 
@@ -593,7 +597,7 @@ msgstr "Endereços IP autorizados"
 msgid "Always announce default router"
 msgstr "Sempre anuncie o roteador padrão"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -675,7 +679,7 @@ msgstr "Domínios DNS anunciados"
 msgid "Announced DNS servers"
 msgstr "Servidores DNS anunciados"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr "Identidade Anônima"
 
@@ -694,11 +698,11 @@ msgstr "Espaço de Troca (swap) Anônimo"
 msgid "Any zone"
 msgstr "Qualquer zona"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Pedido para aplicar falhou com o estado <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -726,7 +730,7 @@ msgstr ""
 "Atribua partes do prefixo usando este identificador hexadecimal do "
 "subprefixo para esta interface."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Estações associadas"
@@ -740,7 +744,7 @@ msgstr "Associações"
 msgid "Auth Group"
 msgstr "Grupo de Autenticação"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Autenticação"
 
@@ -839,7 +843,7 @@ msgstr "BR / DMR / AFTR"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -857,7 +861,7 @@ msgstr "Voltar para configuração"
 msgid "Backup"
 msgstr "Cópia de Segurança"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Cópia de Segurança / Gravar Firmware"
 
@@ -874,7 +878,7 @@ msgstr "Endereço especificado está incorreto!"
 msgid "Band"
 msgstr "Banda"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr "Intervalo do quadro de monitoramento (Beacon)"
 
@@ -912,7 +916,7 @@ msgstr "Taxa de bits"
 msgid "Bogus NX Domain Override"
 msgstr "Substituir Domínio NX Falsos"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Ponte"
@@ -930,7 +934,7 @@ msgstr "Número da ponte"
 msgid "Bring up on boot"
 msgstr "Levantar na iniciação"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -956,13 +960,13 @@ msgstr "Uso da CPU (%)"
 msgid "Call failed"
 msgstr "A chamada falhou"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancelar"
@@ -985,13 +989,7 @@ msgstr "Cuidado: A atualização do sistema será forçada"
 msgid "Chain"
 msgstr "Cadeia"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Alterações"
 
@@ -999,23 +997,19 @@ msgstr "Alterações"
 msgid "Changes applied."
 msgstr "Alterações aplicadas."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "As mudanças foram revertidas."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Muda a senha do administrador para acessar este dispositivo"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Canal"
@@ -1029,7 +1023,7 @@ msgid "Check filesystems before mount"
 msgstr ""
 "Execute a verificação do sistema de arquivos antes da montagem do dispositivo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "Marque esta opção para remover as redes existentes neste rádio."
 
@@ -1042,7 +1036,7 @@ msgid "Choose mtdblock"
 msgstr "Escolha o bloco mtd"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1054,7 +1048,7 @@ msgstr ""
 "zona associada ou preencha o campo para criar uma nova zona associada a esta "
 "interface."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1062,7 +1056,7 @@ msgstr ""
 "Escolha a rede (s) que deseja anexar a este interface wireless ou preencha o "
 "<em> criar </em> campo para definir uma nova rede."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Cifra"
 
@@ -1086,9 +1080,9 @@ msgstr ""
 "Clique em \"Salvar o bloco mtd\" para baixar o arquivo do bloco mtd "
 "especificado. (NOTA: ESTE RECURSO É PARA PROFISSIONAIS!)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Cliente"
 
@@ -1098,8 +1092,8 @@ msgid "Client ID to send when requesting DHCP"
 msgstr ""
 "Identificador do cliente enviando quando a requisição do DHCP é realizada"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1124,7 +1118,7 @@ msgstr "Fechar a lista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1151,7 +1145,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1164,7 +1158,7 @@ msgstr ""
 "compatibilidade e reduzir a robustez da negociação de chaves, especialmente "
 "em ambientes com muito tráfego."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1180,11 +1174,11 @@ msgstr "A configuração falhou"
 msgid "Configuration files will be kept"
 msgstr "Arquivos de configuração que serão mantidos"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "A configuração foi aplicada."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "A configuração foi revertida!"
 
@@ -1192,7 +1186,7 @@ msgstr "A configuração foi revertida!"
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Confirmação"
 
@@ -1225,7 +1219,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1240,12 +1234,12 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Código do País"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Criar / Atribuir a uma zona de firewall"
 
@@ -1253,11 +1247,11 @@ msgstr "Criar / Atribuir a uma zona de firewall"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Crítico"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Nível de Registro da Cron"
 
@@ -1294,15 +1288,15 @@ msgstr ""
 "Se possível, personaliza o comportamento dos <abbr title=\"Diodo Emissor de "
 "Luz\">LED</abbr>s."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1315,7 +1309,7 @@ msgstr "Servidor DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP e DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1388,7 +1382,7 @@ msgstr "Estado da DSL"
 msgid "DSL line mode"
 msgstr "Modo de linha DSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 "Intervalo <abbr title=\"Mensagem Indicativa de Envio de Tráfego/Delivery "
@@ -1402,14 +1396,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr "Taxa de Dados"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Depurar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Padrão %d"
 
@@ -1450,47 +1444,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" que anuncia diferentes servidores "
 "DNS para os clientes."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Apagar"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Apagar esta rede"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr "Intervalo da Mensagem Indicativa de Envio de Tráfego"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Descrição"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Tema"
 
@@ -1521,7 +1515,7 @@ msgstr ""
 msgid "Device"
 msgstr "Dispositivo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Configuração do Dispositivo"
 
@@ -1538,7 +1532,7 @@ msgstr "O dispositivo está reiniciando..."
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Dispositivo não alcançável!"
 
@@ -1557,12 +1551,12 @@ msgstr "Diagnóstico"
 msgid "Dial number"
 msgstr "Número de discagem"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Diretório"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Desabilitar"
 
@@ -1578,14 +1572,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Desabilitar Cifragem"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "Desabilitar esta rede"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1597,11 +1592,7 @@ msgstr "Desabilitar esta rede"
 msgid "Disabled"
 msgstr "Desabilitado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Desabilitado (padrão)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr "Desassociar quando tiver baixa confirmação de recebimento"
 
@@ -1621,21 +1612,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr "A tentativa de desconexão falhou"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Otimização de Distância"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distância para o computador mais distante da rede (em metros)."
 
@@ -1667,15 +1656,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Não encaminhe buscas por endereço reverso das redes local"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1718,15 +1707,15 @@ msgstr ""
 "Deslocamento <abbr title=\"Razão entre Sinal e Ruído/Signal to Noise Ratio"
 "\">SNR</abbr> do sinal recebido"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1762,17 +1751,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr "Comprimento dos bits EA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Editar"
 
@@ -1784,7 +1773,7 @@ msgstr ""
 "Edite os dados de configuração brutos abaixo para arrumar qualquer erro e "
 "clique em \"Salvar\" para recarregar a página."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Editar esta rede"
 
@@ -1792,12 +1781,12 @@ msgstr "Editar esta rede"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Emergência"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Ativar"
 
@@ -1835,7 +1824,7 @@ msgstr "Ativar a negociação de IPv6 no enlace PPP"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Ativar o encaminhamento de quadros jumbos (Jumbo Frames)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Ativar o cliente <abbr title=\"Network Time Protocol\">NTP</abbr>"
 
@@ -1851,11 +1840,11 @@ msgstr "Ativar servidor TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Ativar funcionalidade de VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "Habilite o botão WPS. requer WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 "Habilitar contramedidas contra o ataque de reinstalação de chave (KRACK)"
@@ -1880,7 +1869,7 @@ msgstr "Habilita o campo DF (Não Fragmentar) dos pacotes encapsulados."
 msgid "Enable this mount"
 msgstr "Ativar esta montagem"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Habilitar esta rede"
 
@@ -1905,7 +1894,7 @@ msgstr ""
 "Grupos da Internet/Internet Group Management Protocol\">IGMP</abbr> "
 "(Snooping) nesta ponte"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1928,17 +1917,17 @@ msgstr "Modo de encapsulamento"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Cifragem"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr "Equipamento do ponto final"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr "Porta do ponto final"
 
@@ -1950,7 +1939,7 @@ msgstr "Entre com valor personalizado"
 msgid "Enter custom values"
 msgstr "Entre com valores personalizados"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Apagando..."
 
@@ -1964,7 +1953,7 @@ msgstr "Apagando..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Erro"
 
@@ -1972,12 +1961,12 @@ msgstr "Erro"
 msgid "Errored seconds (ES)"
 msgstr "Segundos com erro (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
@@ -2013,23 +2002,23 @@ msgstr ""
 msgid "External"
 msgstr "Externo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr "Lista dos Detentor de Chave R0 Externa"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr "Lista dos Detentor de Chave R1 Externa"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Servidor externo de registros do sistema (syslog)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Porta do servidor externo de registro do sistema (syslog)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "Protocolo do servidor externo de registro do sistema (syslog)"
 
@@ -2037,22 +2026,26 @@ msgstr "Protocolo do servidor externo de registro do sistema (syslog)"
 msgid "Extra SSH command options"
 msgstr "Opções adicionais do comando SSH"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 "<abbr title=\"Transição Rápida/Fast Transition\">FT</abbr> sobre  <abbr "
 "title=\"Sistema Distribuído/Distributed System\">DS</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr "<abbr title=\"Transição Rápida/Fast Transition\">FT</abbr> pelo ar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 "Protocolo de <abbr title=\"Transição Rápida/Fast Transition\">FT</abbr>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "A confirmação das mudanças na configuração não foram confirmadas em %d "
@@ -2062,15 +2055,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Arquivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2118,7 +2111,7 @@ msgstr "Terminar"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr "Marca do Firewall"
 
@@ -2158,7 +2151,7 @@ msgstr "Gravar nova imagem do firmware"
 msgid "Flash operations"
 msgstr "Operações na memória flash"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Gravando na flash..."
 
@@ -2166,11 +2159,11 @@ msgstr "Gravando na flash..."
 msgid "Force"
 msgstr "Forçar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "Force o modo 40MHz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Forçar CCMP (AES)"
 
@@ -2178,11 +2171,11 @@ msgstr "Forçar CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Forçar o DHCP nesta rede mesmo se outro servidor for detectado."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Forçar TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forçar TKIP e CCMP (AES)"
 
@@ -2216,7 +2209,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Encaminhar tráfego broadcast"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr "Encaminhar o tráfego do parceiro da malha"
 
@@ -2224,7 +2217,7 @@ msgstr "Encaminhar o tráfego do parceiro da malha"
 msgid "Forwarding mode"
 msgstr "Modo de encaminhamento"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Limiar de Fragmentação"
 
@@ -2233,7 +2226,7 @@ msgstr "Limiar de Fragmentação"
 msgid "Free"
 msgstr "Livre"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2255,19 +2248,19 @@ msgstr "Somente GPRS"
 msgid "Gateway"
 msgstr "Roteador"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr "O endereço do roteador padrão é inválido"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Acesso remoto a portas encaminhadas"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2275,8 +2268,8 @@ msgstr "Configurações Gerais"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configurações Gerais"
 
@@ -2284,7 +2277,7 @@ msgstr "Configurações Gerais"
 msgid "Generate Config"
 msgstr "Gerar Configuração"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 "Gerar a <abbr title=\"Chave mestre do emparelhamento/Pairwise Master Key"
@@ -2294,7 +2287,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Gerar arquivo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "A senha de confirmação informada não casa. Senha não alterada!"
 
@@ -2313,8 +2306,8 @@ msgstr "Opções de rede globais"
 msgid "Go to password configuration..."
 msgstr "Ir para a configuração de senha..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2346,7 +2339,7 @@ msgstr ""
 "Erros de Código de Erro de Cabeçalho (<abbr title=\"Header Error Code\">HEC</"
 "abbr>)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2354,7 +2347,7 @@ msgstr ""
 "Aqui você pode configurar os aspectos básicos do seu equipamento, como o "
 "nome do equipamento ou o fuso horário."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "Ocultar <abbr title=\"Identificador de Conjunto de Serviços Estendidos"
@@ -2367,7 +2360,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "Equipamento"
 
@@ -2394,7 +2387,7 @@ msgstr "Conteúdo da etiqueta única do equipamento"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Nome do equipamento"
 
@@ -2417,7 +2410,7 @@ msgstr ""
 "Grupo <abbr title=\"Diffie-Hellman\">DH</abbr>  do <abbr title=\"Internet "
 "Key Exchange/Troca de Chaves na Internet\">IKE</abbr>"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "Endereços IP"
 
@@ -2640,7 +2633,7 @@ msgstr "IPv6-sobre-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-sobre-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identidade PEAP"
 
@@ -2760,7 +2753,7 @@ msgstr "Tempo limite de inatividade"
 msgid "Inbound:"
 msgstr "Entrando:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Informação"
 
@@ -2798,7 +2791,7 @@ msgstr "Instalar extensões de protocolo..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
 
@@ -2806,7 +2799,7 @@ msgstr "Interface"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr "Dispositivo da interface %q foi migrada automaticamente de %q para &q."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Configuração da Interface"
 
@@ -2836,7 +2829,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "Nome da Interface"
 
@@ -2866,7 +2859,7 @@ msgstr "Erro Interno no Servidor"
 msgid "Invalid"
 msgstr "Valor inválido"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2890,7 +2883,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2898,7 +2891,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Usuário e/ou senha inválida! Por favor, tente novamente."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "Isolar Clientes"
 
@@ -2917,15 +2910,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "É necessário JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Conectar à Rede"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Conectar à Rede: Busca por Rede Sem Fio"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "Juntando-se à rede %q"
 
@@ -2942,15 +2935,15 @@ msgstr "Registro do Kernel"
 msgid "Kernel Version"
 msgstr "Versão do Kernel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Chave"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Chave #%d"
 
@@ -2994,11 +2987,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Etiqueta"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Idioma"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Idioma e Estilo"
 
@@ -3038,7 +3031,7 @@ msgstr "Deixe vazio para detectar automaticamente"
 msgid "Leave empty to use the current WAN address"
 msgstr "Deixe vazio para usar o endereço WAN atual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -3084,7 +3077,7 @@ msgstr ""
 "Lista dos servidores <abbr title=\"Domain Name System\">DNS</abbr> para "
 "encaminhar as requisições"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -3098,7 +3091,7 @@ msgstr ""
 "um endereço MAC de destino ao solicitar a chave PMK-R1 a partir do R0KH que "
 "o STA usado durante a Associação de Domínio de Mobilidade Inicial."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3132,11 +3125,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr "Interfaces de Escuta"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "Porta de Escuta"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Escuta apenas na interface especificada. Se não especificado, escuta em todas"
@@ -3160,11 +3153,7 @@ msgstr "Carga Média"
 msgid "Loading"
 msgstr "Carregando"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3204,7 +3193,7 @@ msgid "Local Startup"
 msgstr "Iniciação Local"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Hora Local"
 
@@ -3243,7 +3232,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Localizar consultas"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Nível de detalhamento de saída dos registros"
 
@@ -3251,7 +3240,7 @@ msgstr "Nível de detalhamento de saída dos registros"
 msgid "Log queries"
 msgstr "Registar as consultas"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Registrando os eventos"
 
@@ -3284,22 +3273,22 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "Endereço MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filtro de Endereço MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Filtro de MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Lista de MAC"
 
@@ -3327,7 +3316,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 "<abbr title=\"Maximum Transmission Unit/Unidade Máxima de Transmissão\">MTU</"
@@ -3351,7 +3340,7 @@ msgstr ""
 msgid "Manual"
 msgstr "Manual"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3361,7 +3350,7 @@ msgstr ""
 "Taxa de Dados Atingível Máxima (<abbr title=\"Maximum Attainable Data Rate"
 "\">ATTNDR</abbr>)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3387,7 +3376,7 @@ msgstr "Tempo máximo, em segundos, para esperar que o modem fique pronto"
 msgid "Maximum number of leased addresses."
 msgstr "Número máximo de endereços atribuídos."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3400,7 +3389,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3412,11 +3401,11 @@ msgstr "Memória"
 msgid "Memory usage (%)"
 msgstr "Uso da memória (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr "Identificador da Malha"
 
@@ -3427,7 +3416,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Métrica"
 
@@ -3439,7 +3428,7 @@ msgstr "Porta de monitoramento do espelho"
 msgid "Mirror source port"
 msgstr "Porta de origem do espelho"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr "Domínio da Mobilidade"
 
@@ -3447,8 +3436,8 @@ msgstr "Domínio da Mobilidade"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Modo"
@@ -3479,16 +3468,16 @@ msgstr "A consulta das informações do modem falhou"
 msgid "Modem init timeout"
 msgstr "Estouro de tempo da iniciação do modem"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3501,7 +3490,7 @@ msgstr "Entrada de Montagem"
 msgid "Mount Point"
 msgstr "Ponto de Montagem"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3551,7 +3540,7 @@ msgstr "Mover para baixo"
 msgid "Move up"
 msgstr "Mover para cima"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3576,11 +3565,11 @@ msgstr "Proxy NDP"
 msgid "NT Domain"
 msgstr "Domínio NT"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Candidatos a servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3588,7 +3577,7 @@ msgstr "Candidatos a servidor NTP"
 msgid "Name"
 msgstr "Nome"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Nome da nova rede"
 
@@ -3598,8 +3587,8 @@ msgstr "Navegação"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3632,7 +3621,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Próximo »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3641,7 +3630,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Nenhum Servidor DHCP configurado para esta interface"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3653,7 +3642,7 @@ msgstr "Sem NAT-T"
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3684,11 +3673,12 @@ msgstr "Nenhum cache negativo"
 msgid "No password set!"
 msgstr "Nenhuma senha definida!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3737,7 +3727,7 @@ msgstr "Sem caracter curinga"
 msgid "None"
 msgstr "Nenhum"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3767,7 +3757,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Aviso"
 
@@ -3779,7 +3769,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr "Número de entradas DNS em cache (máximo é 10000, 0 desabilita o cache)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3846,24 +3836,24 @@ msgstr "Abrir lista..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr "OpenConnect (CISCO AnyConnect)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "Frequência de Operação"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Opção alterada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Opção removida"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "Opcional"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3883,7 +3873,7 @@ msgstr ""
 "um servidor, use este sufixo (como '::1') para formar o endereço IPv6 ('a:b:"
 "c:d::1') para esta interface."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
@@ -3891,15 +3881,15 @@ msgstr ""
 "Opcional. Adiciona uma camada extra de cifragem simétrica para resistência "
 "pós quântica."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Opcional. Cria rotas para endereços IP Autorizados para este parceiro."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr "Opcional. Descrição do parceiro."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
@@ -3907,15 +3897,15 @@ msgstr ""
 "Opcional. Equipamento do parceiro. Nomes serão resolvido antes de levantar a "
 "interface."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr "Opcional. Unidade Máxima de Transmissão da interface do túnel."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr "Opcional. Porta do parceiro."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
@@ -3924,7 +3914,7 @@ msgstr ""
 "(desabilitado). O valor recomendado caso este dispositivo esteja atrás de "
 "uma NAT é 25."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "Opcional. Porta UDP usada para pacotes saintes ou entrantes."
 
@@ -3986,7 +3976,7 @@ msgstr "Sobrescrever o TOS"
 msgid "Override TTL"
 msgstr "Sobrescrever o TTL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "Sobrescrever o nome da nova interface"
 
@@ -4011,7 +4001,7 @@ msgstr "Sobrescrever a tabela usada para as rotas internas"
 msgid "Overview"
 msgstr "Visão geral"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -4056,7 +4046,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr "Código PIN rejeitado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr "PMK R1 Push"
 
@@ -4111,29 +4101,29 @@ msgid "Part of zone %q"
 msgstr "Parte da zona %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Senha"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Autenticação por senha"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Senha da Chave Privada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "Senha da Chave Privada interna"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -4141,31 +4131,31 @@ msgstr ""
 msgid "Password2"
 msgstr "Senha2"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Caminho para o Certificado da AC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Caminho para o Certificado do Cliente"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Caminho para a Chave Privada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "Caminho para o certificado AC interno"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "Caminho para o Certificado do Cliente interno"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "Caminho para a Chave Privada interna"
 
@@ -4192,7 +4182,7 @@ msgstr "Endereço IP do parceiro para atribuir"
 msgid "Peer address is missing"
 msgstr "O endereço do parceiro está ausente"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr "Parceiros"
 
@@ -4212,7 +4202,7 @@ msgstr "Restaurar as configuração iniciais"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr "Manutenção da Conexão Persistente"
 
@@ -4252,7 +4242,7 @@ msgstr "Entre com o seu usuário e senha."
 msgid "Policy"
 msgstr "Política"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Porta"
 
@@ -4289,7 +4279,7 @@ msgstr "Preferir UMTS"
 msgid "Prefix Delegated"
 msgstr "Prefixo Delegado"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr "Chave Compartilhada"
 
@@ -4310,11 +4300,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr "Evite escutar nestas Interfaces."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Impede a comunicação de cliente para cliente"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "Chave Privada"
 
@@ -4345,7 +4335,7 @@ msgstr "Protocolo"
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Fornecer serviço <abbr title=\"Network Time Protocol\">NTP</abbr>"
 
@@ -4353,15 +4343,15 @@ msgstr "Fornecer serviço <abbr title=\"Network Time Protocol\">NTP</abbr>"
 msgid "Provide new network"
 msgstr "Prover nova rede"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Ad-Hoc falso (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "Chave Pública"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4392,11 +4382,11 @@ msgstr ""
 "Consulte todos os servidores <abbr title=\\\"Sistema de Nomes de Domínios\\"
 "\">DNS</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr "Validade da Chave R0"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr "Detentor da Chave R1"
 
@@ -4404,11 +4394,11 @@ msgstr "Detentor da Chave R1"
 msgid "RFC3947 NAT-T mode"
 msgstr "Modo NAT-T (RFC3947)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Limiar RTS/CTS"
 
@@ -4424,31 +4414,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Taxa de RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Porta de contabilidade do RADIUS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Segredo da contabilidade do RADIUS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Servidor da contabilidade do RADIUS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Porta de autenticação do RADIUS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Segredo da autenticação do RADIUS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Servidor da autenticação do RADIUS"
 
@@ -4503,7 +4493,7 @@ msgstr "Tráfego em Tempo Real"
 msgid "Realtime Wireless"
 msgstr "Rede sem fio em Tempo Real"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr "Limite para Reassociação"
 
@@ -4511,7 +4501,7 @@ msgstr "Limite para Reassociação"
 msgid "Rebind protection"
 msgstr "Proteção contra \"Rebind\""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reiniciar"
@@ -4529,7 +4519,7 @@ msgstr "Reinicia o sistema operacional do seu dispositivo"
 msgid "Receive"
 msgstr "Receber"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr "Recomendado. Endereços IP da interface do WireGuard."
 
@@ -4569,11 +4559,11 @@ msgstr "Endereço IPv4 remoto"
 msgid "Remote IPv4 address or FQDN"
 msgstr "Endereço IPv4 remoto ou FQDN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Remover"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Substituir a configuração da rede sem fio"
 
@@ -4589,7 +4579,7 @@ msgstr "Solicita prefixo IPv6 de tamanho"
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "Necessário"
 
@@ -4598,15 +4588,15 @@ msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 "Obrigatório para alguns provedores de internet, ex. Charter com DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr "Obrigatório. Chave privada codificada em Base64 para esta interface."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr "Necessário. Chave Pública do parceiro codificada como Base64."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
@@ -4616,27 +4606,27 @@ msgstr ""
 "usar dentro do túnel. Normalmente é o endereço IP do parceiro no túnel e as "
 "redes que o parceiro roteia através do túnel."
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4650,31 +4640,31 @@ msgstr ""
 "Exige o suporte DNSSEC do servidor superior; verifica se as respostas não "
 "assinadas realmente vêm de domínios não assinados"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4725,10 +4715,8 @@ msgstr "Restauração"
 msgid "Restore backup"
 msgstr "Restaurar cópia de segurança"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Relevar/esconder senha"
 
@@ -4736,16 +4724,16 @@ msgstr "Relevar/esconder senha"
 msgid "Revert"
 msgstr "Reverter"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "Reverter as mudanças"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 "O pedido para reverter as configurações falhou com o estado <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "Revertendo configurações..."
 
@@ -4761,7 +4749,7 @@ msgstr "Diretório raiz para arquivos disponibilizados pelo TFTP"
 msgid "Root preparation"
 msgstr "Prepação da raiz (/)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr "Roteie Andereços IP Autorizados"
 
@@ -4777,8 +4765,8 @@ msgstr "Tipo de rota"
 msgid "Router Advertisement-Service"
 msgstr "Serviço de Anúncio de Roteador"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Senha do Roteador"
 
@@ -4821,8 +4809,8 @@ msgstr "SHA256"
 msgid "SNR"
 msgstr "SNR"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Acesso SSH"
 
@@ -4838,14 +4826,14 @@ msgstr "Porta do servidor SSH"
 msgid "SSH username"
 msgstr "Usuário do SSH"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "Chaves SSH"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4854,19 +4842,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Salvar"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salvar & Aplicar"
@@ -4879,24 +4865,20 @@ msgstr "Salvar o bloco mtd"
 msgid "Save mtdblock contents"
 msgstr "Salvar o conteúdo do bloco mtd"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Procurar"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Tarefas Agendadas"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Seção adicionada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Seção removida"
 
@@ -4914,9 +4896,9 @@ msgstr ""
 "do formato da imagem falhar. Use somente se você estiver confiante que a "
 "firmware está correta e é destinada para seu dispositivo!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4994,7 +4976,7 @@ msgstr ""
 msgid "Short GI"
 msgstr "Intervalo de guarda curto"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr "Preâmbulo curto"
 
@@ -5014,12 +4996,12 @@ msgstr "Desligar esta interface"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Sinal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -5039,7 +5021,7 @@ msgstr "Tamanho"
 msgid "Size of DNS query cache"
 msgstr "Tamanho do cache de consultas DNS"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -5056,7 +5038,7 @@ msgstr "Pular para o conteúdo"
 msgid "Skip to navigation"
 msgstr "Pular para a navegação"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "VLAN em Software"
@@ -5097,10 +5079,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "Especifica o diretório que o dispositivo está conectado"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Especifica a porta de escuta deste <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -5117,7 +5095,7 @@ msgstr ""
 "Especifica a quantidade máxima de segundos antes de considerar que um "
 "equipamento está morto"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -5144,7 +5122,7 @@ msgstr ""
 "Especifica a unidade máxima de transmissão (<abbr title=\"Maximum "
 "Transmission Unit\">MTU</abbr>) ao invés do valor padrão (1280 bytes)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Especifique a chave de cifragem secreta aqui."
 
@@ -5158,16 +5136,16 @@ msgstr "Iniciar"
 msgid "Start priority"
 msgstr "Prioridade de iniciação"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "Iniciando a aplicação da configuração..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "Iniciando o escaneamento da rede sem fio..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Iniciação"
 
@@ -5187,7 +5165,7 @@ msgstr "Alocações Estáticas"
 msgid "Static Routes"
 msgstr "Rotas Estáticas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5204,13 +5182,13 @@ msgstr ""
 "configurações não dinâmicas onde um computador com a alocação correspondente "
 "é provido."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Estado"
@@ -5225,12 +5203,12 @@ msgstr "Parar"
 msgid "Strict order"
 msgstr "Ordem Exata"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Enviar"
 
@@ -5270,7 +5248,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Máscara da porta do Switch"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Switch VLAN"
@@ -5285,11 +5263,11 @@ msgstr "Trocar o protocolo"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5299,7 +5277,7 @@ msgstr "Sincronizar com o navegador"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5310,11 +5288,11 @@ msgstr "Sistema"
 msgid "System Log"
 msgstr "Registro do Sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Propriedades do Sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Tamanho do buffer de registro do sistema"
 
@@ -5383,7 +5361,7 @@ msgid ""
 msgstr ""
 "O prefixo IPv6 atribuído pelo provedor, geralmente termina com<code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5401,7 +5379,7 @@ msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 "O arquivo de configuração não pode ser carregado devido ao seguinte erro:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5456,11 +5434,11 @@ msgstr "As seguintes regras estão atualmente ativas neste sistema."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5491,7 +5469,7 @@ msgstr "O comprimento do prefixo IPv6 em bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "O endereço IPv4 local sobre o qual o túnel será criado (opcional)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5512,7 +5490,7 @@ msgstr ""
 "uma porta para o enlace superior (uplink) e as demais portas são utilizadas "
 "para a rede local."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5520,7 +5498,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr "A chave eletrônica enviada é inválida ou já expirou!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5528,7 +5506,7 @@ msgstr ""
 "O sistema está apagando agora a partição da configuração e irá reiniciar "
 "quando terminado."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5540,7 +5518,7 @@ msgstr ""
 "da sua configuração, pode ser necessário renovar o endereço do seu "
 "computador para poder conectar novamente ao roteador."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5561,7 +5539,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Não existem alocações ativas."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5580,7 +5558,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "Este endereço IPv4 do repassar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5671,22 +5649,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "Esta página fornece informações sobre as conexões de rede ativas."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Esta seção ainda não contêm valores"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Sincronização de horário"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Fuso Horário"
 
@@ -5745,7 +5723,7 @@ msgstr "Modo de disparo"
 msgid "Tunnel ID"
 msgstr "Identificador do Túnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interface de Tunelamento"
@@ -5840,12 +5818,12 @@ msgstr ""
 "Segundos de indisponibilidade (<abbr title=\"Unavailable Seconds\">UAS</"
 "abbr>)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Erro desconhecido (%s)"
@@ -5854,7 +5832,7 @@ msgstr "Erro desconhecido (%s)"
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5865,11 +5843,12 @@ msgstr "Não gerenciado"
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Alterações Não Salvas"
 
@@ -5912,15 +5891,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Enviar arquivo..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -6065,11 +6044,11 @@ msgstr ""
 msgid "Used"
 msgstr "Usado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Posição da Chave Usada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -6151,32 +6130,32 @@ msgstr "Verificar"
 msgid "Virtual dynamic interface"
 msgstr "Interface virtual dinâmica"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "WEP Sistema Aberto"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "WEP Chave Compartilhada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP Senha"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Modo WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA Senha"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6192,7 +6171,7 @@ msgstr "Esperando a aplicação das mudanças..."
 msgid "Waiting for command to complete..."
 msgstr "Esperando o término do comando..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -6200,8 +6179,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr "Esperando pelo dispositivo..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Atenção"
 
@@ -6209,11 +6188,11 @@ msgstr "Atenção"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr "Atenção: Existem mudanças não salvas que serão perdidas ao reiniciar!"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6225,7 +6204,7 @@ msgstr ""
 msgid "Width"
 msgstr "Largura"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr "VPN WireGuard"
@@ -6236,13 +6215,13 @@ msgstr "VPN WireGuard"
 msgid "Wireless"
 msgstr "Rede sem fio"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Dispositivo de Rede sem Fio"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6252,7 +6231,7 @@ msgstr "Rede sem Fio"
 msgid "Wireless Overview"
 msgstr "Visão Geral da Rede sem Fio"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Segurança da Rede sem Fio"
 
@@ -6272,11 +6251,11 @@ msgstr "Rede sem fio está desabilitada"
 msgid "Wireless is not associated"
 msgstr "Rede sem fio está não conectada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "A rede sem fio está desabilitada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "A rede sem fio está habilitada"
 
@@ -6284,11 +6263,11 @@ msgstr "A rede sem fio está habilitada"
 msgid "Write received DNS requests to syslog"
 msgstr "Escreva as requisições DNS para o servidor de registro (syslog)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Escrever registro do sistema (log) no arquivo"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6321,19 +6300,19 @@ msgstr ""
 "Você precisa habilitar o JavaScript no seu navegador ou o LuCI não irá "
 "funcionar corretamente."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6344,7 +6323,7 @@ msgstr "qualquer"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6402,7 +6381,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "desativar"
 
@@ -6504,7 +6483,11 @@ msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr ""
 "arquivo local de <abbr title=\"Sistema de Nomes de Domínios\">DNS</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "minutos"
 
@@ -6524,7 +6507,7 @@ msgstr "sem link"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "nenhum"
 
@@ -6535,8 +6518,8 @@ msgid "not present"
 msgstr "não presente"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6550,6 +6533,10 @@ msgstr "desligado"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "ligado"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6568,7 +6555,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "aleatório"
 
@@ -6582,8 +6569,8 @@ msgstr "modo retransmissor"
 msgid "routed"
 msgstr "roteado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6604,11 +6591,15 @@ msgstr "sem estado"
 msgid "stateless + stateful"
 msgstr "sem estado + com estado"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "etiquetado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr "unidades de tempo (TUs / 1.024 ms) [1000-65535]"
 
@@ -6627,7 +6618,7 @@ msgstr "desconhecido"
 msgid "unlimited"
 msgstr "ilimitado"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6808,6 +6799,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6818,6 +6813,15 @@ msgstr "sim"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Desabilitado (padrão)"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Acesso remoto a portas encaminhadas"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Especifica a porta de escuta deste <em>Dropbear</em>"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Switch %q (%s)"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- Campo Adicional --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Por favor escolha --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- personalizado --"
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr "Carga de 1 Minuto:"
 msgid "15 Minute Load:"
 msgstr "Carga de 15 minutos:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Carga 5 Minutos:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr ""
 "<abbr title=\"Identificador de Conjunto Básico de Serviços\">BSSID</abbr>"
@@ -174,7 +175,7 @@ msgstr ""
 "Os servidores de <abbr title=\"Servidor de Nomes de Domínio\">DNS</abbr> "
 "serão consultados pela ordem no ficheiro resolv"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "<abbr title=\"Identificador de Conjunto de Serviços Estendidos\">ESSID</abbr>"
@@ -212,7 +213,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Configuração do <abbr title=\"Diodo Emissor de Luz\">LED</abbr>"
 
@@ -255,7 +256,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -336,8 +337,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Concentrador de Acesso"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Access Point (AP)"
 
@@ -370,17 +371,17 @@ msgstr "Concessões DHCP Ativas"
 msgid "Active DHCPv6 Leases"
 msgstr "Concessões DHCPv6 Ativas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -411,10 +412,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -429,7 +433,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Adicionar uma nova interface..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -478,8 +482,8 @@ msgstr "Administração"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -489,11 +493,11 @@ msgstr "Definições Avançadas"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -519,24 +523,24 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Permitir autenticação <abbr title=\"Shell Seguro\">SSH</abbr> por senha"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Permitir todos, excepto os listados"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Permitir somente os listados"
 
@@ -544,16 +548,16 @@ msgstr "Permitir somente os listados"
 msgid "Allow localhost"
 msgstr "Permitir localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Permitir que hosts remotos se conectem às portas encaminhadas do SSH local"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Permitir o login como root só com password"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Permitir que o utilizador <em>root</em> faça login só com password"
 
@@ -563,7 +567,7 @@ msgid ""
 msgstr ""
 "Permitir respostas a montante na gama 127.0.0.1/8, p.e. para serviços RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -571,7 +575,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -650,7 +654,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -669,11 +673,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Qualquer zona"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -697,7 +701,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Estações Associadas"
@@ -711,7 +715,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Autenticação"
 
@@ -806,7 +810,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -824,7 +828,7 @@ msgstr "Voltar à configuração"
 msgid "Backup"
 msgstr "Backup"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Backup / Flashar Firmware"
 
@@ -841,7 +845,7 @@ msgstr "Endereço mal especificado!"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -879,7 +883,7 @@ msgstr "Taxa de bits"
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Bridge"
@@ -897,7 +901,7 @@ msgstr "Número de unidade da bridge"
 msgid "Bring up on boot"
 msgstr "Levantar no arranque"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -922,13 +926,13 @@ msgstr "Uso da CPU (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Cancelar"
@@ -951,13 +955,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Cadeia"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Alterações"
 
@@ -965,23 +963,19 @@ msgstr "Alterações"
 msgid "Changes applied."
 msgstr "Alterações aplicadas."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Altera a password de administrador para acesso ao dispositivo"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Canal"
@@ -994,7 +988,7 @@ msgstr "Verificar"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -1007,7 +1001,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1019,7 +1013,7 @@ msgstr ""
 "coloque em branco o campo <em>criar</em> para definir a nova zona e ligar-"
 "lhe a interface."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1027,7 +1021,7 @@ msgstr ""
 "Escolha a rede(s) à(s) qual(is) deseja ligar esta interface wireless ou "
 "preencha o campo <em>criar</em> para definir a nova rede."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Cifra"
 
@@ -1049,9 +1043,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Cliente"
 
@@ -1060,8 +1054,8 @@ msgstr "Cliente"
 msgid "Client ID to send when requesting DHCP"
 msgstr "ID de cliente a enviar para pedidos de DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1086,7 +1080,7 @@ msgstr "Fechar lista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1113,7 +1107,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1121,7 +1115,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1137,11 +1131,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1149,7 +1143,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Confirmação"
 
@@ -1182,7 +1176,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1193,12 +1187,12 @@ msgstr ""
 msgid "Country"
 msgstr "País"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Código do País"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Criar / Atribuir a uma zona de firewall"
 
@@ -1206,11 +1200,11 @@ msgstr "Criar / Atribuir a uma zona de firewall"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Critico"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Nível de Log do Cron"
 
@@ -1245,15 +1239,15 @@ msgstr ""
 "Customiza o comportamento dos <abbr title=\"Diodo Emissor de Luz\">LED</"
 "abbr>s, se possível."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1266,7 +1260,7 @@ msgstr "Servidor DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP e DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1339,7 +1333,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1351,14 +1345,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Depurar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr ""
 
@@ -1399,47 +1393,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" informa os clientes de diferentes "
 "servidores DNS."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Apagar"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Apagar esta rede"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Descrição"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Tema"
 
@@ -1470,7 +1464,7 @@ msgstr ""
 msgid "Device"
 msgstr "Dispositivo"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Configuração do Dispositivo"
 
@@ -1487,7 +1481,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1505,12 +1499,12 @@ msgstr "Diagnósticos"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Directório"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Desativar"
 
@@ -1526,14 +1520,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1545,11 +1540,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Desativado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1568,21 +1559,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Optimização de Distância"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distância para o último host da rede em metros."
 
@@ -1613,15 +1602,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Não encaminhar lookups reversos para as redes locais"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1661,15 +1650,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Instância do Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1704,17 +1693,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Metodo-EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Editar"
 
@@ -1724,7 +1713,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Editar esta rede"
 
@@ -1732,12 +1721,12 @@ msgstr "Editar esta rede"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Emergência"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Ativar"
 
@@ -1772,7 +1761,7 @@ msgstr "Ativar a negociação IPv6 no link PPP"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Ativar a passagem de Jumbo Frames"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Ativar o cliente NTP"
 
@@ -1788,11 +1777,11 @@ msgstr "Ativar o servidor TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Ativar a funcionalidade VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1816,7 +1805,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "Ativar este mount"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1838,7 +1827,7 @@ msgstr "Ativado"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1859,17 +1848,17 @@ msgstr "Modo de encapsulamento"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Encriptação"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1881,7 +1870,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "A apagar..."
 
@@ -1895,7 +1884,7 @@ msgstr "A apagar..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Erro"
 
@@ -1903,12 +1892,12 @@ msgstr "Erro"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptador Ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch Ethernet"
@@ -1945,23 +1934,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Servidor externo de logs de sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Porta do Servidor externo de logs de sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1969,19 +1958,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1989,15 +1982,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Ficheiro"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2042,7 +2035,7 @@ msgstr "Terminar"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2082,7 +2075,7 @@ msgstr "Flashar nova imagem do firmware"
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "A programar...."
 
@@ -2090,11 +2083,11 @@ msgstr "A programar...."
 msgid "Force"
 msgstr "Forçar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Forçar CCMP (AES)"
 
@@ -2102,11 +2095,11 @@ msgstr "Forçar CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Forçar DHCP nesta rede mesmo se outro servidor for detectado."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Forçar TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forçar TKIP e CCMP (AES)"
 
@@ -2138,7 +2131,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "Encaminhar trafego de broadcast"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2146,7 +2139,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Modo de encaminhamento"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Margem de Fragmentação"
 
@@ -2155,7 +2148,7 @@ msgstr "Margem de Fragmentação"
 msgid "Free"
 msgstr "Livre"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2177,19 +2170,19 @@ msgstr "Só GPRS"
 msgid "Gateway"
 msgstr "Gateway"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Portas de gateway"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2197,8 +2190,8 @@ msgstr "Definições Gerais"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configuração Geral"
 
@@ -2206,7 +2199,7 @@ msgstr "Configuração Geral"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2214,7 +2207,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Gerar arquivo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 "A confirmação de password não corresponde, a password não foi alterada!"
@@ -2234,8 +2227,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr "Ir para a configuração da password"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2265,7 +2258,7 @@ msgstr "Suspender"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2273,7 +2266,7 @@ msgstr ""
 "Aqui pode configurar os aspectos básicos do seu equipamento, como o nome do "
 "host ou o fuso horário."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "Ocultar <abbr title=\"Identificador de Conjunto de Serviços Estendidos"
@@ -2286,7 +2279,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2312,7 +2305,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Hostname"
 
@@ -2333,7 +2326,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2554,7 +2547,7 @@ msgstr "IPv6-sobre-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-sobre-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identidade"
 
@@ -2666,7 +2659,7 @@ msgstr "Tempo de inatividade"
 msgid "Inbound:"
 msgstr "Entrada:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Info"
 
@@ -2704,7 +2697,7 @@ msgstr "Instalar extensões do protocolo..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interface"
 
@@ -2712,7 +2705,7 @@ msgstr "Interface"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Configuração da Interface"
 
@@ -2742,7 +2735,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2772,7 +2765,7 @@ msgstr "Erro Interno do Servidor"
 msgid "Invalid"
 msgstr "Valor inválido"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2793,7 +2786,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2801,7 +2794,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Username inválido e/ou a password! Por favor, tente novamente."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2821,15 +2814,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "É necessário JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Associar Rede"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Associar Rede: Procurar Redes Wireless"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2846,15 +2839,15 @@ msgstr "Registo do Kernel"
 msgid "Kernel Version"
 msgstr "Versão do Kernel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Chave"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Chave #%d"
 
@@ -2898,11 +2891,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Etiqueta"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Idioma"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Língua e Tema"
 
@@ -2942,7 +2935,7 @@ msgstr "Deixar em branco para auto-detecção"
 msgid "Leave empty to use the current WAN address"
 msgstr "Deixar em branco para usar o endereço WAN actual"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -2986,7 +2979,7 @@ msgstr ""
 "Lista de servidores <abbr title=\"Sistema Nomes de Domínio\">DNS</abbr> para "
 "onde encaminhar os pedidos"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2995,7 +2988,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3020,11 +3013,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Escutar apenas na interface fornecida ou, se não especificada, em todas"
@@ -3048,11 +3041,7 @@ msgstr "Carga Média"
 msgid "Loading"
 msgstr "A carregar"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3092,7 +3081,7 @@ msgid "Local Startup"
 msgstr "Arranque Local"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Hora Local"
 
@@ -3129,7 +3118,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Localizar consultas"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Nível de output do log"
 
@@ -3137,7 +3126,7 @@ msgstr "Nível de output do log"
 msgid "Log queries"
 msgstr "Registo das consultas"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3168,22 +3157,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "Endereço-MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filtro de Endereço-MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Filtro-MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Lista-MAC"
 
@@ -3211,7 +3200,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3231,7 +3220,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3239,7 +3228,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3265,7 +3254,7 @@ msgstr "Número máximo de segundos a esperar pelo modem para ficar pronto"
 msgid "Maximum number of leased addresses."
 msgstr "Número máximo de endereços concessionados."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3278,7 +3267,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3290,11 +3279,11 @@ msgstr "Memória"
 msgid "Memory usage (%)"
 msgstr "Uso de memória (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3305,7 +3294,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Métrica"
 
@@ -3317,7 +3306,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3325,8 +3314,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Modo"
@@ -3357,16 +3346,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3379,7 +3368,7 @@ msgstr "Montar Entrada"
 msgid "Mount Point"
 msgstr "Ponto de Montagem"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3429,7 +3418,7 @@ msgstr "Subir"
 msgid "Move up"
 msgstr "Descer"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3454,11 +3443,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Candidatos a servidor NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3466,7 +3455,7 @@ msgstr "Candidatos a servidor NTP"
 msgid "Name"
 msgstr "Nome"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Nome da nova rede"
 
@@ -3476,8 +3465,8 @@ msgstr "Navegação"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3510,7 +3499,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Seguinte »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3519,7 +3508,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Sem Servidor DHCP configurado nesta interface"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3531,7 +3520,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3562,11 +3551,12 @@ msgstr "Sem cache negativa"
 msgid "No password set!"
 msgstr "Sem password definida!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3611,7 +3601,7 @@ msgstr ""
 msgid "None"
 msgstr "Nenhum"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3641,7 +3631,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Reparo"
 
@@ -3653,7 +3643,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3719,24 +3709,24 @@ msgstr "Abrir lista..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Opção alterada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Opção removida"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3750,41 +3740,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3844,7 +3834,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3866,7 +3856,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3911,7 +3901,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3966,29 +3956,29 @@ msgid "Part of zone %q"
 msgstr "Parte da zona %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Senha"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Autenticação por senha"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Senha da Chave Privada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3996,31 +3986,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Directorio do Certificado CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Caminho para o Certificado de Cliente"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Caminho da Chave Privada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -4047,7 +4037,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4067,7 +4057,7 @@ msgstr "Executar reset"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4107,7 +4097,7 @@ msgstr "Insira o seu username e password."
 msgid "Policy"
 msgstr "Política"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Porta"
 
@@ -4143,7 +4133,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4162,11 +4152,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Impede a comunicação cliente-a-cliente"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4197,7 +4187,7 @@ msgstr "Protocolo"
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4205,15 +4195,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4240,11 +4230,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4252,11 +4242,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS Threshold"
 
@@ -4272,31 +4262,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr "Taxa RX"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Porta-Conta-Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Segredo-Conta-Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Servidor-Conta-Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Porta-Autenticação-Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Segredo-Autenticação-Radius"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Servidor-Autenticação-Radius"
 
@@ -4346,7 +4336,7 @@ msgstr "Tráfego em Tempo Real"
 msgid "Realtime Wireless"
 msgstr "Wireless em Tempo Real"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4354,7 +4344,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "Religar protecção"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reiniciar"
@@ -4372,7 +4362,7 @@ msgstr "Reinicia o seu dispositivo"
 msgid "Receive"
 msgstr "Receber"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4412,11 +4402,11 @@ msgstr "Endereço IPv4 remoto"
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Remover"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Substituir configuração wireless"
 
@@ -4432,7 +4422,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4440,42 +4430,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "Necessário para certos ISPs, p.ex. Charter with DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4487,31 +4477,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4562,10 +4552,8 @@ msgstr "Restauração"
 msgid "Restore backup"
 msgstr "Restaurar backup"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Revelar/esconder password"
 
@@ -4573,15 +4561,15 @@ msgstr "Revelar/esconder password"
 msgid "Revert"
 msgstr "Reverter"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4597,7 +4585,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4613,8 +4601,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Password do Router"
 
@@ -4657,8 +4645,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Acesso SSH"
 
@@ -4674,14 +4662,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "Chaves-SSH"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4690,19 +4678,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Salvar"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salvar & Aplicar"
@@ -4715,24 +4701,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Procurar"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Tarefas Agendadas"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Secção adicionada"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Secção removida"
 
@@ -4747,9 +4729,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4818,7 +4800,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4838,12 +4820,12 @@ msgstr "Desligar esta interface"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Sinal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4863,7 +4845,7 @@ msgstr "Tamanho"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4880,7 +4862,7 @@ msgstr "Ir para o conteúdo"
 msgid "Skip to navigation"
 msgstr "Ir para a navegação"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4918,10 +4900,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Especifica as portas de escuta desta instância <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4934,7 +4912,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4957,7 +4935,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4971,16 +4949,16 @@ msgstr "Iniciar"
 msgid "Start priority"
 msgstr "Prioridade de inicialização"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr ""
 
@@ -5000,7 +4978,7 @@ msgstr "Atribuições Estáticas"
 msgid "Static Routes"
 msgstr "Rotas Estáticas"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5013,13 +4991,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -5034,12 +5012,12 @@ msgstr "Parar"
 msgid "Strict order"
 msgstr "Ordem exacta"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Enviar"
 
@@ -5077,7 +5055,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5092,11 +5070,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5106,7 +5084,7 @@ msgstr "Sincronizar com o browser"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5117,11 +5095,11 @@ msgstr "Sistema"
 msgid "System Log"
 msgstr "Registo do Sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Propriedades do Sistema"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5189,7 +5167,7 @@ msgstr ""
 "O prefixo IPv6 atribuído ao provider, habitualmente termina com <code>::</"
 "code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5205,7 +5183,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5259,11 +5237,11 @@ msgstr "As seguintes regras estão actualmente acivas neste sistema."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5294,7 +5272,7 @@ msgstr "O comprimento do prefixo IPv6 em bits"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5314,7 +5292,7 @@ msgstr ""
 "diferentes. Muitas vezes existe por defeito uma porta de Uplink  para uma "
 "ligação para a rede acima como a internet ou outras portas de uma rede local."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5322,7 +5300,7 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5330,7 +5308,7 @@ msgstr ""
 "O sistema está agora a limpar a partição de configuração e irá reiniciar-se "
 "quando terminar."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5343,7 +5321,7 @@ msgstr ""
 "da sua configuração, ode ser necessário renovar o endereço do seu computador "
 "para poder ligar novamente ao router."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5364,7 +5342,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Não há concessões ativas."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5383,7 +5361,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5462,22 +5440,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr "Esta página fornece informações sobre as ligações de rede ativas."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Esta secção ainda não contêm valores"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Sincronização Horária"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Fuso Horário"
 
@@ -5535,7 +5513,7 @@ msgstr "Modo de Trigger"
 msgid "Tunnel ID"
 msgstr "ID do Túnel"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interface de Túnel"
@@ -5628,12 +5606,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5642,7 +5620,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5653,11 +5631,12 @@ msgstr "Não gerido"
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Alterações não Guardadas"
 
@@ -5695,15 +5674,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Carregar arquivo..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5841,11 +5820,11 @@ msgstr ""
 msgid "Used"
 msgstr "Usado"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5925,32 +5904,32 @@ msgstr "Verificar"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Sistema Aberto WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Chave partilhada WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Palavra-Passe WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Modo WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Palavra-Passe WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5966,7 +5945,7 @@ msgstr "A aguardar que as mudanças sejam aplicadas..."
 msgid "Waiting for command to complete..."
 msgstr "A aguardar que o comando termine..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5974,8 +5953,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Aviso"
 
@@ -5983,11 +5962,11 @@ msgstr "Aviso"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5999,7 +5978,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -6010,13 +5989,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Rede Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adaptador Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6026,7 +6005,7 @@ msgstr "Rede Wireless"
 msgid "Wireless Overview"
 msgstr "Vista Global Wireless"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Segurança Wireless"
 
@@ -6046,11 +6025,11 @@ msgstr "Wireless desativada"
 msgid "Wireless is not associated"
 msgstr "Wireless não associada"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Wireless está desativado."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "A rede wireless está ativada"
 
@@ -6058,11 +6037,11 @@ msgstr "A rede wireless está ativada"
 msgid "Write received DNS requests to syslog"
 msgstr "Escrever os pedidos de DNS para o syslog"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6095,19 +6074,19 @@ msgstr ""
 "Tem de activar o JavaScript no seu browser ou a LuCI não funcionará "
 "corretamente."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6118,7 +6097,7 @@ msgstr "qualquer"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6177,7 +6156,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "desativar"
 
@@ -6279,7 +6258,11 @@ msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr ""
 "Ficheiro local de <abbr title=\"Sistema de Nomes de Domínios\">DNS</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6298,7 +6281,7 @@ msgstr "sem link"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "nenhum"
 
@@ -6309,8 +6292,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6324,6 +6307,10 @@ msgstr "desligado"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "ligado"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6342,7 +6329,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6356,8 +6343,8 @@ msgstr ""
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6378,11 +6365,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6401,7 +6392,7 @@ msgstr "desconhecido"
 msgid "unlimited"
 msgstr "ilimitado"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6582,6 +6573,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6592,6 +6587,12 @@ msgstr "sim"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Portas de gateway"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Especifica as portas de escuta desta instância <em>Dropbear</em>"
 
 #~ msgid "VLANs on %q (%s)"
 #~ msgstr "VLANs em %q (%s)"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -2172,7 +2172,7 @@ msgstr "Gateway"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Portas de gateway"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6587,9 +6587,6 @@ msgstr "sim"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Portas de gateway"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Especifica as portas de escuta desta instância <em>Dropbear</em>"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -2126,7 +2126,7 @@ msgstr "Gateway"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Porturile gateway"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6470,9 +6470,6 @@ msgstr "da"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Inapoi"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Porturile gateway"
 
 #~ msgid "Antenna 1"
 #~ msgstr "Antena 1"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -16,11 +16,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -62,19 +63,19 @@ msgid "-- Additional Field --"
 msgstr "-- Camp suplimentar --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Te rog sa alegi --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- particularizat --"
@@ -97,7 +98,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -109,7 +110,7 @@ msgstr "Incarcarea in ultimul minut"
 msgid "15 Minute Load:"
 msgstr "Incarcarea in ultimele 15 minute"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -122,35 +123,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Incarcarea in ultimele 5 minute"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -170,7 +171,7 @@ msgstr ""
 "<abbr title=\"Domain Name System\">DNS</abbr> serverul va interoga in "
 "vederea procesarii fisierului"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -205,7 +206,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Configurare"
 
@@ -246,7 +247,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -327,8 +328,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "Concentrator de Access "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Punct de Acces"
 
@@ -359,17 +360,17 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -400,10 +401,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -416,7 +420,7 @@ msgstr "Adauga un sufix local numelor servite din fisierele de tip hosts"
 msgid "Add new interface..."
 msgstr "Adauga interfata noua.."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -465,8 +469,8 @@ msgstr "Administrare"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -476,11 +480,11 @@ msgstr "Setari avansate"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Alerta"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -506,24 +510,24 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Permite autentificarea prin parola a <abbr title=\"Secure Shell\">SSH</abbr> "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Permite toate cu exceptia celor listate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Permite doar cele listate"
 
@@ -531,15 +535,15 @@ msgstr "Permite doar cele listate"
 msgid "Allow localhost"
 msgstr "Permite localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr "Permite statiilor externe sa se conecteze la porturile SSH locale"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Permite autentificarea contului root cu parola"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Permite contului <em>root</em> sa se autentifice cu parola"
 
@@ -549,7 +553,7 @@ msgid ""
 msgstr ""
 "Permite raspuns upstream in plaja 127.0.0.0/8, e.g. pentru serviciile RBL"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -557,7 +561,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -636,7 +640,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -655,11 +659,11 @@ msgstr ""
 msgid "Any zone"
 msgstr "Orice Zona"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -683,7 +687,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Statiile asociate"
@@ -697,7 +701,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Autentificare"
 
@@ -792,7 +796,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -810,7 +814,7 @@ msgstr "Inapoi la Configurare"
 msgid "Backup"
 msgstr "Salveaza"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Salveaza / Scrie Firmware"
 
@@ -827,7 +831,7 @@ msgstr "Adresa specificata gresit !"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -862,7 +866,7 @@ msgstr "Bitrate"
 msgid "Bogus NX Domain Override"
 msgstr "Bogus NX Domain Override"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Punte"
@@ -880,7 +884,7 @@ msgstr "Numarul unitatii in punte"
 msgid "Bring up on boot"
 msgstr "Activeaza la pornire"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -905,13 +909,13 @@ msgstr "Utilizarea procesorului (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Anuleaza"
@@ -934,13 +938,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Lant"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Modificari"
 
@@ -948,23 +946,19 @@ msgstr "Modificari"
 msgid "Changes applied."
 msgstr "Modificari aplicate."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Schimba parola administratorului pentru accesarea dispozitivului"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Canal"
@@ -977,7 +971,7 @@ msgstr "Verificare"
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -990,7 +984,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1001,13 +995,13 @@ msgstr ""
 "<em>nespecificat</em> pentru a sterge interfata sau golire <em>creaza</em> "
 "camp ce defineste o zona noua asociata interfetei."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1027,9 +1021,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr ""
 
@@ -1038,8 +1032,8 @@ msgstr ""
 msgid "Client ID to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1062,7 +1056,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1089,7 +1083,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1097,7 +1091,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1113,11 +1107,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1125,7 +1119,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Confirmare"
 
@@ -1158,7 +1152,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1169,12 +1163,12 @@ msgstr ""
 msgid "Country"
 msgstr "Tara"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Codul de tara"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
@@ -1182,11 +1176,11 @@ msgstr ""
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Critic"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr ""
 
@@ -1219,15 +1213,15 @@ msgid ""
 "\">LED</abbr>s if possible."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1240,7 +1234,7 @@ msgstr "Server DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP si DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1313,7 +1307,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1325,14 +1319,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr ""
 
@@ -1370,47 +1364,47 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Sterge"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Sterge aceasta retea"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Descriere"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr ""
 
@@ -1441,7 +1435,7 @@ msgstr ""
 msgid "Device"
 msgstr "Dispozitiv"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Configurarea dispozitivului"
 
@@ -1458,7 +1452,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1476,12 +1470,12 @@ msgstr "Diagnosticuri"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Director"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Dezactiveaza"
 
@@ -1497,14 +1491,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1516,11 +1511,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Dezactivat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1539,21 +1530,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Optimizarea distantei"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Distanta catre cel mai departat membru din retea in metri."
 
@@ -1577,15 +1566,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1623,15 +1612,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Instanta dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1660,17 +1649,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Editeaza"
 
@@ -1680,7 +1669,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Editeaza aceasta retea"
 
@@ -1688,12 +1677,12 @@ msgstr "Editeaza aceasta retea"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Urgenta"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Activeaza"
 
@@ -1728,7 +1717,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1744,11 +1733,11 @@ msgstr "Activeaza serverul TFTP"
 msgid "Enable VLAN functionality"
 msgstr "Activeaza VLAN-urile"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1772,7 +1761,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1794,7 +1783,7 @@ msgstr "Activat"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1815,17 +1804,17 @@ msgstr "Modul de incapsulare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Criptare"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1837,7 +1826,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Stergere..."
 
@@ -1851,7 +1840,7 @@ msgstr "Stergere..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Eroare"
 
@@ -1859,12 +1848,12 @@ msgstr "Eroare"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Adaptor de retea ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Switch-ul ethernet"
@@ -1898,23 +1887,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Server de log-uri extern"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Portul serverului de log-uri extern"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1922,19 +1911,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1942,15 +1935,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Fisier"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -1995,7 +1988,7 @@ msgstr "Termina"
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2035,7 +2028,7 @@ msgstr ""
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2043,11 +2036,11 @@ msgstr ""
 msgid "Force"
 msgstr "Forteaza"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Forteaza CCMP (AES)"
 
@@ -2056,11 +2049,11 @@ msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 "Forteaza facilitatea DHCP in aceasta retea chiar daca alt server DHCP exista."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Forteaza TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Forteaza TKIP si CCMP (AES)"
 
@@ -2092,7 +2085,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2100,7 +2093,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr ""
 
@@ -2109,7 +2102,7 @@ msgstr ""
 msgid "Free"
 msgstr "Liber"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2131,19 +2124,19 @@ msgstr "Doar GPRS"
 msgid "Gateway"
 msgstr "Gateway"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Porturile gateway"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2151,8 +2144,8 @@ msgstr "Setari principale"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Configurare generala"
 
@@ -2160,7 +2153,7 @@ msgstr "Configurare generala"
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2168,7 +2161,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Confirmarea parolei nu se potriveste cu prima, parola neschimbata !"
 
@@ -2187,8 +2180,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2218,7 +2211,7 @@ msgstr ""
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2226,7 +2219,7 @@ msgstr ""
 "Aici poti configura aspectele de baza ale dispozitivului cum ar fi numele "
 "sau fusul orar."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Ascunde <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2237,7 +2230,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2262,7 +2255,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Numele de host"
 
@@ -2283,7 +2276,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2504,7 +2497,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identitate"
 
@@ -2610,7 +2603,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr "Intrare:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Informatii"
 
@@ -2648,7 +2641,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Interfata"
 
@@ -2656,7 +2649,7 @@ msgstr "Interfata"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Configurarea interfetei"
 
@@ -2686,7 +2679,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2716,7 +2709,7 @@ msgstr "Eroare interna de server"
 msgid "Invalid"
 msgstr "Invalid"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2736,7 +2729,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2744,7 +2737,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Utilizator si/sau parola invalide! Incearcati din nou."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2764,15 +2757,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "Ai nevoie de JavaScript !"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2789,15 +2782,15 @@ msgstr "Log-ul kernelului"
 msgid "Kernel Version"
 msgstr "Versiunea de kernel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2841,11 +2834,11 @@ msgstr ""
 msgid "Label"
 msgstr "Eticheta"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Limba"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Limba si stilul interfetei"
 
@@ -2885,7 +2878,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Legenda:"
 
@@ -2927,7 +2920,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2936,7 +2929,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2961,11 +2954,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -2988,11 +2981,7 @@ msgstr "Incarcarea medie"
 msgid "Loading"
 msgstr "Incarcare"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3032,7 +3021,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Ora locala"
 
@@ -3064,7 +3053,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3072,7 +3061,7 @@ msgstr ""
 msgid "Log queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3103,22 +3092,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr ""
 
@@ -3146,7 +3135,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3166,7 +3155,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3174,7 +3163,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3200,7 +3189,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3213,7 +3202,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3225,11 +3214,11 @@ msgstr "Memorie"
 msgid "Memory usage (%)"
 msgstr "Utilizarea memoriei (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3240,7 +3229,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrica"
 
@@ -3252,7 +3241,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3260,8 +3249,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Mod"
@@ -3292,16 +3281,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3314,7 +3303,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3362,7 +3351,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr ""
 
@@ -3387,11 +3376,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3399,7 +3388,7 @@ msgstr ""
 msgid "Name"
 msgstr "Nume"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Numele interfetei noi"
 
@@ -3409,8 +3398,8 @@ msgstr "Navigare"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3443,7 +3432,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Mai departe »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3452,7 +3441,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Nici un server DHCP configurat pentru aceasta interfata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3464,7 +3453,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3495,11 +3484,12 @@ msgstr ""
 msgid "No password set!"
 msgstr "Nici o parola setata !"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3544,7 +3534,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3574,7 +3564,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Notificare"
 
@@ -3586,7 +3576,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3652,24 +3642,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Optiunea schimbata"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Optiunea eliminata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3683,41 +3673,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3777,7 +3767,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3799,7 +3789,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prezentare generala"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3844,7 +3834,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3899,29 +3889,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Parola"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Autentificarea cu parola"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Parola cheii private"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3929,31 +3919,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Calea catre certificatul CA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Calea catre cheia privata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3980,7 +3970,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4000,7 +3990,7 @@ msgstr "Reseteaza"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4040,7 +4030,7 @@ msgstr "Introdu utilizatorul si parola."
 msgid "Policy"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4076,7 +4066,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4095,11 +4085,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4130,7 +4120,7 @@ msgstr ""
 msgid "Protocol"
 msgstr "Protocol"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4138,15 +4128,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4173,11 +4163,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4185,11 +4175,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr ""
 
@@ -4205,31 +4195,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4279,7 +4269,7 @@ msgstr "Traficul in timp real"
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4287,7 +4277,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Rebooteaza"
@@ -4305,7 +4295,7 @@ msgstr "Rebooteaza sistemul de operare al dispozitivului tau"
 msgid "Receive"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4345,11 +4335,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Elimina"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Inlocuieste configuratia wireless"
 
@@ -4365,7 +4355,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4373,42 +4363,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4420,31 +4410,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4495,10 +4485,8 @@ msgstr "Restaureaza"
 msgid "Restore backup"
 msgstr "Reface backup-ul"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Arata / ascunde parola"
 
@@ -4506,15 +4494,15 @@ msgstr "Arata / ascunde parola"
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4530,7 +4518,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4546,8 +4534,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Parola routerului"
 
@@ -4587,8 +4575,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Acces SSH"
 
@@ -4604,14 +4592,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "Cheile SSH"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4620,19 +4608,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Salveaza"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Salveaza si aplica"
@@ -4645,24 +4631,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Operatiuni programate"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Sectiune adaugata"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Sectiune eliminata"
 
@@ -4677,9 +4659,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4748,7 +4730,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4768,12 +4750,12 @@ msgstr "Opreste aceasta interfata"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Semnal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4793,7 +4775,7 @@ msgstr "Marime"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4810,7 +4792,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4848,10 +4830,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4864,7 +4842,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4887,7 +4865,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4901,16 +4879,16 @@ msgstr "Start"
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Pornire"
 
@@ -4930,7 +4908,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr "Rute statice"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4943,13 +4921,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -4964,12 +4942,12 @@ msgstr "Stop"
 msgid "Strict order"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Trimite"
 
@@ -5007,7 +4985,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5022,11 +5000,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5036,7 +5014,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5047,11 +5025,11 @@ msgstr "Sistem"
 msgid "System Log"
 msgstr "Log de sistem"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Proprietati sistem"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5117,7 +5095,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5131,7 +5109,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5177,11 +5155,11 @@ msgstr ""
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5211,7 +5189,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5225,7 +5203,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5233,13 +5211,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5247,7 +5225,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5266,7 +5244,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5285,7 +5263,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5359,22 +5337,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Fusul orar"
 
@@ -5429,7 +5407,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Interfata de tunel"
@@ -5522,12 +5500,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Necunoscut"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5536,7 +5514,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5547,11 +5525,12 @@ msgstr "Neadministrate"
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Modificari nesalvate"
 
@@ -5589,15 +5568,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5735,11 +5714,11 @@ msgstr ""
 msgid "Used"
 msgstr "Folosit"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Slot de cheie folosit"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5819,32 +5798,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Sistem deschis WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Sistem de cheie impartasita WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Parola WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Mod WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Parola WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5860,7 +5839,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5868,8 +5847,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Avertizare"
 
@@ -5877,11 +5856,11 @@ msgstr "Avertizare"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5893,7 +5872,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5904,13 +5883,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Adaptorul wireless"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5920,7 +5899,7 @@ msgstr "Retea wireless"
 msgid "Wireless Overview"
 msgstr "Sumarul wireless"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Securitate wireless"
 
@@ -5940,11 +5919,11 @@ msgstr "Wireless-ul este dezactivat"
 msgid "Wireless is not associated"
 msgstr "Wireless-ul este ne-asociat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Reteaua wireless este dezactivata"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Reteaua wireless este activata"
 
@@ -5952,11 +5931,11 @@ msgstr "Reteaua wireless este activata"
 msgid "Write received DNS requests to syslog"
 msgstr "Scrie cererile DNS primite in syslog"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -5982,19 +5961,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6005,7 +5984,7 @@ msgstr "oricare"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6063,7 +6042,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "dezactiveaza"
 
@@ -6162,7 +6141,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6181,7 +6164,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr ""
 
@@ -6192,8 +6175,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6206,6 +6189,10 @@ msgstr ""
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:205
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
@@ -6225,7 +6212,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6239,8 +6226,8 @@ msgstr ""
 msgid "routed"
 msgstr "rutat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6261,11 +6248,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "etichetat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6284,7 +6275,7 @@ msgstr "necunoscut"
 msgid "unlimited"
 msgstr "nelimitat"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6465,6 +6456,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6475,6 +6470,9 @@ msgstr "da"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Inapoi"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Porturile gateway"
 
 #~ msgid "Antenna 1"
 #~ msgstr "Antena 1"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -2218,7 +2218,7 @@ msgstr "Шлюз"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Порты шлюза"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6767,9 +6767,6 @@ msgstr "« Назад"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Отключено (по умолчанию)"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Порты шлюза"
 
 #~ msgid "Loading SSH keys…"
 #~ msgstr "Загрузка SSH ключей..."

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -19,11 +19,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr "%.1f дБ"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr "%d бит"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr "%d неверных полей"
 
@@ -65,19 +66,19 @@ msgid "-- Additional Field --"
 msgstr "-- Дополнительно --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Сделайте выбор --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- пользовательский --"
@@ -100,7 +101,7 @@ msgstr "-- проверка по uuid --"
 msgid "-- please select --"
 msgstr "-- сделайте выбор --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 "0 = не использовать порог RSSI, 1 = не изменять значение по умолчанию "
@@ -114,7 +115,7 @@ msgstr "Загрузка за 1 минуту:"
 msgid "15 Minute Load:"
 msgstr "Загрузка за 15 минут:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr "4-х значный шестнадцатеричный ID"
 
@@ -127,35 +128,35 @@ msgstr "464XLAT (CLAT)"
 msgid "5 Minute Load:"
 msgstr "Загрузка за 5 минут:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr "6-октетный идентификатор в виде шестнадцатеричной строки без двоеточий"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr "802.11r Быстрый Роуминг"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr "802.11w Association SA Query максимальное время ожидания"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr "802.11w время ожидания повтора Association SA Query"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr "802.11w Management Frame Protection"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr "802.11w максимальное время ожидания"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr "802.11w время ожидания повтора"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Идентификатор Набора Базовых Сервисов\">BSSID</abbr>"
 
@@ -175,7 +176,7 @@ msgstr ""
 "<abbr title=\"Система доменных имен\">DNS</abbr> сервера будут опрошены в "
 "порядке, определенном в resolvfile файле"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Расширенный идентификатор обслуживания\">ESSID</abbr>"
 
@@ -210,7 +211,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "<abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-суффикс (hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "Настройка <abbr title=\"Светодиод\">LED</abbr> индикации"
 
@@ -256,7 +257,7 @@ msgstr ""
 "<br />Внимание: вы должны вручную перезапустить службу cron, если этот файл "
 "был пустым перед внесением ваших изменений."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr "Директория с таким же именем уже существует."
 
@@ -337,8 +338,8 @@ msgstr "Отсутствующий интерфейс"
 msgid "Access Concentrator"
 msgstr "Концентратор доступа"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Точка доступа"
 
@@ -371,17 +372,17 @@ msgstr "Активные DHCP аренды"
 msgid "Active DHCPv6 Leases"
 msgstr "Активные DHCPv6 аренды"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -412,10 +413,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr "Добавить ключ"
 
@@ -429,7 +433,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Добавить новый интерфейс..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr "Добавить узел (peer)"
 
@@ -478,8 +482,8 @@ msgstr "Управление"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -489,11 +493,11 @@ msgstr "Дополнительные настройки"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr "Aggregate Transmit Power (ACTATP)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Тревога"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -520,27 +524,27 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr "Выделять IP-адреса последовательно"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Разрешить <abbr title=\"Secure Shell\">SSH</abbr> аутентификацию с помощью "
 "пароля"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 "Разрешить режиму AP отключение абонентов на основании низкого уровня "
 "подтверждения (Acknowledge) успешности получения TCP-сегментов"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Разрешить все, кроме перечисленных"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "Разрешить использование стандарта 802.11b"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Разрешить только перечисленные"
 
@@ -548,17 +552,17 @@ msgstr "Разрешить только перечисленные"
 msgid "Allow localhost"
 msgstr "Разрешить локальный хост"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Разрешить удаленным хостам подключаться к локальным перенаправленным портам "
 "SSH"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Root входит по паролю"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 "Разрешить пользователю <em>root</em> входить в систему с помощью пароля"
@@ -570,7 +574,7 @@ msgstr ""
 "Разрешить ответы внешней сети в диапазоне 127.0.0.0/8, например, для RBL-"
 "сервисов"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "Разрешенные IP-адреса"
 
@@ -578,7 +582,7 @@ msgstr "Разрешенные IP-адреса"
 msgid "Always announce default router"
 msgstr "Объявлять всегда, как маршрутизатор по умолчанию"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -661,7 +665,7 @@ msgstr "Объявить DNS домены"
 msgid "Announced DNS servers"
 msgstr "Объявить DNS сервера"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr "Анонимная идентификация"
 
@@ -680,11 +684,11 @@ msgstr "Неизвестный swap"
 msgid "Any zone"
 msgstr "Любая зона"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Ошибка <code>%h</code> запроса на применение"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr "Применить без проверки"
 
@@ -711,7 +715,7 @@ msgstr ""
 "Назначьте префикс части, используя этот шестнадцатеричный ID вложенного "
 "исправления для этого интерфейса."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Подключенные клиенты"
@@ -725,7 +729,7 @@ msgstr "Ассоциации"
 msgid "Auth Group"
 msgstr "Группа аутентификации"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Аутентификация"
 
@@ -826,7 +830,7 @@ msgstr "BR / DMR / AFTR"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -844,7 +848,7 @@ msgstr "Назад к настройкам"
 msgid "Backup"
 msgstr "Резервное копирование"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Резервное копирование / Перепрошивка"
 
@@ -861,7 +865,7 @@ msgstr "Указан неправильный адрес!"
 msgid "Band"
 msgstr "Диапазон"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr "Интервал рассылки пакетов Beacon"
 
@@ -901,7 +905,7 @@ msgstr "Скорость"
 msgid "Bogus NX Domain Override"
 msgstr "Переопределение поддельного NX-домена"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Мост"
@@ -919,7 +923,7 @@ msgstr "Номер моста"
 msgid "Bring up on boot"
 msgstr "Запустить при загрузке"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr "Обзор..."
 
@@ -945,13 +949,13 @@ msgstr "Загрузка ЦП (%)"
 msgid "Call failed"
 msgstr "Ошибка вызова"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Отменить"
@@ -974,13 +978,7 @@ msgstr "Внимание: выбрано принудительное обнов
 msgid "Chain"
 msgstr "Цепочка"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr "Изменить пароль"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Изменения"
 
@@ -988,23 +986,19 @@ msgstr "Изменения"
 msgid "Changes applied."
 msgstr "Изменения приняты."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "Изменения были возвращены назад."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Изменить пароль администратора для доступа к устройству"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr "Изменение пароля..."
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Канал"
@@ -1017,7 +1011,7 @@ msgstr "Проверить"
 msgid "Check filesystems before mount"
 msgstr "Проверка файловых систем перед монтированием"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 "Проверьте эту опцию, чтобы удалить существующие сети беспроводного "
@@ -1032,7 +1026,7 @@ msgid "Choose mtdblock"
 msgstr "Выберите MTD раздел"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1044,7 +1038,7 @@ msgstr ""
 "заполните поле <em>'создать'</em>, чтобы определить новую зону и прикрепить "
 "к ней этот интерфейс."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1053,7 +1047,7 @@ msgstr ""
 "беспроводной сети или заполните поле <em>создать</em>, чтобы создать новый "
 "интерфейс."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Алгоритм шифрования"
 
@@ -1077,9 +1071,9 @@ msgstr ""
 "Нажмите \"Сохранить MTD раздел\" для скачивания образа указанного MTD "
 "раздела (ВНИМАНИЕ: ДАННЫЙ ФУНКЦИОНАЛ ТОЛЬКО ДЛЯ ОПЫТНЫХ ПОЛЬЗОВАТЕЛЕЙ)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Клиент"
 
@@ -1088,8 +1082,8 @@ msgstr "Клиент"
 msgid "Client ID to send when requesting DHCP"
 msgstr "ID клиента при DHCP-запросе"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr "Закрыть"
 
@@ -1114,7 +1108,7 @@ msgstr "Закрыть список..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1141,7 +1135,7 @@ msgstr ""
 msgid "Comment"
 msgstr "Комментарий"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1153,7 +1147,7 @@ msgstr ""
 "Может вызвать проблемы совместимости и снижение надежности согласования "
 "нового ключа, при наличии большого трафика."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1169,11 +1163,11 @@ msgstr "Ошибка конфигурации"
 msgid "Configuration files will be kept"
 msgstr "Конфигурационные файлы будут сохранены"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "Конфигурация применена"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "Конфигурация возвращена назад!"
 
@@ -1181,7 +1175,7 @@ msgstr "Конфигурация возвращена назад!"
 msgid "Confirm disconnect"
 msgstr "Подтверждение отключения"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Подтверждение пароля"
 
@@ -1214,7 +1208,7 @@ msgstr ""
 msgid "Continue"
 msgstr "Продолжить"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1228,12 +1222,12 @@ msgstr ""
 msgid "Country"
 msgstr "Страна"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Код страны"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Создать / назначить зону сетевого экрана"
 
@@ -1241,11 +1235,11 @@ msgstr "Создать / назначить зону сетевого экран
 msgid "Create interface"
 msgstr "Создать интерфейс"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Критическая ситуация"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Запись событий cron"
 
@@ -1282,15 +1276,15 @@ msgstr ""
 "Настройка поведения светодиодной индикации <abbr title=\"Светодиод\">LED</"
 "abbr> устройства, если это возможно."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr "DAE-клиент"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr "DAE-порт"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr "DAE-секрет"
 
@@ -1303,7 +1297,7 @@ msgstr "DHCP-сервер"
 msgid "DHCP and DNS"
 msgstr "DHCP и DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1376,7 +1370,7 @@ msgstr "Состояние DSL"
 msgid "DSL line mode"
 msgstr "DSL линейный режим"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr "Интервал DTIM"
 
@@ -1388,14 +1382,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr "Скорость передачи данных"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Отладка"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "По умолчанию %d"
 
@@ -1436,47 +1430,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\", чтобы известить клиентов о DNS-"
 "серверах."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Удалить"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr "Удалить ключ"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr "Нет разрешений на удаление"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr "Ошибка запроса на удаление: %d %s"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Удалить эту сеть"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr "Интервал сообщений, регламентирующий доставку трафика"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Описание"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr "Отменить выбор"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Тема оформления"
 
@@ -1507,7 +1501,7 @@ msgstr "Зона назначения"
 msgid "Device"
 msgstr "Устройство"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Настройка устройства"
 
@@ -1524,7 +1518,7 @@ msgstr "Перезагрузка..."
 msgid "Device is restarting…"
 msgstr "Устройство перезапускается..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Устройство недоступно!"
 
@@ -1542,12 +1536,12 @@ msgstr "Диагностика"
 msgid "Dial number"
 msgstr "Dial номер"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Папка"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Отключить"
 
@@ -1563,14 +1557,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Отключить шифрование"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr "Отключить отслеживание неактивности клиентов"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "Отключить данную сеть"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1582,11 +1577,7 @@ msgstr "Отключить данную сеть"
 msgid "Disabled"
 msgstr "Отключено"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Отключено (по умолчанию)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr "Не ассоциировать при низком подтверждении"
 
@@ -1605,21 +1596,19 @@ msgstr "Отключить"
 msgid "Disconnection attempt failed"
 msgstr "Ошибка попытки отключения"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "Отклонить"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Оптимизация расстояния"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Расстояние до самого удалённого сетевого узла в метрах."
 
@@ -1649,15 +1638,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr "Не перенаправлять обратные DNS-запросы для локальных сетей"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Вы действительно хотите удалить «%s»?"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr "Вы действительно хотите удалить следующий SSH ключ?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Вы действительно хотите рекурсивно удалить директорию «%s»?"
 
@@ -1697,15 +1686,15 @@ msgstr "Скачать MTD раздел"
 msgid "Downstream SNR offset"
 msgstr "SNR offset внутренней сети"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr "Перетащите, чтобы изменить порядок"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Экземпляр Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1739,17 +1728,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr "EA-bits длина"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "Метод EAP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Изменить"
 
@@ -1761,7 +1750,7 @@ msgstr ""
 "Изменить данные конфигурации raw выше, чтобы исправить любую ошибку и "
 "нажмите 'Сохранить', чтобы перезагрузить страницу."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Редактировать эту сеть"
 
@@ -1769,12 +1758,12 @@ msgstr "Редактировать эту сеть"
 msgid "Edit wireless network"
 msgstr "Редактировать беспроводную сеть"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Чрезвычайная ситуация"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Включить"
 
@@ -1811,7 +1800,7 @@ msgstr "Включить IPv6-согласование на PPP-соединен
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Пропускать Jumbo-кадры"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Включить NTP-клиент"
 
@@ -1827,11 +1816,11 @@ msgstr "Включить TFTP-сервер"
 msgid "Enable VLAN functionality"
 msgstr "Включить поддержку VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "Включить WPS при нажатии на кнопку, в режиме WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "Включить защиту от атаки KRACK"
 
@@ -1855,7 +1844,7 @@ msgstr "Включите флаг DF (не Фрагментировать) ин�
 msgid "Enable this mount"
 msgstr "Включить эту точку монтирования"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Включить данную сеть"
 
@@ -1877,7 +1866,7 @@ msgstr "Включено"
 msgid "Enables IGMP snooping on this bridge"
 msgstr "Включает IGMP snooping на данном мосту"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1900,17 +1889,17 @@ msgstr "Режим инкапсуляции"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Шифрование"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr "Конечный узел"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr "Порт конечного узла"
 
@@ -1922,7 +1911,7 @@ msgstr "Введите пользовательское значение"
 msgid "Enter custom values"
 msgstr "Введите пользовательские значения"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Стирание..."
 
@@ -1936,7 +1925,7 @@ msgstr "Стирание..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Ошибка"
 
@@ -1944,12 +1933,12 @@ msgstr "Ошибка"
 msgid "Errored seconds (ES)"
 msgstr "Ошибочные секунды (ES)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet-адаптер"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet-коммутатор"
@@ -1985,23 +1974,23 @@ msgstr ""
 msgid "External"
 msgstr "Внешний"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr "Внешний R0 Key Holder List"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr "Внешний R0 Key Holder List"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Внешний сервер системного журнала"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Порт внешнего сервера системного журнала"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "Внешний протокол лог-сервера"
 
@@ -2009,19 +1998,23 @@ msgstr "Внешний протокол лог-сервера"
 msgid "Extra SSH command options"
 msgstr "Дополнительные опции команды SSH"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr "FT над DS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr "FT над the Air"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr "FT протокол"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 "Не удалось подтвердить применение в течении %d сек., ожидание отката..."
@@ -2030,15 +2023,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Файл"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr "Файл не доступен"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr "Имя файла"
 
@@ -2086,7 +2079,7 @@ msgstr "Завершить"
 msgid "Firewall"
 msgstr "Межсетевой экран"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr "Метка межсетевого экрана"
 
@@ -2126,7 +2119,7 @@ msgstr "Установить новый образ прошивки"
 msgid "Flash operations"
 msgstr "Операции с прошивкой"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Прошивка..."
 
@@ -2134,11 +2127,11 @@ msgstr "Прошивка..."
 msgid "Force"
 msgstr "Назначить"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "Принудительно использовать режим 40 МГц"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Назначить CCMP (AES)"
 
@@ -2146,11 +2139,11 @@ msgstr "Назначить CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Назначить DHCP в этой сети, даже если найден другой сервер."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Назначить TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Назначить TKIP и CCMP (AES)"
 
@@ -2182,7 +2175,7 @@ msgstr "Секунды прямой коррекции ошибок (FECS)"
 msgid "Forward broadcast traffic"
 msgstr "Перенаправлять широковещательный трафик"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr "Перенаправлять запросы трафика Mesh"
 
@@ -2190,7 +2183,7 @@ msgstr "Перенаправлять запросы трафика Mesh"
 msgid "Forwarding mode"
 msgstr "Режим перенаправления"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Порог фрагментации"
 
@@ -2199,7 +2192,7 @@ msgstr "Порог фрагментации"
 msgid "Free"
 msgstr "Свободно"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2223,19 +2216,19 @@ msgstr "Только GPRS"
 msgid "Gateway"
 msgstr "Шлюз"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr "Неверный адрес шлюза"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Порты шлюза"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2243,8 +2236,8 @@ msgstr "Основные настройки"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Основные настройки"
 
@@ -2252,7 +2245,7 @@ msgstr "Основные настройки"
 msgid "Generate Config"
 msgstr "Создать config"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr "Создать PMK локально"
 
@@ -2260,7 +2253,7 @@ msgstr "Создать PMK локально"
 msgid "Generate archive"
 msgstr "Создать архив"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Введённые пароли не совпадают, пароль не изменён!"
 
@@ -2279,8 +2272,8 @@ msgstr "Основные настройки сети"
 msgid "Go to password configuration..."
 msgstr "Перейти к настройке пароля..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2310,7 +2303,7 @@ msgstr "Перезапустить"
 msgid "Header Error Code Errors (HEC)"
 msgstr "Ошибки контроля ошибок заголовка (HEC)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2318,7 +2311,7 @@ msgstr ""
 "Здесь вы можете настроить основные параметры вашего устройства, такие как "
 "имя хоста или часовой пояс."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Скрыть <abbr title=\"Расширенный идентификатор сети\">ESSID</abbr>"
 
@@ -2329,7 +2322,7 @@ msgstr "Скрыть пустые цепочки"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "Хост"
 
@@ -2354,7 +2347,7 @@ msgstr "Содержимое Host-Uniq тега"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Имя хоста"
 
@@ -2375,7 +2368,7 @@ msgstr "Гибрид"
 msgid "IKE DH Group"
 msgstr "IKE DH Group"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "IP-адреса"
 
@@ -2596,7 +2589,7 @@ msgstr "IPv6 через IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6 через IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Идентификация EAP"
 
@@ -2715,7 +2708,7 @@ msgstr "Промежуток времени бездействия"
 msgid "Inbound:"
 msgstr "Входящий:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Информация"
 
@@ -2753,7 +2746,7 @@ msgstr "Установить расширения протокола..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Интерфейс"
 
@@ -2761,7 +2754,7 @@ msgstr "Интерфейс"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr "Интерфейс %q устройство авт.перемещается из %q в %q."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Настройка сети"
 
@@ -2791,7 +2784,7 @@ msgstr "Интерфейс запускается..."
 msgid "Interface is stopping..."
 msgstr "Интерфейс останавливается..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "Имя интерфейса"
 
@@ -2821,7 +2814,7 @@ msgstr "Внутренняя ошибка сервера"
 msgid "Invalid"
 msgstr "Неверно"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr "Неверная строка Base64 ключа"
 
@@ -2843,7 +2836,7 @@ msgstr "Неверный аргумент"
 msgid "Invalid command"
 msgstr "Неверная команда"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr "Неверное шестнадцатеричное значение"
 
@@ -2851,7 +2844,7 @@ msgstr "Неверное шестнадцатеричное значение"
 msgid "Invalid username and/or password! Please try again."
 msgstr "Неверный логин и/или пароль! Попробуйте снова."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "Изолировать клиентов"
 
@@ -2870,15 +2863,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "Требуется JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Подключение к сети"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Найденные точки доступа Wi-Fi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "Подключение к сети: %q"
 
@@ -2895,15 +2888,15 @@ msgstr "Журнал ядра"
 msgid "Kernel Version"
 msgstr "Версия ядра"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Пароль (ключ)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Ключ №%d"
 
@@ -2947,11 +2940,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Метка"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Язык"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Язык и тема"
 
@@ -2991,7 +2984,7 @@ msgstr "Оставьте поле пустым для автоопределен
 msgid "Leave empty to use the current WAN address"
 msgstr "Оставьте пустым для использования текущего адреса WAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "События:"
 
@@ -3035,7 +3028,7 @@ msgstr ""
 "Список <abbr title=\"Domain Name System\">DNS</abbr>-серверов для "
 "перенаправления запросов"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -3049,7 +3042,7 @@ msgstr ""
 "PMK-R1 из R0KH , который использовался STA во время начальной ассоциации "
 "доменов Mobility."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3079,11 +3072,11 @@ msgstr "Список хостов, поставляющих поддельные
 msgid "Listen Interfaces"
 msgstr "Интерфейс для входящих соединений"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "Порт для входящих соединений"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Принимать подключения только на указанном интерфейсе или, если интерфейс не "
@@ -3108,11 +3101,7 @@ msgstr "Средняя загрузка"
 msgid "Loading"
 msgstr "Загрузка"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr "Загрузка SSH ключей..."
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr "Загрузка содержимого директории..."
 
@@ -3152,7 +3141,7 @@ msgid "Local Startup"
 msgstr "Запуск пакетов и служб пользователя, при включении устройства"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Дата и время"
 
@@ -3191,7 +3180,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Локализовывать запросы"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Запись событий"
 
@@ -3199,7 +3188,7 @@ msgstr "Запись событий"
 msgid "Log queries"
 msgstr "Запись запросов"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Настройка журнала"
 
@@ -3230,22 +3219,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-адрес"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Фильтр MAC-адресов"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-фильтр"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Список MAC"
 
@@ -3273,7 +3262,7 @@ msgstr "МГц"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3295,7 +3284,7 @@ msgstr ""
 msgid "Manual"
 msgstr "Вручную"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr "Мастер"
 
@@ -3303,7 +3292,7 @@ msgstr "Мастер"
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr "Max. Attainable Data Rate (ATTNDR)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr "Максимально разрешенное значение интервала прослушивания клиента"
 
@@ -3329,7 +3318,7 @@ msgstr "Максимальное время ожидания готовност�
 msgid "Maximum number of leased addresses."
 msgstr "Максимальное количество арендованных адресов"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr "Максимальная мощность передачи"
 
@@ -3342,7 +3331,7 @@ msgstr "Максимальная мощность передачи"
 msgid "Mbit/s"
 msgstr "Мбит/с"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr "Средняя"
 
@@ -3354,11 +3343,11 @@ msgstr "Оперативная память (RAM)"
 msgid "Memory usage (%)"
 msgstr "Использование памяти (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr "Mesh ID"
 
@@ -3369,7 +3358,7 @@ msgstr "Метод не найден"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Метрика"
 
@@ -3381,7 +3370,7 @@ msgstr "Зеркальный порт наблюдения"
 msgid "Mirror source port"
 msgstr "Зеркальный исходящий порт"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr "Мобильный домен"
 
@@ -3389,8 +3378,8 @@ msgstr "Мобильный домен"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Режим"
@@ -3421,16 +3410,16 @@ msgstr "Ошибка запроса информации о модеме"
 msgid "Modem init timeout"
 msgstr "Время ожидания инициализации модема"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Монитор"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr "Слишком мало символов"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr "Больше..."
 
@@ -3443,7 +3432,7 @@ msgstr "Настройка config файла fstab (/etc/config/fstab)"
 msgid "Mount Point"
 msgstr "Точка монтирования"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3493,7 +3482,7 @@ msgstr "Переместить вниз"
 msgid "Move up"
 msgstr "Переместить вверх"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3518,11 +3507,11 @@ msgstr "NDP-прокси"
 msgid "NT Domain"
 msgstr "NT домен"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Список NTP-серверов"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3530,7 +3519,7 @@ msgstr "Список NTP-серверов"
 msgid "Name"
 msgstr "Имя"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Имя новой сети"
 
@@ -3540,8 +3529,8 @@ msgstr "Навигация"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3574,7 +3563,7 @@ msgstr "Новое имя интерфейса..."
 msgid "Next »"
 msgstr "Следующий »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "Нет"
@@ -3583,7 +3572,7 @@ msgstr "Нет"
 msgid "No DHCP Server configured for this interface"
 msgstr "DHCP-сервер не настроен для этого интерфейса"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr "Без шифрования"
 
@@ -3595,7 +3584,7 @@ msgstr "Без NAT-T"
 msgid "No data received"
 msgstr "Данные не получены"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr "Нет элементов в этом каталоге"
 
@@ -3626,11 +3615,12 @@ msgstr "Отключить кэш отрицательных ответов"
 msgid "No password set!"
 msgstr "Пароль не установлен!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr "Узлы ещё не определены"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr "Нет публичных ключей"
 
@@ -3675,7 +3665,7 @@ msgstr "Не использовать wildcard"
 msgid "None"
 msgstr "Ничего"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Нормально"
 
@@ -3705,7 +3695,7 @@ msgstr "Не запускается при загрузке"
 msgid "Not supported"
 msgstr "Не поддерживается"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Заметка"
 
@@ -3719,7 +3709,7 @@ msgstr ""
 "Количество кэшированных DNS записей (максимум — 10000, 0 — отключить "
 "кэширование)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr "Количество параллельных потоков используемых для компрессии"
 
@@ -3785,24 +3775,24 @@ msgstr "Открыть список..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr "OpenConnect (CISCO AnyConnect)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "Настройка частоты"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Опция изменена"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Опция удалена"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "Необязательно"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3822,7 +3812,7 @@ msgstr ""
 "d::'), используйте суффикс на вроде ('::1') для этого IPv6 адреса ('a:b:c:"
 "d::1') для этого интерфейса."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
@@ -3830,31 +3820,31 @@ msgstr ""
 "Необязательно. Base64-шифрованный общий ключ. Добавляет дополнительный слой "
 "криптографии с симметричным ключом для постквантовой устойчивости."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 "Необязательно. Создавать маршруты для разрешенных IP адресов для этого узла."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr "Необязательно. Описание узла."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 "Необязательно. Имя хоста пира. Имена разрешаются до появления интерфейса."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr "Необязательно. MTU туннельного интерфейса."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr "Необязательно. Порт узла."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
@@ -3863,7 +3853,7 @@ msgstr ""
 "'0' (отключено). Рекомендуемое значение, если это устройство находится за "
 "NAT 25."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 "Необязательно. Udp-порт, используемый для исходящих и входящих пакетов."
@@ -3924,7 +3914,7 @@ msgstr "Отвергать TOS"
 msgid "Override TTL"
 msgstr "Отвергать TTL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "Назначить имя интерфейса по умолчанию"
 
@@ -3948,7 +3938,7 @@ msgstr "Назначить таблицу внутренних маршруто�
 msgid "Overview"
 msgstr "Обзор"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Перезаписать существующий файл «%s»?"
 
@@ -3993,7 +3983,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr "PIN код отвергнут"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr "PMK R1 Push"
 
@@ -4048,29 +4038,29 @@ msgid "Part of zone %q"
 msgstr "Часть зоны %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Пароль"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "С помощью пароля"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Пароль к Приватному ключу"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "Пароль к внутреннему Приватному ключу"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr "Сложность пароля"
 
@@ -4078,31 +4068,31 @@ msgstr "Сложность пароля"
 msgid "Password2"
 msgstr "Пароль2"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr "Перетащите файл SSH ключа или вставьте содержимое..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Путь к CA-сертификату"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Путь к Client-сертификату"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Путь к Приватному ключу"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "Путь к внутренним CA-сертификатам"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "Путь к внутренним Client-сертификатам"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "Путь к внутреннему Приватному ключу"
 
@@ -4129,7 +4119,7 @@ msgstr "Запрос IP адреса назначения"
 msgid "Peer address is missing"
 msgstr "Отсутствует адрес пира"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr "Пиры"
 
@@ -4149,7 +4139,7 @@ msgstr "Выполнить сброс"
 msgid "Permission denied"
 msgstr "Доступ запрещён"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr "Постоянно держать включенным"
 
@@ -4189,7 +4179,7 @@ msgstr "Введите логин и пароль."
 msgid "Policy"
 msgstr "Политика"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Порт"
 
@@ -4225,7 +4215,7 @@ msgstr "Предпочитать UMTS"
 msgid "Prefix Delegated"
 msgstr "Делегированный префикс"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr "Предварительный ключ"
 
@@ -4246,11 +4236,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr "Запретить прослушивание этих интерфейсов."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Не позволяет клиентам обмениваться друг с другом информацией"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "Приватный ключ"
 
@@ -4281,7 +4271,7 @@ msgstr "Прот."
 msgid "Protocol"
 msgstr "Протокол"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Включить NTP-сервер"
 
@@ -4289,15 +4279,15 @@ msgstr "Включить NTP-сервер"
 msgid "Provide new network"
 msgstr "Предоставлять новую сеть"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Псевдо Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "Публичный ключ"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4332,11 +4322,11 @@ msgstr ""
 "Опрашивать все имеющиеся внешние <abbr title=\"Domain Name System\">DNS</"
 "abbr>-серверы"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr "R0 Key время жизни"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr "R1 Key Holder"
 
@@ -4344,11 +4334,11 @@ msgstr "R1 Key Holder"
 msgid "RFC3947 NAT-T mode"
 msgstr "RFC3947 NAT-T режим"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr "Порог RSSI для присоединения"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Порог RTS/CTS"
 
@@ -4364,31 +4354,31 @@ msgstr "Получение (RX)"
 msgid "RX Rate"
 msgstr "Скорость получения"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr "Скорость получения / Скорость отправки"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Порт Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Секрет Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Сервер Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Порт Radius-Authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Секрет Radius-Authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Сервер Radius-Authentication"
 
@@ -4443,7 +4433,7 @@ msgstr "Трафик в реальном времени"
 msgid "Realtime Wireless"
 msgstr "Беспроводная сеть в реальном времени"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr "Срок реассоциации"
 
@@ -4451,7 +4441,7 @@ msgstr "Срок реассоциации"
 msgid "Rebind protection"
 msgstr "Защита от DNS Rebinding"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Перезагрузка"
@@ -4470,7 +4460,7 @@ msgstr ""
 msgid "Receive"
 msgstr "Приём"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr "Рекомендуемый. IP адреса интерфейса WireGuard."
 
@@ -4510,11 +4500,11 @@ msgstr "Удалённый IPv4-адрес"
 msgid "Remote IPv4 address or FQDN"
 msgstr "Удалённый IPv4-адрес или FQDN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Удалить"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Заменить настройку беспроводного соединения"
 
@@ -4530,7 +4520,7 @@ msgstr "Запрос IPv6 префикс длины"
 msgid "Request timeout"
 msgstr "Таймаут запроса"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "Обязательно"
 
@@ -4539,15 +4529,15 @@ msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 "Требуется для некоторых Интернет провайдеров, например использующих DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr "Обязательно. Приватный ключ в кодировке Base64 для этого интерфейса."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr "Обязательно. Публичный ключ узла в кодировке Base64."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
@@ -4556,27 +4546,27 @@ msgstr ""
 "Обязательно. IP-адреса и префиксы, которые разрешено использовать этому пиру "
 "внутри туннеля. Обычно IP-адреса и сети пира маршрутизируются через туннель."
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr "Требуется hostapd"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr "Требуется hostapd с поддержкой EAP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr "Требуется hostapd с поддержкой OWE"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr "Требуется hostapd с поддержкой SAE"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4592,31 +4582,31 @@ msgstr ""
 "Требуется поддержка внешней сетью DNSSEC; убедитесь, что ответы не "
 "подписанного домена действительно поступают от не подписанных доменов"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr "Требуется wpa-supplicant"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr "Требуется wpa-supplicant с поддержкой EAP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr "Требуется wpa-supplicant с поддержкой OWE"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "Требуется wpa-supplicant с поддержкой SAE"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4667,10 +4657,8 @@ msgstr "Восстановление"
 msgid "Restore backup"
 msgstr "Восстановить резервную копию"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Показать/скрыть пароль"
 
@@ -4678,15 +4666,15 @@ msgstr "Показать/скрыть пароль"
 msgid "Revert"
 msgstr "Вернуть"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "Вернуть изменения"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Ошибка <code>%h</code> отмены конфигурации"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "Отмена конфигурации..."
 
@@ -4702,7 +4690,7 @@ msgstr "Корневая директория для файлов сервера
 msgid "Root preparation"
 msgstr "Подготовка корневой директории"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr "Маршрутизировать разрешенные IP-адреса"
 
@@ -4718,8 +4706,8 @@ msgstr "Тип маршрута"
 msgid "Router Advertisement-Service"
 msgstr "Доступные режимы работы"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Пароль маршрутизатора"
 
@@ -4761,8 +4749,8 @@ msgstr "SHA256"
 msgid "SNR"
 msgstr "SNR"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "Доступ по SSH"
 
@@ -4778,14 +4766,14 @@ msgstr "Порт сервера SSH"
 msgid "SSH username"
 msgstr "SSH логин"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH ключи"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4794,19 +4782,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "Разделы подкачки (swap)"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Сохранить"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Сохранить и применить"
@@ -4819,24 +4805,20 @@ msgstr "Сохранить MTD раздел"
 msgid "Save mtdblock contents"
 msgstr "Сохранить содержимое MTD раздела"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr "Сохранение ключей..."
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Поиск"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Запланированные задания"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Строки добавлены"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Строки удалены"
 
@@ -4854,9 +4836,9 @@ msgstr ""
 "формата завершается с ошибкой. Используйте эту опцию только если уверены, "
 "что файл образа корректный и предназначен именно для данного устройства!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr "Выбрать файл..."
 
@@ -4928,7 +4910,7 @@ msgstr "Секунды с большим числом ошибок (SES)."
 msgid "Short GI"
 msgstr "Short GI"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr "Короткая преамбула"
 
@@ -4948,12 +4930,12 @@ msgstr "Выключить этот интерфейс"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Сигнал"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr "Сигнал / шум"
 
@@ -4973,7 +4955,7 @@ msgstr "Размер"
 msgid "Size of DNS query cache"
 msgstr "Размер кэша DNS запроса"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr "Размер ZRam в мегабайтах"
 
@@ -4990,7 +4972,7 @@ msgstr "Перейти к содержимому"
 msgid "Skip to navigation"
 msgstr "Перейти к навигации"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Программное обеспечение VLAN"
@@ -5031,10 +5013,6 @@ msgstr "Адрес источника"
 msgid "Specifies the directory the device is attached to"
 msgstr "Папка, к которой монтируется раздел устройства"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Порт данного процесса <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -5050,7 +5028,7 @@ msgid ""
 msgstr ""
 "Максимальное количество секунд, после которого узлы считаются отключёнными"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -5081,7 +5059,7 @@ msgstr ""
 "Укажите MTU (Максимальный Объем Данных), отличный от стандартного (1280 "
 "байт)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Укажите закрытый ключ."
 
@@ -5095,16 +5073,16 @@ msgstr "Старт"
 msgid "Start priority"
 msgstr "Приоритет"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "Применение конфигурации..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "Начато сканирование беспроводных сетей..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Загрузка"
 
@@ -5124,7 +5102,7 @@ msgstr "Постоянные аренды"
 msgid "Static Routes"
 msgstr "Статические маршруты"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5140,13 +5118,13 @@ msgstr ""
 "имён DHCP-клиентам. Постоянная аренда также необходима для статических "
 "интерфейсов, в которых обслуживаются только клиенты с присвоенными адресами."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr "Максимально допустимое время бездействия клиента"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Состояние"
@@ -5161,12 +5139,12 @@ msgstr "Остановить"
 msgid "Strict order"
 msgstr "Строгий порядок"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr "Сильная"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Применить"
 
@@ -5206,7 +5184,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Изменить маску порта"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Изменить VLAN"
@@ -5221,11 +5199,11 @@ msgstr "Изменить протокол"
 msgid "Switch to CIDR list notation"
 msgstr "Переключить в формат CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr "Символическая ссылка"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr "Синхронизировать с NTP-сервером"
 
@@ -5235,7 +5213,7 @@ msgstr "Синхронизировать с браузером"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5246,11 +5224,11 @@ msgstr "Система"
 msgid "System Log"
 msgstr "Системный журнал"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Свойства системы"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Размер системного журнала"
 
@@ -5319,7 +5297,7 @@ msgid ""
 msgstr ""
 "Назначенный провайдеру префикс IPv6, обычно заканчивается на <code>::</code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5335,7 +5313,7 @@ msgstr "Архив резервной копии не является прав�
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "Не удалось загрузить config файл из-за следующей ошибки:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5396,11 +5374,11 @@ msgstr "На данном устройстве активны следующие
 msgid "The gateway address must not be a local IP address"
 msgstr "Адрес шлюза не должен быть локальным IP-адресом."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr "Указанный публичный SSH ключ уже добавлен."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5432,7 +5410,7 @@ msgstr "Длина префикса IPv6 в битах"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "Локальный адрес IPv4, по которому создается туннель (необязательно)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr "Имя сети уже используется"
 
@@ -5453,7 +5431,7 @@ msgstr ""
 "внешней сети, например к Интернету и другие порты предназначенные для "
 "внутренней — локальной сети."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr "Выбранный режим %s несовместим с шифрованием %s"
 
@@ -5461,13 +5439,13 @@ msgstr "Выбранный режим %s несовместим с шифров�
 msgid "The submitted security token is invalid or already expired!"
 msgstr "Представленный маркер безопасности недействителен или уже истек!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "Идёт удаление настроек раздела с последующей перезагрузкой системы."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5479,7 +5457,7 @@ msgstr ""
 "потребуется обновить адрес компьютера, чтобы снова подключиться к "
 "устройству, в зависимости от настроек."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "Пароль администратора успешно изменен."
 
@@ -5500,7 +5478,7 @@ msgstr "Нет активных арендованных адресов"
 msgid "There are no active leases."
 msgstr "Нет активных арендованных адресов."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr "Нет изменений для применения"
 
@@ -5519,7 +5497,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "IPv4-адрес ретранслятора"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr "Этот тип аутентификации не применим к выбранному методу EAP"
 
@@ -5612,22 +5590,22 @@ msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Страница содержит список всех активных на данный момент сетевых соединений."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Здесь не содержатся необходимые значения"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Синхронизация времени"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr "Интервал регенерации ключей GTK"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Часовой пояс"
 
@@ -5686,7 +5664,7 @@ msgstr "Режим работы"
 msgid "Tunnel ID"
 msgstr "Идентификатор туннеля"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Интерфейс туннеля"
@@ -5779,12 +5757,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Секунды неготовности (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Неизвестная ошибка (%s)"
@@ -5793,7 +5771,7 @@ msgstr "Неизвестная ошибка (%s)"
 msgid "Unknown error code"
 msgstr "Неизвестный код ошибки"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5804,11 +5782,12 @@ msgstr "Неуправляемый"
 msgid "Unmount"
 msgstr "Отмонтировать"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr "Ключ без имени"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Не принятые изменения"
 
@@ -5850,15 +5829,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Загрузка архива..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr "Загрузка файла"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr "Загрузка файла..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr "Ошибка запроса на загрузку: %d %s"
 
@@ -6005,11 +5984,11 @@ msgstr ""
 msgid "Used"
 msgstr "Использовано"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Используемый слот ключа"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -6092,32 +6071,32 @@ msgstr "Проверить"
 msgid "Virtual dynamic interface"
 msgstr "Виртуальный динамический интерфейс"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Открытая система WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Общий ключ WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Пароль WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Режим WMM"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Пароль WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6133,7 +6112,7 @@ msgstr "Ожидание применения изменений..."
 msgid "Waiting for command to complete..."
 msgstr "Ожидание завершения выполнения команды..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr "Ожидание применения конфигурации... %d сек"
 
@@ -6141,8 +6120,8 @@ msgstr "Ожидание применения конфигурации... %d с�
 msgid "Waiting for device..."
 msgstr "Ожидание подключения устройства..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Внимание"
 
@@ -6152,11 +6131,11 @@ msgstr ""
 "Предупреждение: Есть не сохраненные изменения, которые будут потеряны при "
 "перезагрузке!"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr "Слабая"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6171,7 +6150,7 @@ msgstr ""
 msgid "Width"
 msgstr "Ширина"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr "WireGuard VPN"
@@ -6182,13 +6161,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "Wi-Fi"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Беспроводной адаптер"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6198,7 +6177,7 @@ msgstr "Беспроводная сеть"
 msgid "Wireless Overview"
 msgstr "Список беспроводных сетей"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Безопасность беспроводной сети"
 
@@ -6218,11 +6197,11 @@ msgstr "Беспроводная сеть отключена"
 msgid "Wireless is not associated"
 msgstr "Беспроводная сеть не связана"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Беспроводная сеть отключена"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Беспроводная сеть включена"
 
@@ -6230,11 +6209,11 @@ msgstr "Беспроводная сеть включена"
 msgid "Write received DNS requests to syslog"
 msgstr "Записывать полученные DNS-запросы в системный журнал"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Записывать системные события в файл"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Да"
@@ -6268,19 +6247,19 @@ msgstr ""
 "Вам необходимо включить JavaScript в вашем браузере для корректной работы "
 "LuCI."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr "Алгоритм компрессии ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr "Потоки компрессии ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr "Настройки ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr "Размер ZRam"
 
@@ -6291,7 +6270,7 @@ msgstr "любой"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6349,7 +6328,7 @@ msgstr "дБ"
 msgid "dBm"
 msgstr "дБм"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "отключить"
 
@@ -6450,7 +6429,11 @@ msgstr "ключ длиной 5 или 13 символов"
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "Локальный <abbr title=\"Служба доменных имён\">DNS</abbr>-файл"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "минут(ы)"
 
@@ -6469,7 +6452,7 @@ msgstr "нет соединения"
 msgid "non-empty value"
 msgstr "не пустое значение"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "нет"
 
@@ -6480,8 +6463,8 @@ msgid "not present"
 msgstr "не существует"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6495,6 +6478,10 @@ msgstr "выключено"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "включено"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6513,7 +6500,7 @@ msgstr "положительное десятичное число"
 msgid "positive integer value"
 msgstr "положительное целое число"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "случайно"
 
@@ -6527,8 +6514,8 @@ msgstr "режим передачи"
 msgid "routed"
 msgstr "маршрутизируемый"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr "секунды"
 
@@ -6549,11 +6536,15 @@ msgstr "stateless"
 msgid "stateless + stateful"
 msgstr "stateless + stateful"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "с тегом"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr "единицы измерения времени (TUs / 1.024 ms) [1000-65535]"
 
@@ -6572,7 +6563,7 @@ msgstr "неизвестный"
 msgid "unlimited"
 msgstr "неограниченный"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6753,6 +6744,10 @@ msgstr "значение длиной %d или менее символов"
 msgid "value with at most %d characters"
 msgstr "значение длиной %d или более символов"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6763,6 +6758,27 @@ msgstr "да"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Change login password"
+#~ msgstr "Изменить пароль"
+
+#~ msgid "Changing password…"
+#~ msgstr "Изменение пароля..."
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Отключено (по умолчанию)"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Порты шлюза"
+
+#~ msgid "Loading SSH keys…"
+#~ msgstr "Загрузка SSH ключей..."
+
+#~ msgid "Saving keys…"
+#~ msgstr "Сохранение ключей..."
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Порт данного процесса <em>Dropbear</em>"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Коммутатор %q (%s)"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -13,11 +13,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -59,19 +60,19 @@ msgid "-- Additional Field --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr ""
@@ -94,7 +95,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -106,7 +107,7 @@ msgstr ""
 msgid "15 Minute Load:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -119,35 +120,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr ""
 
@@ -165,7 +166,7 @@ msgid ""
 "order of the resolvfile"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -199,7 +200,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr ""
 
@@ -238,7 +239,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -316,8 +317,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr ""
 
@@ -348,17 +349,17 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -389,10 +390,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -405,7 +409,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -454,8 +458,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -465,11 +469,11 @@ msgstr ""
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -495,23 +499,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr ""
 
@@ -519,15 +523,15 @@ msgstr ""
 msgid "Allow localhost"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 
@@ -536,7 +540,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -544,7 +548,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -623,7 +627,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -642,11 +646,11 @@ msgstr ""
 msgid "Any zone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -670,7 +674,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr ""
@@ -684,7 +688,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr ""
 
@@ -779,7 +783,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr ""
@@ -797,7 +801,7 @@ msgstr ""
 msgid "Backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr ""
 
@@ -814,7 +818,7 @@ msgstr ""
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -849,7 +853,7 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr ""
@@ -867,7 +871,7 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -892,13 +896,13 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr ""
@@ -921,13 +925,7 @@ msgstr ""
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr ""
 
@@ -935,23 +933,19 @@ msgstr ""
 msgid "Changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
-msgstr ""
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr ""
@@ -964,7 +958,7 @@ msgstr ""
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -977,7 +971,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -985,13 +979,13 @@ msgid ""
 "interface to it."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1011,9 +1005,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr ""
 
@@ -1022,8 +1016,8 @@ msgstr ""
 msgid "Client ID to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1046,7 +1040,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1073,7 +1067,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1081,7 +1075,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1097,11 +1091,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1109,7 +1103,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr ""
 
@@ -1142,7 +1136,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1153,12 +1147,12 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
@@ -1166,11 +1160,11 @@ msgstr ""
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr ""
 
@@ -1203,15 +1197,15 @@ msgid ""
 "\">LED</abbr>s if possible."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1224,7 +1218,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1297,7 +1291,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1309,14 +1303,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr ""
 
@@ -1354,47 +1348,47 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr ""
 
@@ -1425,7 +1419,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr ""
 
@@ -1442,7 +1436,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1460,12 +1454,12 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr ""
 
@@ -1479,14 +1473,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1498,11 +1493,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1521,21 +1512,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr ""
 
@@ -1559,15 +1548,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1605,15 +1594,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1642,17 +1631,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr ""
 
@@ -1662,7 +1651,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr ""
 
@@ -1670,12 +1659,12 @@ msgstr ""
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr ""
 
@@ -1710,7 +1699,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1726,11 +1715,11 @@ msgstr ""
 msgid "Enable VLAN functionality"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1754,7 +1743,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1776,7 +1765,7 @@ msgstr ""
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1797,17 +1786,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1819,7 +1808,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr ""
 
@@ -1833,7 +1822,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr ""
 
@@ -1841,12 +1830,12 @@ msgstr ""
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1880,23 +1869,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1904,19 +1893,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1924,15 +1917,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -1977,7 +1970,7 @@ msgstr ""
 msgid "Firewall"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2017,7 +2010,7 @@ msgstr ""
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2025,11 +2018,11 @@ msgstr ""
 msgid "Force"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr ""
 
@@ -2037,11 +2030,11 @@ msgstr ""
 msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
@@ -2073,7 +2066,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2081,7 +2074,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr ""
 
@@ -2090,7 +2083,7 @@ msgstr ""
 msgid "Free"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2112,19 +2105,19 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2132,8 +2125,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
@@ -2141,7 +2134,7 @@ msgstr ""
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2149,7 +2142,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2168,8 +2161,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2199,13 +2192,13 @@ msgstr ""
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -2216,7 +2209,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2241,7 +2234,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr ""
 
@@ -2262,7 +2255,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2483,7 +2476,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr ""
 
@@ -2589,7 +2582,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr ""
 
@@ -2627,7 +2620,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
 
@@ -2635,7 +2628,7 @@ msgstr ""
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr ""
 
@@ -2665,7 +2658,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2695,7 +2688,7 @@ msgstr ""
 msgid "Invalid"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2715,7 +2708,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2723,7 +2716,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2740,15 +2733,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2765,15 +2758,15 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2817,11 +2810,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr ""
 
@@ -2861,7 +2854,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2903,7 +2896,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2912,7 +2905,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2937,11 +2930,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -2964,11 +2957,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3008,7 +2997,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr ""
 
@@ -3040,7 +3029,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3048,7 +3037,7 @@ msgstr ""
 msgid "Log queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3079,22 +3068,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr ""
 
@@ -3122,7 +3111,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3142,7 +3131,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3150,7 +3139,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3176,7 +3165,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3189,7 +3178,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3201,11 +3190,11 @@ msgstr ""
 msgid "Memory usage (%)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3216,7 +3205,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
 
@@ -3228,7 +3217,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3236,8 +3225,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr ""
@@ -3268,16 +3257,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3290,7 +3279,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3338,7 +3327,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr ""
 
@@ -3363,11 +3352,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3375,7 +3364,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr ""
 
@@ -3385,8 +3374,8 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3419,7 +3408,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3428,7 +3417,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3440,7 +3429,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3471,11 +3460,12 @@ msgstr ""
 msgid "No password set!"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3520,7 +3510,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr ""
 
@@ -3550,7 +3540,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr ""
 
@@ -3562,7 +3552,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3628,24 +3618,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3659,41 +3649,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3753,7 +3743,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3775,7 +3765,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3820,7 +3810,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3875,29 +3865,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3905,31 +3895,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3956,7 +3946,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -3976,7 +3966,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4016,7 +4006,7 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr ""
 
@@ -4052,7 +4042,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4071,11 +4061,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4106,7 +4096,7 @@ msgstr ""
 msgid "Protocol"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4114,15 +4104,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4149,11 +4139,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4161,11 +4151,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr ""
 
@@ -4181,31 +4171,31 @@ msgstr ""
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4253,7 +4243,7 @@ msgstr ""
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4261,7 +4251,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr ""
@@ -4279,7 +4269,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4319,11 +4309,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4339,7 +4329,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4347,42 +4337,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4394,31 +4384,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4469,10 +4459,8 @@ msgstr ""
 msgid "Restore backup"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr ""
 
@@ -4480,15 +4468,15 @@ msgstr ""
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4504,7 +4492,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4520,8 +4508,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr ""
 
@@ -4561,8 +4549,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr ""
 
@@ -4578,14 +4566,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr ""
@@ -4594,19 +4582,17 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4619,24 +4605,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr ""
 
@@ -4651,9 +4633,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4722,7 +4704,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4742,12 +4724,12 @@ msgstr ""
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4767,7 +4749,7 @@ msgstr ""
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4784,7 +4766,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4822,10 +4804,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4838,7 +4816,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4861,7 +4839,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4875,16 +4853,16 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr ""
 
@@ -4904,7 +4882,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4917,13 +4895,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr ""
@@ -4938,12 +4916,12 @@ msgstr ""
 msgid "Strict order"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr ""
 
@@ -4981,7 +4959,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -4996,11 +4974,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5010,7 +4988,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5021,11 +4999,11 @@ msgstr ""
 msgid "System Log"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5091,7 +5069,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5105,7 +5083,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5151,11 +5129,11 @@ msgstr ""
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5185,7 +5163,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5199,7 +5177,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5207,13 +5185,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5221,7 +5199,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5240,7 +5218,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5257,7 +5235,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5331,22 +5309,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr ""
 
@@ -5401,7 +5379,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5494,12 +5472,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5508,7 +5486,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5519,11 +5497,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5561,15 +5540,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5707,11 +5686,11 @@ msgstr ""
 msgid "Used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5791,32 +5770,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5830,7 +5809,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5838,8 +5817,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr ""
 
@@ -5847,11 +5826,11 @@ msgstr ""
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5863,7 +5842,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5874,13 +5853,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5890,7 +5869,7 @@ msgstr ""
 msgid "Wireless Overview"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr ""
 
@@ -5910,11 +5889,11 @@ msgstr ""
 msgid "Wireless is not associated"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr ""
 
@@ -5922,11 +5901,11 @@ msgstr ""
 msgid "Write received DNS requests to syslog"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -5952,19 +5931,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -5975,7 +5954,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6033,7 +6012,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr ""
 
@@ -6132,7 +6111,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6151,7 +6134,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr ""
 
@@ -6162,8 +6145,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6176,6 +6159,10 @@ msgstr ""
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:205
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
@@ -6195,7 +6182,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6209,8 +6196,8 @@ msgstr ""
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6231,11 +6218,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6254,7 +6245,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6433,6 +6424,10 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:441
 msgid "value with at most %d characters"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -2126,7 +2126,7 @@ msgstr "Gateway"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Gateway-portar"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6472,9 +6472,6 @@ msgstr "« Bakåt"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Inaktiverad (standard)"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Gateway-portar"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "Anger lyssningsporten för den här <em>Dropbear</em>-instansen"

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -15,11 +15,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -61,19 +62,19 @@ msgid "-- Additional Field --"
 msgstr "-- Ytterligare fält --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Vänligen välj --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- anpassad --"
@@ -96,7 +97,7 @@ msgstr "-- matcha enligt uuid --"
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -108,7 +109,7 @@ msgstr "Belastning senaste minuten:"
 msgid "15 Minute Load:"
 msgstr "Belastning senaste 15 minutrarna:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -121,35 +122,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "Belastning senaste 5 minutrarna:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr "802.11r Snabb förvandling"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -167,7 +168,7 @@ msgid ""
 "order of the resolvfile"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -204,7 +205,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Lysdiod\">LED</abbr>-konfiguration"
 
@@ -245,7 +246,7 @@ msgstr ""
 "<br/>Notera att: du måste starta om cron-tjänsten om crontab-filen var tom "
 "innan den ändrades."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -323,8 +324,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Accesspunkt"
 
@@ -355,17 +356,17 @@ msgstr "Aktiva DHCP-kontrakt"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktiva DHCPv6-kontrakt"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -396,10 +397,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -412,7 +416,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Lägg till ett nytt gränssnitt"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -461,8 +465,8 @@ msgstr "Administration"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -472,11 +476,11 @@ msgstr "Avancerade inställningar"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Varning"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -503,23 +507,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr "Allokera IP sekventiellt"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Tillåt <abbr title=\"Secure Shell\">SSH</abbr> lösenordsautentisering"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Tillåt alla utom listade"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Tillåt enbart listade"
 
@@ -527,17 +531,17 @@ msgstr "Tillåt enbart listade"
 msgid "Allow localhost"
 msgstr "Tillåt localhost"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Tillåt fjärrstyrda värdar att ansluta via SSH till lokalt vidarebefordrade "
 "portar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Tillåt root-inloggningar med lösenord"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Tillåt <em>root</em>-användaren att logga in med lösenord"
 
@@ -546,7 +550,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "Tillåtna IP-adresser"
 
@@ -554,7 +558,7 @@ msgstr "Tillåtna IP-adresser"
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -633,7 +637,7 @@ msgstr "Aviserade DNS-domäner"
 msgid "Announced DNS servers"
 msgstr "Aviserade DNS-servrar"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr "Anonym identitet"
 
@@ -652,11 +656,11 @@ msgstr "Anonym Swap"
 msgid "Any zone"
 msgstr "Någon zon"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -680,7 +684,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Associerade stationer"
@@ -694,7 +698,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr "Autentiseringsgrupp"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Autentisering"
 
@@ -789,7 +793,7 @@ msgstr "BR / DMR / AFTR"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -807,7 +811,7 @@ msgstr "Backa till konfiguration"
 msgid "Backup"
 msgstr "Säkerhetskopiera"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Säkerhetskopiera / Flasha inre mjukvara"
 
@@ -824,7 +828,7 @@ msgstr "Fel adress angiven!"
 msgid "Band"
 msgstr "Band"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -859,7 +863,7 @@ msgstr "Bithastighet"
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Brygga"
@@ -877,7 +881,7 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -903,13 +907,13 @@ msgstr "CPU-användning (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Avbryt"
@@ -932,13 +936,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Kedja"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Ändringar"
 
@@ -946,23 +944,19 @@ msgstr "Ändringar"
 msgid "Changes applied."
 msgstr "Tillämpade ändringar"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Ändrar administratörens lösenord för att få tillgång till enheten"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Kanal"
@@ -975,7 +969,7 @@ msgstr "Kontrollera"
 msgid "Check filesystems before mount"
 msgstr "Kontrollera filsystemen innan de monteras"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 "Bocka för det här alternativet för att ta bort befintliga nätverk från den "
@@ -990,7 +984,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -998,13 +992,13 @@ msgid ""
 "interface to it."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Chiffer"
 
@@ -1024,9 +1018,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Klient"
 
@@ -1035,8 +1029,8 @@ msgstr "Klient"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Klient-ID att skicka vid DHCP-förfrågning"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1059,7 +1053,7 @@ msgstr "Stäng ner lista..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1086,7 +1080,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1094,7 +1088,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1110,11 +1104,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1122,7 +1116,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Bekräftelse"
 
@@ -1155,7 +1149,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1166,12 +1160,12 @@ msgstr ""
 msgid "Country"
 msgstr "Land"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Landskod"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
@@ -1179,11 +1173,11 @@ msgstr ""
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Kritisk"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Loggnivå för Cron"
 
@@ -1216,15 +1210,15 @@ msgid ""
 "\">LED</abbr>s if possible."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1237,7 +1231,7 @@ msgstr "DHCP-server"
 msgid "DHCP and DNS"
 msgstr "DHCP och DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1310,7 +1304,7 @@ msgstr "DSL-status"
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1322,14 +1316,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr "Datahastighet"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Avlusa"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Standard %d"
 
@@ -1367,47 +1361,47 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Radera"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Ta bort det här nätverket"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Beskrivning"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr ""
 
@@ -1438,7 +1432,7 @@ msgstr ""
 msgid "Device"
 msgstr "Enhet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Enhetskonfiguration"
 
@@ -1455,7 +1449,7 @@ msgstr "Enheten startar om..."
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Enheten kan inte nås"
 
@@ -1473,12 +1467,12 @@ msgstr ""
 msgid "Dial number"
 msgstr "Slå nummer"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Mapp"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Inaktivera"
 
@@ -1494,14 +1488,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Inaktivera kryptering"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1513,11 +1508,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Inaktiverad"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Inaktiverad (standard)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1536,21 +1527,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Avståndsoptimering"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Avstånd till nätverksmledlemmen längst bort i metrar."
 
@@ -1576,15 +1565,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1624,15 +1613,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Dropbear-instans"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1661,17 +1650,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP-metod"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Redigera"
 
@@ -1681,7 +1670,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Redigera det här nätverket"
 
@@ -1689,12 +1678,12 @@ msgstr "Redigera det här nätverket"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Nödsituation"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Aktivera"
 
@@ -1729,7 +1718,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Aktivera NTP-klient"
 
@@ -1745,11 +1734,11 @@ msgstr "Aktivera TFTP-server"
 msgid "Enable VLAN functionality"
 msgstr "Aktivera VLAN-funktionalitet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "Aktivera WPS-tryckknapp, kräver WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "Kräver ominstallation av nyckel (KRACK) motåtgärder"
 
@@ -1773,7 +1762,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "Aktivera den här monteringen"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1795,7 +1784,7 @@ msgstr "Aktiverad"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1816,17 +1805,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1838,7 +1827,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Raderar..."
 
@@ -1852,7 +1841,7 @@ msgstr "Raderar..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Fel"
 
@@ -1860,12 +1849,12 @@ msgstr "Fel"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet-adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1899,23 +1888,23 @@ msgstr ""
 msgid "External"
 msgstr "Externt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1923,19 +1912,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr "Extra alternativ för SSH-kommandot"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1943,15 +1936,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -1996,7 +1989,7 @@ msgstr "Avsluta"
 msgid "Firewall"
 msgstr "Brandvägg"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2036,7 +2029,7 @@ msgstr ""
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Skriver..."
 
@@ -2044,11 +2037,11 @@ msgstr "Skriver..."
 msgid "Force"
 msgstr "Tvinga"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Tvinga CCMP (AES)"
 
@@ -2056,11 +2049,11 @@ msgstr "Tvinga CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Tvinga DHCP på det här nätverket även om en annan server är upptäckt."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Tvinga TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Tvinga TKIP och CCMP (AES)"
 
@@ -2092,7 +2085,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2100,7 +2093,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "Vidarebefordringsläge"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr ""
 
@@ -2109,7 +2102,7 @@ msgstr ""
 msgid "Free"
 msgstr "Fritt"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2131,19 +2124,19 @@ msgstr "Endast GPRS"
 msgid "Gateway"
 msgstr "Gateway"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Gateway-portar"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2151,8 +2144,8 @@ msgstr "Generella inställningar"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
@@ -2160,7 +2153,7 @@ msgstr ""
 msgid "Generate Config"
 msgstr "Generera konfig"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2168,7 +2161,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Generera arkiv"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Angiven lösenordsbekräftelse matchade inte, lösenordet ändrades inte!"
 
@@ -2187,8 +2180,8 @@ msgstr "Globala nätverksalternativ"
 msgid "Go to password configuration..."
 msgstr "Gå till lösenordskonfiguration..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2218,13 +2211,13 @@ msgstr "Lägg på"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Göm <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2235,7 +2228,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "Värd"
 
@@ -2260,7 +2253,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Värdnamn"
 
@@ -2281,7 +2274,7 @@ msgstr "Hybrid"
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "IP-adresser"
 
@@ -2502,7 +2495,7 @@ msgstr "IPv6-över-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-över-IPv4 (6till4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Identitet"
 
@@ -2608,7 +2601,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr "Ankommande"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Info"
 
@@ -2646,7 +2639,7 @@ msgstr "Installera protokoll-förlängningar..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Gränssnitt"
 
@@ -2654,7 +2647,7 @@ msgstr "Gränssnitt"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Konfiguration av gränssnitt"
 
@@ -2684,7 +2677,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "Gränssnittets namn"
 
@@ -2714,7 +2707,7 @@ msgstr "Internt server-fel"
 msgid "Invalid"
 msgstr "Ogiltig"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2734,7 +2727,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2742,7 +2735,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Ogiltigt användarnamn och/eller lösenord! Vänligen försök igen."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "Isolera klienter"
 
@@ -2759,15 +2752,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "JavaScript krävs!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Anslut till nätverk"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Anslut till nätverk: Trådlös skanning"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "Ansluter till nätverk: %q"
 
@@ -2784,15 +2777,15 @@ msgstr "Kernel-logg"
 msgid "Kernel Version"
 msgstr "Kernel-version"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Nyckel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Nyckel #%d"
 
@@ -2836,11 +2829,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Märke"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Språk"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Språk och Stil"
 
@@ -2880,7 +2873,7 @@ msgstr "Lämna tom för att upptäcka automatiskt"
 msgid "Leave empty to use the current WAN address"
 msgstr "Lämna tom för att använda den nuvarande WAN-adressen"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2922,7 +2915,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2931,7 +2924,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2956,11 +2949,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "Lyssningsportar"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Lyssna endast på det angivna gränssnittet eller, om o-specificerat på alla"
@@ -2984,11 +2977,7 @@ msgstr "Snitt-belastning"
 msgid "Loading"
 msgstr "Laddar"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3028,7 +3017,7 @@ msgid "Local Startup"
 msgstr "Lokal uppstart"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Lokal tid"
 
@@ -3060,7 +3049,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Lokalisera förfrågningar"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3068,7 +3057,7 @@ msgstr ""
 msgid "Log queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3099,22 +3088,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-adress"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Filter för MAC-adress"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-filter"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC-lista"
 
@@ -3142,7 +3131,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3162,7 +3151,7 @@ msgstr ""
 msgid "Manual"
 msgstr "Manuell"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3170,7 +3159,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3196,7 +3185,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3209,7 +3198,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3221,11 +3210,11 @@ msgstr "Minne"
 msgid "Memory usage (%)"
 msgstr "Minnesanvändning (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3236,7 +3225,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metrisk"
 
@@ -3248,7 +3237,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3256,8 +3245,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Läge"
@@ -3288,16 +3277,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Övervaka"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3310,7 +3299,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr "Monteringspunkt"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3358,7 +3347,7 @@ msgstr "Flytta ner"
 msgid "Move up"
 msgstr "Flytta upp"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS-ID"
 
@@ -3383,11 +3372,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr "NT-domän"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "NTP-serverkandidater"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3395,7 +3384,7 @@ msgstr "NTP-serverkandidater"
 msgid "Name"
 msgstr "Namn"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Namnet på det nya nätverket"
 
@@ -3405,8 +3394,8 @@ msgstr "Navigering"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3439,7 +3428,7 @@ msgstr ""
 msgid "Next »"
 msgstr "Nästa »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3448,7 +3437,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "Det finns ingen DHCP-server inställd för det här gränssnittet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3460,7 +3449,7 @@ msgstr "Ingen NAT-T"
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3491,11 +3480,12 @@ msgstr "Ingen negativ cache"
 msgid "No password set!"
 msgstr "Inget lösenord inställt!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3540,7 +3530,7 @@ msgstr ""
 msgid "None"
 msgstr "Ingen"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Normal"
 
@@ -3570,7 +3560,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Avisering"
 
@@ -3582,7 +3572,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3648,24 +3638,24 @@ msgstr "Öppna lista..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr "OpenConnect (CISCO AnyConnect)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Alternativet ändrades"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Alternativet togs bort"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "Valfri"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3679,41 +3669,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3773,7 +3763,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3795,7 +3785,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Överblick"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3840,7 +3830,7 @@ msgstr "PIN-kod"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3895,29 +3885,29 @@ msgid "Part of zone %q"
 msgstr "Del av zon %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Lösenord"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Lösenordsautentisering"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Den privata nyckelns lösenord"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "Lösenordet för den inre privata nyckeln"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3925,31 +3915,31 @@ msgstr ""
 msgid "Password2"
 msgstr "Lösenord2"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Genväg till CA-certifikat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Genväg till klient-certifikat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Genväg till privat nyckel"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "Genväg till det inre CA-certifikatet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "Genväg till det inre klient-certifikatet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "Genväg till den inre privata nyckeln"
 
@@ -3976,7 +3966,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -3996,7 +3986,7 @@ msgstr "Utför återställning"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4036,7 +4026,7 @@ msgstr "Vänligen ange ditt användarnamn och lösenord."
 msgid "Policy"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Port"
 
@@ -4072,7 +4062,7 @@ msgstr "Föredra UMTS"
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4091,11 +4081,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr "Förhindra lyssning på dessa gränssnitt."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Förhindrar kommunikation klient-till-klient"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "Privat nyckel"
 
@@ -4126,7 +4116,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4134,15 +4124,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "Publik nyckel"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4169,11 +4159,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4181,11 +4171,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr ""
 
@@ -4201,31 +4191,31 @@ msgstr "RT"
 msgid "RX Rate"
 msgstr "RX-hastighet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4275,7 +4265,7 @@ msgstr "Trafik i realtid"
 msgid "Realtime Wireless"
 msgstr "Trådlöst i realtid"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4283,7 +4273,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Starta om"
@@ -4301,7 +4291,7 @@ msgstr "Startar om din enhets operativsystem"
 msgid "Receive"
 msgstr "Ta emot"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr "Rekommenderad. WireGuard-gränssnittets IP-adress"
 
@@ -4341,11 +4331,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Ta bort"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Ersätt trådlös konfiguration"
 
@@ -4361,7 +4351,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "Krävs!"
 
@@ -4369,42 +4359,42 @@ msgstr "Krävs!"
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4416,31 +4406,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4491,10 +4481,8 @@ msgstr "Återställ"
 msgid "Restore backup"
 msgstr "Återställ säkerhetskopian"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Visa/göm lösenord"
 
@@ -4502,15 +4490,15 @@ msgstr "Visa/göm lösenord"
 msgid "Revert"
 msgstr "Återgå"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4526,7 +4514,7 @@ msgstr "Root-mappen för filer som skickas via TFTP"
 msgid "Root preparation"
 msgstr "Root-förberedelse"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4542,8 +4530,8 @@ msgstr "Typ av rutt"
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Router-lösenord"
 
@@ -4583,8 +4571,8 @@ msgstr "SHA256"
 msgid "SNR"
 msgstr "SNR"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH-åtkomst"
 
@@ -4600,14 +4588,14 @@ msgstr "SSH-serverns port"
 msgid "SSH username"
 msgstr "Användarnamn för SSH"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH-nycklar"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4616,19 +4604,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Spara"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Spara och Verkställ"
@@ -4641,24 +4627,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Skanna"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Schemalagda uppgifter"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Sektionen lades till"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Sektionen togs bort"
 
@@ -4673,9 +4655,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4744,7 +4726,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4764,12 +4746,12 @@ msgstr "Stäng ner det här gränssnittet"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Signal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4789,7 +4771,7 @@ msgstr "Storlek"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4806,7 +4788,7 @@ msgstr "Hoppa över till innehåll"
 msgid "Skip to navigation"
 msgstr "Hoppa över till navigering"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4844,10 +4826,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Anger lyssningsporten för den här <em>Dropbear</em>-instansen"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4860,7 +4838,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4883,7 +4861,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Ange den hemliga krypteringsnyckeln här."
 
@@ -4897,16 +4875,16 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr ""
 
@@ -4926,7 +4904,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr "Statiska rutter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4939,13 +4917,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Status"
@@ -4960,12 +4938,12 @@ msgstr ""
 msgid "Strict order"
 msgstr "Strikt sortering"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Skicka in"
 
@@ -5003,7 +4981,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "Byt VLAN"
@@ -5018,11 +4996,11 @@ msgstr "Byt protokoll"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5032,7 +5010,7 @@ msgstr "Synkronisera med webbläsare"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5043,11 +5021,11 @@ msgstr "System"
 msgid "System Log"
 msgstr "Systemlogg"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Systemets egenskaper"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5113,7 +5091,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5127,7 +5105,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5173,11 +5151,11 @@ msgstr ""
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5207,7 +5185,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5221,7 +5199,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5229,13 +5207,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5243,7 +5221,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5262,7 +5240,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "Det finns inga aktiva kontrakt."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5281,7 +5259,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5355,22 +5333,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Synkronisering av tid"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Tidszon"
 
@@ -5427,7 +5405,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr "Tunnel-ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Tunnelgränssnitt"
@@ -5520,12 +5498,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Otillgängliga Sekunder (UAS)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Okänd"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5534,7 +5512,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5545,11 +5523,12 @@ msgstr ""
 msgid "Unmount"
 msgstr "Avmontera"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Osparade ändringar"
 
@@ -5587,15 +5566,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Ladda upp arkiv..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5733,11 +5712,11 @@ msgstr ""
 msgid "Used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5817,32 +5796,32 @@ msgstr "Verkställ"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Öppet System WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP-lösenordsfras"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM-läge"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA-lösenordsfras"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5856,7 +5835,7 @@ msgstr "Väntar på att ändringarna ska tillämpas..."
 msgid "Waiting for command to complete..."
 msgstr "Väntar på att kommandot ska avsluta..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5864,8 +5843,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr "Väntar på enheten..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Varning"
 
@@ -5874,11 +5853,11 @@ msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 "Varning: Det finns osparade ändringar som kommer att förloras vid omstart!"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5890,7 +5869,7 @@ msgstr ""
 msgid "Width"
 msgstr "Bredd"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5901,13 +5880,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Trådlöst"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Trådlös adapter"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5917,7 +5896,7 @@ msgstr "Trådlöst nätverk"
 msgid "Wireless Overview"
 msgstr "Trådlös överblick"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Trådlös säkerhet"
 
@@ -5937,11 +5916,11 @@ msgstr "Trådlöst är avstängt"
 msgid "Wireless is not associated"
 msgstr "Trådlöst är inte associerat"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Trådlöst nätverk är avstängt"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Trådlöst nätverk är aktiverat"
 
@@ -5949,11 +5928,11 @@ msgstr "Trådlöst nätverk är aktiverat"
 msgid "Write received DNS requests to syslog"
 msgstr "Skriv mottagna DNS-förfrågningar till syslogg"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Skriv systemlogg till fil"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -5981,19 +5960,19 @@ msgstr ""
 "Du måste aktivera JavaScript i din webbläsare, annars kommer inte LuCi att "
 "fungera korrekt."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6004,7 +5983,7 @@ msgstr "något"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6062,7 +6041,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "stäng ner"
 
@@ -6161,7 +6140,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "lokal <abbr title=\"Domain Name System\">DNS</abbr>-fil"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "minuter"
 
@@ -6180,7 +6163,7 @@ msgstr "ingen länk"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr ""
 
@@ -6191,8 +6174,8 @@ msgid "not present"
 msgstr "inte tillgängligt"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6206,6 +6189,10 @@ msgstr "av"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "på"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6224,7 +6211,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6238,8 +6225,8 @@ msgstr "relä-läge"
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6260,11 +6247,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "taggad"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6283,7 +6274,7 @@ msgstr "okänd"
 msgid "unlimited"
 msgstr "obegränsat"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6464,6 +6455,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6474,6 +6469,15 @@ msgstr "ja"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Bakåt"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Inaktiverad (standard)"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Gateway-portar"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Anger lyssningsporten för den här <em>Dropbear</em>-instansen"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Byt %q (%s)"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -5,11 +5,12 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -51,19 +52,19 @@ msgid "-- Additional Field --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr ""
@@ -86,7 +87,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -98,7 +99,7 @@ msgstr ""
 msgid "15 Minute Load:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -111,35 +112,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr ""
 
@@ -157,7 +158,7 @@ msgid ""
 "order of the resolvfile"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -191,7 +192,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr ""
 
@@ -230,7 +231,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -308,8 +309,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr ""
 
@@ -340,17 +341,17 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -381,10 +382,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -397,7 +401,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -446,8 +450,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -457,11 +461,11 @@ msgstr ""
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -487,23 +491,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr ""
 
@@ -511,15 +515,15 @@ msgstr ""
 msgid "Allow localhost"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 
@@ -528,7 +532,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -536,7 +540,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -615,7 +619,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -634,11 +638,11 @@ msgstr ""
 msgid "Any zone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -662,7 +666,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr ""
@@ -676,7 +680,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr ""
 
@@ -771,7 +775,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr ""
@@ -789,7 +793,7 @@ msgstr ""
 msgid "Backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -841,7 +845,7 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr ""
@@ -859,7 +863,7 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -884,13 +888,13 @@ msgstr ""
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr ""
@@ -913,13 +917,7 @@ msgstr ""
 msgid "Chain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr ""
 
@@ -927,23 +925,19 @@ msgstr ""
 msgid "Changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
-msgstr ""
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr ""
@@ -956,7 +950,7 @@ msgstr ""
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -969,7 +963,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -977,13 +971,13 @@ msgid ""
 "interface to it."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1003,9 +997,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr ""
 
@@ -1014,8 +1008,8 @@ msgstr ""
 msgid "Client ID to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1038,7 +1032,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1065,7 +1059,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1073,7 +1067,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1089,11 +1083,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1101,7 +1095,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr ""
 
@@ -1134,7 +1128,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1145,12 +1139,12 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
@@ -1158,11 +1152,11 @@ msgstr ""
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr ""
 
@@ -1195,15 +1189,15 @@ msgid ""
 "\">LED</abbr>s if possible."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1216,7 +1210,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1289,7 +1283,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1301,14 +1295,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr ""
 
@@ -1346,47 +1340,47 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr ""
 
@@ -1417,7 +1411,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr ""
 
@@ -1434,7 +1428,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1452,12 +1446,12 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr ""
 
@@ -1471,14 +1465,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1490,11 +1485,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1513,21 +1504,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr ""
 
@@ -1551,15 +1540,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1597,15 +1586,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1634,17 +1623,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr ""
 
@@ -1654,7 +1643,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr ""
 
@@ -1662,12 +1651,12 @@ msgstr ""
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr ""
 
@@ -1702,7 +1691,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1718,11 +1707,11 @@ msgstr ""
 msgid "Enable VLAN functionality"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1746,7 +1735,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1768,7 +1757,7 @@ msgstr ""
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1789,17 +1778,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1811,7 +1800,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr ""
 
@@ -1825,7 +1814,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr ""
 
@@ -1833,12 +1822,12 @@ msgstr ""
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1872,23 +1861,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1896,19 +1885,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1916,15 +1909,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -1969,7 +1962,7 @@ msgstr ""
 msgid "Firewall"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2009,7 +2002,7 @@ msgstr ""
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2017,11 +2010,11 @@ msgstr ""
 msgid "Force"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr ""
 
@@ -2029,11 +2022,11 @@ msgstr ""
 msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
@@ -2065,7 +2058,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2073,7 +2066,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr ""
 
@@ -2082,7 +2075,7 @@ msgstr ""
 msgid "Free"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2104,19 +2097,19 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2124,8 +2117,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
@@ -2133,7 +2126,7 @@ msgstr ""
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2141,7 +2134,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2160,8 +2153,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2191,13 +2184,13 @@ msgstr ""
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -2208,7 +2201,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2233,7 +2226,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr ""
 
@@ -2254,7 +2247,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2475,7 +2468,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr ""
 
@@ -2581,7 +2574,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr ""
 
@@ -2619,7 +2612,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
 
@@ -2627,7 +2620,7 @@ msgstr ""
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr ""
 
@@ -2657,7 +2650,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2687,7 +2680,7 @@ msgstr ""
 msgid "Invalid"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2707,7 +2700,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2715,7 +2708,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2732,15 +2725,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2757,15 +2750,15 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2809,11 +2802,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr ""
 
@@ -2853,7 +2846,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2895,7 +2888,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2904,7 +2897,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2929,11 +2922,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -2956,11 +2949,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3000,7 +2989,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr ""
 
@@ -3032,7 +3021,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3040,7 +3029,7 @@ msgstr ""
 msgid "Log queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3071,22 +3060,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr ""
 
@@ -3114,7 +3103,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3134,7 +3123,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3142,7 +3131,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3168,7 +3157,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3181,7 +3170,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3193,11 +3182,11 @@ msgstr ""
 msgid "Memory usage (%)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3208,7 +3197,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
 
@@ -3220,7 +3209,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3228,8 +3217,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr ""
@@ -3260,16 +3249,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3282,7 +3271,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3330,7 +3319,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr ""
 
@@ -3355,11 +3344,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3367,7 +3356,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr ""
 
@@ -3377,8 +3366,8 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3411,7 +3400,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3420,7 +3409,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3432,7 +3421,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3463,11 +3452,12 @@ msgstr ""
 msgid "No password set!"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3512,7 +3502,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr ""
 
@@ -3542,7 +3532,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr ""
 
@@ -3554,7 +3544,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3620,24 +3610,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3651,41 +3641,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3745,7 +3735,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3767,7 +3757,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3812,7 +3802,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3867,29 +3857,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3897,31 +3887,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3948,7 +3938,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -3968,7 +3958,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4008,7 +3998,7 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr ""
 
@@ -4044,7 +4034,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4063,11 +4053,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4098,7 +4088,7 @@ msgstr ""
 msgid "Protocol"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4106,15 +4096,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4141,11 +4131,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4153,11 +4143,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr ""
 
@@ -4173,31 +4163,31 @@ msgstr ""
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4245,7 +4235,7 @@ msgstr ""
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4253,7 +4243,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr ""
@@ -4271,7 +4261,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4311,11 +4301,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4331,7 +4321,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4339,42 +4329,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4386,31 +4376,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4461,10 +4451,8 @@ msgstr ""
 msgid "Restore backup"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr ""
 
@@ -4472,15 +4460,15 @@ msgstr ""
 msgid "Revert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4496,7 +4484,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4512,8 +4500,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr ""
 
@@ -4553,8 +4541,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr ""
 
@@ -4570,14 +4558,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr ""
@@ -4586,19 +4574,17 @@ msgstr ""
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr ""
@@ -4611,24 +4597,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr ""
 
@@ -4643,9 +4625,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4714,7 +4696,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4734,12 +4716,12 @@ msgstr ""
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4759,7 +4741,7 @@ msgstr ""
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4776,7 +4758,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4814,10 +4796,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4830,7 +4808,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4853,7 +4831,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4867,16 +4845,16 @@ msgstr ""
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr ""
 
@@ -4896,7 +4874,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4909,13 +4887,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr ""
@@ -4930,12 +4908,12 @@ msgstr ""
 msgid "Strict order"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr ""
 
@@ -4973,7 +4951,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -4988,11 +4966,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5002,7 +4980,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5013,11 +4991,11 @@ msgstr ""
 msgid "System Log"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5083,7 +5061,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5097,7 +5075,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5143,11 +5121,11 @@ msgstr ""
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5177,7 +5155,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5191,7 +5169,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5199,13 +5177,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5213,7 +5191,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5232,7 +5210,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5249,7 +5227,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5323,22 +5301,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr ""
 
@@ -5393,7 +5371,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5486,12 +5464,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5500,7 +5478,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5511,11 +5489,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5553,15 +5532,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5699,11 +5678,11 @@ msgstr ""
 msgid "Used"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5783,32 +5762,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5822,7 +5801,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5830,8 +5809,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr ""
 
@@ -5839,11 +5818,11 @@ msgstr ""
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5855,7 +5834,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5866,13 +5845,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5882,7 +5861,7 @@ msgstr ""
 msgid "Wireless Overview"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr ""
 
@@ -5902,11 +5881,11 @@ msgstr ""
 msgid "Wireless is not associated"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr ""
 
@@ -5914,11 +5893,11 @@ msgstr ""
 msgid "Write received DNS requests to syslog"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -5944,19 +5923,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -5967,7 +5946,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6025,7 +6004,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr ""
 
@@ -6124,7 +6103,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6143,7 +6126,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr ""
 
@@ -6154,8 +6137,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6168,6 +6151,10 @@ msgstr ""
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:205
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
@@ -6187,7 +6174,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6201,8 +6188,8 @@ msgstr ""
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6223,11 +6210,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6246,7 +6237,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6425,6 +6416,10 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:441
 msgid "value with at most %d characters"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -16,11 +16,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -62,19 +63,19 @@ msgid "-- Additional Field --"
 msgstr "-- Ek Alan--"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Lütfen seçiniz --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- özel --"
@@ -97,7 +98,7 @@ msgstr "-- uuid'e göre eşleştir --"
 msgid "-- please select --"
 msgstr "-- lütfen seçin --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -109,7 +110,7 @@ msgstr "1 Dakikalık Yük:"
 msgid "15 Minute Load:"
 msgstr "15 Dakikalık Yük:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr "4 karakterli HEX ID"
 
@@ -122,35 +123,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "5 Dakikalık Yük:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\\\"Temel Servis Ayar Tanımlayıcısı\\\"> BSSID </abbr>"
 
@@ -168,7 +169,7 @@ msgid ""
 "order of the resolvfile"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -204,7 +205,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Ayarları"
 
@@ -247,7 +248,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -325,8 +326,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Erişim Noktası"
 
@@ -359,17 +360,17 @@ msgstr "Aktif DHCP Kiraları"
 msgid "Active DHCPv6 Leases"
 msgstr "Aktif DHCPv6 Kiraları"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -400,10 +401,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -416,7 +420,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr "Yeni arabirim ekle..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -465,8 +469,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -476,11 +480,11 @@ msgstr "Gelişmiş Ayarlar"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Uyarı"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -507,24 +511,24 @@ msgid "Allocate IP sequentially"
 msgstr ""
 
 # "Secure Shell" için ne kullanılabilinir bir fikrim yok.
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "<abbr title=\"Secure Shell\">SSH</abbr> parola kimlik doğrulamasına izin ver"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Listelenenlerin haricindekilere izin ver"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Yanlızca listelenenlere izin ver"
 
@@ -532,15 +536,15 @@ msgstr "Yanlızca listelenenlere izin ver"
 msgid "Allow localhost"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 
@@ -549,7 +553,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -557,7 +561,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -636,7 +640,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -655,11 +659,11 @@ msgstr ""
 msgid "Any zone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -683,7 +687,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "İlişkili istasyonlar"
@@ -697,7 +701,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Kimlik Doğrulama"
 
@@ -792,7 +796,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -810,7 +814,7 @@ msgstr "Yapılandırmaya dön"
 msgid "Backup"
 msgstr "Yedekleme"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Yedek/Firmware Yazma"
 
@@ -827,7 +831,7 @@ msgstr ""
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -862,7 +866,7 @@ msgstr "Bit hızı"
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Köprü"
@@ -880,7 +884,7 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -905,13 +909,13 @@ msgstr "CPU kullanımı (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Vazgeç"
@@ -934,13 +938,7 @@ msgstr ""
 msgid "Chain"
 msgstr "Zincir"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Değişiklikler"
 
@@ -948,23 +946,19 @@ msgstr "Değişiklikler"
 msgid "Changes applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
-msgstr ""
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Kanal"
@@ -977,7 +971,7 @@ msgstr ""
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -990,7 +984,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -998,13 +992,13 @@ msgid ""
 "interface to it."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1026,9 +1020,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr ""
 
@@ -1037,8 +1031,8 @@ msgstr ""
 msgid "Client ID to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1061,7 +1055,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1088,7 +1082,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1096,7 +1090,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1112,11 +1106,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1124,7 +1118,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Onayla"
 
@@ -1157,7 +1151,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1168,12 +1162,12 @@ msgstr ""
 msgid "Country"
 msgstr "Ülke"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Ülke Kodu"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr ""
 
@@ -1181,11 +1175,11 @@ msgstr ""
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Kritik"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr ""
 
@@ -1218,15 +1212,15 @@ msgid ""
 "\">LED</abbr>s if possible."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1239,7 +1233,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1312,7 +1306,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1324,14 +1318,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Varsayılan"
 
@@ -1369,47 +1363,47 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Sil"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Bu ağı sil"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Açıklama"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Tasarım"
 
@@ -1440,7 +1434,7 @@ msgstr ""
 msgid "Device"
 msgstr "Cihaz"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Cihaz Yapılandırması"
 
@@ -1457,7 +1451,7 @@ msgstr "Cihaz yeniden başlatılıyor..."
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Cihaz ulaşılamaz!"
 
@@ -1475,12 +1469,12 @@ msgstr "Tanı"
 msgid "Dial number"
 msgstr "Arama numarası"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Dizin"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Pasif"
 
@@ -1496,14 +1490,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Şifrelemeyi Devre Dışı"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "Ağ devre dışı"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1515,11 +1510,7 @@ msgstr "Ağ devre dışı"
 msgid "Disabled"
 msgstr "Devre dışı"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Devre dışı (varsayılan)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1538,21 +1529,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr "Bağlantı kesme girişimi başarısız oldu"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "Reddet"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Mesafe Optimizasyonu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr ""
 
@@ -1576,15 +1565,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1622,15 +1611,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1659,17 +1648,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr ""
 
@@ -1679,7 +1668,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr ""
 
@@ -1687,12 +1676,12 @@ msgstr ""
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr ""
 
@@ -1727,7 +1716,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1743,11 +1732,11 @@ msgstr ""
 msgid "Enable VLAN functionality"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1771,7 +1760,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1793,7 +1782,7 @@ msgstr ""
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1814,17 +1803,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1836,7 +1825,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr ""
 
@@ -1850,7 +1839,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr ""
 
@@ -1858,12 +1847,12 @@ msgstr ""
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr ""
@@ -1897,23 +1886,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1921,19 +1910,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1941,15 +1934,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -1994,7 +1987,7 @@ msgstr ""
 msgid "Firewall"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2034,7 +2027,7 @@ msgstr "Yeni firmware dosyasını yaz"
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2042,11 +2035,11 @@ msgstr ""
 msgid "Force"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr ""
 
@@ -2054,11 +2047,11 @@ msgstr ""
 msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
@@ -2090,7 +2083,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2098,7 +2091,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr ""
 
@@ -2107,7 +2100,7 @@ msgstr ""
 msgid "Free"
 msgstr "Boş"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2129,19 +2122,19 @@ msgstr ""
 msgid "Gateway"
 msgstr "Ağ Geçidi"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2149,8 +2142,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
@@ -2158,7 +2151,7 @@ msgstr ""
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2166,7 +2159,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "Arşiv oluştur"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2185,8 +2178,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2216,13 +2209,13 @@ msgstr ""
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 
@@ -2233,7 +2226,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2258,7 +2251,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr ""
 
@@ -2279,7 +2272,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2500,7 +2493,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr ""
 
@@ -2606,7 +2599,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr ""
 
@@ -2644,7 +2637,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr ""
 
@@ -2652,7 +2645,7 @@ msgstr ""
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr ""
 
@@ -2682,7 +2675,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2712,7 +2705,7 @@ msgstr ""
 msgid "Invalid"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2732,7 +2725,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2740,7 +2733,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2757,15 +2750,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2782,15 +2775,15 @@ msgstr ""
 msgid "Kernel Version"
 msgstr "Çekirdek Versiyonu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2834,11 +2827,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr ""
 
@@ -2878,7 +2871,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2920,7 +2913,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2929,7 +2922,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2954,11 +2947,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -2981,11 +2974,7 @@ msgstr "Ortalama Yük"
 msgid "Loading"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3025,7 +3014,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Yerel Zaman"
 
@@ -3057,7 +3046,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3065,7 +3054,7 @@ msgstr ""
 msgid "Log queries"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3096,22 +3085,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-Adres"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr ""
 
@@ -3139,7 +3128,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3159,7 +3148,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3167,7 +3156,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3193,7 +3182,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3206,7 +3195,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3218,11 +3207,11 @@ msgstr "Bellek"
 msgid "Memory usage (%)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3233,7 +3222,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr ""
 
@@ -3245,7 +3234,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3253,8 +3242,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr ""
@@ -3285,16 +3274,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3307,7 +3296,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3355,7 +3344,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr ""
 
@@ -3380,11 +3369,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3392,7 +3381,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr ""
 
@@ -3402,8 +3391,8 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3436,7 +3425,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3445,7 +3434,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3457,7 +3446,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3488,11 +3477,12 @@ msgstr ""
 msgid "No password set!"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3537,7 +3527,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr ""
 
@@ -3567,7 +3557,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr ""
 
@@ -3579,7 +3569,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3645,24 +3635,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3676,41 +3666,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3770,7 +3760,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3792,7 +3782,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Genel Bakış"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3837,7 +3827,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3892,29 +3882,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3922,31 +3912,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3973,7 +3963,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -3993,7 +3983,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4033,7 +4023,7 @@ msgstr ""
 msgid "Policy"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr ""
 
@@ -4069,7 +4059,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4088,11 +4078,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4123,7 +4113,7 @@ msgstr ""
 msgid "Protocol"
 msgstr "Protokol"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4131,15 +4121,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4166,11 +4156,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4178,11 +4168,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr ""
 
@@ -4198,31 +4188,31 @@ msgstr ""
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4270,7 +4260,7 @@ msgstr ""
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4278,7 +4268,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr ""
@@ -4296,7 +4286,7 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4336,11 +4326,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4356,7 +4346,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4364,42 +4354,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4411,31 +4401,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4486,10 +4476,8 @@ msgstr "Geri Yükleme"
 msgid "Restore backup"
 msgstr "Yedeklemeyi geri yükle"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr ""
 
@@ -4497,15 +4485,15 @@ msgstr ""
 msgid "Revert"
 msgstr "Dönmek"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "Değişiklikleri geri al"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4521,7 +4509,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4537,8 +4525,8 @@ msgstr "Yönlendirme Tipi"
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Yönlendirici Parolası"
 
@@ -4578,8 +4566,8 @@ msgstr "SHA256"
 msgid "SNR"
 msgstr "SNR"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH Erişimi"
 
@@ -4595,14 +4583,14 @@ msgstr "SSH sunucu portu"
 msgid "SSH username"
 msgstr "SSH kullanıcı adı"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4611,19 +4599,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Kaydet"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Kaydet & Uygula"
@@ -4636,24 +4622,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Tara"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Zamanlanmış Görevler"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Bölüm eklendi"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Bölüm kaldırıldı"
 
@@ -4668,9 +4650,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4739,7 +4721,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4759,12 +4741,12 @@ msgstr ""
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Sinyal"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4784,7 +4766,7 @@ msgstr "Boyut"
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4801,7 +4783,7 @@ msgstr ""
 msgid "Skip to navigation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4839,10 +4821,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4855,7 +4833,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4878,7 +4856,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4892,16 +4870,16 @@ msgstr "Başlat"
 msgid "Start priority"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr ""
 
@@ -4921,7 +4899,7 @@ msgstr ""
 msgid "Static Routes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4934,13 +4912,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Durum"
@@ -4955,12 +4933,12 @@ msgstr "Durdur"
 msgid "Strict order"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Gönder"
 
@@ -4998,7 +4976,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5013,11 +4991,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5027,7 +5005,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5038,11 +5016,11 @@ msgstr "Sistem"
 msgid "System Log"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5108,7 +5086,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5122,7 +5100,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5168,11 +5146,11 @@ msgstr ""
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5202,7 +5180,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5216,7 +5194,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5224,13 +5202,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5238,7 +5216,7 @@ msgid ""
 "settings."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5257,7 +5235,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5274,7 +5252,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5348,22 +5326,22 @@ msgstr ""
 msgid "This page gives an overview over currently active network connections."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr ""
 
@@ -5418,7 +5396,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5511,12 +5489,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5525,7 +5503,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5536,11 +5514,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr ""
 
@@ -5578,15 +5557,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5724,11 +5703,11 @@ msgstr ""
 msgid "Used"
 msgstr "Kullanılmış"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5808,32 +5787,32 @@ msgstr "Kontrol"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5847,7 +5826,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5855,8 +5834,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Uyarı"
 
@@ -5864,11 +5843,11 @@ msgstr "Uyarı"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5880,7 +5859,7 @@ msgstr ""
 msgid "Width"
 msgstr "Genişlik"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5891,13 +5870,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "Kablosuz"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5907,7 +5886,7 @@ msgstr ""
 msgid "Wireless Overview"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr ""
 
@@ -5927,11 +5906,11 @@ msgstr ""
 msgid "Wireless is not associated"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr ""
 
@@ -5939,11 +5918,11 @@ msgstr ""
 msgid "Write received DNS requests to syslog"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -5971,19 +5950,19 @@ msgstr ""
 "LuCI'nin düzgün çalışması için tarayıcınızda Java Scripti "
 "etkinleştirmelisiniz."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -5994,7 +5973,7 @@ msgstr "herhangi"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6052,7 +6031,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "etkin değil"
 
@@ -6151,7 +6130,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "yerel <abbr title=\"Domain Name System\">DNS</abbr> dosyası"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "dakika"
 
@@ -6170,7 +6153,7 @@ msgstr "bağlantı yok"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "hiçbiri"
 
@@ -6181,8 +6164,8 @@ msgid "not present"
 msgstr "mevcut değil"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6196,6 +6179,10 @@ msgstr "kapalı"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "açık"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6214,7 +6201,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "rastgele"
 
@@ -6228,8 +6215,8 @@ msgstr "anahtarlama modu"
 msgid "routed"
 msgstr "yönlendirildi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6250,11 +6237,15 @@ msgstr "durumsuz"
 msgid "stateless + stateful"
 msgstr "durumsuz + durumlu"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "etiketlendi"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6273,7 +6264,7 @@ msgstr "bilinmeyen"
 msgid "unlimited"
 msgstr "sınırsız"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6454,6 +6445,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6464,6 +6459,9 @@ msgstr "evet"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Geri"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Devre dışı (varsayılan)"
 
 #~ msgid "Antenna 1"
 #~ msgstr "1. Anten"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -13,11 +13,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr "%.1f дБ"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr "%d біт"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr "%d неприпустимі поля"
 
@@ -59,19 +60,19 @@ msgid "-- Additional Field --"
 msgstr "-- Додаткові поля --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- Оберіть --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- нетипово --"
@@ -94,7 +95,7 @@ msgstr "-- відповідно UUID --"
 msgid "-- please select --"
 msgstr "-- виберіть --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 "0 = не використовувати поріг RSSI, 1 = не змінюваим типові значення драйвера"
@@ -107,7 +108,7 @@ msgstr "Навантаження за 1 хвилину:"
 msgid "15 Minute Load:"
 msgstr "Навантаження за 15 хвилин:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr "4-симв. шістнадцятковий ID"
 
@@ -120,36 +121,36 @@ msgstr "464XLAT (CLAT)"
 msgid "5 Minute Load:"
 msgstr "Навантаження за 5 хвилин:"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 "6-октетний ідентифікатор у вигляді шістнадцяткового рядка – без двокрапок"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr "Швидкий перехід 802.11r"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr "Максимальний тайм-аут запиту асоціації 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr "Тайм-аут повторювання запиту асоціації 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr "Захист кадрів управління 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr "Максимальний тайм-аут 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr "Тайм-аут повторювання 802.11w"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr ""
 "<abbr title=\"Basic Service Set Identifier — ідентифікатор основної служби "
@@ -175,7 +176,7 @@ msgstr ""
 "<abbr title=\"Domain Name System — система доменних імен\">DNS</abbr>-"
 "сервери буде опитано в порядку, визначеному файлом <em>resolvfile</em>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "<abbr title=\"Extended Service Set Identifier — ідентифікатор розширеної "
@@ -213,7 +214,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr "<abbr title=\"Інтернет-протокол версії 6\">IPv6</abbr>-суфікс (hex)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr ""
 "Налаштування <abbr title=\"Light Emitting Diode — світлодіод\">LED</abbr>"
@@ -262,7 +263,7 @@ msgstr ""
 "<br/>Примітка: якщо перед редагуванням, файл crontab був порожній, вам "
 "потрібно вручну перезапустити служби cron."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr "Каталог з такою ж назвою вже існує."
 
@@ -351,8 +352,8 @@ msgstr "Відсутній інтерфейс"
 msgid "Access Concentrator"
 msgstr "Концентратор доступу"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Точка доступу"
 
@@ -383,17 +384,17 @@ msgstr "Активні оренди DHCP"
 msgid "Active DHCPv6 Leases"
 msgstr "Активні оренди DHCPv6"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -424,10 +425,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr "Додати ключ"
 
@@ -440,7 +444,7 @@ msgstr "Додавати суфікс локального домену до і�
 msgid "Add new interface..."
 msgstr "Додати новий інтерфейс..."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr "Додати вузол"
 
@@ -489,8 +493,8 @@ msgstr "Адміністрування"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -500,11 +504,11 @@ msgstr "Додаткові параметри"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr "Сукупна потужність передавача"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "Тривога"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -530,28 +534,28 @@ msgstr "Виділяти IP-адреси послідовно, починаюч�
 msgid "Allocate IP sequentially"
 msgstr "Виділяти IP послідовно"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr ""
 "Дозволити <abbr title=\"Secure Shell — безпечна оболонка\">SSH</abbr>-"
 "перевірку пароля"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 "Дозволити режиму AP відключення абонентів на підставі низького рівня <abbr "
 "title=\"Підтвердження (Acknowledge) успішності отримання TCP-сегменту\">ACK</"
 "abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Дозволити всі, крім зазначених"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "Дозволяти застарілі швидк. 802.11b"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Дозволити тільки зазначені"
 
@@ -559,17 +563,17 @@ msgstr "Дозволити тільки зазначені"
 msgid "Allow localhost"
 msgstr "Дозволити локальний вузол"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 "Дозволити віддаленим вузлам підключення до локальних переспрямованих портів "
 "SSH"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "Дозволити root-вхід із паролем"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "Дозволити користувачеві <em>root</em> вхід у систему з паролем"
 
@@ -580,7 +584,7 @@ msgstr ""
 "Дозволити висхідні відповіді від клієнта на сервер у діапазоні 127.0.0.0/8, "
 "наприклад, для RBL-послуг"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "Дозволено IP-адреси"
 
@@ -588,7 +592,7 @@ msgstr "Дозволено IP-адреси"
 msgid "Always announce default router"
 msgstr "Завжди оголошувати типовим маршрутизатором"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -672,7 +676,7 @@ msgstr "Оголошено DNS-домени"
 msgid "Announced DNS servers"
 msgstr "Оголошено DNS-сервери"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr "Анонімне посвідчення"
 
@@ -691,11 +695,11 @@ msgstr "Анонімний своп"
 msgid "Any zone"
 msgstr "Будь-яка зона"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "Сталася помилка запиту на застосування зі статусом <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr "Застосувати без позначки"
 
@@ -723,7 +727,7 @@ msgstr ""
 "Призначати для цього інтерфейсу частину префікса, використовуючи цей "
 "шістнадцятковий ID субпрефікса."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "Приєднано станції"
@@ -737,7 +741,7 @@ msgstr "З'єднань"
 msgid "Auth Group"
 msgstr "Група автентифікації"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Автентифікація"
 
@@ -833,7 +837,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -851,7 +855,7 @@ msgstr "Повернутися до конфігурації"
 msgid "Backup"
 msgstr "Резервне копіювання"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "Рез. копіювання / Перепрош."
 
@@ -868,7 +872,7 @@ msgstr "Вказано неправильну адресу!"
 msgid "Band"
 msgstr "Діапазон"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr "Інтервал маяка"
 
@@ -908,7 +912,7 @@ msgstr "Швидкість потоку"
 msgid "Bogus NX Domain Override"
 msgstr "Відкидати підробки NX-домену"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "Міст"
@@ -926,7 +930,7 @@ msgstr "Номер моста"
 msgid "Bring up on boot"
 msgstr "Піднімати при завантаженні"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr "Огляд…"
 
@@ -952,13 +956,13 @@ msgstr "Завантаження ЦП, %"
 msgid "Call failed"
 msgstr "Не вдалося здійснити виклик"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Скасувати"
@@ -981,13 +985,7 @@ msgstr "Увага: систему буде оновлено примусово"
 msgid "Chain"
 msgstr "Ланцюжок"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr "Змінити пароль для входу"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Зміни"
 
@@ -995,23 +993,19 @@ msgstr "Зміни"
 msgid "Changes applied."
 msgstr "Зміни застосовано."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "Зміни було скасовано."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "Зміна пароля адміністратора для доступу до пристрою"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr "Зміна пароля…"
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Канал"
@@ -1024,7 +1018,7 @@ msgstr "Перевірити"
 msgid "Check filesystems before mount"
 msgstr "Перевірити файлову систему перед монтуванням"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "Позначте цей параметр, щоб видалити існуючі мережі з цього радіо."
 
@@ -1037,7 +1031,7 @@ msgid "Choose mtdblock"
 msgstr "Виберіть mtdblock"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1049,7 +1043,7 @@ msgstr ""
 "або заповніть поле <em>створити</em>, щоб визначити нову зону і прикріпити "
 "до неї інтерфейс."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1057,7 +1051,7 @@ msgstr ""
 "Оберіть мережі, які ви хочете прикріпити до цього бездротового інтерфейсу "
 "або заповніть поле <em>створити</em>, щоб визначити нову мережу."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "Шифр"
 
@@ -1081,9 +1075,9 @@ msgstr ""
 "Натисніть \"Зберегти mtdblock\", щоб завантажити вказаний файл mtdblock. "
 "(ПРИМІТКА: ЦЕ ФУНКЦІЯ ДЛЯ ПРОФЕСІОНАЛІВ!)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Клієнт"
 
@@ -1092,8 +1086,8 @@ msgstr "Клієнт"
 msgid "Client ID to send when requesting DHCP"
 msgstr "Ідентифікатор клієнта для відправки при запиті DHCP"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr "Закрити"
 
@@ -1118,7 +1112,7 @@ msgstr "Згорнути список..."
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1145,7 +1139,7 @@ msgstr ""
 msgid "Comment"
 msgstr "Примітка"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1157,7 +1151,7 @@ msgstr ""
 "Може викликати проблеми сумісності та зниження стійкості узгодження ключа, "
 "особливо в середовищах з великою завантаженістю трафіку."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1173,11 +1167,11 @@ msgstr "Помилка налаштування"
 msgid "Configuration files will be kept"
 msgstr "Конфігураційні файли буде збережено"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "Конфігурацію застосовано."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "Конфігурацію було відкочено!"
 
@@ -1185,7 +1179,7 @@ msgstr "Конфігурацію було відкочено!"
 msgid "Confirm disconnect"
 msgstr "Підтвердіть від'єднання"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Підтвердження"
 
@@ -1218,7 +1212,7 @@ msgstr ""
 msgid "Continue"
 msgstr "Продовжити"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1233,12 +1227,12 @@ msgstr ""
 msgid "Country"
 msgstr "Країна"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Код країни"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Створити / Визначити зону брандмауера"
 
@@ -1246,11 +1240,11 @@ msgstr "Створити / Визначити зону брандмауера"
 msgid "Create interface"
 msgstr "Створити інтерфейс"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "Критичний"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Рівень виведення інформації Cron"
 
@@ -1288,15 +1282,15 @@ msgstr ""
 "Налаштування поведінки <abbr title=\"Light Emitting Diode — світлодіод"
 "\">LED</abbr>, якщо це можливо."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr "Клієнт DAE"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr "Порт DAE"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr "Секрет DAE"
 
@@ -1309,7 +1303,7 @@ msgstr "Сервер DHCP"
 msgid "DHCP and DNS"
 msgstr "DHCP та DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1382,7 +1376,7 @@ msgstr "Стан DSL"
 msgid "DSL line mode"
 msgstr "Режим лінії DSL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 "Інтервал <abbr title=\"Delivery Traffic Indication Message — Повідомлення "
@@ -1396,14 +1390,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr "Швидк. передавання"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "Зневаджування"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "Типово %d"
 
@@ -1444,47 +1438,47 @@ msgstr ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\", щоб оголошувати різні DNS-"
 "сервери для клієнтів."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Видалити"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr "Видалити ключ"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr "Дозволу на видалення не надано"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr "Помилка запиту на видалення: %d %s"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "Видалити цю мережу"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr "Інтервал повідомлень індикації доправлення трафіку"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Опис"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr "Скасувати вибір"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Стиль"
 
@@ -1515,7 +1509,7 @@ msgstr "Зона призначення"
 msgid "Device"
 msgstr "Пристрій"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "Конфігурація пристрою"
 
@@ -1532,7 +1526,7 @@ msgstr "Пристрій перезавантажується..."
 msgid "Device is restarting…"
 msgstr "Пристрій перезавантажується…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "Пристрій недосяжний!"
 
@@ -1550,12 +1544,12 @@ msgstr "Діагностика"
 msgid "Dial number"
 msgstr "Набір номера"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "Каталог"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "Вимкнути"
 
@@ -1571,14 +1565,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "Вимкнути шифрування"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr "Вимкнути опитування неактивності"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "Вимкнути цю мережу"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1590,11 +1585,7 @@ msgstr "Вимкнути цю мережу"
 msgid "Disabled"
 msgstr "Вимкнено"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "Вимкнено (типово)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr "Роз'єднувати за низького підтвердження"
 
@@ -1613,21 +1604,19 @@ msgstr "Від’єднати"
 msgid "Disconnection attempt failed"
 msgstr "Спроба від'єднання не вдалася"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "Відхилити"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Оптимізація за відстанню"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Відстань до найвіддаленішого вузла мережі в метрах."
 
@@ -1660,15 +1649,15 @@ msgstr ""
 "Не переспрямовувати зворотні <abbr title=\"Domain Name System — система "
 "доменних імен\">DNS</abbr>-запити для локальних мереж"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr "Справді видалити \"%s\"?"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr "Справді видалити такий SSH ключ?"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr "Справді рекурсивно видалити каталог \"%s\"?"
 
@@ -1709,15 +1698,15 @@ msgstr "Завантажити mtdblock"
 msgid "Downstream SNR offset"
 msgstr "Низхідний зсув SNR"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr "Перетягніть, щоб змінити порядок"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Реалізація Dropbear"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1752,17 +1741,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr "Довжина EA-бітів"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP-Метод"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Редагувати"
 
@@ -1774,7 +1763,7 @@ msgstr ""
 "Щоб виправити якусь помилку, відредагуйте вихідні дані конфігурації вище і "
 "натисніть \"Зберегти\", щоб перезавантажити сторінку."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "Редагувати цю мережу"
 
@@ -1782,12 +1771,12 @@ msgstr "Редагувати цю мережу"
 msgid "Edit wireless network"
 msgstr "Редагування бездротової мережі"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "Аварійний"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "Увімкнути"
 
@@ -1824,7 +1813,7 @@ msgstr "Увімкнути узгодження IPv6 для PPP-з'єднань"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "Пропускати Jumbo-фрейми"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "Увімкнути клієнта NTP"
 
@@ -1840,11 +1829,11 @@ msgstr "Увімкнути TFTP-сервер"
 msgid "Enable VLAN functionality"
 msgstr "Увімкнути підтримку VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "Увімкнути кнопку WPS, потребує WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "Увімкнути протидію<br />перевстановленню ключів (KRACK)"
 
@@ -1868,7 +1857,7 @@ msgstr "Увімкнути прапорець DF (Don't Fragment) для інк�
 msgid "Enable this mount"
 msgstr "Увімкнути це монтування"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "Увімкнути цю мережу"
 
@@ -1890,7 +1879,7 @@ msgstr "Увімкнено"
 msgid "Enables IGMP snooping on this bridge"
 msgstr "Вмикає відстеження IGMP на цьому мосту"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1914,17 +1903,17 @@ msgstr "Режим інкапсуляції"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Шифрування"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr "Кінцевий вузол"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr "Порт кінцевого вузла"
 
@@ -1936,7 +1925,7 @@ msgstr "Введіть власне значення"
 msgid "Enter custom values"
 msgstr "Введіть власні значення"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "Видалення..."
 
@@ -1950,7 +1939,7 @@ msgstr "Видалення..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Помилка"
 
@@ -1958,12 +1947,12 @@ msgstr "Помилка"
 msgid "Errored seconds (ES)"
 msgstr "Секунд з помилками (<abbr title=\"Errored seconds\">ES</abbr>)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Ethernet-адаптер"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Ethernet-комутатор"
@@ -1997,23 +1986,23 @@ msgstr "Термін оренди адрес, мінімум 2 хвилини (<
 msgid "External"
 msgstr "Зовнішнє"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr "Зовнішній список власників ключів R0"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr "Зовнішній список власників ключів R1"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "Зовнішній сервер системного журналу"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "Порт зовнішнього сервера системного журналу"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "Протокол зовнішнього сервера системного журналу"
 
@@ -2021,19 +2010,23 @@ msgstr "Протокол зовнішнього сервера системно�
 msgid "Extra SSH command options"
 msgstr "Додаткові параметри команд SSH"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr "FT через DS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr "FT через повітря"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr "Протокол FT"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "Не вдалося підтвердити застосування на протязі %d с, очікуємо відкату…"
 
@@ -2041,15 +2034,15 @@ msgstr "Не вдалося підтвердити застосування на
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "Файл"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr "Файл недоступний"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr "Ім'я файлу"
 
@@ -2096,7 +2089,7 @@ msgstr "Готово"
 msgid "Firewall"
 msgstr "Брандмауер"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr "Позначка брандмауера"
 
@@ -2136,7 +2129,7 @@ msgstr "Прошити новий образ мікропрограми"
 msgid "Flash operations"
 msgstr "Операції прошивання"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "Перепрошиваємо..."
 
@@ -2144,11 +2137,11 @@ msgstr "Перепрошиваємо..."
 msgid "Force"
 msgstr "Примусово"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "Примусово режим '40MHz'"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "Примусово CCMP (AES)"
 
@@ -2156,11 +2149,11 @@ msgstr "Примусово CCMP (AES)"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "Примусово DHCP у цій мережі, навіть якщо виявлено інший сервер."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "Примусово TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "Примусово TKIP та CCMP (AES)"
 
@@ -2192,7 +2185,7 @@ msgstr "Секунди прямого коригування помилок (FEC
 msgid "Forward broadcast traffic"
 msgstr "Переспрямовувати широкомовний трафік"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr "Переспрямовувати одноранговий трафік"
 
@@ -2200,7 +2193,7 @@ msgstr "Переспрямовувати одноранговий трафік"
 msgid "Forwarding mode"
 msgstr "Режим переспрямовування"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Поріг фрагментації"
 
@@ -2209,7 +2202,7 @@ msgstr "Поріг фрагментації"
 msgid "Free"
 msgstr "Вільно"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2233,19 +2226,19 @@ msgstr "Тільки GPRS"
 msgid "Gateway"
 msgstr "Шлюз"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr "Неприпустима адреса шлюзу"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "Порти шлюзу"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2253,8 +2246,8 @@ msgstr "Загальні параметри"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "Загальні налаштування"
 
@@ -2262,7 +2255,7 @@ msgstr "Загальні налаштування"
 msgid "Generate Config"
 msgstr "Cтворити конфігурацію"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr "Генерувати PMK локально"
 
@@ -2270,7 +2263,7 @@ msgstr "Генерувати PMK локально"
 msgid "Generate archive"
 msgstr "Cтворити архів"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "Оскільки пароль і підтвердження не співпадають, то пароль не змінено!"
 
@@ -2289,8 +2282,8 @@ msgstr "Глобальні параметри мережі"
 msgid "Go to password configuration..."
 msgstr "Перейти до конфігурації пароля..."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2322,7 +2315,7 @@ msgstr ""
 "Помилки коду помилок заголовка (<abbr title=\"Header Error Control\">HEC</"
 "abbr>)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2330,7 +2323,7 @@ msgstr ""
 "Тут ви можете налаштувати основні параметри вигляду вашого пристрою, такі як "
 "назва (ім'я) вузла або часовий пояс."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr ""
 "Приховати <abbr title=\"Extended Service Set Identifier — ідентифікатор "
@@ -2343,7 +2336,7 @@ msgstr "Приховати порожні ланцюжки"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "Вузол"
 
@@ -2368,7 +2361,7 @@ msgstr "Зміст тегу Host-Uniq"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Назва (ім'я) вузла"
 
@@ -2389,7 +2382,7 @@ msgstr "Гібрид"
 msgid "IKE DH Group"
 msgstr "Група IKE DH"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "IP-адреси"
 
@@ -2612,7 +2605,7 @@ msgstr "IPv6 через IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6 через IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Посвідчення"
 
@@ -2731,7 +2724,7 @@ msgstr "Тайм-аут бездіяльності"
 msgid "Inbound:"
 msgstr "Вхідний:"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "Інформація"
 
@@ -2769,7 +2762,7 @@ msgstr "Інсталяція розширень протоколу..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Інтерфейс"
 
@@ -2777,7 +2770,7 @@ msgstr "Інтерфейс"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr "Пристрій інтерфейсу %q автоматичного мігрував із %q на %q."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "Конфігурація інтерфейсу"
 
@@ -2807,7 +2800,7 @@ msgstr "Інтерфейс запускається…"
 msgid "Interface is stopping..."
 msgstr "Інтерфейс зупиняється…"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "Назва інтерфейсу"
 
@@ -2837,7 +2830,7 @@ msgstr "Внутрішня помилка сервера"
 msgid "Invalid"
 msgstr "Неприпустимо"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr "Неприпустимий рядок ключа Base64"
 
@@ -2860,7 +2853,7 @@ msgstr "Неприпустимий аргумент"
 msgid "Invalid command"
 msgstr "Неприпустима команда"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr "Неприпустиме шістнадцяткове значення"
 
@@ -2868,7 +2861,7 @@ msgstr "Неприпустиме шістнадцяткове значення"
 msgid "Invalid username and/or password! Please try again."
 msgstr "Неприпустиме ім'я користувача та/або пароль! Спробуйте ще раз."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "Ізолювати клієнтів"
 
@@ -2887,15 +2880,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr "Потрібен JavaScript!"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "Підключення до мережі"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "Підключення до мережі: Сканування бездротових мереж"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "Приєднання до мережі: %q"
 
@@ -2912,15 +2905,15 @@ msgstr "Журнал ядра"
 msgid "Kernel Version"
 msgstr "Версія ядра"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Ключ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "Ключ #%d"
 
@@ -2964,11 +2957,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "Мітка"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Мова"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "Мова та стиль"
 
@@ -3008,7 +3001,7 @@ msgstr "Залиште поле порожнім для автовизначен
 msgid "Leave empty to use the current WAN address"
 msgstr "Залиште порожнім, щоб використовувати поточну адресу WAN"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "Легенда:"
 
@@ -3054,7 +3047,7 @@ msgstr ""
 "Список <abbr title=\"Domain Name System\">DNS</abbr>-серверів для "
 "переспрямовування запитів"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -3070,7 +3063,7 @@ msgstr ""
 "ключа R0\">R0KH</abbr>, як станції, що була використана під час початкової "
 "асоціації домену мобільності."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -3104,11 +3097,11 @@ msgstr "Список доменів, які підтримують резуль�
 msgid "Listen Interfaces"
 msgstr "Інтерфейси прослуховування"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "Порти прослуховування"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 "Прослуховувати тільки на цьому інтерфейсі, або на всіх (якщо <em>не "
@@ -3133,11 +3126,7 @@ msgstr "Середнє навантаження"
 msgid "Loading"
 msgstr "Завантаження"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr "Завантаження SSH-ключів…"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr "Завантаження вмісту каталогу…"
 
@@ -3177,7 +3166,7 @@ msgid "Local Startup"
 msgstr "Локальний запуск"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Місцевий час"
 
@@ -3216,7 +3205,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Локалізувати запити"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "Рівень виведення інформаціі до журналу"
 
@@ -3224,7 +3213,7 @@ msgstr "Рівень виведення інформаціі до журналу
 msgid "Log queries"
 msgstr "Журнал запитів"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "Журналювання"
 
@@ -3257,22 +3246,22 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-адреса"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Фільтр MAC-адрес"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-фільтр"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC-список"
 
@@ -3300,7 +3289,7 @@ msgstr " МГц"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3322,7 +3311,7 @@ msgstr ""
 msgid "Manual"
 msgstr "Вручну"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr "Основний"
 
@@ -3330,7 +3319,7 @@ msgstr "Основний"
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr "Макс. досяжна швидкість передачі даних (ATTNDR)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr "Максимальний дозволений інтервал прослуховування"
 
@@ -3356,7 +3345,7 @@ msgstr "Максимальний час очікування готовност�
 msgid "Maximum number of leased addresses."
 msgstr "Максимальна кількість орендованих адрес."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr "Максимальна потужність передавача"
 
@@ -3369,7 +3358,7 @@ msgstr "Максимальна потужність передавача"
 msgid "Mbit/s"
 msgstr "Мбіт/с"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr "Середня"
 
@@ -3381,11 +3370,11 @@ msgstr "Пам'ять"
 msgid "Memory usage (%)"
 msgstr "Використання пам'яті, %"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr "Mesh"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr "Mesh Id"
 
@@ -3396,7 +3385,7 @@ msgstr "Метод не знайдено"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Метрика"
 
@@ -3408,7 +3397,7 @@ msgstr "Дзеркало порту диспетчера"
 msgid "Mirror source port"
 msgstr "Дзеркало вихідного порту"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr "Домен мобільності"
 
@@ -3416,8 +3405,8 @@ msgstr "Домен мобільності"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Режим"
@@ -3448,16 +3437,16 @@ msgstr "Помилка запиту інформації про модем"
 msgid "Modem init timeout"
 msgstr "Тайм-аут ініціалізації модему"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Диспетчер"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr "Більше символів"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr "Докладніше…"
 
@@ -3470,7 +3459,7 @@ msgstr "Вхід монтування"
 msgid "Mount Point"
 msgstr "Точка монтування"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3520,7 +3509,7 @@ msgstr "Вниз"
 msgid "Move up"
 msgstr "Вгору"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "Ідентифікатор NAS"
 
@@ -3545,11 +3534,11 @@ msgstr "NDP-проксі"
 msgid "NT Domain"
 msgstr "Домен NT"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "Кандидати для синхронізації сервера NTP"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3557,7 +3546,7 @@ msgstr "Кандидати для синхронізації сервера NTP"
 msgid "Name"
 msgstr "Ім'я"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "Назва нової мережі"
 
@@ -3567,8 +3556,8 @@ msgstr "Навігація"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3601,7 +3590,7 @@ msgstr "Нова назва інтерфейсу…"
 msgid "Next »"
 msgstr "Наступний »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "№"
@@ -3610,7 +3599,7 @@ msgstr "№"
 msgid "No DHCP Server configured for this interface"
 msgstr "Немає DHCP-сервера, налаштованого для цього інтерфейсу"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr "Без шифрування"
 
@@ -3622,7 +3611,7 @@ msgstr "Немає NAT-T"
 msgid "No data received"
 msgstr "Жодних даних не отримано"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr "У цьому каталозі немає записів"
 
@@ -3653,11 +3642,12 @@ msgstr "Ніяких негативних кешувань"
 msgid "No password set!"
 msgstr "Пароль не встановлено!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr "Жодного вузла ще не визначено"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr "Відкритих ключів поки що немає."
 
@@ -3702,7 +3692,7 @@ msgstr "Без шаблону заміни"
 msgid "None"
 msgstr "Жоден"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "Нормальний"
 
@@ -3732,7 +3722,7 @@ msgstr "Не запущено під час завантаження"
 msgid "Not supported"
 msgstr "Не підтримується"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "Попередження"
 
@@ -3744,7 +3734,7 @@ msgstr "DNS-запит"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr "Кількість кешованих записів DNS (макс. - 10000, 0 - без кешування)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr "Кількість паралельних потоків, що використовуються для стиснення"
 
@@ -3810,24 +3800,24 @@ msgstr "Відкрити список..."
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "Робоча частота"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "Опція змінена"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "Опція видалена"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "Необов'язково"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3847,7 +3837,7 @@ msgstr ""
 "отримано від сервера делегування, для формування IPv6-адреси інтерфейсу  "
 "(наприклад, 'a:b:c:d::1') використовуйте суфікс ('::1')."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
@@ -3856,30 +3846,30 @@ msgstr ""
 "Додавання додатково рівня шифрування із симетричним ключем для пост-"
 "квантової стійкості."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Необов'язково. Створити для цього вузла маршрути для дозволених IP."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr "Необов'язково. Опис вузла."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr "Необов'язково. Хост вузла. Імена буде виділено до підняття інтерфейсу."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 "Необов'язково. Максимальний блок передаваних даних тунельного інтерфейсу."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr "Необов'язково. Порт вузла."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
@@ -3888,7 +3878,7 @@ msgstr ""
 "значення - 0 (вимкнено). Рекомендоване значення для цього пристрою за NAT - "
 "25."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 "Необов'язково. UDP-порт, який використовується для вихідних та вхідних "
@@ -3950,7 +3940,7 @@ msgstr "Перевизначити TOS"
 msgid "Override TTL"
 msgstr "Перевизначити TTL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "Перевизначення типового імені інтерфейсу"
 
@@ -3975,7 +3965,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr "Перезаписати існуючий файл \"%s\"?"
 
@@ -4022,7 +4012,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr "PIN-код відхилено"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr "Проштовхуваня PMK R1"
 
@@ -4077,29 +4067,29 @@ msgid "Part of zone %q"
 msgstr "Частина зони %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Пароль"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Автентифікація за паролем"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Пароль закритого ключа"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "Пароль внутрішнього закритого ключа"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr "Надійність пароля"
 
@@ -4107,31 +4097,31 @@ msgstr "Надійність пароля"
 msgid "Password2"
 msgstr "Пароль2"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr "Вставте або перетягніть файл SSH-ключа…"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Шлях до центру сертифікції"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "Шлях до сертифікату клієнта"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Шлях до закритого ключа"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "Шлях до внутрішнього CA-сертифікату"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "Шлях до внутрішнього сертифікату клієнта"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "Шлях до внутрішнього закритого ключа"
 
@@ -4158,7 +4148,7 @@ msgstr "Запит IP-адреси призначення"
 msgid "Peer address is missing"
 msgstr "Відсутня адреса вузла"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr "Вузли"
 
@@ -4178,7 +4168,7 @@ msgstr "Виконати відновлення"
 msgid "Permission denied"
 msgstr "Дозволу не надано"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr "Завжди тримати ввімкненим"
 
@@ -4218,7 +4208,7 @@ msgstr "Введіть ім'я користувача і пароль."
 msgid "Policy"
 msgstr "Політика"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Порт"
 
@@ -4254,7 +4244,7 @@ msgstr "Переважно UMTS"
 msgid "Prefix Delegated"
 msgstr "Делеговано префікс"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr "Заздалегідь установлений спільний ключ"
 
@@ -4275,11 +4265,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr "Перешкоджати прослуховуванню цих інтерфейсів."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Перешкоджати спілкуванню клієнт-клієнт"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "Приватний ключ"
 
@@ -4310,7 +4300,7 @@ msgstr "Прот."
 msgid "Protocol"
 msgstr "Протокол"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "Забезпечувати сервер NTP"
 
@@ -4318,15 +4308,15 @@ msgstr "Забезпечувати сервер NTP"
 msgid "Provide new network"
 msgstr "Укажіть нову мережу"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Псевдо Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "Відкритий ключ"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4359,11 +4349,11 @@ msgstr ""
 "Запит усіх наявних висхідних <abbr title=\"Domain Name System — система "
 "доменних імен\">DNS</abbr>-серверів"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr "Тривалість життя ключа R0"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr "Власник ключа R1"
 
@@ -4371,11 +4361,11 @@ msgstr "Власник ключа R1"
 msgid "RFC3947 NAT-T mode"
 msgstr "Режим RFC3947 NAT-T"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr "Поріг RSSI для приєднання"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "Поріг RTS/CTS"
 
@@ -4391,31 +4381,31 @@ msgstr "Одержано"
 msgid "RX Rate"
 msgstr "Швидкість приймання"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr "Швидкість прийм./перед."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Порт Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Секрет Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Сервер Radius-Accounting"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Порт Radius-Authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Секрет Radius-Authentication"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Сервер Radius-Authentication"
 
@@ -4470,7 +4460,7 @@ msgstr "Трафік у реальному часі"
 msgid "Realtime Wireless"
 msgstr "Бездротові мережі у реальному часі"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr "Кінцевий термін реассоціації"
 
@@ -4478,7 +4468,7 @@ msgstr "Кінцевий термін реассоціації"
 msgid "Rebind protection"
 msgstr "Захист від переприв'язки"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Перезавантаження"
@@ -4496,7 +4486,7 @@ msgstr "Перезавантажити операційну систему ва�
 msgid "Receive"
 msgstr "Приймання"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr "Рекомендовано. IP-адреси інтерфейсу WireGuard."
 
@@ -4536,11 +4526,11 @@ msgstr "Віддалена адреса IPv4"
 msgid "Remote IPv4 address or FQDN"
 msgstr "Віддалена адреса IPv4 або FQDN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Видалити"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "Замінити конфігурацію бездротової мережі"
 
@@ -4556,7 +4546,7 @@ msgstr "Запит довжини IPv6-префіксу"
 msgid "Request timeout"
 msgstr "Час очікування запиту минув"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "Вимагається"
 
@@ -4564,15 +4554,15 @@ msgstr "Вимагається"
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "Вимагається для деяких провайдерів, наприклад, Charter із DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr "Вимагається. Base64-кодований закритий ключ для цього інтерфейсу."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr "Вимагається. Base64-кодований відкритий ключ вузла."
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
@@ -4582,27 +4572,27 @@ msgstr ""
 "використовувати всередині тунелю. Зазвичай тунельні IP-адреси вузла та "
 "мережі маршрутів вузла через тунель."
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr "Потребує hostapd"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr "Потребує hostapd з підтримкою EAP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr "Потребує hostapd з підтримкою OWE"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr "Потребує hostapd з підтримкою SAE"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4618,31 +4608,31 @@ msgstr ""
 "Потребує підтримки висхідною мережею DNSSEC; переконайтеся, що відповіді "
 "непідписаного домену дійсно походять із непідписаних доменів"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr "Потребує wpa-суплікатора"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr "Потребує wpa-суплікатора з підтримкою EAP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr "Потребує wpa-суплікатора з підтримкою OWE"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr "Потребує wpa-суплікатора з підтримкою SAE"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4693,10 +4683,8 @@ msgstr "Відновлення"
 msgid "Restore backup"
 msgstr "Відновити з резервної копії"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "Показати/приховати пароль"
 
@@ -4704,15 +4692,15 @@ msgstr "Показати/приховати пароль"
 msgid "Revert"
 msgstr "Скасувати"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "Скасувати зміни"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "Помилка запиту на скасування зі статусом <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "Відкат конфігурації…"
 
@@ -4728,7 +4716,7 @@ msgstr "Кореневий каталог для файлів TFTP"
 msgid "Root preparation"
 msgstr "Підготовка Root"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr "Маршрутизація дозволених IP-адрес"
 
@@ -4744,8 +4732,8 @@ msgstr "Тип маршруту"
 msgid "Router Advertisement-Service"
 msgstr "Служба оголошень маршрутизатора"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "Пароль маршрутизатора"
 
@@ -4787,8 +4775,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH-доступ"
 
@@ -4804,14 +4792,14 @@ msgstr "Порт сервера SSH"
 msgid "SSH username"
 msgstr "Ім'я користувача SSH"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH-ключі"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4820,19 +4808,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Зберегти"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Зберегти і застосувати"
@@ -4845,24 +4831,20 @@ msgstr "Зберегти mtdblock"
 msgid "Save mtdblock contents"
 msgstr "Зберегти вміст mtdblock"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr "Збереження ключів…"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Сканувати"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Заплановані завдання"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "Секцію додано"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "Секцію видалено"
 
@@ -4880,9 +4862,9 @@ msgstr ""
 "виберіть \"Примусове оновлення\". Використовуйте тільки якщо ви впевнені, що "
 "мікропрограма є правильною і призначена для вашого пристрою!"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr "Виберіть файл…"
 
@@ -4957,7 +4939,7 @@ msgstr ""
 msgid "Short GI"
 msgstr "Short GI"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr "Коротка преамбула"
 
@@ -4977,12 +4959,12 @@ msgstr "Вимкнути цей інтерфейс"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "Сигнал"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr "Сигнал / шум"
 
@@ -5002,7 +4984,7 @@ msgstr "Розмір"
 msgid "Size of DNS query cache"
 msgstr "Розмір кешу запитів DNS"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr "Розмір пристрою ZRam у мегабайтах"
 
@@ -5019,7 +5001,7 @@ msgstr "Перейти до вмісту"
 msgid "Skip to navigation"
 msgstr "Перейти до навігації"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "Програмово реалізований VLAN"
@@ -5060,10 +5042,6 @@ msgstr "Адреса джерела"
 msgid "Specifies the directory the device is attached to"
 msgstr "Визначає каталог, до якого приєднаний пристрій"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "Визначає порт прослуховування цієї реалізації <em>Dropbear</em>"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -5080,7 +5058,7 @@ msgstr ""
 "Визначає максимальний час (секунди), після якого вважається, що вузли "
 "\"мертві\""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -5110,7 +5088,7 @@ msgstr ""
 "Вкажіть MTU (Maximum Transmission Unit — максимальний блок передавання), "
 "відмінний від типового (1280 байт)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "Вкажіть тут секретний ключ шифрування."
 
@@ -5124,16 +5102,16 @@ msgstr "Запустити"
 msgid "Start priority"
 msgstr "Стартовий пріоритет"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "Розпочато застосування конфігурації…"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "Розпочато сканування бездротових мереж..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "Запуск"
 
@@ -5153,7 +5131,7 @@ msgstr "Статичні оренди"
 msgid "Static Routes"
 msgstr "Статичні маршрути"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -5170,13 +5148,13 @@ msgstr ""
 "конфігурацій інтерфейсів, коли обслуговуються тільки вузли з відповідною "
 "орендою."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr "Обмеження бездіяльності станції"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Стан"
@@ -5191,12 +5169,12 @@ msgstr "Зупинити"
 msgid "Strict order"
 msgstr "Строгий порядок"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr "Висока"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Надіслати"
 
@@ -5236,7 +5214,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr "Маска портів комутатора"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "VLAN комутатора"
@@ -5251,11 +5229,11 @@ msgstr "Протокол комутатора"
 msgid "Switch to CIDR list notation"
 msgstr "Перейти до позначення списку CIDR"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr "Символічне посилання"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr "Синхронізувати з NTP-сервером"
 
@@ -5265,7 +5243,7 @@ msgstr "Синхронізувати з браузером"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5276,11 +5254,11 @@ msgstr "Система"
 msgid "System Log"
 msgstr "Системний журнал"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "Властивості системи"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "Розмір буфера системного журналу"
 
@@ -5350,7 +5328,7 @@ msgstr ""
 "Призначений провайдером IPv6-префікс, зазвичай закінчується на <code>::</"
 "code>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5366,7 +5344,7 @@ msgstr "Архів резервної копії не є правильним ф
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "Файл конфігурації не вдалося завантажити через таку помилку:"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5424,11 +5402,11 @@ msgstr "Наразі в цій системі активні такі прави
 msgid "The gateway address must not be a local IP address"
 msgstr "Адреса шлюзу не повинна бути локальною IP-адресою"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr "Наданий відкритий SSH-ключ вже було додано."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5460,7 +5438,7 @@ msgstr "Довжина IPv6-префікса в бітах"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "Локальна адреса IPv4, за якою створюється тунель (необов'язково)."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr "Назва мережі вже використовується"
 
@@ -5482,7 +5460,7 @@ msgstr ""
 "більшою мережею, такою наприклад, як Інтернет, а інші порти — для локальної "
 "мережі."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr "Обраний режим %s несумісний із шифруванням %s"
 
@@ -5490,7 +5468,7 @@ msgstr "Обраний режим %s несумісний із шифруван�
 msgid "The submitted security token is invalid or already expired!"
 msgstr "Поданий маркер безпеки недійсний або вже збіг!"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
@@ -5498,7 +5476,7 @@ msgstr ""
 "Зараз система видаляє розділ конфігурації і коли закінчить, "
 "перезавантажиться."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5510,7 +5488,7 @@ msgstr ""
 "під'єднатися. Залежно від налаштувань, можливо, треба буде оновити адресу "
 "вашого комп'ютера, щоб знову отримати доступ до пристрою."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "Системний пароль успішно змінено."
 
@@ -5531,7 +5509,7 @@ msgstr "Немає жодних активних оренд"
 msgid "There are no active leases."
 msgstr "Активних оренд немає."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr "Немає жодних змін до застосування"
 
@@ -5550,7 +5528,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr "Це IPv4-адреса ретранслятора"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr "Цей тип автентифікації не застосовується до вибраного методу EAP."
 
@@ -5644,22 +5622,22 @@ msgstr "У цьому списку наведено працюючі нараз�
 msgid "This page gives an overview over currently active network connections."
 msgstr "Ця сторінка надає огляд поточних активних мережевих підключень."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Ця секція поки що не містить значень"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "Синхронізація часу"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr "Інтервал часу для зміни ключа GTK"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Часовий пояс"
 
@@ -5718,7 +5696,7 @@ msgstr "Режим запуску"
 msgid "Tunnel ID"
 msgstr "Ідентифікатор тунелю"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "Інтерфейс тунелю"
@@ -5811,12 +5789,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Недоступні секунди (<abbr title=\"Unavailable Seconds\">UAS</abbr>)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "Невідома помилка (%s)"
@@ -5825,7 +5803,7 @@ msgstr "Невідома помилка (%s)"
 msgid "Unknown error code"
 msgstr "Невідомий код помилки"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5836,11 +5814,12 @@ msgstr "Некерований"
 msgid "Unmount"
 msgstr "Демонтувати"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr "Безіменний ключ"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Незбережені зміни"
 
@@ -5881,15 +5860,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "Відвантажити архів..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr "Відвантажити файл"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr "Відвантажити файл…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr "Не вдалося виконати запит на відвантаження: %s"
 
@@ -6037,11 +6016,11 @@ msgstr ""
 msgid "Used"
 msgstr "Використано"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "Використовується слот ключа"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -6124,32 +6103,32 @@ msgstr "Перевірте"
 msgid "Virtual dynamic interface"
 msgstr "Віртуальний динамічний інтерфейс"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "Відкрита система WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "Спільний ключ WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "Парольна фраза WEP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "Режим <abbr title=\"Wi-Fi Multimedia\">WMM</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "Парольна фраза WPA"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -6165,7 +6144,7 @@ msgstr "Очікуємо, доки зміни наберуть чинності.
 msgid "Waiting for command to complete..."
 msgstr "Очікуємо завершення виконання команди..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr "Очікування на застосування конфігурації… %d c"
 
@@ -6173,8 +6152,8 @@ msgstr "Очікування на застосування конфігурац�
 msgid "Waiting for device..."
 msgstr "Очікуємо пристрій..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "Застереження"
 
@@ -6183,11 +6162,11 @@ msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 "Застереження: Є незбережені зміни, які буде втрачено при перезавантаженні!"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr "Слабка"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -6202,7 +6181,7 @@ msgstr ""
 msgid "Width"
 msgstr "Ширина"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr "WireGuard VPN"
@@ -6213,13 +6192,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "Бездротові мережі"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Бездротовий адаптер"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -6229,7 +6208,7 @@ msgstr "Бездротова мережа"
 msgid "Wireless Overview"
 msgstr "Огляд бездротових мереж"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "Безпека бездротової мережі"
 
@@ -6249,11 +6228,11 @@ msgstr "Бездротову мережу вимкнено"
 msgid "Wireless is not associated"
 msgstr "Бездротову мережу не пов'язано"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "Бездротову мережу вимкнено"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "Бездротову мережу ввімкнено"
 
@@ -6261,11 +6240,11 @@ msgstr "Бездротову мережу ввімкнено"
 msgid "Write received DNS requests to syslog"
 msgstr "Записувати отримані DNS-запити до системного журналу"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "Записувати cистемний журнал до файлу"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "Так"
@@ -6299,19 +6278,19 @@ msgstr ""
 "Вам слід увімкнути JavaScript у вашому браузері, або LuCI не буде працювати "
 "належним чином."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr "Алгоритм стиснення ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr "Потоки стиснення ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr "Налаштування ZRam"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr "Розмір ZRam"
 
@@ -6322,7 +6301,7 @@ msgstr "будь-який"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6380,7 +6359,7 @@ msgstr "дБ"
 msgid "dBm"
 msgstr "дБм"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "вимкнено"
 
@@ -6483,7 +6462,11 @@ msgstr ""
 "Локальний <abbr title=\"Domain Name System — система доменних імен\">DNS</"
 "abbr>-файл"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "хв."
 
@@ -6502,7 +6485,7 @@ msgstr "нема з'єднання"
 msgid "non-empty value"
 msgstr "непусте значення"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "нема нічого"
 
@@ -6513,8 +6496,8 @@ msgid "not present"
 msgstr "не присутній"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6528,6 +6511,10 @@ msgstr "вимкнено"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "увімкнено"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6546,7 +6533,7 @@ msgstr "додатне десяткове значення"
 msgid "positive integer value"
 msgstr "додатне ціле значення"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "випадковий"
 
@@ -6560,8 +6547,8 @@ msgstr "режим реле"
 msgid "routed"
 msgstr "спрямовано"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr "с"
 
@@ -6582,11 +6569,15 @@ msgstr "БЕЗ збереження стану"
 msgid "stateless + stateful"
 msgstr "БЕЗ та ЗІ збереженням стану"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "позначено"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr "одиниці часу (TUs / 1.024 ms) [1000-65535]"
 
@@ -6605,7 +6596,7 @@ msgstr "невідомий"
 msgid "unlimited"
 msgstr "необмежений"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6786,6 +6777,10 @@ msgstr "значення з принаймні %d символів"
 msgid "value with at most %d characters"
 msgstr "значення з не більше %d символів"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6796,6 +6791,27 @@ msgstr "так"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Change login password"
+#~ msgstr "Змінити пароль для входу"
+
+#~ msgid "Changing password…"
+#~ msgstr "Зміна пароля…"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "Вимкнено (типово)"
+
+#~ msgid "Gateway ports"
+#~ msgstr "Порти шлюзу"
+
+#~ msgid "Loading SSH keys…"
+#~ msgstr "Завантаження SSH-ключів…"
+
+#~ msgid "Saving keys…"
+#~ msgstr "Збереження ключів…"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "Визначає порт прослуховування цієї реалізації <em>Dropbear</em>"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "Комутатор %q (%s)"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -2228,7 +2228,7 @@ msgstr "Шлюз"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "Порти шлюзу"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6800,9 +6800,6 @@ msgstr "« Назад"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "Вимкнено (типово)"
-
-#~ msgid "Gateway ports"
-#~ msgstr "Порти шлюзу"
 
 #~ msgid "Loading SSH keys…"
 #~ msgstr "Завантаження SSH-ключів…"

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -16,11 +16,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "---Mục bổ sung---"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "--Hãy chọn--"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "--tùy chỉnh--"
@@ -98,7 +99,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -110,7 +111,7 @@ msgstr ""
 msgid "15 Minute Load:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -123,35 +124,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Dịch vụ căn bản đặt Identifier\">BSSID</abbr>"
 
@@ -169,7 +170,7 @@ msgid ""
 "order of the resolvfile"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Mở rộng dịch vụ đặt Identifier\">ESSID</abbr>"
 
@@ -205,7 +206,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 
@@ -244,7 +245,7 @@ msgid ""
 "was empty before editing."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -322,8 +323,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "Điểm truy cập"
 
@@ -354,17 +355,17 @@ msgstr ""
 msgid "Active DHCPv6 Leases"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -395,10 +396,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -411,7 +415,7 @@ msgstr ""
 msgid "Add new interface..."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -460,8 +464,8 @@ msgstr "Quản trị"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -471,11 +475,11 @@ msgstr ""
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -501,23 +505,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "Cho phép <abbr title=\"Secure Shell\">SSH</abbr> xác thực mật mã"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "Cho phép tất cả trừ danh sách liệt kê"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "Chỉ cho phép danh sách liệt kê"
 
@@ -525,15 +529,15 @@ msgstr "Chỉ cho phép danh sách liệt kê"
 msgid "Allow localhost"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr ""
 
@@ -542,7 +546,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -550,7 +554,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -629,7 +633,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -648,11 +652,11 @@ msgstr ""
 msgid "Any zone"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -676,7 +680,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr ""
@@ -690,7 +694,7 @@ msgstr ""
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "Xác thực"
 
@@ -785,7 +789,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr ""
@@ -803,7 +807,7 @@ msgstr ""
 msgid "Backup"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr ""
 
@@ -820,7 +824,7 @@ msgstr ""
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -855,7 +859,7 @@ msgstr ""
 msgid "Bogus NX Domain Override"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr ""
@@ -873,7 +877,7 @@ msgstr ""
 msgid "Bring up on boot"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -898,13 +902,13 @@ msgstr "CPU usage (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "Bỏ qua"
@@ -927,13 +931,7 @@ msgstr ""
 msgid "Chain"
 msgstr "chuỗi"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "Thay đổi"
 
@@ -941,23 +939,19 @@ msgstr "Thay đổi"
 msgid "Changes applied."
 msgstr "Thay đổi đã áp dụng"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
-msgstr ""
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "Kênh"
@@ -970,7 +964,7 @@ msgstr ""
 msgid "Check filesystems before mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -983,7 +977,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -991,13 +985,13 @@ msgid ""
 "interface to it."
 msgstr "Giao diện này chưa thuộc về bất kỳ firewall zone nào."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr ""
 
@@ -1017,9 +1011,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "Client"
 
@@ -1028,8 +1022,8 @@ msgstr "Client"
 msgid "Client ID to send when requesting DHCP"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1052,7 +1046,7 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1079,7 +1073,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1087,7 +1081,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1103,11 +1097,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr ""
 
@@ -1115,7 +1109,7 @@ msgstr ""
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "Xác nhận"
 
@@ -1148,7 +1142,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1159,12 +1153,12 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "Mã quốc gia"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "Tạo/ gán firewall-zone"
 
@@ -1172,11 +1166,11 @@ msgstr "Tạo/ gán firewall-zone"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr ""
 
@@ -1211,15 +1205,15 @@ msgstr ""
 "Tùy chỉnh chế độ của thiết bị <abbr title=\"Light Emitting Diode\">LED</"
 "abbr>s nếu có thể."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1232,7 +1226,7 @@ msgstr ""
 msgid "DHCP and DNS"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1305,7 +1299,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1317,14 +1311,14 @@ msgstr ""
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr ""
 
@@ -1362,47 +1356,47 @@ msgid ""
 "servers to clients."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "Xóa"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "Mô tả"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "Thiết kế"
 
@@ -1433,7 +1427,7 @@ msgstr ""
 msgid "Device"
 msgstr "Công cụ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr ""
 
@@ -1450,7 +1444,7 @@ msgstr ""
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr ""
 
@@ -1468,12 +1462,12 @@ msgstr ""
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr ""
 
@@ -1487,14 +1481,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1506,11 +1501,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1529,21 +1520,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "Khoảng cách tối ưu"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "Khoảng cách tới thành viên xa nhất trong mạng lưới tính bằng mét"
 
@@ -1571,15 +1560,15 @@ msgstr ""
 msgid "Do not forward reverse lookups for local networks"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1619,15 +1608,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1659,17 +1648,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP-Method"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "Chỉnh sửa"
 
@@ -1679,7 +1668,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr ""
 
@@ -1687,12 +1676,12 @@ msgstr ""
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr ""
 
@@ -1727,7 +1716,7 @@ msgstr ""
 msgid "Enable Jumbo Frame passthrough"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr ""
 
@@ -1743,11 +1732,11 @@ msgstr ""
 msgid "Enable VLAN functionality"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr ""
 
@@ -1771,7 +1760,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1793,7 +1782,7 @@ msgstr ""
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1814,17 +1803,17 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "Encryption"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1836,7 +1825,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr ""
 
@@ -1850,7 +1839,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "Lỗi"
 
@@ -1858,12 +1847,12 @@ msgstr "Lỗi"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "Bộ tương hợp ethernet"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "Bộ chuyển đảo ethernet"
@@ -1897,23 +1886,23 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr ""
 
@@ -1921,19 +1910,23 @@ msgstr ""
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1941,15 +1934,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -1994,7 +1987,7 @@ msgstr ""
 msgid "Firewall"
 msgstr "Firewall"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2034,7 +2027,7 @@ msgstr ""
 msgid "Flash operations"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr ""
 
@@ -2042,11 +2035,11 @@ msgstr ""
 msgid "Force"
 msgstr "Force"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr ""
 
@@ -2054,11 +2047,11 @@ msgstr ""
 msgid "Force DHCP on this network even if another server is detected."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr ""
 
@@ -2090,7 +2083,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2098,7 +2091,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "Ngưỡng cửa Phân đoạn"
 
@@ -2107,7 +2100,7 @@ msgstr "Ngưỡng cửa Phân đoạn"
 msgid "Free"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2129,19 +2122,19 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2149,8 +2142,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr ""
 
@@ -2158,7 +2151,7 @@ msgstr ""
 msgid "Generate Config"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2166,7 +2159,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr ""
 
@@ -2185,8 +2178,8 @@ msgstr ""
 msgid "Go to password configuration..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2216,7 +2209,7 @@ msgstr "Hang Up"
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
@@ -2224,7 +2217,7 @@ msgstr ""
 "Ở đây bạn có thể cấu hình những đặc tính cơ bản của thiết bị như tên máy chủ "
 "hoặc múi giờ."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "Giấu <abbr title=\"Chế độ mở rộng đặt Identifier\">ESSID</abbr>"
 
@@ -2235,7 +2228,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2260,7 +2253,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "Tên host"
 
@@ -2281,7 +2274,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2502,7 +2495,7 @@ msgstr ""
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "Nhận dạng"
 
@@ -2613,7 +2606,7 @@ msgstr ""
 msgid "Inbound:"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr ""
 
@@ -2651,7 +2644,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "Giao diện "
 
@@ -2659,7 +2652,7 @@ msgstr "Giao diện "
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr ""
 
@@ -2689,7 +2682,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr ""
 
@@ -2719,7 +2712,7 @@ msgstr ""
 msgid "Invalid"
 msgstr "Giá trị nhập vào không hợp lí"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2739,7 +2732,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2747,7 +2740,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "Tên và mật mã không đúng. Xin thử lại "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr ""
 
@@ -2767,15 +2760,15 @@ msgstr ""
 msgid "JavaScript required!"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2792,15 +2785,15 @@ msgstr "Kernel Log"
 msgid "Kernel Version"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "Phím "
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr ""
 
@@ -2844,11 +2837,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "Ngôn ngữ"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr ""
 
@@ -2888,7 +2881,7 @@ msgstr ""
 msgid "Leave empty to use the current WAN address"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr ""
 
@@ -2930,7 +2923,7 @@ msgid ""
 "requests to"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2939,7 +2932,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2964,11 +2957,11 @@ msgstr ""
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
 
@@ -2991,11 +2984,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3035,7 +3024,7 @@ msgid "Local Startup"
 msgstr ""
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "Giờ địa phương"
 
@@ -3067,7 +3056,7 @@ msgstr ""
 msgid "Localise queries"
 msgstr "Tra vấn địa phương"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr ""
 
@@ -3075,7 +3064,7 @@ msgstr ""
 msgid "Log queries"
 msgstr "Bản ghi tra vấn"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr ""
 
@@ -3106,22 +3095,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "Lọc địa chỉ MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "Lọc MAC"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "Danh sách MAC"
 
@@ -3149,7 +3138,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr ""
 
@@ -3169,7 +3158,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3177,7 +3166,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3203,7 +3192,7 @@ msgstr ""
 msgid "Maximum number of leased addresses."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3216,7 +3205,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3228,11 +3217,11 @@ msgstr "Bộ nhớ"
 msgid "Memory usage (%)"
 msgstr "Memory usage (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3243,7 +3232,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "Metric"
 
@@ -3255,7 +3244,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3263,8 +3252,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "Chế độ"
@@ -3295,16 +3284,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "Monitor"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3317,7 +3306,7 @@ msgstr ""
 msgid "Mount Point"
 msgstr "Lắp điểm"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3367,7 +3356,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3392,11 +3381,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3404,7 +3393,7 @@ msgstr ""
 msgid "Name"
 msgstr "Tên"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr ""
 
@@ -3414,8 +3403,8 @@ msgstr "Sự điều hướng"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3448,7 +3437,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3457,7 +3446,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3469,7 +3458,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3500,11 +3489,12 @@ msgstr ""
 msgid "No password set!"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3549,7 +3539,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr ""
 
@@ -3579,7 +3569,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr ""
 
@@ -3591,7 +3581,7 @@ msgstr ""
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3657,24 +3647,24 @@ msgstr ""
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3688,41 +3678,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3782,7 +3772,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3804,7 +3794,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Nhìn chung"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3849,7 +3839,7 @@ msgstr ""
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3904,29 +3894,29 @@ msgid "Part of zone %q"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "Mật mã"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "Xác thực mật mã"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "Mật mã của private key"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3934,31 +3924,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "Đường dẫn tới CA-Certificate"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "Đường dẫn tới private key"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3985,7 +3975,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4005,7 +3995,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4045,7 +4035,7 @@ msgstr "Nhập tên và mật mã"
 msgid "Policy"
 msgstr "Chính sách"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "Cửa "
 
@@ -4081,7 +4071,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4100,11 +4090,11 @@ msgstr ""
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "Ngăn chặn giao tiếp giữa client-và-client"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4135,7 +4125,7 @@ msgstr "Prot."
 msgid "Protocol"
 msgstr "Protocol"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr ""
 
@@ -4143,15 +4133,15 @@ msgstr ""
 msgid "Provide new network"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "Pseudo Ad-Hoc (ahdemo)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4178,11 +4168,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4190,11 +4180,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS Threshold"
 
@@ -4210,31 +4200,31 @@ msgstr "RX"
 msgid "RX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr ""
 
@@ -4284,7 +4274,7 @@ msgstr ""
 msgid "Realtime Wireless"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4292,7 +4282,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "Reboot"
@@ -4310,7 +4300,7 @@ msgstr "Reboots hệ điều hành của công cụ"
 msgid "Receive"
 msgstr "Receive"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4350,11 +4340,11 @@ msgstr ""
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "Loại bỏ"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr ""
 
@@ -4370,7 +4360,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4378,42 +4368,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4425,31 +4415,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4500,10 +4490,8 @@ msgstr ""
 msgid "Restore backup"
 msgstr "Phục hồi backup"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr ""
 
@@ -4511,15 +4499,15 @@ msgstr ""
 msgid "Revert"
 msgstr "Revert"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr ""
 
@@ -4535,7 +4523,7 @@ msgstr ""
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4551,8 +4539,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr ""
 
@@ -4594,8 +4582,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr ""
 
@@ -4611,14 +4599,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4627,19 +4615,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "Lưu"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "Lưu & áp dụng "
@@ -4652,24 +4638,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "Scan"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "Scheduled Tasks"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr ""
 
@@ -4684,9 +4666,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4755,7 +4737,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4775,12 +4757,12 @@ msgstr ""
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4800,7 +4782,7 @@ msgstr "Dung lượng "
 msgid "Size of DNS query cache"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4817,7 +4799,7 @@ msgstr "Nhảy tới nội dung"
 msgid "Skip to navigation"
 msgstr "Chuyển đến mục định hướng"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4855,10 +4837,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr ""
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4871,7 +4849,7 @@ msgid ""
 "dead"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4894,7 +4872,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr ""
 
@@ -4908,16 +4886,16 @@ msgstr "Bắt đầu "
 msgid "Start priority"
 msgstr "Bắt đầu ưu tiên"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr ""
 
@@ -4937,7 +4915,7 @@ msgstr "Thống kê leases"
 msgid "Static Routes"
 msgstr "Static Routes"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4950,13 +4928,13 @@ msgid ""
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "Tình trạng"
@@ -4971,12 +4949,12 @@ msgstr ""
 msgid "Strict order"
 msgstr "Yêu cầu nghiêm ngặt"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "Trình "
 
@@ -5014,7 +4992,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5029,11 +5007,11 @@ msgstr ""
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5043,7 +5021,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5054,11 +5032,11 @@ msgstr "Hệ thống"
 msgid "System Log"
 msgstr "System Log"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr ""
 
@@ -5124,7 +5102,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5138,7 +5116,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5188,11 +5166,11 @@ msgstr ""
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5222,7 +5200,7 @@ msgstr ""
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5236,7 +5214,7 @@ msgid ""
 "next greater network like the internet and other ports for a local network."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5244,13 +5222,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5262,7 +5240,7 @@ msgstr ""
 "một vài phút cho tới khi kết nối lại. Có thể cần phải làm mới địa chỉ của "
 "máy tính để tiếp cận thiết bị một lần nữa, phụ thuộc vào cài đặt của bạn. "
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5283,7 +5261,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5300,7 +5278,7 @@ msgstr ""
 msgid "This IPv4 address of the relay"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5379,22 +5357,22 @@ msgid "This page gives an overview over currently active network connections."
 msgstr ""
 "Trang này cung cấp một tổng quan về đang hoạt động kết nối mạng hiện tại."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "Phần này chưa có giá trị nào"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "Múi giờ "
 
@@ -5449,7 +5427,7 @@ msgstr ""
 msgid "Tunnel ID"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr ""
@@ -5542,12 +5520,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5556,7 +5534,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5567,11 +5545,12 @@ msgstr ""
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "Thay đổi không lưu"
 
@@ -5609,15 +5588,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5755,11 +5734,11 @@ msgstr ""
 msgid "Used"
 msgstr "Đã sử dụng"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5839,32 +5818,32 @@ msgstr ""
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM Mode"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5878,7 +5857,7 @@ msgstr ""
 msgid "Waiting for command to complete..."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5886,8 +5865,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr ""
 
@@ -5895,11 +5874,11 @@ msgstr ""
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5911,7 +5890,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5922,13 +5901,13 @@ msgstr ""
 msgid "Wireless"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "Bộ tương hợp không dây"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5938,7 +5917,7 @@ msgstr ""
 msgid "Wireless Overview"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr ""
 
@@ -5958,11 +5937,11 @@ msgstr ""
 msgid "Wireless is not associated"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr ""
 
@@ -5970,11 +5949,11 @@ msgstr ""
 msgid "Write received DNS requests to syslog"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6004,19 +5983,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6027,7 +6006,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6086,7 +6065,7 @@ msgstr ""
 msgid "dBm"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "Vô hiệu hóa"
 
@@ -6187,7 +6166,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "Tập tin <abbr title=\"Domain Name System\">DNS</abbr> địa phương"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6206,7 +6189,7 @@ msgstr ""
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "không "
 
@@ -6217,8 +6200,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6231,6 +6214,10 @@ msgstr ""
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:205
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
@@ -6250,7 +6237,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6264,8 +6251,8 @@ msgstr ""
 msgid "routed"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6286,11 +6273,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6309,7 +6300,7 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6488,6 +6479,10 @@ msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:441
 msgid "value with at most %d characters"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -2146,7 +2146,7 @@ msgstr "网关"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "网关端口"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6560,9 +6560,6 @@ msgstr "« 后退"
 
 #~ msgid "Disabled (default)"
 #~ msgstr "已禁用（默认）"
-
-#~ msgid "Gateway ports"
-#~ msgstr "网关端口"
 
 #~ msgid "Loading SSH keys…"
 #~ msgstr "正在加载 SSH 密钥…"

--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -17,11 +17,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr "%.1f dB"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr "%d Bit"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr "%d 个无效字段"
 
@@ -63,19 +64,19 @@ msgid "-- Additional Field --"
 msgstr "-- 更多选项 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- 请选择 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- 自定义 --"
@@ -98,7 +99,7 @@ msgstr "-- 根据 UUID 匹配 --"
 msgid "-- please select --"
 msgstr "-- 请选择 --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr "0 = 不使用 RSSI 阈值，1 = 驱动默认值"
 
@@ -110,7 +111,7 @@ msgstr "1 分钟负载："
 msgid "15 Minute Load:"
 msgstr "15 分钟负载："
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr "4 字符的十六进制 ID"
 
@@ -123,35 +124,35 @@ msgstr "464XLAT (CLAT)"
 msgid "5 Minute Load:"
 msgstr "5 分钟负载："
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr "十六进制表示的 6 字节标识符，无冒号分隔"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr "802.11r 快速切换"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr "802.11w 关联 SA 查询最大超时"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr "802.11w 关联 SA 查询重试超时"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr "802.11w 管理帧保护"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr "802.11w 最大超时"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr "802.11w 重试超时"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -171,7 +172,7 @@ msgstr ""
 "按照“解析文件”里的顺序查询 <abbr title=\"Domain Name System\">DNS</abbr> 服务"
 "器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -207,7 +208,7 @@ msgstr ""
 "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr> 后缀（十六进制）"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 配置"
 
@@ -250,7 +251,7 @@ msgid ""
 msgstr ""
 "<br/>注意：如果 crontab 文件在编辑前为空，则需要手动重新启动 cron 服务。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -330,8 +331,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "接入集中器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "接入点 AP"
 
@@ -362,17 +363,17 @@ msgstr "已分配的 DHCP 租约"
 msgid "Active DHCPv6 Leases"
 msgstr "已分配的 DHCPv6 租约"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "点对点 Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -403,10 +404,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr "添加密钥"
 
@@ -419,7 +423,7 @@ msgstr "添加本地域名后缀到 HOSTS 文件中的域名"
 msgid "Add new interface..."
 msgstr "添加新接口…"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -468,8 +472,8 @@ msgstr "管理权"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -479,11 +483,11 @@ msgstr "高级设置"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr "总发射功率（ACTATP）"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "警戒"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -509,23 +513,23 @@ msgstr "从最低可用地址开始顺序分配 IP 地址"
 msgid "Allocate IP sequentially"
 msgstr "顺序分配 IP"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "允许 <abbr title=\"Secure Shell\">SSH</abbr> 密码验证"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr "允许 AP 模式时在 low ACK 的情况下断开无线终端"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "仅允许列表外"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "允许传统的 802.11b 速率"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "仅允许列表内"
 
@@ -533,15 +537,15 @@ msgstr "仅允许列表内"
 msgid "Allow localhost"
 msgstr "允许本机"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr "允许远程主机连接到本地 SSH 转发端口"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "允许 root 用户凭密码登录"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "允许 <em>root</em> 用户凭密码登录"
 
@@ -550,7 +554,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr "允许 127.0.0.0/8 回环范围内的上行响应，例如：RBL 服务"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr "允许的 IP"
 
@@ -558,7 +562,7 @@ msgstr "允许的 IP"
 msgid "Always announce default router"
 msgstr "总是通告默认路由"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -638,7 +642,7 @@ msgstr "通告的 DNS 域名"
 msgid "Announced DNS servers"
 msgstr "通告的 DNS 服务器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr "匿名身份"
 
@@ -657,11 +661,11 @@ msgstr "自动挂载未配置的 Swap 分区"
 msgid "Any zone"
 msgstr "任意区域"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr "应用请求失败，状态 <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -685,7 +689,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr "将此十六进制子 ID 前缀分配给此接口"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "已连接站点"
@@ -699,7 +703,7 @@ msgstr "关联数"
 msgid "Auth Group"
 msgstr "认证组"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "认证"
 
@@ -794,7 +798,7 @@ msgstr "BR / DMR / AFTR"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -812,7 +816,7 @@ msgstr "返回至配置"
 msgid "Backup"
 msgstr "备份"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "备份/升级"
 
@@ -829,7 +833,7 @@ msgstr "指定了错误的地址！"
 msgid "Band"
 msgstr "频宽"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr "Beacon 间隔"
 
@@ -866,7 +870,7 @@ msgstr "传输速率"
 msgid "Bogus NX Domain Override"
 msgstr "忽略虚假空域名解析"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "桥接"
@@ -884,7 +888,7 @@ msgstr "桥接号"
 msgid "Bring up on boot"
 msgstr "开机自动运行"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -909,13 +913,13 @@ msgstr "CPU 使用率（%）"
 msgid "Call failed"
 msgstr "调用失败"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "取消"
@@ -938,13 +942,7 @@ msgstr "注意：将强制进行系统升级"
 msgid "Chain"
 msgstr "链"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr "更改登录密码"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "更改数"
 
@@ -952,23 +950,19 @@ msgstr "更改数"
 msgid "Changes applied."
 msgstr "更改已应用。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "更改已恢复。"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "更改访问设备的管理员密码"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr "正在更改密码…"
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "信道"
@@ -981,7 +975,7 @@ msgstr "检查"
 msgid "Check filesystems before mount"
 msgstr "在挂载前检查文件系统"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr "选中此选项以从无线中删除现有网络。"
 
@@ -994,7 +988,7 @@ msgid "Choose mtdblock"
 msgstr "选择 mtdblock"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -1004,13 +998,13 @@ msgstr ""
 "为此接口分配所属的防火墙区域，选择“不指定”可将该接口移出已关联的区域，或者填"
 "写“创建”栏来创建一个新的区域，并将当前接口与之建立关联。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
 msgstr "选择指派到此无线接口的网络，或者填写“创建”栏来新建网络。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "算法"
 
@@ -1032,9 +1026,9 @@ msgstr ""
 "单击“保存 mtdblock”以下载指定的 mtdblock 文件。（注意：此功能适用于专业人"
 "士！）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "客户端 Client"
 
@@ -1043,8 +1037,8 @@ msgstr "客户端 Client"
 msgid "Client ID to send when requesting DHCP"
 msgstr "请求 DHCP 时发送的客户端 ID"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr "关闭"
 
@@ -1067,7 +1061,7 @@ msgstr "关闭列表…"
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1094,7 +1088,7 @@ msgstr ""
 msgid "Comment"
 msgstr "备注"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1105,7 +1099,7 @@ msgstr ""
 "杂度。此解决方法可能会导致互操作性问题，并降低密钥协商的可靠性，特别是在流量"
 "负载较重的环境中。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1121,11 +1115,11 @@ msgstr "配置失败"
 msgid "Configuration files will be kept"
 msgstr "将保留配置文件"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "配置已应用。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "配置已回滚！"
 
@@ -1133,7 +1127,7 @@ msgstr "配置已回滚！"
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "确认密码"
 
@@ -1166,7 +1160,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1179,12 +1173,12 @@ msgstr ""
 msgid "Country"
 msgstr "国家"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "国家代码"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "创建/分配防火墙区域"
 
@@ -1192,11 +1186,11 @@ msgstr "创建/分配防火墙区域"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "致命错误"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Cron 日志级别"
 
@@ -1230,15 +1224,15 @@ msgid ""
 "\">LED</abbr>s if possible."
 msgstr "自定义此设备的 <abbr title=\"Light Emitting Diode\">LED</abbr> 行为。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr "DAE 客户端"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr "DAE 端口"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr "DAE 加密"
 
@@ -1251,7 +1245,7 @@ msgstr "DHCP 服务器"
 msgid "DHCP and DNS"
 msgstr "DHCP/DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1324,7 +1318,7 @@ msgstr "DSL 状态"
 msgid "DSL line mode"
 msgstr "DSL 线路模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr "DTIM 间隔"
 
@@ -1336,14 +1330,14 @@ msgstr "DUID"
 msgid "Data Rate"
 msgstr "数据速率"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "调试"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "默认 %d"
 
@@ -1383,47 +1377,47 @@ msgstr ""
 "设置 DHCP 的附加选项，例如设定 \"<code>6,192.168.2.1,192.168.2.2</code>\" 表"
 "示通告不同的 DNS 服务器给客户端。"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "删除"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr "删除密钥"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "删除此网络"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr "发送流量指示消息间隔"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "描述"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "主题"
 
@@ -1454,7 +1448,7 @@ msgstr ""
 msgid "Device"
 msgstr "设备"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "设备配置"
 
@@ -1471,7 +1465,7 @@ msgstr "设备正在重启…"
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "无法连接到设备"
 
@@ -1489,12 +1483,12 @@ msgstr "网络诊断"
 msgid "Dial number"
 msgstr "拨号号码"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "目录"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "禁用"
 
@@ -1510,14 +1504,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr "禁用加密"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr "禁用不活动轮询"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr "禁用此网络"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1529,11 +1524,7 @@ msgstr "禁用此网络"
 msgid "Disabled"
 msgstr "已禁用"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr "已禁用（默认）"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr "在低 Ack 应答时断开连接"
 
@@ -1552,21 +1543,19 @@ msgstr "断开连接"
 msgid "Disconnection attempt failed"
 msgstr "尝试断开连接失败"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "解除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "距离优化"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "最远网络用户的距离（米）。"
 
@@ -1593,15 +1582,15 @@ msgstr "不转发公共域名服务器无法回应的请求"
 msgid "Do not forward reverse lookups for local networks"
 msgstr "不转发本地网络的反向查询"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr "您真的要删除以下 SSH 密钥吗？"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1640,15 +1629,15 @@ msgstr "下载 mtdblock"
 msgid "Downstream SNR offset"
 msgstr "下游 SNR 偏移"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Dropbear 实例"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1680,17 +1669,17 @@ msgstr ""
 msgid "EA-bits length"
 msgstr "EA-位长"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP 类型"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "编辑"
 
@@ -1700,7 +1689,7 @@ msgid ""
 "reload the page."
 msgstr "编辑上方的原始配置数据来修复错误，点击“保存”按钮以重新载入此页面。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "编辑此网络"
 
@@ -1708,12 +1697,12 @@ msgstr "编辑此网络"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "紧急"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "启用"
 
@@ -1749,7 +1738,7 @@ msgstr "在 PPP 链路上启用 IPv6 协商"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "启用巨型帧透传"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "启用 NTP 客户端"
 
@@ -1765,11 +1754,11 @@ msgstr "启用 TFTP 服务器"
 msgid "Enable VLAN functionality"
 msgstr "启用 VLAN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "启用 WPS 一键加密按钮，需要 WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "启用密钥重新安装（KRACK）对策"
 
@@ -1793,7 +1782,7 @@ msgstr "启用后报文的 DF（禁止分片）标志。"
 msgid "Enable this mount"
 msgstr "启用此挂载点"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr "启用此网络"
 
@@ -1815,7 +1804,7 @@ msgstr "已启用"
 msgid "Enables IGMP snooping on this bridge"
 msgstr "在此桥接上启用 IGMP 窥探"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1836,17 +1825,17 @@ msgstr "封装模式"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "加密"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr "端点主机"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr "端点端口"
 
@@ -1858,7 +1847,7 @@ msgstr "输入自定义值"
 msgid "Enter custom values"
 msgstr "输入自定义值"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "擦除中…"
 
@@ -1872,7 +1861,7 @@ msgstr "擦除中…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "错误"
 
@@ -1880,12 +1869,12 @@ msgstr "错误"
 msgid "Errored seconds (ES)"
 msgstr "错误秒数（ES）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "以太网适配器"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "以太网交换机"
@@ -1919,23 +1908,23 @@ msgstr "租用地址的到期时间，最短 2 分钟（<code>2m</code>）。"
 msgid "External"
 msgstr "外部"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr "外部 <abbr title=\"R0 Key Holder\">R0KH</abbr> 列表"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr "外部 <abbr title=\"R1 Key Holder\">R1KH</abbr> 列表"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "外部系统日志服务器地址"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "外部系统日志服务器端口"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "外部系统日志服务器协议"
 
@@ -1943,19 +1932,23 @@ msgstr "外部系统日志服务器协议"
 msgid "Extra SSH command options"
 msgstr "额外的 SSH 命令选项"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr "FT over DS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr "FT over the Air"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr "FT 协议"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr "在 %d 秒内确认应用失败，等待回滚…"
 
@@ -1963,15 +1956,15 @@ msgstr "在 %d 秒内确认应用失败，等待回滚…"
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "文件"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2016,7 +2009,7 @@ msgstr "完成"
 msgid "Firewall"
 msgstr "防火墙"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr "防火墙标识"
 
@@ -2056,7 +2049,7 @@ msgstr "刷写新的固件"
 msgid "Flash operations"
 msgstr "刷新操作"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "正在刷写…"
 
@@ -2064,11 +2057,11 @@ msgstr "正在刷写…"
 msgid "Force"
 msgstr "强制"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "强制 40MHz 模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "强制 CCMP（AES）"
 
@@ -2076,11 +2069,11 @@ msgstr "强制 CCMP（AES）"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "即使检测到另一台服务器，也要强制使用此网络上的 DHCP。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "强制 TKIP"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "强制 TKIP 和 CCMP（AES）"
 
@@ -2112,7 +2105,7 @@ msgstr "前向纠错秒数（FECS）"
 msgid "Forward broadcast traffic"
 msgstr "转发广播数据包"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr "转发 mesh 节点数据包"
 
@@ -2120,7 +2113,7 @@ msgstr "转发 mesh 节点数据包"
 msgid "Forwarding mode"
 msgstr "转发模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "分片阈值"
 
@@ -2129,7 +2122,7 @@ msgstr "分片阈值"
 msgid "Free"
 msgstr "空闲数"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2151,19 +2144,19 @@ msgstr "仅 GPRS"
 msgid "Gateway"
 msgstr "网关"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr "网关地址无效"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "网关端口"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2171,8 +2164,8 @@ msgstr "基本设置"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "基本设置"
 
@@ -2180,7 +2173,7 @@ msgstr "基本设置"
 msgid "Generate Config"
 msgstr "生成配置"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr "本地生成 PMK"
 
@@ -2188,7 +2181,7 @@ msgstr "本地生成 PMK"
 msgid "Generate archive"
 msgstr "生成备份"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "由于密码验证不匹配，密码没有更改！"
 
@@ -2207,8 +2200,8 @@ msgstr "全局网络选项"
 msgid "Go to password configuration..."
 msgstr "跳转到密码配置页…"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2238,13 +2231,13 @@ msgstr "挂起"
 msgid "Header Error Code Errors (HEC)"
 msgstr "请求头错误代码错误（HEC）"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr "此处配置设备的基础信息，如主机名称或时区。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "隐藏 <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2255,7 +2248,7 @@ msgstr "隐藏空链"
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr "主机"
 
@@ -2280,7 +2273,7 @@ msgstr "Host-Uniq 标签内容"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "主机名"
 
@@ -2301,7 +2294,7 @@ msgstr "混合"
 msgid "IKE DH Group"
 msgstr "IKE DH 组"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr "IP 地址"
 
@@ -2522,7 +2515,7 @@ msgstr "IPv6-over-IPv4 (6rd)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6-over-IPv4 (6to4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "鉴权"
 
@@ -2634,7 +2627,7 @@ msgstr "活动超时"
 msgid "Inbound:"
 msgstr "入站："
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "信息"
 
@@ -2672,7 +2665,7 @@ msgstr "安装扩展协议…"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "接口"
 
@@ -2680,7 +2673,7 @@ msgstr "接口"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr "接口设备 %q 从 %q 自动迁移到了 %q。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "接口配置"
 
@@ -2710,7 +2703,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "接口名称"
 
@@ -2740,7 +2733,7 @@ msgstr "内部服务器错误"
 msgid "Invalid"
 msgstr "无效"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2760,7 +2753,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2768,7 +2761,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "无效的用户名和/或密码！请重试。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "隔离客户端"
 
@@ -2785,15 +2778,15 @@ msgstr "您尝试刷写的固件与本路由器不兼容，请重新验证固件
 msgid "JavaScript required!"
 msgstr "需要 JavaScript！"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "加入网络"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "加入网络：搜索无线"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr "加入网络：%q"
 
@@ -2810,15 +2803,15 @@ msgstr "内核日志"
 msgid "Kernel Version"
 msgstr "内核版本"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "密码"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "密码 #%d"
 
@@ -2862,11 +2855,11 @@ msgstr "LLC"
 msgid "Label"
 msgstr "卷标"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "语言"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "语言和界面"
 
@@ -2906,7 +2899,7 @@ msgstr "留空则自动探测"
 msgid "Leave empty to use the current WAN address"
 msgstr "留空则使用当前 WAN 地址"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "图例："
 
@@ -2949,7 +2942,7 @@ msgid ""
 msgstr ""
 "将请求转发到的 <abbr title=\"Domain Name System\">DNS</abbr> 服务器列表"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2961,7 +2954,7 @@ msgstr ""
 "进制字符串）。<br />在从初始移动域关联期间使用的 R0KH 中请求 PMK-R1 密钥时，"
 "该列表用于将 R0KH-ID（NAS 标识符）映射到目标 MAC 地址。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2990,11 +2983,11 @@ msgstr "允许虚假空域名响应的服务器列表"
 msgid "Listen Interfaces"
 msgstr "监听接口"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr "监听端口"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr "仅监听指定的接口，未指定则监听全部"
 
@@ -3017,11 +3010,7 @@ msgstr "平均负载"
 msgid "Loading"
 msgstr "加载中"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr "正在加载 SSH 密钥…"
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3061,7 +3050,7 @@ msgid "Local Startup"
 msgstr "本地启动脚本"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "本地时间"
 
@@ -3093,7 +3082,7 @@ msgstr "如果有多个 IP 可用，则根据请求来源的子网来本地化�
 msgid "Localise queries"
 msgstr "本地化查询"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "日志记录等级"
 
@@ -3101,7 +3090,7 @@ msgstr "日志记录等级"
 msgid "Log queries"
 msgstr "记录查询日志"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "日志"
 
@@ -3132,22 +3121,22 @@ msgstr "MAC"
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC 地址"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "MAC 地址过滤"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC 过滤"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC 列表"
 
@@ -3175,7 +3164,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "MTU"
 
@@ -3195,7 +3184,7 @@ msgstr "确保使用以下命令来复制根文件系统："
 msgid "Manual"
 msgstr "手动"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3203,7 +3192,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr "最大可达数据速率（ATTNDR）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr "允许的最大监听间隔"
 
@@ -3229,7 +3218,7 @@ msgstr "调制解调器就绪的最大等待时间（秒）"
 msgid "Maximum number of leased addresses."
 msgstr "最大地址分配数量。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3242,7 +3231,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr "中等"
 
@@ -3254,11 +3243,11 @@ msgstr "内存"
 msgid "Memory usage (%)"
 msgstr "内存使用率（%）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr "Mesh ID"
 
@@ -3269,7 +3258,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "跃点数"
 
@@ -3281,7 +3270,7 @@ msgstr "数据包镜像监听端口"
 msgid "Mirror source port"
 msgstr "数据包镜像源端口"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr "移动域"
 
@@ -3289,8 +3278,8 @@ msgstr "移动域"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "模式"
@@ -3321,16 +3310,16 @@ msgstr "调制解调器信息查询失败"
 msgid "Modem init timeout"
 msgstr "调制解调器初始化超时"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "监听"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr "需要更多字符"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3343,7 +3332,7 @@ msgstr "挂载项目"
 msgid "Mount Point"
 msgstr "挂载点"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3391,7 +3380,7 @@ msgstr "下移"
 msgid "Move up"
 msgstr "上移"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr "NAS ID"
 
@@ -3416,11 +3405,11 @@ msgstr "NDP 代理"
 msgid "NT Domain"
 msgstr "NT 域"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "候选 NTP 服务器"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3428,7 +3417,7 @@ msgstr "候选 NTP 服务器"
 msgid "Name"
 msgstr "名称"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "新网络的名称"
 
@@ -3438,8 +3427,8 @@ msgstr "导航"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3472,7 +3461,7 @@ msgstr ""
 msgid "Next »"
 msgstr "前进 »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr "无"
@@ -3481,7 +3470,7 @@ msgstr "无"
 msgid "No DHCP Server configured for this interface"
 msgstr "本接口未配置 DHCP 服务器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3493,7 +3482,7 @@ msgstr "无 NAT-T"
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3524,11 +3513,12 @@ msgstr "禁用无效信息缓存"
 msgid "No password set!"
 msgstr "未设置密码！"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr "当前还没有公钥。"
 
@@ -3573,7 +3563,7 @@ msgstr "非全部地址"
 msgid "None"
 msgstr "无"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "正常"
 
@@ -3603,7 +3593,7 @@ msgstr "开机时不启动"
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "注意"
 
@@ -3615,7 +3605,7 @@ msgstr "Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr "缓存的 DNS 条目数量（最大 10000，0 表示不缓存）"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr "用于压缩的并行线程数"
 
@@ -3681,24 +3671,24 @@ msgstr "打开列表…"
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr "OpenConnect (CISCO AnyConnect)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "工作频率"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "选项已更改"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "选项已移除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr "可选"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3716,35 +3706,35 @@ msgstr ""
 "权服务器获取到 IPv6 前缀（如“a:b:c:d::”），使用后缀（如 “::1”）合成 IPv6 地址"
 "（“a:b:c:d::1”）分配给此接口。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr "可选，Base64 编码的预共享密钥。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "可选，为此 Peer 创建允许 IP 的路由。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr "可选，Peer 的描述。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr "可选，Peer 的主机。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr "可选，隧道接口的最大传输单元。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr "可选，Peer 的端口。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
@@ -3752,7 +3742,7 @@ msgstr ""
 "可选，Keep-Alive 消息之间的秒数，默认为 0（禁用）。如果此设备位于 NAT 之后，"
 "建议使用的值为 25。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr "可选，用于传出和传入数据包的 UDP 端口。"
 
@@ -3812,7 +3802,7 @@ msgstr "重设 TOS"
 msgid "Override TTL"
 msgstr "重设 TTL"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr "重设默认接口名称"
 
@@ -3834,7 +3824,7 @@ msgstr "重设内部路由表"
 msgid "Overview"
 msgstr "总览"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3879,7 +3869,7 @@ msgstr "PIN"
 msgid "PIN code rejected"
 msgstr "PIN 码被拒绝"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr "R1 推送 PMK"
 
@@ -3934,29 +3924,29 @@ msgid "Part of zone %q"
 msgstr "区域 %q"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "密码"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "密码验证"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "私有密钥"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr "内部私钥的密码"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr "密码强度"
 
@@ -3964,31 +3954,31 @@ msgstr "密码强度"
 msgid "Password2"
 msgstr "密码 2"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr "粘贴或拖动 SSH 密钥文件……"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "CA 证书路径"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "客户端证书路径"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "私钥路径"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr "内部 CA 证书的路径"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr "内部客户端证书的路径"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr "内部私钥的路径"
 
@@ -4015,7 +4005,7 @@ msgstr "要分配的 Peer IP 地址"
 msgid "Peer address is missing"
 msgstr "Peer 地址缺失"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr "Peers"
 
@@ -4035,7 +4025,7 @@ msgstr "执行重置"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr "持续 Keep-Alive"
 
@@ -4075,7 +4065,7 @@ msgstr "请输入用户名和密码。"
 msgid "Policy"
 msgstr "策略"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "端口"
 
@@ -4111,7 +4101,7 @@ msgstr "首选 UMTS"
 msgid "Prefix Delegated"
 msgstr "分发前缀"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr "预共享密钥"
 
@@ -4130,11 +4120,11 @@ msgstr "在指定数量的 LCP 响应故障后假定链路已断开，0 为忽�
 msgid "Prevent listening on these interfaces."
 msgstr "不监听这些接口。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "禁止客户端间通信"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr "私钥"
 
@@ -4165,7 +4155,7 @@ msgstr "协议"
 msgid "Protocol"
 msgstr "协议"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "作为 NTP 服务器提供服务"
 
@@ -4173,15 +4163,15 @@ msgstr "作为 NTP 服务器提供服务"
 msgid "Provide new network"
 msgstr "添加新网络"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "伪装 Ad-Hoc（ahdemo）"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr "公钥"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4211,11 +4201,11 @@ msgid ""
 msgstr ""
 "查询所有可用的上游 <abbr title=\"Domain Name System\">DNS</abbr> 服务器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr "R0 密钥生存期"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr "R1 密钥持有者"
 
@@ -4223,11 +4213,11 @@ msgstr "R1 密钥持有者"
 msgid "RFC3947 NAT-T mode"
 msgstr "RFC3947 NAT-T 模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr "RSSI 加入阈值"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS 阈值"
 
@@ -4243,31 +4233,31 @@ msgstr "接收"
 msgid "RX Rate"
 msgstr "接收速率"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Radius 计费端口"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Radius 计费密钥"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Radius 计费服务器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Radius 认证端口"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Radius 认证密钥"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Radius 认证服务器"
 
@@ -4318,7 +4308,7 @@ msgstr "实时流量"
 msgid "Realtime Wireless"
 msgstr "实时无线"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr "重关联截止时间"
 
@@ -4326,7 +4316,7 @@ msgstr "重关联截止时间"
 msgid "Rebind protection"
 msgstr "重绑定保护"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "重启"
@@ -4344,7 +4334,7 @@ msgstr "重启您设备上的系统"
 msgid "Receive"
 msgstr "接收"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr "推荐，WireGuard 接口的 IP 地址。"
 
@@ -4384,11 +4374,11 @@ msgstr "远程 IPv4 地址"
 msgid "Remote IPv4 address or FQDN"
 msgstr "远程 IPv4 地址或 FQDN"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "移除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "重置无线配置"
 
@@ -4404,7 +4394,7 @@ msgstr "请求指定长度的 IPv6 前缀"
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr "必须"
 
@@ -4412,15 +4402,15 @@ msgstr "必须"
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "某些 ISP 需要，例如：同轴线网络 DOCSIS 3"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr "必须，此接口的 Base64 编码私钥。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr "必须，Peer 的 Base64 编码公钥。"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
@@ -4429,27 +4419,27 @@ msgstr ""
 "必须，允许该 Peer 在隧道中使用的 IP 地址和前缀，通常是该 Peer 的隧道 IP 地址"
 "和通过隧道的路由网络。"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4463,31 +4453,31 @@ msgid ""
 "come from unsigned domains"
 msgstr "需要上级支持 DNSSEC，验证未签名的响应确实是来自未签名的域名"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4538,10 +4528,8 @@ msgstr "恢复"
 msgid "Restore backup"
 msgstr "恢复配置"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "显示/隐藏 密码"
 
@@ -4549,15 +4537,15 @@ msgstr "显示/隐藏 密码"
 msgid "Revert"
 msgstr "恢复"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr "恢复更改"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr "恢复请求失败，状态 <code>%h</code>"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "正在恢复配置…"
 
@@ -4573,7 +4561,7 @@ msgstr "TFTP 服务器的根目录"
 msgid "Root preparation"
 msgstr "根目录准备"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr "路由允许的 IP"
 
@@ -4589,8 +4577,8 @@ msgstr "路由类型"
 msgid "Router Advertisement-Service"
 msgstr "路由通告服务"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "主机密码"
 
@@ -4630,8 +4618,8 @@ msgstr "SHA256"
 msgid "SNR"
 msgstr "SNR"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH 访问"
 
@@ -4647,14 +4635,14 @@ msgstr "SSH 服务器端口"
 msgid "SSH username"
 msgstr "SSH 用户名"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH 密钥"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "SSID"
@@ -4663,19 +4651,17 @@ msgstr "SSID"
 msgid "SWAP"
 msgstr "交换分区"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "保存"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存并应用"
@@ -4688,24 +4674,20 @@ msgstr "保存 mtdblock"
 msgid "Save mtdblock contents"
 msgstr "保存 mtdblock 内容"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr "正在保存密钥…"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "扫描"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "计划任务"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "添加的节点"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "移除的节点"
 
@@ -4722,9 +4704,9 @@ msgstr ""
 "即使映像文件检查失败，也“强制升级”以烧录映像。仅在您确定固件正确且适用于您的"
 "设备时使用！"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4795,7 +4777,7 @@ msgstr "严重误码秒（SES）"
 msgid "Short GI"
 msgstr "Short GI"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr "Short Preamble"
 
@@ -4815,12 +4797,12 @@ msgstr "关闭此接口"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "信号"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4840,7 +4822,7 @@ msgstr "大小"
 msgid "Size of DNS query cache"
 msgstr "DNS 查询缓存的大小"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr "ZRam 设备的大小（以兆字节为单位）"
 
@@ -4857,7 +4839,7 @@ msgstr "跳到内容"
 msgid "Skip to navigation"
 msgstr "跳转到导航"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr "软件 VLAN"
@@ -4897,10 +4879,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "指定设备的挂载目录"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "指定此 <em>Dropbear</em> 实例的监听端口"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4913,7 +4891,7 @@ msgid ""
 "dead"
 msgstr "判断主机已下线的超时时间（秒）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4936,7 +4914,7 @@ msgid ""
 "bytes)."
 msgstr "设置 MTU（最大传输单位），缺省值：1280 bytes"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "在此指定密钥。"
 
@@ -4950,16 +4928,16 @@ msgstr "开始"
 msgid "Start priority"
 msgstr "启动优先级"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "开始应用配置…"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "正在启动无线扫描…"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "启动项"
 
@@ -4979,7 +4957,7 @@ msgstr "静态地址分配"
 msgid "Static Routes"
 msgstr "静态路由"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4994,13 +4972,13 @@ msgstr ""
 "静态租约用于给 DHCP 客户端分配固定的 IP 地址和主机标识。只有指定的主机才能连"
 "接，并且接口须为非动态配置。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr "非活动站点限制"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "状态"
@@ -5015,12 +4993,12 @@ msgstr "关闭"
 msgid "Strict order"
 msgstr "严谨查序"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr "强"
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "提交"
 
@@ -5058,7 +5036,7 @@ msgstr "交换机 %q 具有未知的拓扑结构，VLAN 设置可能不正确。
 msgid "Switch Port Mask"
 msgstr "交换机端口掩码"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr "交换机 VLAN"
@@ -5073,11 +5051,11 @@ msgstr "切换协议"
 msgid "Switch to CIDR list notation"
 msgstr "切换到 CIDR 列表记法"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr "与 NTP 服务器同步"
 
@@ -5087,7 +5065,7 @@ msgstr "同步浏览器时间"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5098,11 +5076,11 @@ msgstr "系统"
 msgid "System Log"
 msgstr "系统日志"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "系统属性"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "系统日志缓冲区大小"
 
@@ -5168,7 +5146,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr "运营商特定的 IPv6 前缀，通常以 <code>::</code> 为结尾"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5184,7 +5162,7 @@ msgstr "备份存档似乎不是有效的 gzip 文件。"
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr "由于以下错误，配置文件无法被加载："
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5234,11 +5212,11 @@ msgstr "以下规则当前在系统中处于活动状态。"
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr "已添加给定的 SSH 公钥。"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5268,7 +5246,7 @@ msgstr "IPv6 前缀长度（位）"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr "所创建隧道的本地 IPv4 地址（可选）。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5286,7 +5264,7 @@ msgstr ""
 "abbr> 也常用于分割不同网段。默认通常是一条上行端口连接 ISP，其余端口为本地子"
 "网。"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5294,13 +5272,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr "提交的安全令牌无效或已过期！"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "系统正在擦除配置分区，完成后会自动重启。"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
 "few minutes before you try to reconnect. It might be necessary to renew the "
@@ -5310,7 +5288,7 @@ msgstr ""
 "正在刷写系统…<br />切勿关闭电源！ DO NOT POWER OFF THE DEVICE!<br />等待数分"
 "钟后即可尝试重新连接到路由。您可能需要更改计算机的 IP 地址以重新连接。"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr "系统密码已更改成功。"
 
@@ -5329,7 +5307,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "没有已分配的租约。"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5346,7 +5324,7 @@ msgstr "尚未设置密码。请为 root 用户设置密码以保护主机并启
 msgid "This IPv4 address of the relay"
 msgstr "中继的 IPv4 地址"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5425,22 +5403,22 @@ msgstr "系统中正在运行的进程概况和它们的状态信息。"
 msgid "This page gives an overview over currently active network connections."
 msgstr "活跃的网络连接概况。"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "尚无任何配置"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "时间同步"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr "重新加密 GTK 的时间间隔"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "时区"
 
@@ -5497,7 +5475,7 @@ msgstr "触发模式"
 msgid "Tunnel ID"
 msgstr "隧道 ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "隧道接口"
@@ -5590,12 +5568,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "不可用秒数（UAS）"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "未知"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr "未知错误（%s）"
@@ -5604,7 +5582,7 @@ msgstr "未知错误（%s）"
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5615,11 +5593,12 @@ msgstr "不配置协议"
 msgid "Unmount"
 msgstr "卸载分区"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr "未命名的密钥"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "未保存的配置"
 
@@ -5659,15 +5638,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "上传备份…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5808,11 +5787,11 @@ msgstr ""
 msgid "Used"
 msgstr "已用"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "启用密码组"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5894,32 +5873,32 @@ msgstr "验证"
 msgid "Virtual dynamic interface"
 msgstr "虚拟动态接口"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "WEP 开放式系统"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "WEP 共享密钥"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP 密钥"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "WMM 模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA 密钥"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5935,7 +5914,7 @@ msgstr "正在应用更改…"
 msgid "Waiting for command to complete..."
 msgstr "等待命令执行完成…"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5943,8 +5922,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr "等待设备…"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "警告"
 
@@ -5952,11 +5931,11 @@ msgstr "警告"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr "警告：一些未保存的配置将在重启后丢失！"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr "弱"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5970,7 +5949,7 @@ msgstr ""
 msgid "Width"
 msgstr "频宽"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr "WireGuard VPN"
@@ -5981,13 +5960,13 @@ msgstr "WireGuard VPN"
 msgid "Wireless"
 msgstr "无线"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "无线适配器"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5997,7 +5976,7 @@ msgstr "无线网络"
 msgid "Wireless Overview"
 msgstr "无线概况"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "无线安全"
 
@@ -6017,11 +5996,11 @@ msgstr "无线未开启"
 msgid "Wireless is not associated"
 msgstr "无线未关联"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "无线网络已禁用"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "无线网络已启用"
 
@@ -6029,11 +6008,11 @@ msgstr "无线网络已启用"
 msgid "Write received DNS requests to syslog"
 msgstr "将收到的 DNS 请求写入系统日志"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "将系统日志写入文件"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr "是"
@@ -6061,19 +6040,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr "必须开启浏览器的 JavaScript 支持，否则 LuCI 无法正常工作。"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr "ZRam 压缩算法"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr "ZRam 压缩流"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr "ZRam 设置"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr "ZRam 大小"
 
@@ -6084,7 +6063,7 @@ msgstr "任意"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6142,7 +6121,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "禁用"
 
@@ -6243,7 +6222,11 @@ msgstr "密钥为 5 或 13 个字符"
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "本地 <abbr title=\"Domain Name System\">DNS</abbr> 解析文件"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr "分钟"
 
@@ -6262,7 +6245,7 @@ msgstr "未连接"
 msgid "non-empty value"
 msgstr "非空值"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "无"
 
@@ -6273,8 +6256,8 @@ msgid "not present"
 msgstr "不存在"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6288,6 +6271,10 @@ msgstr "关"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "开"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6306,7 +6293,7 @@ msgstr "正十进制值"
 msgid "positive integer value"
 msgstr "正整数值"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr "随机"
 
@@ -6320,8 +6307,8 @@ msgstr "中继模式"
 msgid "routed"
 msgstr "已路由"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr "秒"
 
@@ -6342,11 +6329,15 @@ msgstr "无状态"
 msgid "stateless + stateful"
 msgstr "无状态 + 有状态"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "已标记"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr "时间单位（TUs / 1.024ms）[1000-65535]"
 
@@ -6365,7 +6356,7 @@ msgstr "未知"
 msgid "unlimited"
 msgstr "无限制"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6546,6 +6537,10 @@ msgstr "值至少为 %d 个字符"
 msgid "value with at most %d characters"
 msgstr "值至多为 %d 个字符"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6556,6 +6551,27 @@ msgstr "是"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 后退"
+
+#~ msgid "Change login password"
+#~ msgstr "更改登录密码"
+
+#~ msgid "Changing password…"
+#~ msgstr "正在更改密码…"
+
+#~ msgid "Disabled (default)"
+#~ msgstr "已禁用（默认）"
+
+#~ msgid "Gateway ports"
+#~ msgstr "网关端口"
+
+#~ msgid "Loading SSH keys…"
+#~ msgstr "正在加载 SSH 密钥…"
+
+#~ msgid "Saving keys…"
+#~ msgstr "正在保存密钥…"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "指定此 <em>Dropbear</em> 实例的监听端口"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "交换机 %q（%s）"

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -2137,7 +2137,7 @@ msgstr "閘道"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Gateway Ports"
-msgstr ""
+msgstr "閘道埠號"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
@@ -6517,9 +6517,6 @@ msgstr "是的"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 倒退"
-
-#~ msgid "Gateway ports"
-#~ msgstr "閘道埠號"
 
 #~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
 #~ msgstr "指定這個 <em>Dropbear</em>的監聽埠"

--- a/modules/luci-base/po/zh-tw/base.po
+++ b/modules/luci-base/po/zh-tw/base.po
@@ -15,11 +15,12 @@ msgstr ""
 msgid "%.1f dB"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:109
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:122
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:264
 msgid "%d Bit"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2189
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2194
 msgid "%d invalid field(s)"
 msgstr ""
 
@@ -61,19 +62,19 @@ msgid "-- Additional Field --"
 msgstr "-- 更多選項 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:258
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1568
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:309
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:409
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1173
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1780
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:414
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1178
 #: modules/luci-base/luasrc/view/cbi/header.htm:5
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:88
 msgid "-- Please choose --"
 msgstr "-- 請選擇 --"
 
 #: modules/luci-base/htdocs/luci-static/resources/cbi.js:259
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:410
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1174
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1179
 #: modules/luci-base/luasrc/view/cbi/header.htm:6
 msgid "-- custom --"
 msgstr "-- 自訂 --"
@@ -96,7 +97,7 @@ msgstr ""
 msgid "-- please select --"
 msgstr "-- 請選擇 --"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "0 = not using RSSI threshold, 1 = do not change driver default"
 msgstr ""
 
@@ -108,7 +109,7 @@ msgstr "1分鐘負載"
 msgid "15 Minute Load:"
 msgstr "15分鐘負載"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "4-character hexadecimal ID"
 msgstr ""
 
@@ -121,35 +122,35 @@ msgstr ""
 msgid "5 Minute Load:"
 msgstr "5分鐘負載"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "6-octet identifier as a hex string - no colons"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid "802.11r Fast Transition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w Association SA Query maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w Association SA Query retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "802.11w Management Frame Protection"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1547
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1567
 msgid "802.11w maximum timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1554
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1574
 msgid "802.11w retry timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:830
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:831
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 msgstr "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
 
@@ -167,7 +168,7 @@ msgid ""
 "order of the resolvfile"
 msgstr "將會按照指定的順序查詢<abbr title=\"Domain Name System\">DNS</abbr>"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:819
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:820
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -202,7 +203,7 @@ msgid "<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Suffix (hex)"
 msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:40
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:35
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:33
 msgid "<abbr title=\"Light Emitting Diode\">LED</abbr> Configuration"
 msgstr "<abbr title=\"Light Emitting Diode\">LED</abbr> 設定"
 
@@ -245,7 +246,7 @@ msgid ""
 "was empty before editing."
 msgstr "注意: 如果這個檔案在編輯之前是空的,您將需要重新啟動cron服務"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1600
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1605
 msgid "A directory with the same name already exists."
 msgstr ""
 
@@ -325,8 +326,8 @@ msgstr ""
 msgid "Access Concentrator"
 msgstr "接入集線器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Access Point"
 msgstr "存取點 (AP)"
 
@@ -357,17 +358,17 @@ msgstr "已分配的DHCP租用"
 msgid "Active DHCPv6 Leases"
 msgstr "已分配的DHCPv6租用"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2185
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2190
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:804
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:23
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:686
-#: modules/luci-base/htdocs/luci-static/resources/form.js:688
-#: modules/luci-base/htdocs/luci-static/resources/form.js:701
-#: modules/luci-base/htdocs/luci-static/resources/form.js:702
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1327
+#: modules/luci-base/htdocs/luci-static/resources/form.js:902
+#: modules/luci-base/htdocs/luci-static/resources/form.js:904
+#: modules/luci-base/htdocs/luci-static/resources/form.js:917
+#: modules/luci-base/htdocs/luci-static/resources/form.js:918
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1539
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:25
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:189
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:197
@@ -398,10 +399,13 @@ msgstr ""
 msgid "Add VLAN"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:143
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:149
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:14
+msgid "Add instance"
+msgstr ""
+
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:153
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:250
 msgid "Add key"
 msgstr ""
 
@@ -414,7 +418,7 @@ msgstr "添加本地網域微碼到HOSTS檔案"
 msgid "Add new interface..."
 msgstr "增加新界面"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:96
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:99
 msgid "Add peer"
 msgstr ""
 
@@ -463,8 +467,8 @@ msgstr "管理"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:505
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:896
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:24
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:742
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:799
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:50
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:34
 msgid "Advanced Settings"
@@ -474,11 +478,11 @@ msgstr "進階設定"
 msgid "Aggregate Transmit Power(ACTATP)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:174
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:166
 msgid "Alert"
 msgstr "警示"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1829
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1834
 #: modules/luci-base/luasrc/model/network.lua:1416
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:54
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:78
@@ -504,23 +508,23 @@ msgstr ""
 msgid "Allocate IP sequentially"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Allow <abbr title=\"Secure Shell\">SSH</abbr> password authentication"
 msgstr "允許 <abbr title=\"Secure Shell\">SSH</abbr> 密碼驗證"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Allow AP mode to disconnect STAs based on low ACK condition"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:891
 msgid "Allow all except listed"
 msgstr "僅允許列表外"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:766
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:767
 msgid "Allow legacy 802.11b rates"
 msgstr "允許舊型 802.11b 頻率"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:890
 msgid "Allow listed only"
 msgstr "僅允許列表內"
 
@@ -528,15 +532,15 @@ msgstr "僅允許列表內"
 msgid "Allow localhost"
 msgstr "允許本機"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:47
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
 msgid "Allow remote hosts to connect to local SSH forwarded ports"
 msgstr "允許遠端主機連接到本機SSH轉送通訊埠"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:38
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow root logins with password"
 msgstr "允許root登入"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:39
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:30
 msgid "Allow the <em>root</em> user to login with password"
 msgstr "允許 <em>root</em> 使用者登入"
 
@@ -545,7 +549,7 @@ msgid ""
 "Allow upstream responses in the 127.0.0.0/8 range, e.g. for RBL services"
 msgstr "允許127.0.0.0/8範圍內的上游回應，例如：RBL服務"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid "Allowed IPs"
 msgstr ""
 
@@ -553,7 +557,7 @@ msgstr ""
 msgid "Always announce default router"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
@@ -632,7 +636,7 @@ msgstr ""
 msgid "Announced DNS servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1480
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1496
 msgid "Anonymous Identity"
 msgstr ""
 
@@ -651,11 +655,11 @@ msgstr "自動掛載swap分區"
 msgid "Any zone"
 msgstr "任意區域"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2529
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2522
 msgid "Apply request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2415
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
 msgid "Apply unchecked"
 msgstr ""
 
@@ -679,7 +683,7 @@ msgid ""
 "Assign prefix parts using this hexadecimal subprefix ID for this interface."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1947
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1967
 #: modules/luci-mod-status/luasrc/view/admin_status/index/60-wifi.htm:22
 msgid "Associated Stations"
 msgstr "已連接裝置"
@@ -693,7 +697,7 @@ msgstr "已連接裝置"
 msgid "Auth Group"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1405
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Authentication"
 msgstr "認證"
 
@@ -788,7 +792,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:106
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1600
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1620
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:176
 msgid "BSSID"
 msgstr "BSSID"
@@ -806,7 +810,7 @@ msgstr "返回至設定"
 msgid "Backup"
 msgstr "備份"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:38
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:36
 msgid "Backup / Flash Firmware"
 msgstr "備份/升級韌體"
 
@@ -823,7 +827,7 @@ msgstr "指定了錯誤的位置！"
 msgid "Band"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:784
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:785
 msgid "Beacon Interval"
 msgstr ""
 
@@ -860,7 +864,7 @@ msgstr "傳輸速率"
 msgid "Bogus NX Domain Override"
 msgstr "忽略NX網域解析"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1835
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1840
 #: modules/luci-base/luasrc/model/network.lua:1420
 msgid "Bridge"
 msgstr "橋接"
@@ -878,7 +882,7 @@ msgstr "橋接單位號碼"
 msgid "Bring up on boot"
 msgstr "開機自動執行"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1692
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1697
 msgid "Browse…"
 msgstr ""
 
@@ -903,13 +907,13 @@ msgstr "CPU 使用率 (%)"
 msgid "Call failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1784
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1789
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:14
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:52
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:711
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:948
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1819
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:176
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1839
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:191
 #: modules/luci-mod-system/luasrc/view/admin_system/upgrade.htm:60
 msgid "Cancel"
 msgstr "取消"
@@ -932,13 +936,7 @@ msgstr ""
 msgid "Chain"
 msgstr "鏈"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:9
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:24
-msgid "Change login password"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 msgid "Changes"
 msgstr "待修改"
 
@@ -946,23 +944,19 @@ msgstr "待修改"
 msgid "Changes applied."
 msgstr "修改已套用"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2552
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2545
 msgid "Changes have been reverted."
 msgstr "設定值已還原."
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 msgid "Changes the administrator password for accessing the device"
 msgstr "修改管理員密碼"
-
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:10
-msgid "Changing password…"
-msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/wireless_modefreq.htm:162
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:77
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:130
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:376
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1598
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1618
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:186
 msgid "Channel"
 msgstr "頻道"
@@ -975,7 +969,7 @@ msgstr "檢查"
 msgid "Check filesystems before mount"
 msgstr "在掛載前先檢查檔案系統"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Check this option to delete the existing networks from this radio."
 msgstr ""
 
@@ -988,7 +982,7 @@ msgid "Choose mtdblock"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid ""
 "Choose the firewall zone you want to assign to this interface. Select "
 "<em>unspecified</em> to remove the interface from the associated zone or "
@@ -998,7 +992,7 @@ msgstr ""
 "選擇您要指定給這介面的防火牆區. 撿選<em>unspecified</em>以便從指定區域除這個"
 "介面或者填寫<em>create</em>欄以便定義附加這個介面到一個新的區域上."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
 msgid ""
 "Choose the network(s) you want to attach to this wireless interface or fill "
 "out the <em>create</em> field to define a new network."
@@ -1006,7 +1000,7 @@ msgstr ""
 "選擇您要附加到無線網路介面的多個網路或者填寫<em>create</em> 以便定義一個新的"
 "網路."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1022
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
 msgid "Cipher"
 msgstr "加密方式"
 
@@ -1026,9 +1020,9 @@ msgid ""
 "FEATURE IS FOR PROFESSIONALS! )"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2184
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:802
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2189
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "Client"
 msgstr "用戶端"
 
@@ -1037,8 +1031,8 @@ msgstr "用戶端"
 msgid "Client ID to send when requesting DHCP"
 msgstr "當要求DHCP時要傳送的用戶識別碼ID"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:145
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:151
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:155
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:161
 msgid "Close"
 msgstr ""
 
@@ -1061,7 +1055,7 @@ msgstr "關閉清單"
 #: modules/luci-base/luasrc/view/lease_status.htm:98
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:118
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1945
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1965
 #: modules/luci-mod-network/luasrc/view/admin_network/iface_status.htm:6
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:398
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:11
@@ -1088,7 +1082,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid ""
 "Complicates key reinstallation attacks on the client side by disabling "
 "retransmission of EAPOL-Key frames that are used to install keys. This "
@@ -1096,7 +1090,7 @@ msgid ""
 "negotiation especially in environments with heavy traffic load."
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2292
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
 #: modules/luci-base/luasrc/controller/admin/uci.lua:11
 #: modules/luci-mod-system/luasrc/view/admin_system/backupfiles.htm:9
 #: modules/luci-mod-system/luasrc/view/admin_system/flashops.htm:13
@@ -1112,11 +1106,11 @@ msgstr ""
 msgid "Configuration files will be kept"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2463
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2456
 msgid "Configuration has been applied."
 msgstr "設定值已套用"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2395
 msgid "Configuration has been rolled back!"
 msgstr "設定值已復原"
 
@@ -1124,7 +1118,7 @@ msgstr "設定值已復原"
 msgid "Confirm disconnect"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:43
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:50
 msgid "Confirmation"
 msgstr "再確認"
 
@@ -1157,7 +1151,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2438
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2431
 msgid ""
 "Could not regain access to the device after applying the configuration "
 "changes. You might need to reconnect if you modified network related "
@@ -1168,12 +1162,12 @@ msgstr ""
 msgid "Country"
 msgstr "國別"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:763
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:764
 msgid "Country Code"
 msgstr "國別碼"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:443
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1809
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1829
 msgid "Create / Assign firewall-zone"
 msgstr "建立/指定防火牆作用區"
 
@@ -1181,11 +1175,11 @@ msgstr "建立/指定防火牆作用區"
 msgid "Create interface"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:165
 msgid "Critical"
 msgstr "緊急"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:177
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
 msgid "Cron Log Level"
 msgstr "Cron日誌等級"
 
@@ -1222,15 +1216,15 @@ msgstr ""
 "如果可以的話,自訂這個設備的 <abbr title=\"Light Emitting Diode\">LED</"
 "abbr>s ."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1210
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1223
 msgid "DAE-Client"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "DAE-Port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1226
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1239
 msgid "DAE-Secret"
 msgstr ""
 
@@ -1243,7 +1237,7 @@ msgstr "DHCP伺服器"
 msgid "DHCP and DNS"
 msgstr "DHCP 和 DNS"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1385
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:16
 #: modules/luci-base/luasrc/model/network.lua:968
 msgid "DHCP client"
@@ -1316,7 +1310,7 @@ msgstr ""
 msgid "DSL line mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "DTIM Interval"
 msgstr ""
 
@@ -1328,14 +1322,14 @@ msgstr "DHCP獨立式別碼DUID "
 msgid "Data Rate"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:168
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:179
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:160
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
 msgid "Debug"
 msgstr "除錯"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1218
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1231
 msgid "Default %d"
 msgstr "預設 %d"
 
@@ -1375,47 +1369,47 @@ msgstr ""
 "定義額外的DHCP選項,例如\"<code>6,192.168.2.1,192.168.2.2</code>\"將會通告不同"
 "的DNS伺服器到客戶端."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:750
-#: modules/luci-base/htdocs/luci-static/resources/form.js:998
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1004
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1312
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1753
+#: modules/luci-base/htdocs/luci-static/resources/form.js:966
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1210
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1216
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1524
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1758
 #: modules/luci-base/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:16
 msgid "Delete"
 msgstr "刪除"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:178
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:187
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:193
 msgid "Delete key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1649
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1654
 msgid "Delete permission denied"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1651
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1656
 msgid "Delete request failed: %d %s"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:722
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723
 msgid "Delete this network"
 msgstr "刪除這個網路"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:962
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:963
 msgid "Delivery Traffic Indication Message Interval"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Description"
 msgstr "描述"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1749
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1754
 msgid "Deselect"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:223
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:215
 msgid "Design"
 msgstr "設計規劃"
 
@@ -1446,7 +1440,7 @@ msgstr ""
 msgid "Device"
 msgstr "設備"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:736
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:737
 msgid "Device Configuration"
 msgstr "設定設備"
 
@@ -1463,7 +1457,7 @@ msgstr "設備重新啟動中..."
 msgid "Device is restarting…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2437
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2430
 msgid "Device unreachable!"
 msgstr "無法連線到設備!"
 
@@ -1481,12 +1475,12 @@ msgstr "診斷"
 msgid "Dial number"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1549
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1554
 msgid "Directory"
 msgstr "目錄"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Disable"
 msgstr "關閉"
 
@@ -1501,14 +1495,15 @@ msgstr ""
 msgid "Disable Encryption"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:972
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:973
 msgid "Disable Inactivity Polling"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Disable this network"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1534
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:76
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:107
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:99
@@ -1520,11 +1515,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "關閉"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1519
-msgid "Disabled (default)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:986
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:987
 msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
@@ -1543,21 +1534,19 @@ msgstr ""
 msgid "Disconnection attempt failed"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1163
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1990
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2310
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2403
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1614
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1375
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1995
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2314
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2401
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1634
 msgid "Dismiss"
 msgstr "忽略"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance Optimization"
 msgstr "最佳化距離"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:769
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:770
 msgid "Distance to farthest network member in meters."
 msgstr "到最遠的網路距離以米表示."
 
@@ -1584,15 +1573,15 @@ msgstr "對不被公用名稱伺服器回應的請求不轉發"
 msgid "Do not forward reverse lookups for local networks"
 msgstr "對本地網域不轉發反解析鎖定"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1634
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1639
 msgid "Do you really want to delete \"%s\" ?"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:173
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:188
 msgid "Do you really want to delete the following SSH key?"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1632
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1637
 msgid "Do you really want to recursively delete the directory \"%s\" ?"
 msgstr ""
 
@@ -1632,15 +1621,15 @@ msgstr ""
 msgid "Downstream SNR offset"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:953
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1169
 msgid "Drag to reorder"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:9
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:11
 msgid "Dropbear Instance"
 msgstr "Dropbear SSH例子"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:6
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
 msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
@@ -1671,17 +1660,17 @@ msgstr "幫用戶端動態發配DHCP位址. 假如關閉的話,僅有有靜態�
 msgid "EA-bits length"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
 msgid "EAP-Method"
 msgstr "EAP協定驗證方式"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:973
-#: modules/luci-base/htdocs/luci-static/resources/form.js:974
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1238
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1188
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1191
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1450
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:154
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:160
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:291
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:719
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:720
 msgid "Edit"
 msgstr "編輯"
 
@@ -1691,7 +1680,7 @@ msgid ""
 "reload the page."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:717
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:718
 msgid "Edit this network"
 msgstr "修改這個網路"
 
@@ -1699,12 +1688,12 @@ msgstr "修改這個網路"
 msgid "Edit wireless network"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:175
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
 msgid "Emergency"
 msgstr "緊急"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:714
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:753
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:715
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:754
 msgid "Enable"
 msgstr "啟用"
 
@@ -1739,7 +1728,7 @@ msgstr "啟用PPP連結上的IPv6交涉"
 msgid "Enable Jumbo Frame passthrough"
 msgstr "啟用超大訊框透穿"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:243
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:235
 msgid "Enable NTP client"
 msgstr "啟用NTP同步功能"
 
@@ -1755,11 +1744,11 @@ msgstr "啟用TFTP伺服器"
 msgid "Enable VLAN functionality"
 msgstr "啟用VLAN功能"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1595
 msgid "Enable WPS pushbutton, requires WPA(2)-PSK"
 msgstr "啟用 WPS 按鈕, 這需要 WPA(2)-PSK"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1562
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1582
 msgid "Enable key reinstallation (KRACK) countermeasures"
 msgstr "啟用金鑰重新安裝攻擊 (KRACK) 因應對策"
 
@@ -1783,7 +1772,7 @@ msgstr ""
 msgid "Enable this mount"
 msgstr "啟用掛載點"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:712
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:713
 msgid "Enable this network"
 msgstr ""
 
@@ -1805,7 +1794,7 @@ msgstr "啟用"
 msgid "Enables IGMP snooping on this bridge"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1294
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 msgid ""
 "Enables fast roaming among access points that belong to the same Mobility "
 "Domain"
@@ -1826,17 +1815,17 @@ msgstr "封裝模式"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:129
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:991
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1601
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:992
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1621
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:177
 msgid "Encryption"
 msgstr "加密"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid "Endpoint Host"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Endpoint Port"
 msgstr ""
 
@@ -1848,7 +1837,7 @@ msgstr ""
 msgid "Enter custom values"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:273
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:271
 msgid "Erasing..."
 msgstr "刪除中..."
 
@@ -1862,7 +1851,7 @@ msgstr "刪除中..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:110
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:164
 msgid "Error"
 msgstr "錯誤"
 
@@ -1870,12 +1859,12 @@ msgstr "錯誤"
 msgid "Errored seconds (ES)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1847
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1852
 #: modules/luci-base/luasrc/model/network.lua:1432
 msgid "Ethernet Adapter"
 msgstr "乙太網路卡"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1838
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1843
 #: modules/luci-base/luasrc/model/network.lua:1422
 msgid "Ethernet Switch"
 msgstr "乙太交換器"
@@ -1910,23 +1899,23 @@ msgstr "釋放位址的過期週期,最少兩分鐘 (<code>2m</code>)."
 msgid "External"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid "External R0 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid "External R1 Key Holder List"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:149
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:141
 msgid "External system log server"
 msgstr "外部系統日誌伺服器"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:154
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:146
 msgid "External system log server port"
 msgstr "外部系統日誌伺服器埠號"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:151
 msgid "External system log server protocol"
 msgstr "外部系統日誌伺服器通訊協定"
 
@@ -1934,19 +1923,23 @@ msgstr "外部系統日誌伺服器通訊協定"
 msgid "Extra SSH command options"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1351
 msgid "FT over DS"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1336
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1352
 msgid "FT over the Air"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1349
 msgid "FT protocol"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2390
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:82
+msgid "Failed to change the system password."
+msgstr ""
+
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2389
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
 msgstr ""
 
@@ -1954,15 +1947,15 @@ msgstr ""
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1556
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1561
 msgid "File"
 msgstr "檔案"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1509
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1514
 msgid "File not accessible"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1693
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
 msgid "Filename"
 msgstr ""
 
@@ -2007,7 +2000,7 @@ msgstr "完成"
 msgid "Firewall"
 msgstr "防火牆"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid "Firewall Mark"
 msgstr ""
 
@@ -2047,7 +2040,7 @@ msgstr "更新新版韌體映像檔"
 msgid "Flash operations"
 msgstr "執行更新"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:194
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:192
 msgid "Flashing..."
 msgstr "更新中..."
 
@@ -2055,11 +2048,11 @@ msgstr "更新中..."
 msgid "Force"
 msgstr "強制"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:781
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:782
 msgid "Force 40MHz mode"
 msgstr "強制使用 40MHz 模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
 msgid "Force CCMP (AES)"
 msgstr "強制使用CCMP (AES)加密"
 
@@ -2067,11 +2060,11 @@ msgstr "強制使用CCMP (AES)加密"
 msgid "Force DHCP on this network even if another server is detected."
 msgstr "在網路上即使偵測到其它伺服器也強制採用DHCP的設定"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1031
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
 msgid "Force TKIP"
 msgstr "強制使用TKIP加密"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1032
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1033
 msgid "Force TKIP and CCMP (AES)"
 msgstr "強制使用TKIP+CCMP (AES)加密"
 
@@ -2103,7 +2096,7 @@ msgstr ""
 msgid "Forward broadcast traffic"
 msgstr "轉發廣播流量"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:808
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:809
 msgid "Forward mesh peer traffic"
 msgstr ""
 
@@ -2111,7 +2104,7 @@ msgstr ""
 msgid "Forwarding mode"
 msgstr "轉發模式"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:773
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:774
 msgid "Fragmentation Threshold"
 msgstr "分片閥值"
 
@@ -2120,7 +2113,7 @@ msgstr "分片閥值"
 msgid "Free"
 msgstr "空閒"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
@@ -2142,19 +2135,19 @@ msgstr "僅用GPRS"
 msgid "Gateway"
 msgstr "閘道"
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:35
+msgid "Gateway Ports"
+msgstr ""
+
 #: modules/luci-base/htdocs/luci-static/resources/network.js:9
 #: modules/luci-base/luasrc/model/network.lua:29
 msgid "Gateway address is invalid"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:46
-msgid "Gateway ports"
-msgstr "閘道埠號"
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:67
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:275
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:23
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:111
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/mount.lua:49
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab/swap.lua:33
 msgid "General Settings"
@@ -2162,8 +2155,8 @@ msgstr "一般設定"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:895
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:740
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:795
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:741
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
 msgid "General Setup"
 msgstr "一般設置"
 
@@ -2171,7 +2164,7 @@ msgstr "一般設置"
 msgid "Generate Config"
 msgstr "生成設定檔"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid "Generate PMK locally"
 msgstr ""
 
@@ -2179,7 +2172,7 @@ msgstr ""
 msgid "Generate archive"
 msgstr "製作壓縮檔"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:26
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:74
 msgid "Given password confirmation did not match, password not changed!"
 msgstr "鍵入的密碼不吻合,密碼將不變更"
 
@@ -2198,8 +2191,8 @@ msgstr "全域網路設定"
 msgid "Go to password configuration..."
 msgstr "前往密碼設定頁"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:896
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1404
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1112
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1616
 #: modules/luci-base/luasrc/view/cbi/full_valueheader.htm:4
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:58
 msgid "Go to relevant configuration page"
@@ -2229,13 +2222,13 @@ msgstr ""
 msgid "Header Error Code Errors (HEC)"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:103
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:95
 msgid ""
 "Here you can configure the basic aspects of your device like its hostname or "
 "the timezone."
 msgstr "在這裡設置基本設定值,如主機名稱或者時區...等"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:941
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 msgstr "隱藏 <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
@@ -2246,7 +2239,7 @@ msgstr ""
 
 #: modules/luci-base/luasrc/view/lease_status.htm:92
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:110
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1939
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1959
 msgid "Host"
 msgstr ""
 
@@ -2271,7 +2264,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/hosts.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:124
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:116
 msgid "Hostname"
 msgstr "主機名稱"
 
@@ -2292,7 +2285,7 @@ msgstr ""
 msgid "IKE DH Group"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "IP Addresses"
 msgstr ""
 
@@ -2513,7 +2506,7 @@ msgstr "IPv6凌駕IPv4外(第6版)"
 msgid "IPv6-over-IPv4 (6to4)"
 msgstr "IPv6凌駕IPv4外(6轉4)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1462
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1478
 msgid "Identity"
 msgstr "特性"
 
@@ -2623,7 +2616,7 @@ msgstr "閒置過期"
 msgid "Inbound:"
 msgstr "輸入"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:169
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:161
 msgid "Info"
 msgstr "訊息"
 
@@ -2661,7 +2654,7 @@ msgstr "安裝延伸協定中..."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:26
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:47
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:134
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Interface"
 msgstr "介面"
 
@@ -2669,7 +2662,7 @@ msgstr "介面"
 msgid "Interface %q device auto-migrated from %q to %q."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:791
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:792
 msgid "Interface Configuration"
 msgstr "介面設定"
 
@@ -2699,7 +2692,7 @@ msgstr ""
 msgid "Interface is stopping..."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Interface name"
 msgstr "界面名稱"
 
@@ -2729,7 +2722,7 @@ msgstr "內部伺服器發生錯誤"
 msgid "Invalid"
 msgstr "無效"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:7
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:10
 msgid "Invalid Base64 key string"
 msgstr ""
 
@@ -2749,7 +2742,7 @@ msgstr ""
 msgid "Invalid command"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:77
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:80
 msgid "Invalid hexadecimal value"
 msgstr ""
 
@@ -2757,7 +2750,7 @@ msgstr ""
 msgid "Invalid username and/or password! Please try again."
 msgstr "不正確的用戶名稱和/或者密碼!請再試一次."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Isolate Clients"
 msgstr "隔離用戶端"
 
@@ -2775,15 +2768,15 @@ msgstr "它顯示您正嘗試更新不適用於這個flash記憶體的映像檔,
 msgid "JavaScript required!"
 msgstr "需要Java腳本"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1671
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1691
 msgid "Join Network"
 msgstr "加入網路"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1608
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1628
 msgid "Join Network: Wireless Scan"
 msgstr "加入網路:無線網路掃描"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1833
 msgid "Joining Network: %q"
 msgstr ""
 
@@ -2800,15 +2793,15 @@ msgstr "核心日誌"
 msgid "Kernel Version"
 msgstr "核心版本"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1235
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1248
 msgid "Key"
 msgstr "密碼"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1260
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1261
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1262
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1263
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1275
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1276
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1277
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1278
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1279
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1291
 msgid "Key #%d"
 msgstr "鑰匙  #%d"
 
@@ -2852,11 +2845,11 @@ msgstr "LLC邏輯鏈結控制層"
 msgid "Label"
 msgstr "標籤"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:204
 msgid "Language"
 msgstr "語言"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:114
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:106
 msgid "Language and Style"
 msgstr "語言與主題"
 
@@ -2896,7 +2889,7 @@ msgstr "保持空白以便自動偵測"
 msgid "Leave empty to use the current WAN address"
 msgstr "保持空白以便採用現今的寬頻位址"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2294
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
 msgid "Legend:"
 msgstr "圖例:"
 
@@ -2938,7 +2931,7 @@ msgid ""
 "requests to"
 msgstr "列出 <abbr title=\"Domain Name System\">DNS</abbr> 伺服器以便轉發請求"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1361
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1377
 msgid ""
 "List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-"
 "Identifier,128-bit key as hex string. <br />This list is used to map R0KH-ID "
@@ -2947,7 +2940,7 @@ msgid ""
 "Association."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1365
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1381
 msgid ""
 "List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID "
 "as 6 octets with colons,128-bit key as hex string. <br />This list is used "
@@ -2972,11 +2965,11 @@ msgstr "列出供應偽裝NX網域成果的主機群"
 msgid "Listen Interfaces"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Listen Port"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:16
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr "只許在給予的介面上聆聽, 如果未指定, 全都允許"
 
@@ -2999,11 +2992,7 @@ msgstr "平均掛載"
 msgid "Loading"
 msgstr "讀取中"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:35
-msgid "Loading SSH keys…"
-msgstr ""
-
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1814
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1819
 msgid "Loading directory contents…"
 msgstr ""
 
@@ -3043,7 +3032,7 @@ msgid "Local Startup"
 msgstr "本地啟動"
 
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:25
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
 msgid "Local Time"
 msgstr "本地時間"
 
@@ -3076,7 +3065,7 @@ msgstr "若有多個IP可用, 本地化主機名稱端看請求的子網路而�
 msgid "Localise queries"
 msgstr "本地化網路請求"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:167
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:159
 msgid "Log output level"
 msgstr "日誌輸出等級"
 
@@ -3084,7 +3073,7 @@ msgstr "日誌輸出等級"
 msgid "Log queries"
 msgstr "日誌查詢"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:112
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:104
 msgid "Logging"
 msgstr "系統日誌"
 
@@ -3115,22 +3104,22 @@ msgstr ""
 #: modules/luci-base/luasrc/view/lease_status.htm:73
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:109
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:35
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1938
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1958
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:53
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:86
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:133
 msgid "MAC-Address"
 msgstr "MAC-位址"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:885
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:886
 msgid "MAC-Address Filter"
 msgstr "MAC-位址過濾"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:798
 msgid "MAC-Filter"
 msgstr "MAC-過濾"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:892
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:893
 msgid "MAC-List"
 msgstr "MAC-清單"
 
@@ -3158,7 +3147,7 @@ msgstr "MHz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:53
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:53
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "MTU"
 msgstr "最大傳輸單位MTU"
 
@@ -3178,7 +3167,7 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2183
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2188
 msgid "Master"
 msgstr ""
 
@@ -3186,7 +3175,7 @@ msgstr ""
 msgid "Max. Attainable Data Rate (ATTNDR)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:982
 msgid "Maximum allowed Listen Interval"
 msgstr ""
 
@@ -3212,7 +3201,7 @@ msgstr "等待數據機待命的最大秒數"
 msgid "Maximum number of leased addresses."
 msgstr "釋放出的位址群最大數量"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid "Maximum transmit power"
 msgstr ""
 
@@ -3225,7 +3214,7 @@ msgstr ""
 msgid "Mbit/s"
 msgstr "Mbit/s"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
 msgid "Medium"
 msgstr ""
 
@@ -3237,11 +3226,11 @@ msgstr "記憶體"
 msgid "Memory usage (%)"
 msgstr "記憶體使用 (%)"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2186
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2191
 msgid "Mesh"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:805
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:806
 msgid "Mesh Id"
 msgstr ""
 
@@ -3252,7 +3241,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:76
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:104
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Metric"
 msgstr "公測單位"
 
@@ -3264,7 +3253,7 @@ msgstr ""
 msgid "Mirror source port"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1337
 msgid "Mobility Domain"
 msgstr ""
 
@@ -3272,8 +3261,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:105
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:126
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:360
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:800
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1599
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:801
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1619
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:175
 msgid "Mode"
 msgstr "模式"
@@ -3304,16 +3293,16 @@ msgstr ""
 msgid "Modem init timeout"
 msgstr "數據機初始化終結時間"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2187
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2192
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:880
 msgid "Monitor"
 msgstr "監視"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
 msgid "More Characters"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:841
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1057
 msgid "More…"
 msgstr ""
 
@@ -3326,7 +3315,7 @@ msgstr "掛載項目"
 msgid "Mount Point"
 msgstr "掛載點"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:28
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:26
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:36
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:137
 msgid "Mount Points"
@@ -3374,7 +3363,7 @@ msgstr "往下移"
 msgid "Move up"
 msgstr "往上移"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid "NAS ID"
 msgstr " 網路附存伺服器ID"
 
@@ -3399,11 +3388,11 @@ msgstr ""
 msgid "NT Domain"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:272
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:264
 msgid "NTP server candidates"
 msgstr "NTP伺服器備選"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:876
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1092
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:27
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:553
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:658
@@ -3411,7 +3400,7 @@ msgstr "NTP伺服器備選"
 msgid "Name"
 msgstr "名稱"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid "Name of the new network"
 msgstr "新網路的名稱"
 
@@ -3421,8 +3410,8 @@ msgstr "導覽"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:69
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:108
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:833
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1937
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:834
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1957
 #: modules/luci-mod-status/luasrc/view/admin_status/connections.htm:389
 #: modules/luci-mod-status/luasrc/view/admin_status/index/30-network.htm:8
 #: modules/luci-mod-status/luasrc/view/admin_status/routes.htm:73
@@ -3455,7 +3444,7 @@ msgstr ""
 msgid "Next »"
 msgstr "下一個 »"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:108
 msgid "No"
 msgstr ""
@@ -3464,7 +3453,7 @@ msgstr ""
 msgid "No DHCP Server configured for this interface"
 msgstr "在這個介面尚無DHCP伺服器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1048
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
 msgid "No Encryption"
 msgstr ""
 
@@ -3476,7 +3465,7 @@ msgstr ""
 msgid "No data received"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1759
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1764
 msgid "No entries in this directory"
 msgstr ""
 
@@ -3507,11 +3496,12 @@ msgstr "拒絕無效網域的快取"
 msgid "No password set!"
 msgstr "尚未設定密碼!"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:101
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:104
 msgid "No peers defined yet"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:116
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:129
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:271
 msgid "No public keys present yet."
 msgstr ""
 
@@ -3556,7 +3546,7 @@ msgstr ""
 msgid "None"
 msgstr "無"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:172
 msgid "Normal"
 msgstr "正常"
 
@@ -3586,7 +3576,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:170
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:162
 msgid "Notice"
 msgstr "通知"
 
@@ -3598,7 +3588,7 @@ msgstr "DNS偵錯Nslookup"
 msgid "Number of cached DNS entries (max is 10000, 0 is no caching)"
 msgstr "快取DNS項目數量(最大值為10000,輸入0代表不快取)"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "Number of parallel threads used for compression"
 msgstr ""
 
@@ -3664,24 +3654,24 @@ msgstr "開啟清單"
 msgid "OpenConnect (CISCO AnyConnect)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:756
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:757
 msgid "Operating frequency"
 msgstr "操作頻率"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2301
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2306
 msgid "Option changed"
 msgstr "選項已變更"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2303
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2308
 msgid "Option removed"
 msgstr "選項已移除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1520
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:63
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1535
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:66
 msgid "Optional"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:73
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:76
 msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
@@ -3695,41 +3685,41 @@ msgid ""
 "for the interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:105
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:108
 msgid "Optional. Description of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:125
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:128
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:68
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:71
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:129
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "Optional. Port of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:51
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:54
 msgid "Optional. UDP port used for outgoing and incoming packets."
 msgstr ""
 
@@ -3789,7 +3779,7 @@ msgstr ""
 msgid "Override TTL"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:953
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:954
 msgid "Override default interface name"
 msgstr ""
 
@@ -3811,7 +3801,7 @@ msgstr "覆蓋之前內部使用的路由表"
 msgid "Overview"
 msgstr "預覽"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1601
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1606
 msgid "Overwrite existing file \"%s\" ?"
 msgstr ""
 
@@ -3856,7 +3846,7 @@ msgstr "PIN碼"
 msgid "PIN code rejected"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1356
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1372
 msgid "PMK R1 Push"
 msgstr ""
 
@@ -3911,29 +3901,29 @@ msgid "Part of zone %q"
 msgstr "區域 %q 的部分 "
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1498
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:35
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1514
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:104
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:58
 msgid "Password"
 msgstr "密碼"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:29
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:24
 msgid "Password authentication"
 msgstr "密碼驗證"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1398
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1414
 msgid "Password of Private Key"
 msgstr "私人金鑰密碼"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1455
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1471
 msgid "Password of inner Private Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:14
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:18
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:28
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:32
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Password strength"
 msgstr ""
 
@@ -3941,31 +3931,31 @@ msgstr ""
 msgid "Password2"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:37
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:244
 msgid "Paste or drag SSH key file…"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1380
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Path to CA-Certificate"
 msgstr "CA-證書的路徑"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1386
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1402
 msgid "Path to Client-Certificate"
 msgstr "用戶端-證書的路徑"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1392
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1408
 msgid "Path to Private Key"
 msgstr "私人金鑰的路徑"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1437
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1453
 msgid "Path to inner CA-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1443
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1459
 msgid "Path to inner Client-Certificate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1449
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1465
 msgid "Path to inner Private Key"
 msgstr ""
 
@@ -3992,7 +3982,7 @@ msgstr ""
 msgid "Peer address is missing"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:86
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:89
 msgid "Peers"
 msgstr ""
 
@@ -4012,7 +4002,7 @@ msgstr "執行重置"
 msgid "Permission denied"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:133
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:136
 msgid "Persistent Keep Alive"
 msgstr ""
 
@@ -4052,7 +4042,7 @@ msgstr "請輸入您的用戶名稱和密碼"
 msgid "Policy"
 msgstr "策略"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:22
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:20
 msgid "Port"
 msgstr "埠"
 
@@ -4088,7 +4078,7 @@ msgstr ""
 msgid "Prefix Delegated"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:114
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:117
 msgid "Preshared Key"
 msgstr ""
 
@@ -4107,11 +4097,11 @@ msgstr "假若在給于多次的 LCP 呼叫失敗後終點將死, 使用0忽略�
 msgid "Prevent listening on these interfaces."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:949
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:950
 msgid "Prevents client-to-client communication"
 msgstr "防止用戶端對用戶端的通訊"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Private Key"
 msgstr ""
 
@@ -4142,7 +4132,7 @@ msgstr "協定."
 msgid "Protocol"
 msgstr "協定"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:268
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:260
 msgid "Provide NTP server"
 msgstr "啟用NTP伺服器"
 
@@ -4150,15 +4140,15 @@ msgstr "啟用NTP伺服器"
 msgid "Provide new network"
 msgstr "提供新網路"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:879
 msgid "Pseudo Ad-Hoc (ahdemo)"
 msgstr "偽裝Ad-Hoc (ahdemo模式)"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Public Key"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:30
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:278
 msgid ""
 "Public keys allow for the passwordless SSH logins with a higher security "
 "compared to the use of plain passwords. In order to upload a new key to the "
@@ -4185,11 +4175,11 @@ msgid ""
 "servers"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "R0 Key Lifetime"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1350
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1366
 msgid "R1 Key Holder"
 msgstr ""
 
@@ -4197,11 +4187,11 @@ msgstr ""
 msgid "RFC3947 NAT-T mode"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:813
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:814
 msgid "RSSI threshold for joining"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:777
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:778
 msgid "RTS/CTS Threshold"
 msgstr "RTS/CTS門檻"
 
@@ -4217,31 +4207,31 @@ msgstr "接收"
 msgid "RX Rate"
 msgstr "接收速率"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1941
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1961
 msgid "RX Rate / TX Rate"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1194
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1207
 msgid "Radius-Accounting-Port"
 msgstr "Radius-驗証帳號-埠"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1202
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1215
 msgid "Radius-Accounting-Secret"
 msgstr "Radius-合法帳號-密碼"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1186
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1199
 msgid "Radius-Accounting-Server"
 msgstr "Radius-合法帳號-伺服器"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1170
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1183
 msgid "Radius-Authentication-Port"
 msgstr "Radius-驗証-埠"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1178
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1191
 msgid "Radius-Authentication-Secret"
 msgstr "Radius-驗証-密碼"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1162
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Radius-Authentication-Server"
 msgstr "Radius-驗証-伺服器"
 
@@ -4291,7 +4281,7 @@ msgstr "即時流量"
 msgid "Realtime Wireless"
 msgstr "即時無線網路"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "Reassociation Deadline"
 msgstr ""
 
@@ -4299,7 +4289,7 @@ msgstr ""
 msgid "Rebind protection"
 msgstr "重新綁護"
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:48
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:46
 #: modules/luci-mod-system/luasrc/view/admin_system/reboot.htm:9
 msgid "Reboot"
 msgstr "重開機"
@@ -4317,7 +4307,7 @@ msgstr "重啟您設備的作業系統"
 msgid "Receive"
 msgstr "接收"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:59
 msgid "Recommended. IP addresses of the WireGuard interface."
 msgstr ""
 
@@ -4357,11 +4347,11 @@ msgstr "遠端IPv4位址"
 msgid "Remote IPv4 address or FQDN"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:724
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:725
 msgid "Remove"
 msgstr "移除"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1806
 msgid "Replace wireless configuration"
 msgstr "替代性無線設定"
 
@@ -4377,7 +4367,7 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1536
 msgid "Required"
 msgstr ""
 
@@ -4385,42 +4375,42 @@ msgstr ""
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr "對特定的ISP需要,例如.DOCSIS 3 加速有線電視寬頻網路"
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:46
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:49
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:110
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:113
 msgid "Required. Base64-encoded public key of peer."
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:119
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:122
 msgid ""
 "Required. IP addresses and prefixes that this peer is allowed to use inside "
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1095
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1096
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1097
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 msgid "Requires hostapd"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1101
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1103
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1102
 msgid "Requires hostapd with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1098
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1099
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1100
 msgid "Requires hostapd with SAE support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1517
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
 "Requires the 'full' version of wpad/hostapd and support from the wifi driver "
 "<br />(as of Jan 2019: ath9k, ath10k, mwlwifi and mt76)"
@@ -4432,31 +4422,31 @@ msgid ""
 "come from unsigned domains"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1107
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1108
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1109
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1119
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1120
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1121
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1122
 msgid "Requires wpa-supplicant"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1113
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with EAP support"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1115
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1114
 msgid "Requires wpa-supplicant with OWE support"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1110
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1111
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1112
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1125
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1124
 msgid "Requires wpa-supplicant with SAE support"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1356
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1355
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:30
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:66
@@ -4507,10 +4497,8 @@ msgstr "還原"
 msgid "Restore backup"
 msgstr "還原之前備份設定"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:114
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:115
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:38
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:46
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:119
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:120
 msgid "Reveal/hide password"
 msgstr "明示/隱藏 密碼"
 
@@ -4518,15 +4506,15 @@ msgstr "明示/隱藏 密碼"
 msgid "Revert"
 msgstr "回溯"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2409
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2405
 msgid "Revert changes"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2561
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2554
 msgid "Revert request failed with status <code>%h</code>"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2541
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2534
 msgid "Reverting configuration…"
 msgstr "正在還原設定值..."
 
@@ -4542,7 +4530,7 @@ msgstr "透過TFTP存取根目錄檔案"
 msgid "Root preparation"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:123
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
 msgstr ""
 
@@ -4558,8 +4546,8 @@ msgstr ""
 msgid "Router Advertisement-Service"
 msgstr ""
 
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:43
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:15
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:27
 msgid "Router Password"
 msgstr "路由器密碼"
 
@@ -4599,8 +4587,8 @@ msgstr ""
 msgid "SNR"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:5
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:9
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:18
 msgid "SSH Access"
 msgstr "SSH存取"
 
@@ -4616,14 +4604,14 @@ msgstr ""
 msgid "SSH username"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:20
-#: modules/luci-mod-system/luasrc/view/admin_system/sshkeys.htm:27
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:19
 msgid "SSH-Keys"
 msgstr "SSH-金鑰"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:104
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:127
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1597
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1617
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:174
 msgid "SSID"
 msgstr "基地台服務設定識別碼SSID"
@@ -4632,19 +4620,17 @@ msgstr "基地台服務設定識別碼SSID"
 msgid "SWAP"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1167
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1352
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1379
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1351
 #: modules/luci-base/luasrc/view/cbi/error.htm:17
 #: modules/luci-base/luasrc/view/cbi/footer.htm:26
 #: modules/luci-base/luasrc/view/cbi/header.htm:17
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:48
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:133
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:54
 msgid "Save"
 msgstr "保存"
 
-#: modules/luci-base/htdocs/luci-static/resources/luci.js:1348
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2316
+#: modules/luci-base/htdocs/luci-static/resources/luci.js:1347
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2318
 #: modules/luci-base/luasrc/view/cbi/footer.htm:22
 msgid "Save & Apply"
 msgstr "保存並啟用"
@@ -4657,24 +4643,20 @@ msgstr ""
 msgid "Save mtdblock contents"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
-msgid "Saving keys…"
-msgstr ""
-
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:698
 msgid "Scan"
 msgstr "掃描"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:39
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:25
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:23
 msgid "Scheduled Tasks"
 msgstr "排程任務"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2297
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2302
 msgid "Section added"
 msgstr "新增的區段"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2299
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2304
 msgid "Section removed"
 msgstr "區段移除"
 
@@ -4689,9 +4671,9 @@ msgid ""
 "your device!"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1511
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1641
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1804
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1516
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1646
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1809
 msgid "Select file…"
 msgstr ""
 
@@ -4760,7 +4742,7 @@ msgstr ""
 msgid "Short GI"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:959
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:960
 msgid "Short Preamble"
 msgstr ""
 
@@ -4780,12 +4762,12 @@ msgstr "關閉這個介面"
 #: modules/luci-base/luasrc/view/wifi_assoclist.htm:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:47
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:132
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1596
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1616
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:173
 msgid "Signal"
 msgstr "信號"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1940
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1960
 msgid "Signal / Noise"
 msgstr ""
 
@@ -4805,7 +4787,7 @@ msgstr "大小"
 msgid "Size of DNS query cache"
 msgstr "DNS請求快取大小"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "Size of the ZRam device in megabytes"
 msgstr ""
 
@@ -4822,7 +4804,7 @@ msgstr "跳到內容"
 msgid "Skip to navigation"
 msgstr "跳到導覽"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1427
 msgid "Software VLAN"
 msgstr ""
@@ -4862,10 +4844,6 @@ msgstr ""
 msgid "Specifies the directory the device is attached to"
 msgstr "指定這個設備被附掛到那個目錄"
 
-#: modules/luci-mod-system/luasrc/model/cbi/admin_system/dropbear.lua:23
-msgid "Specifies the listening port of this <em>Dropbear</em> instance"
-msgstr "指定這個 <em>Dropbear</em>的監聽埠"
-
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
@@ -4878,7 +4856,7 @@ msgid ""
 "dead"
 msgstr "指定可請求的最大秒數直到駭客主機死亡為止"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:760
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:761
 msgid ""
 "Specifies the maximum transmit power the wireless radio may use. Depending "
 "on regulatory requirements and wireless usage, the actual transmit power may "
@@ -4901,7 +4879,7 @@ msgid ""
 "bytes)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "Specify the secret encryption key here."
 msgstr "指定加密金鑰在此."
 
@@ -4915,16 +4893,16 @@ msgstr "啟用"
 msgid "Start priority"
 msgstr "啟用優先權順序"
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2506
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2499
 msgid "Starting configuration apply…"
 msgstr "開始套用設定值..."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1606
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1626
 msgid "Starting wireless scan..."
 msgstr "開始無線掃描..."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:120
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:24
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:22
 msgid "Startup"
 msgstr "開機自動執行"
 
@@ -4944,7 +4922,7 @@ msgstr "靜態租約"
 msgid "Static Routes"
 msgstr "靜態路由"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1382
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:172
 #: modules/luci-base/luasrc/model/network.lua:966
 msgid "Static address"
@@ -4959,13 +4937,13 @@ msgstr ""
 "靜態租約是用來指定固定的IP位址和表示的主機名稱給予DHCP用戶端. 它們也需要非動"
 "態介面設定值以便獲取相應租約的主機服務."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "Station inactivity limit"
 msgstr ""
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:40
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:337
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:745
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:746
 #: modules/luci-mod-status/luasrc/view/admin_status/index.htm:128
 msgid "Status"
 msgstr "狀態"
@@ -4980,12 +4958,12 @@ msgstr "停止"
 msgid "Strict order"
 msgstr "嚴謹順序"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:16
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:30
 msgid "Strong"
 msgstr ""
 
 #: modules/luci-base/luasrc/view/cbi/simpleform.htm:61
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1843
 msgid "Submit"
 msgstr "提交"
 
@@ -5023,7 +5001,7 @@ msgstr ""
 msgid "Switch Port Mask"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1841
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1846
 #: modules/luci-base/luasrc/model/network.lua:1425
 msgid "Switch VLAN"
 msgstr ""
@@ -5038,11 +5016,11 @@ msgstr "切換協定"
 msgid "Switch to CIDR list notation"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1547
 msgid "Symbolic link"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:77
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:71
 msgid "Sync with NTP-Server"
 msgstr ""
 
@@ -5052,7 +5030,7 @@ msgstr "與瀏覽器同步時間"
 
 #: modules/luci-base/luasrc/controller/admin/index.lua:47
 #: modules/luci-mod-status/luasrc/view/admin_status/index/10-system.htm:14
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:102
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:94
 #: modules/luci-mod-system/luasrc/controller/admin/system.lua:10
 #: modules/luci-mod-system/luasrc/view/admin_system/applyreboot.htm:39
 msgid "System"
@@ -5063,11 +5041,11 @@ msgstr "系統"
 msgid "System Log"
 msgstr "系統日誌"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:99
 msgid "System Properties"
 msgstr "系統屬性"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:136
 msgid "System log buffer size"
 msgstr "系統日誌緩衝大小"
 
@@ -5133,7 +5111,7 @@ msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr "指定到這供應商的IPv6字首, 通常用 <code>::</code>結尾"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1788
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1808
 msgid ""
 "The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</"
 "code> and <code>_</code>"
@@ -5149,7 +5127,7 @@ msgstr ""
 msgid "The configuration file could not be loaded due to the following error:"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2397
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2396
 msgid ""
 "The device could not be reached within %d seconds after applying the pending "
 "changes, which caused the configuration to be rolled back for safety "
@@ -5201,11 +5179,11 @@ msgstr "以下的規則現正作用在系統中."
 msgid "The gateway address must not be a local IP address"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:144
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:154
 msgid "The given SSH public key has already been added."
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:150
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:160
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
@@ -5235,7 +5213,7 @@ msgstr "這IPv6開頭以位元計的長度"
 msgid "The local IPv4 address over which the tunnel is created (optional)."
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1794
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1814
 msgid "The network name is already used"
 msgstr ""
 
@@ -5253,7 +5231,7 @@ msgstr ""
 "Local Area Network\">VLAN</abbr>群經常用來分割網路區段. 預設經常會有一個上傳"
 "埠來連接到下一個大型網路類似Intenet而其它埠則用來本地區網使用."
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1150
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1149
 msgid "The selected %s mode is incompatible with %s encryption"
 msgstr ""
 
@@ -5261,13 +5239,13 @@ msgstr ""
 msgid "The submitted security token is invalid or already expired!"
 msgstr ""
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:274
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:272
 msgid ""
 "The system is erasing the configuration partition now and will reboot itself "
 "when finished."
 msgstr "系統正在刪除設定分割並且當完成時將自行重開."
 
-#: modules/luci-mod-system/luasrc/controller/admin/system.lua:195
+#: modules/luci-mod-system/luasrc/controller/admin/system.lua:193
 #, fuzzy
 msgid ""
 "The system is flashing now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a "
@@ -5278,7 +5256,7 @@ msgstr ""
 "系統正在刷機中.<br /> 請勿關閉設備!<br />  請等待數分鐘直到您重新連線. 可能需"
 "要更新您電腦的位址以便再次連接設備, 端看您的設定. "
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:15
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:80
 msgid "The system password has been successfully changed."
 msgstr ""
 
@@ -5298,7 +5276,7 @@ msgstr ""
 msgid "There are no active leases."
 msgstr "租賃尚未啟動."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2521
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2514
 msgid "There are no changes to apply"
 msgstr ""
 
@@ -5315,7 +5293,7 @@ msgstr "路由器尚未設密碼. 請設定root密碼以便保護web介面及啟
 msgid "This IPv4 address of the relay"
 msgstr "IPv4位址的轉驛"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1432
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1448
 msgid "This authentication type is not applicable to the selected EAP method."
 msgstr ""
 
@@ -5395,22 +5373,22 @@ msgstr "這清單提供目前正在執行的系統的執行緒和狀態的預覽
 msgid "This page gives an overview over currently active network connections."
 msgstr "這一頁提供目前正在活動中網路連線的預覽."
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:720
-#: modules/luci-base/htdocs/luci-static/resources/form.js:848
+#: modules/luci-base/htdocs/luci-static/resources/form.js:936
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1064
 #: modules/luci-base/luasrc/view/cbi/tblsection.htm:172
 #: modules/luci-base/luasrc/view/cbi/tsection.htm:32
 msgid "This section contains no values yet"
 msgstr "這部分尚未有任何設定值."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:113
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:105
 msgid "Time Synchronization"
 msgstr "校時同步"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
 msgid "Time interval for rekeying GTK"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:127
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:119
 msgid "Timezone"
 msgstr "時區"
 
@@ -5467,7 +5445,7 @@ msgstr "觸發模式"
 msgid "Tunnel ID"
 msgstr "通道ID"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1844
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1849
 #: modules/luci-base/luasrc/model/network.lua:1430
 msgid "Tunnel Interface"
 msgstr "通道介面"
@@ -5560,12 +5538,12 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1384
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1386
 #: modules/luci-base/luasrc/model/network.lua:970
 msgid "Unknown"
 msgstr "未知"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1537
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1539
 #: modules/luci-base/luasrc/model/network.lua:1137
 msgid "Unknown error (%s)"
 msgstr ""
@@ -5574,7 +5552,7 @@ msgstr ""
 msgid "Unknown error code"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1381
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1383
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-base/luasrc/model/network.lua:964
 msgid "Unmanaged"
@@ -5585,11 +5563,12 @@ msgstr "未託管"
 msgid "Unmount"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:107
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:120
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:262
 msgid "Unnamed key"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2256
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2261
 msgid "Unsaved Changes"
 msgstr "尚未存檔的修改"
 
@@ -5629,15 +5608,15 @@ msgstr ""
 msgid "Upload archive..."
 msgstr "上傳壓縮檔..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1698
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1703
 msgid "Upload file"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1673
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1678
 msgid "Upload file…"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:1618
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:1623
 msgid "Upload request failed: %s"
 msgstr ""
 
@@ -5778,11 +5757,11 @@ msgstr ""
 msgid "Used"
 msgstr "已使用"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1257
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1273
 msgid "Used Key Slot"
 msgstr "已使用的關鍵插槽"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
@@ -5862,32 +5841,32 @@ msgstr "確認"
 msgid "Virtual dynamic interface"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:906
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:908
 msgid "WDS"
 msgstr "無線分散系統WDS"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1049
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1160
 msgid "WEP Open System"
 msgstr "WEP 開放系統"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1050
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1161
 msgid "WEP Shared Key"
 msgstr "WEP 共享金鑰"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WEP passphrase"
 msgstr "WEP通關密碼"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:945
 msgid "WMM Mode"
 msgstr "無線多媒體機制"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1803
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1823
 msgid "WPA passphrase"
 msgstr "WPA 密碼"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1075
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1074
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
@@ -5903,7 +5882,7 @@ msgstr "等待修改被啟用..."
 msgid "Waiting for command to complete..."
 msgstr "等待完整性指令..."
 
-#: modules/luci-base/htdocs/luci-static/resources/ui.js:2488
+#: modules/luci-base/htdocs/luci-static/resources/ui.js:2481
 msgid "Waiting for configuration to get applied… %ds"
 msgstr ""
 
@@ -5911,8 +5890,8 @@ msgstr ""
 msgid "Waiting for device..."
 msgstr "正在等待裝置..."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:171
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:181
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:173
 msgid "Warning"
 msgstr "警告"
 
@@ -5920,11 +5899,11 @@ msgstr "警告"
 msgid "Warning: There are unsaved changes that will get lost on reboot!"
 msgstr "警告: 目前存在未儲存的設定,這些設定將會在裝置重啟後遺失!"
 
-#: modules/luci-mod-system/luasrc/view/admin_system/password.htm:20
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:34
 msgid "Weak"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1339
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1355
 msgid ""
 "When using a PSK, the PMK can be automatically generated. When enabled, the "
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
@@ -5936,7 +5915,7 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:14
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:17
 #: protocols/luci-proto-wireguard/luasrc/model/network/proto_wireguard.lua:9
 msgid "WireGuard VPN"
 msgstr ""
@@ -5947,13 +5926,13 @@ msgstr ""
 msgid "Wireless"
 msgstr "無線網路"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1832
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1837
 #: modules/luci-base/luasrc/model/network.lua:1418
 msgid "Wireless Adapter"
 msgstr "無線網卡"
 
-#: modules/luci-base/htdocs/luci-static/resources/network.js:1818
-#: modules/luci-base/htdocs/luci-static/resources/network.js:2283
+#: modules/luci-base/htdocs/luci-static/resources/network.js:1823
+#: modules/luci-base/htdocs/luci-static/resources/network.js:2288
 #: modules/luci-base/luasrc/model/network.lua:1404
 #: modules/luci-base/luasrc/model/network.lua:1865
 msgid "Wireless Network"
@@ -5963,7 +5942,7 @@ msgstr "無線網路"
 msgid "Wireless Overview"
 msgstr "無線預覽"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:796
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:797
 msgid "Wireless Security"
 msgstr "無線安全"
 
@@ -5983,11 +5962,11 @@ msgstr "無線被關閉"
 msgid "Wireless is not associated"
 msgstr "無線網路未連結"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is disabled"
 msgstr "無線網路已停用"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:751
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:752
 msgid "Wireless network is enabled"
 msgstr "無線網路已啟用"
 
@@ -5995,11 +5974,11 @@ msgstr "無線網路已啟用"
 msgid "Write received DNS requests to syslog"
 msgstr "寫入已接收的DNS請求到系統日誌中"
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:163
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:155
 msgid "Write system log to file"
 msgstr "將系統日誌寫入檔案"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1542
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1754
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:109
 msgid "Yes"
 msgstr ""
@@ -6027,19 +6006,19 @@ msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
 msgstr "在瀏覽器您必須啟用JavaScript否則LuCI無法正常運作."
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:195
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:187
 msgid "ZRam Compression Algorithm"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:202
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:194
 msgid "ZRam Compression Streams"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:188
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:180
 msgid "ZRam Settings"
 msgstr ""
 
-#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:190
+#: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:182
 msgid "ZRam Size"
 msgstr ""
 
@@ -6050,7 +6029,7 @@ msgstr "任意"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:836
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:844
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:849
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1029
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1030
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:78
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:48
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:51
@@ -6108,7 +6087,7 @@ msgstr "dB"
 msgid "dBm"
 msgstr "dBm"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:888
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "disable"
 msgstr "關閉"
 
@@ -6209,7 +6188,11 @@ msgstr ""
 msgid "local <abbr title=\"Domain Name System\">DNS</abbr> file"
 msgstr "本地<abbr title=\"Domain Name System\">DNS</abbr> 檔案"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1344
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1168
+msgid "medium security"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1360
 msgid "minutes"
 msgstr ""
 
@@ -6228,7 +6211,7 @@ msgstr "無連線"
 msgid "non-empty value"
 msgstr ""
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1234
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1446
 msgid "none"
 msgstr "無"
 
@@ -6239,8 +6222,8 @@ msgid "not present"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:341
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:775
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:779
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:776
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:780
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:163
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:194
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:206
@@ -6254,6 +6237,10 @@ msgstr "關閉"
 #: themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm:242
 msgid "on"
 msgstr "開啟"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "open network"
+msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:56
 #: modules/luci-base/luasrc/view/cbi/firewall_zonelist.htm:46
@@ -6272,7 +6259,7 @@ msgstr ""
 msgid "positive integer value"
 msgstr ""
 
-#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:53
+#: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:56
 msgid "random"
 msgstr ""
 
@@ -6286,8 +6273,8 @@ msgstr ""
 msgid "routed"
 msgstr "路由"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:976
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:968
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:977
 msgid "sec"
 msgstr ""
 
@@ -6308,11 +6295,15 @@ msgstr ""
 msgid "stateless + stateful"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1167
+msgid "strong security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:346
 msgid "tagged"
 msgstr "標籤"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1343
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
 msgstr ""
 
@@ -6331,7 +6322,7 @@ msgstr "未知"
 msgid "unlimited"
 msgstr "無限"
 
-#: modules/luci-base/htdocs/luci-static/resources/form.js:1436
+#: modules/luci-base/htdocs/luci-static/resources/form.js:1648
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:63
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:124
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:355
@@ -6512,6 +6503,10 @@ msgstr ""
 msgid "value with at most %d characters"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1169
+msgid "weak security"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:39
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/network.js:34
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/fstab.lua:221
@@ -6522,6 +6517,12 @@ msgstr "是的"
 #: modules/luci-base/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 倒退"
+
+#~ msgid "Gateway ports"
+#~ msgstr "閘道埠號"
+
+#~ msgid "Specifies the listening port of this <em>Dropbear</em> instance"
+#~ msgstr "指定這個 <em>Dropbear</em>的監聽埠"
 
 #~ msgid "Switch %q (%s)"
 #~ msgstr "交換器 %q (%s)"


### PR DESCRIPTION
- sync translations (luci-base)
- use old translation for "Gateway Ports"
  - original text is replaced from "Gateway ports"
- update Japanese translation