### PR TITLE
i18n: update spanish translations

### DIFF
--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -3,11 +3,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2019-07-23 22:17-0300\n"
-"PO-Revision-Date: 2019-09-17 22:33-0300\n"
+"PO-Revision-Date: 2019-10-09 12:24-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.3\n"
+"X-Generator: Poedit 2.2.4\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
@@ -94,7 +94,7 @@ msgstr "Utilidad de descarga"
 
 #: applications/luci-app-banip/luasrc/view/banip/runtime.htm:126
 msgid "Download Utility, RT Monitor"
-msgstr ""
+msgstr "Utilidad de descarga, Monitor RT"
 
 #: applications/luci-app-banip/luasrc/controller/banip.lua:22
 msgid "Edit Blacklist"
@@ -221,7 +221,7 @@ msgstr "Servicio de baja prioridad"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:28
 msgid "Manual WAN Interface Selection"
-msgstr ""
+msgstr "Selección manual de interfaz WAN"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:100
 msgid "Max. Download Queue"
@@ -302,7 +302,7 @@ msgstr "Demonio SSH"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:43
 msgid "SSH/LuCI RT Monitor"
-msgstr ""
+msgstr "Monitor SSH/LuCI RT"
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/blacklist_tab.lua:27
 #: applications/luci-app-banip/luasrc/model/cbi/banip/configuration_tab.lua:26
@@ -322,11 +322,11 @@ msgstr "Seleccione el tipo de inicio utilizado durante el arranque."
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:127
 msgid "Select your preferred download utility."
-msgstr ""
+msgstr "Seleccione su utilidad de descarga preferida."
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:29
 msgid "Select your preferred interface(s) manually."
-msgstr ""
+msgstr "Seleccione sus interfaces preferidas manualmente."
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:88
 msgid ""
@@ -352,6 +352,8 @@ msgstr ""
 msgid ""
 "Special options for the selected download utility, e.g. '--timeout=20 -O'."
 msgstr ""
+"Opciones especiales para la utilidad de descarga seleccionada, p.e. '--"
+"timeout=20 -O'."
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:144
 msgid "Start Type"
@@ -362,6 +364,8 @@ msgid ""
 "Starts a small log/banIP monitor in the background to block SSH/LuCI brute "
 "force attacks in realtime."
 msgstr ""
+"Inicia un pequeño monitor log/banIP en segundo plano para bloquear los "
+"ataques de fuerza bruta SSH/LuCI en tiempo real."
 
 #: applications/luci-app-banip/luasrc/model/cbi/banip/overview_tab.lua:95
 msgid ""

--- a/applications/luci-app-openvpn/po/es/openvpn.po
+++ b/applications/luci-app-openvpn/po/es/openvpn.po
@@ -3,14 +3,14 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-06-10 03:41+0200\n"
-"PO-Revision-Date: 2019-03-02 14:45-0300\n"
+"PO-Revision-Date: 2019-10-09 12:29-0300\n"
 "Last-Translator: José Vicente <josevteg@gmail.com>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 2.2.4\n"
 "Language-Team: \n"
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:822
@@ -723,7 +723,7 @@ msgstr "Número de puerto TCP/UDP para remoto (default=1194)"
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:710
 msgid "TLS 1.3 or newer cipher"
-msgstr ""
+msgstr "TLS 1.3 o cifrado más reciente"
 
 #: applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua:702
 msgid "TLS cipher"

--- a/applications/luci-app-simple-adblock/po/es/simple-adblock.po
+++ b/applications/luci-app-simple-adblock/po/es/simple-adblock.po
@@ -3,11 +3,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2019-09-17 22:46-0300\n"
+"PO-Revision-Date: 2019-10-09 12:31-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.3\n"
+"X-Generator: Poedit 2.2.4\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
@@ -78,7 +78,7 @@ msgstr "Config de DNSMASQ"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:206
 msgid "DNSMASQ IP Set"
-msgstr ""
+msgstr "DNSMASQ IP Set"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:208
 msgid "DNSMASQ Servers File"
@@ -203,7 +203,7 @@ msgstr "Elige el LED que no se haya usado en"
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:195
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:198
 msgid "Please note that"
-msgstr ""
+msgstr "Tenga en cuenta que"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:187
 msgid "README"
@@ -241,7 +241,7 @@ msgstr "Simple AdBlock"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:51
 msgid "Simple AdBlock Settings"
-msgstr "Configuración de Simple AdBlock "
+msgstr "Configuración de Simple AdBlock"
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
 msgid "Simultaneous processing"
@@ -328,7 +328,7 @@ msgstr "para detalles."
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:195
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:198
 msgid "is not supported on this system."
