### PR TITLE
luci-base: fix typo in german translation

### DIFF
--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -4671,7 +4671,7 @@ msgstr "Wurzelverzeichnis erzeugen"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:126
 msgid "Route Allowed IPs"
-msgstr "Erlaubte IP-Addressen routen"
+msgstr "Erlaubte IP-Adressen routen"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:72
 msgid "Route table"


### PR DESCRIPTION
Signed-off-by: Martin Schiller <ms@dev.tdt.de>