### PR TITLE
luci-theme-openwrt: Fix scrolling issue in syslog (CSS)

### DIFF
--- a/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
+++ b/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
@@ -430,6 +430,7 @@ textarea#syslog {
 	border: 3px solid #cccccc;
 	padding: 5px;
 	font-family: monospace;
+	overflow-y: hidden;
 }
 
 #maincontainer {


### PR DESCRIPTION
Depending on the browser, it is sometimes difficult to scroll if moused over or after clicking or highlighting text. I often have to click outside the text to be able to scroll again. The browser perceives that there is scrolling space/content within the `textarea` element because it is almost, but not exactly, the same size as its parent `div` element, when in reality, there is no more text content. This causes scrolling within the element with a range of just a few pixels, and the rest of the page remains static. Of course, we still want to be able to scroll in the 'x' direction...

So, this is easily solved by adding the "overflow-y" property with value "hidden". Tested by myself on Chrome 64-bit Windows 10

Signed-off-by: Michael Pratt mpratt51@gmail.com