-msgstr ""
+msgstr "no es compatible con este sistema."
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:177
 msgid "none"

--- a/applications/luci-app-statistics/po/es/statistics.po
+++ b/applications/luci-app-statistics/po/es/statistics.po
@@ -3,14 +3,14 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-06-10 03:41+0200\n"
-"PO-Revision-Date: 2019-08-01 23:05-0300\n"
+"PO-Revision-Date: 2019-10-09 12:33-0300\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.3\n"
+"X-Generator: Poedit 2.2.4\n"
 "Language-Team: \n"
 
 #: applications/luci-app-statistics/luasrc/statistics/plugins/apcups.lua:7
@@ -24,7 +24,7 @@ msgstr "Configuración del complemento APCUPS"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/memory.lua:15
 msgid "Absolute values"
-msgstr ""
+msgstr "Valores absolutos"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/iptables.lua:70
 msgid "Action (target)"
@@ -66,6 +66,8 @@ msgstr "Monitorización básica"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:18
 msgid "By setting this, CPU is not aggregate of all processors on the system"
 msgstr ""
+"Al configurar esto, la CPU no es un agregado de todos los procesadores en el "
+"sistema"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/contextswitch.lua:4
 msgid "CPU Context Switches Plugin Configuration"
@@ -270,7 +272,7 @@ msgstr "Configuración del plugin Exec"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:15
 msgid "Extra items"
-msgstr ""
+msgstr "Ítems extra"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/netlink.lua:68
 msgid "Filter class monitoring"
@@ -499,7 +501,7 @@ msgstr "Monitorizar puertos remotos"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpufreq.lua:15
 msgid "More details about frequency usage and transitions"
-msgstr ""
+msgstr "Más detalles sobre el uso de frecuencia y las transiciones"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/curl.lua:20
 msgid "Name"
@@ -587,7 +589,7 @@ msgstr "Plugins de salida"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/memory.lua:23
 msgid "Percent values"
-msgstr ""
+msgstr "Valores porcentuales"
 
 #: applications/luci-app-statistics/luasrc/statistics/plugins/ping.lua:7
 #: applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/ping.lua:7
@@ -604,7 +606,7 @@ msgstr "Puerto"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/apcups.lua:23
 msgid "Port for apcupsd communication"
-msgstr "Puerto para comunicación apcupsd."
+msgstr "Puerto para comunicación apcupsd"
 
 #: applications/luci-app-statistics/luasrc/statistics/plugins/processes.lua:7
 #: applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/processes.lua:7
@@ -650,15 +652,15 @@ msgstr "Configuración del plugin \"Herramienta RRD\""
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:17
 msgid "Report by CPU"
-msgstr ""
+msgstr "Informe por CPU"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:24
 msgid "Report by state"
-msgstr ""
+msgstr "Informe por estado"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:31
 msgid "Report in percent"
-msgstr ""
+msgstr "Informe en porcentaje"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/rrdtool.lua:74
 msgid "Rows per RRA"
@@ -1137,15 +1139,17 @@ msgstr "Monitorización detallada"
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:25
 msgid "When set to true, reports per-state metric (system, user, idle)"
 msgstr ""
+"Cuando se establece en verdadero, informa métrica por estado (sistema, "
+"usuario, inactivo)"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/memory.lua:16
 msgid "When set to true, we request absolute values"
-msgstr ""
+msgstr "Cuando se establece en verdadero, se solicita valores absolutos"
 
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/cpu.lua:32
 #: applications/luci-app-statistics/luasrc/model/cbi/luci_statistics/memory.lua:24
 msgid "When set to true, we request percentage values"
-msgstr ""
+msgstr "Cuando se establece en verdadero, se solicita valores de porcentaje"
 
 #: applications/luci-app-statistics/luasrc/statistics/plugins/iwinfo.lua:7
 #: applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/iwinfo.lua:7

--- a/applications/luci-app-transmission/po/es/transmission.po
+++ b/applications/luci-app-transmission/po/es/transmission.po
@@ -3,14 +3,14 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2012-08-21 22:06+0200\n"
-"PO-Revision-Date: 2019-03-02 12:35-0300\n"
+"PO-Revision-Date: 2019-10-09 12:34-0300\n"
 "Last-Translator: José Vicente <josevteg@gmail.com>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 2.2.4\n"
 "Language-Team: \n"
 
 #: applications/luci-app-transmission/luasrc/model/cbi/transmission.lua:39
@@ -338,7 +338,7 @@ msgstr "Nombre de archivo del script"
 
 #: applications/luci-app-transmission/luasrc/model/cbi/transmission.lua:212
 msgid "Seed queue enabled"
