### PR TITLE
luci-mod-system: refine flash reset

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
+++ b/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
@@ -34,7 +34,7 @@
 				"/proc/mtd": [ "read" ],
 				"/proc/partitions": [ "read" ],
 				"/proc/sys/kernel/hostname": [ "read" ],
-				"/sys/devices/virtual/ubi/*/name": [ "read" ]
+				"/proc/mounts": [ "read" ]
 			},
 			"ubus": {
 				"file": [ "list", "read", "stat" ],

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
@@ -143,17 +143,13 @@ var mapdata = { actions: {}, config: {} };
 
 return L.view.extend({
 	load: function() {
-		var max_ubi = 2, max_ubi_vol = 4;
 		var tasks = [
 			L.resolveDefault(fs.stat('/lib/upgrade/platform.sh'), {}),
 			fs.trimmed('/proc/sys/kernel/hostname'),
 			fs.trimmed('/proc/mtd'),
-			fs.trimmed('/proc/partitions')
+			fs.trimmed('/proc/partitions'),
+			fs.trimmed('/proc/mounts')
 		];
-
-		for (var i = 0; i < max_ubi; i++)
-			for (var j = 0; j < max_ubi_vol; j++)
-				tasks.push(fs.trimmed('/sys/devices/virtual/ubi/ubi%d/ubi%d_%d/name'.format(i, i, j)));
 
 		return Promise.all(tasks);
 	},
@@ -428,7 +424,8 @@ return L.view.extend({
 		    hostname = rpc_replies[1],
 		    procmtd = rpc_replies[2],
 		    procpart = rpc_replies[3],
-		    has_rootfs_data = (procmtd.match(/"rootfs_data"/) != null) || rpc_replies.slice(4).filter(function(n) { return n == 'rootfs_data' })[0],
+		    procmounts = rpc_replies[4],
+		    has_rootfs_data = (procmtd.match(/"rootfs_data"/) != null) || (procmounts.match("overlayfs:\/overlay \/ ") != null),
 		    storage_size = findStorageSize(procmtd, procpart),
 		    m, s, o, ss;
 


### PR DESCRIPTION
We determine flash reset capability by checking overlayfs in /proc/mounts

Traversing the ubi partitions is a little bad, it could not cover all the case
for some case if `rootfs_data` locates at `ubi_vol > 4`

and Traversing is not fast.
