### PR TITLE
luci-app-https_dns_proxy: bugfix: subnet_addr option should be cidr

### DIFF
--- a/applications/luci-app-https_dns_proxy/luasrc/model/cbi/https_dns_proxy.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/model/cbi/https_dns_proxy.lua
@@ -97,7 +97,7 @@ lp.write = function(self, section, value)
 end
 
 sa = s3:option(Value, "subnet_addr", translate("Subnet address"))
-sa.datatype = "ip4prefix"
+sa.datatype = "cidr"
 sa.rmempty  = true
 
 ps = s3:option(Value, "proxy_server", translate("Proxy server"))


### PR DESCRIPTION
Subnet address requires CIDR notation

Signed-off-by: Antoine Deschênes <antoine@antoinedeschenes.com>