### PR TITLE
luci-base: Show a hint when WiFi key is from MAC

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -17,6 +17,9 @@
 
 	-- send as HTML5
 	http.prepare_content("text/html")
+
+	-- Check ssids with default password
+	local unsecurewifikey = sys.wifi.checkkey()
 -%>
 <!DOCTYPE html>
 <html lang="<%=luci.i18n.context.lang%>">
@@ -63,6 +66,18 @@
 					<p><%:There is no password set on this router. Please configure a root password to protect the web interface and enable SSH.%></p>
 					<% if disp.lookup("admin/system/admin") then %>
 					  <div class="right"><a class="btn" href="<%=url("admin/system/admin")%>"><%:Go to password configuration...%></a></div>
+					<% end %>
+				</div>
+			<%- end -%>
+
+			<%- if unsecurewifikey ~= nil then -%>
+				<div class="alert-message warning">
+					<h4><%:Wifi set with LABEL_MAC unsecure key!%></h4>
+					<p>Some WiFi SSIDs are configured using a default key based on your device's MAC.</p>
+					<p>In order to prevent unauthorized WiFi connections, please change the key to the following SSIDs:</p>
+					<p><b><%=unsecurewifikey%></b></p>
+					<% if disp.lookup("admin/network/wireless") then %>
+						<div class="right"><a class="btn" href="<%=url("admin/network/wireless")%>"><%:Go to wifi configuration...%></a></div>
 					<% end %>
 				</div>
 			<%- end -%>

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -30,6 +30,9 @@
 
 	-- send as HTML5
 	http.prepare_content("text/html")
+
+	-- Check ssids with default password
+	local unsecurewifikey = sys.wifi.checkkey()
 -%>
 <!DOCTYPE html>
 <html lang="<%=luci.i18n.context.lang%>">
@@ -213,6 +216,18 @@
 						<p><%:There is no password set on this router. Please configure a root password to protect the web interface and enable SSH.%></p>
 						<% if disp.lookup("admin/system/admin") then %>
 							<div class="right"><a class="btn" href="<%=url("admin/system/admin")%>"><%:Go to password configuration...%></a></div>
+						<% end %>
+					</div>
+				<%- end -%>
+
+				<%- if unsecurewifikey ~= nil then -%>
+					<div class="alert-message warning">
+						<h4><%:Wifi set with LABEL_MAC unsecure key!%></h4>
+						<p>Some WiFi SSIDs are configured using a default key based on your device's MAC.</p>
+						<p>In order to prevent unauthorized WiFi connections, please change the key to the following SSIDs:</p>
+						<p><b><%=unsecurewifikey%></b></p>
+						<% if disp.lookup("admin/network/wireless") then %>
+							<div class="right"><a class="btn" href="<%=url("admin/network/wireless")%>"><%:Go to wifi configuration...%></a></div>
 						<% end %>
 					</div>
 				<%- end -%>

--- a/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
+++ b/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
@@ -18,6 +18,9 @@
 	local node = disp.context.dispatched
 
 	http.prepare_content("application/xhtml+xml")
+
+	-- Check ssids with default password
+	local unsecurewifikey = sys.wifi.checkkey()
 -%>
 
 <?xml version="1.0" encoding="utf-8"?>
@@ -234,4 +237,16 @@
 				<div class="right"><a class="btn" href="<%=url("admin/system/admin")%>"><%:Go to password configuration...%></a></div>
 			<% end %>
 		</div>
+		<%- end -%>
+
+		<%- if unsecurewifikey ~= nil then -%>
+			<div class="alert-message warning">
+				<h4><%:Wifi set with LABEL_MAC unsecure key!%></h4>
+				<p>Some WiFi SSIDs are configured using a default key based on your device's MAC.</p>
+				<p>In order to prevent unauthorized WiFi connections, please change the key to the following SSIDs:</p>
+				<p><b><%=unsecurewifikey%></b></p>
+				<% if disp.lookup("admin/network/wireless") then %>
+					<div class="right"><a class="btn" href="<%=url("admin/network/wireless")%>"><%:Go to wifi configuration...%></a></div>
+				<% end %>
+			</div>
 		<%- end -%>

--- a/themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm
+++ b/themes/luci-theme-rosy/luasrc/view/themes/rosy/header.htm
@@ -51,6 +51,9 @@
 	-- send as HTML5
 	http.prepare_content("text/html")
 
+	-- Check ssids with default password
+	local unsecurewifikey = sys.wifi.checkkey()
+
 	local function nodeurl(prefix, name, query)
 		local u = url(prefix, name)
 		if query then
@@ -283,6 +286,18 @@
 						</p>
 						<div><a class="btn" href="<%=url("admin/system/admin")%>"> <%:Go to password configuration...%></a></div>
 					</div>
+					<%- end -%>
+
+					<%- if unsecurewifikey ~= nil then -%>
+						<div class="alert-message warning">
+							<h4><%:Wifi set with LABEL_MAC unsecure key!%></h4>
+							<p>Some WiFi SSIDs are configured using a default key based on your device's MAC.</p>
+							<p>In order to prevent unauthorized WiFi connections, please change the key to the following SSIDs:</p>
+							<p><b><%=unsecurewifikey%></b></p>
+							<% if disp.lookup("admin/network/wireless") then %>
+								<a class="btn" href="<%=url("admin/network/wireless")%>"><%:Go to wifi configuration...%></a></div>
+							<% end %>
+						</div>
 					<%- end -%>
 
 					<noscript>


### PR DESCRIPTION
Display a hint alerting about WiFi SSIDs configured using
the default key generated from label-mac or eth0-mac.

When all SSIDs are configured using a different key, the default_key
value is removed from system config and the alert gets disabled
completely for better performance.

This PR is related with https://github.com/openwrt/openwrt/pull/2408

Signed-off-by: Manuel Giganto <mgigantoregistros@gmail.com>