### PR TITLE
[19.07] luci-app-https_dns_proxy: bugfix: proper formatting of dhcp server entries

### DIFF
--- a/applications/luci-app-https_dns_proxy/Makefile
+++ b/applications/luci-app-https_dns_proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=HTTPS DNS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for HTTPS DNS Proxy
 LUCI_DEPENDS:=+luci-mod-admin-full +https_dns_proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 include ../../luci.mk
 

--- a/applications/luci-app-https_dns_proxy/luasrc/model/cbi/https_dns_proxy.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/model/cbi/https_dns_proxy.lua
@@ -75,8 +75,8 @@ prov.write = function(self, section, value)
   if n == 0 then
     uci:delete("dhcp", "@dnsmasq[0]", "server")
   end
-  uci_del_list("dhcp", "@dnsmasq[0]", "server", tostring(la_val) .. ":" .. tostring(lp_val))
-  uci_add_list("dhcp", "@dnsmasq[0]", "server", tostring(la_val) .. ":" .. tostring(lp_val))
+  uci_del_list("dhcp", "@dnsmasq[0]", "server", tostring(la_val) .. "#" .. tostring(lp_val))
+  uci_add_list("dhcp", "@dnsmasq[0]", "server", tostring(la_val) .. "#" .. tostring(lp_val))
   uci:save("dhcp")
 end
 


### PR DESCRIPTION

Signed-off-by: Stan Grishin <stangri@melmac.net>