-msgstr "Cola de seed Habilitar "
+msgstr "Cola de seed Habilitar"
 
 #: applications/luci-app-transmission/luasrc/model/cbi/transmission.lua:215
 msgid "Seed queue size"

--- a/applications/luci-app-travelmate/po/es/travelmate.po
+++ b/applications/luci-app-travelmate/po/es/travelmate.po
@@ -3,11 +3,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2019-09-17 22:49-0300\n"
+"PO-Revision-Date: 2019-10-09 13:55-0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.3\n"
+"X-Generator: Poedit 2.2.4\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
@@ -38,7 +38,7 @@ msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
-"procesamiento de travelmate"
+"procesamiento de travelmate."
 
 #: applications/luci-app-travelmate/luasrc/controller/travelmate.lua:21
 msgid "Advanced"
@@ -174,7 +174,7 @@ msgstr "Editar la configuración de Travelmate"
 
 #: applications/luci-app-travelmate/luasrc/controller/travelmate.lua:23
 msgid "Edit Wireless Configuration"
-msgstr "Editar la configuración del WiFi"
+msgstr "Editar la configuración de WiFi"
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua:10
 msgid "Edit Wireless Uplink Configuration"
@@ -331,7 +331,7 @@ msgstr "Abrir"
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_add.lua:146
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/wifi_edit.lua:139
 msgid "Optional Arguments"
-msgstr ""
+msgstr "Argumentos opcionales"
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:101
 msgid ""
@@ -483,6 +483,9 @@ msgid ""
 "Space separated list of additional optional arguments passed to the Auto "
 "Login Script, i.e. username and password"
 msgstr ""
+"Lista separada por espacios de argumentos opcionales adicionales pasados al "
+"Script de inicio de sesión automático, es decir, nombre de usuario y "
+"contraseña"
 
 #: applications/luci-app-travelmate/luasrc/view/travelmate/runtime.htm:113
 msgid "Station ID (RADIO/SSID/BSSID)"
@@ -624,7 +627,7 @@ msgstr "Estaciones WiFi"
 
 #: applications/luci-app-travelmate/luasrc/model/cbi/travelmate/overview_tab.lua:27
 msgid "add it to the wan zone of the firewall."
-msgstr "añadir a la zona wan del firewall"
+msgstr "añadir a la zona wan del firewall."
 
 #: applications/luci-app-travelmate/luasrc/view/travelmate/wifi_scan.htm:56
 msgid "hidden"

--- a/applications/luci-app-uhttpd/po/es/uhttpd.po
+++ b/applications/luci-app-uhttpd/po/es/uhttpd.po
@@ -7,7 +7,7 @@ msgstr ""
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 2.2.4\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
@@ -24,7 +24,7 @@ msgstr "Error 404"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:7
 msgid "A lightweight single-threaded HTTP(S) server"
-msgstr "Un servidor HTTP(S) liviano de un solo hilo."
+msgstr "Un servidor HTTP(S) liviano de un solo hilo"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:20
 msgid "Advanced Settings"
@@ -74,7 +74,7 @@ msgstr ""
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:129
 msgid "Do not follow symlinks outside document root"
-msgstr "No siga los enlaces simbólicos fuera de la raíz del documento."
+msgstr "No siga los enlaces simbólicos fuera de la raíz del documento"
 
 #: applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua:132
 msgid "Do not generate directory listings."

--- a/applications/luci-app-unbound/po/es/unbound.po
+++ b/applications/luci-app-unbound/po/es/unbound.po
@@ -7,7 +7,7 @@ msgstr ""
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 2.2.4\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
@@ -453,6 +453,8 @@ msgid ""
 "Note: local DNS is configured to look at odhpcd, but odhpcd UCI lease "
 "trigger is incorrectly set:"
 msgstr ""
+"Nota: el DNS local está configurado para mirar odhpcd, pero el disparador de "
+"arrendamiento odhpcd UCI está configurado incorrectamente:"
 
 #: applications/luci-app-unbound/luasrc/model/cbi/unbound/zones.lua:16
 msgid ""
@@ -711,7 +713,7 @@ msgstr "Use entradas DNS extra que se encuentran en /etc/config/dhcp"
 #: applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua:232
 msgid "Use menu System/Processes to observe any memory growth"
 msgstr ""
-"Usa el menú Sistema/Procesos para observar cualquier crecimiento de memoria."
+"Usa el menú Sistema/Procesos para observar cualquier crecimiento de memoria"
 
 #: applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua:184
 msgid "WAN DNS"


### PR DESCRIPTION
Updated translations:

* banip
* openvpn
* simple-adblock
* statistics
* transmission
* travelmate
* uhttpd
* unbound

Signed-off-by: Franco Castillo <castillofrancodamian@gmail.com>