### PR TITLE
luci-base: widgets.js: add user and group select

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
@@ -3,6 +3,19 @@
 'require form';
 'require network';
 'require firewall';
+'require fs';
+
+function getUsers() {
+    return fs.lines('/etc/passwd').then(function(lines) {
+        return lines.map(function(line) { return line.split(/:/)[0] });
+    });
+}
+
+function getGroups() {
+    return fs.lines('/etc/group').then(function(lines) {
+        return lines.map(function(line) { return line.split(/:/)[0] });
+    });
+}
 
 var CBIZoneSelect = form.ListValue.extend({
 	__name__: 'CBI.ZoneSelect',
@@ -559,10 +572,48 @@ var CBIDeviceSelect = form.ListValue.extend({
 	},
 });
 
+var CBIUserSelect = form.ListValue.extend({
+	__name__: 'CBI.UserSelect',
+
+	load: function(section_id) {
+		return getUsers().then(L.bind(function(users) {
+			for (var i = 0; i < users.length; i++) {
+				this.value(users[i]);
+			}
+
+			return this.super('load', section_id);
+		}, this));
+	},
+
+	filter: function(section_id, value) {
+		return true;
+	},
+});
+
+var CBIGroupSelect = form.ListValue.extend({
+	__name__: 'CBI.GroupSelect',
+
+	load: function(section_id) {
+		return getGroups().then(L.bind(function(groups) {
+			for (var i = 0; i < groups.length; i++) {
+				this.value(groups[i]);
+			}
+
+			return this.super('load', section_id);
+		}, this));
+	},
+
+	filter: function(section_id, value) {
+		return true;
+	},
+});
+
 
 return L.Class.extend({
 	ZoneSelect: CBIZoneSelect,
 	ZoneForwards: CBIZoneForwards,
 	NetworkSelect: CBINetworkSelect,
 	DeviceSelect: CBIDeviceSelect,
+	UserSelect: CBIUserSelect,
+	GroupSelect: CBIGroupSelect,
 });

--- a/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
+++ b/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
@@ -30,6 +30,8 @@
 				"/etc/filesystems": [ "read" ],
 				"/etc/rc.local": [ "read" ],
 				"/etc/sysupgrade.conf": [ "read" ],
+				"/etc/passwd": [ "read" ],
+				"/etc/group": [ "read" ],
 				"/proc/filesystems": [ "read" ],
 				"/proc/mtd": [ "read" ],
 				"/proc/partitions": [ "read" ],


### PR DESCRIPTION
There's few applications provide user selection.
https://github.com/openwrt/luci/blob/07dbee37f858b93c10fe5114fbe55e36ddb0d654/applications/luci-app-aria2/luasrc/model/cbi/aria2/config.lua#L65 https://github.com/openwrt/luci/blob/9a489da90f1edeb01e88959c3092602bccf50a79/applications/luci-app-transmission/luasrc/model/cbi/transmission.lua#L28
However, after moving to client-siew view, we can't execute command directly from client-side. So I think we need corresponding widgets.
<del>I also removed the `-- Deprecated` comment of execl in util.lua, because rpcd/luci uses this function.</del>