### PR TITLE
luci-app-statistics: fix german translation

### DIFF
--- a/applications/luci-app-statistics/po/de/statistics.po
+++ b/applications/luci-app-statistics/po/de/statistics.po
@@ -1128,7 +1128,7 @@ msgstr ""
 #: applications/luci-app-statistics/luasrc/statistics/plugins/iwinfo.lua:7
 #: applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/iwinfo.lua:7
 msgid "Wireless"
-msgstr "Drahtlos"
+msgstr "WLAN"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/iwinfo.lua:7
 msgid "Wireless iwinfo Plugin Configuration"


### PR DESCRIPTION
... of the msgid "Wireless".

The luci-base also use the same msgid "Wireless", where it is translated
with "WLAN".

The translation in luci-app-statistics overlays the translation in
luci-base, so use the same translation here.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>