### PR TITLE
[19.07] luci-app-https_dns_proxy: better status/control/dhcp integration

### DIFF
--- a/applications/luci-app-https_dns_proxy/Makefile
+++ b/applications/luci-app-https_dns_proxy/Makefile
@@ -10,7 +10,45 @@ LUCI_TITLE:=HTTPS DNS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for HTTPS DNS Proxy
 LUCI_DEPENDS:=+luci-mod-admin-full +https_dns_proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=5
+PKG_RELEASE:=7
+
+define Package/luci-app-https_dns_proxy/postinst
+#!/bin/sh
+# check if we are on real system
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	uci -q batch <<-EOF >/dev/null
+	delete ucitrack.@https_dns_proxy[-1]
+	add ucitrack https_dns_proxy
+	set ucitrack.@https_dns_proxy[-1].init=https_dns_proxy
+	commit ucitrack
+EOF
+	if ! uci -q get dhcp.@dnsmasq[0].doh_backup_server >/dev/null; then
+		for i in $$(uci -q get dhcp.@dnsmasq[0].server); do
+			uci -q add_list dhcp.@dnsmasq[0].doh_backup_server="$${i}"
+		done
+		uci -q commit dhcp
+	fi
+	rm -f /tmp/luci-indexcache
+fi
+exit 0
+endef
+
+define Package/luci-app-https_dns_proxy/prerm
+#!/bin/sh
+# check if we are on real system
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	if uci -q get dhcp.@dnsmasq[0].doh_backup_server >/dev/null; then
+		uci -q del dhcp.@dnsmasq[0].server || true
+		for i in $$(uci -q get dhcp.@dnsmasq[0].doh_backup_server); do
+			uci -q add_list dhcp.@dnsmasq[0].server="$${i}" || true
+		done
+		uci -q delete dhcp.@dnsmasq[0].doh_backup_server
+		uci -q commit dhcp
+		/etc/init.d/dnsmasq restart >/dev/null 2>&1 || true
+	fi
+fi
+exit 0
+endef
 
 include ../../luci.mk
 

--- a/applications/luci-app-https_dns_proxy/luasrc/controller/https_dns_proxy.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/controller/https_dns_proxy.lua
@@ -1,7 +1,103 @@
 module("luci.controller.https_dns_proxy", package.seeall)
 function index()
-	if not nixio.fs.access("/etc/config/https_dns_proxy") then
-		return
+	if nixio.fs.access("/etc/config/https_dns_proxy") then
+		entry({"admin", "services", "https_dns_proxy"}, cbi("https_dns_proxy"), _("HTTPS DNS Proxy"))
+		entry({"admin", "services", "https_dns_proxy", "action"}, call("https_dns_proxy_action"), nil).leaf = true
 	end
-	entry({"admin", "services", "https_dns_proxy"}, cbi("https_dns_proxy"), _("HTTPS DNS Proxy"))
+end
+
+function https_dns_proxy_action(name)
+	local packageName = "https_dns_proxy"
+	if name == "start" then
+		servers_backup()
+		luci.sys.init.start(packageName)
+		servers_apply_doh()
+		luci.util.exec("/etc/init.d/dnsmasq restart >/dev/null 2>&1")
+	elseif name == "action" then
+		luci.util.exec("/etc/init.d/" .. packageName .. " reload >/dev/null 2>&1")
+		luci.util.exec("/etc/init.d/dnsmasq restart >/dev/null 2>&1")
+	elseif name == "stop" then
+		servers_restore()
+		luci.util.exec("/etc/init.d/dnsmasq restart >/dev/null 2>&1")
+		luci.sys.init.stop(packageName)
+	elseif name == "enable" then
+		luci.sys.init.enable(packageName)
+	elseif name == "disable" then
+		luci.sys.init.disable(packageName)
+	end
+	luci.http.prepare_content("text/plain")
+	luci.http.write("0")
+end
+
+local uci = require("luci.model.uci").cursor()
+
+function uci_del_list(conf, sect, opt, value)
+  local lval = uci:get(conf, sect, opt)
+  if lval == nil or lval == "" then
+    lval = {}
+  elseif type(lval) ~= "table" then
+    lval = { lval }
+  end
+
+  local i
+  local changed = false
+  for i = #lval, 1 do
+    if lval[i] == value then
+      table.remove(lval, i)
+      changed = true
+    end
+  end
+
+  if changed then
+    if #lval > 0 then
+      uci:set(conf, sect, opt, lval)
+    else
+      uci:delete(conf, sect, opt)
+    end
+  end
+end
+
+function uci_add_list(conf, sect, opt, value)
+  local lval = uci:get(conf, sect, opt)
+  if lval == nil or lval == "" then
+    lval = {}
+  elseif type(lval) ~= "table" then
+    lval = { lval }
+  end
+
+  lval[#lval+1] = value
+  uci:set(conf, sect, opt, lval)
+end
+
+function servers_restore()
+  local k, v
+	if uci:get("dhcp", "@dnsmasq[0]", "doh_backup_server") then
+		uci:delete("dhcp", "@dnsmasq[0]", "server")
+		for k, v in pairs(uci:get("dhcp", "@dnsmasq[0]", "doh_backup_server")) do
+			uci_del_list("dhcp", "@dnsmasq[0]", "server", v)
+			uci_add_list("dhcp", "@dnsmasq[0]", "server", v)
+		end
+	end
+	uci:commit("dhcp")
+end
+
+function servers_backup()
+  if not uci:get("dhcp", "@dnsmasq[0]", "doh_backup_server") then
+    uci:set("dhcp", "@dnsmasq[0]", "doh_backup_server", uci:get("dhcp", "@dnsmasq[0]", "server"))
+  end
+end
+
+function servers_apply_doh()
+	local n = 0
+	uci:delete("dhcp", "@dnsmasq[0]", "server")
+	uci:foreach("https_dns_proxy", "https_dns_proxy", function(s)
+		local la_val, lp_val
+		la_val = s[".listen_addr"] or "127.0.0.1"
+		lp_val = s[".listen_port"] or n + 5053
+		uci_del_list("dhcp", "@dnsmasq[0]", "server", tostring(la_val) .. "#" .. tostring(lp_val))
+		uci_add_list("dhcp", "@dnsmasq[0]", "server", tostring(la_val) .. "#" .. tostring(lp_val))
+    n = n + 1
+		uci:save("dhcp")
+	end)
+	uci:commit("dhcp")
 end

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/buttons.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/buttons.htm
@@ -1,0 +1,56 @@
+<%#
+  Copyright 2019 Stan Grishin <stangri@melmac.net>
+-%>
+
+<%-
+	local packageName = "https_dns_proxy"
+	local enabledFlag = luci.sys.init.enabled(packageName)
+	local ubusStatus = luci.util.ubus("service", "list", { name = packageName })
+
+	if not ubusStatus or not ubusStatus[packageName] then
+		tmpfsStatusCode = 0
+	else
+		tmpfsStatusCode = 1
+	end
+
+	if tmpfsStatusCode == 0 then
+		btn_start_style = "cbi-button cbi-button-apply important"
+		btn_action_style = "cbi-button cbi-button-apply important"
+		btn_stop_style = "cbi-button cbi-button-reset -disabled"
+	else
+		btn_start_style = "cbi-button cbi-button-apply -disabled"
+		btn_action_style = "cbi-button cbi-button-apply important"
+		btn_stop_style = "cbi-button cbi-button-reset important"
+	end
+	if not enabledFlag then
+		btn_start_style = "cbi-button cbi-button-apply -disabled"
+		btn_action_style = "cbi-button cbi-button-apply -disabled"
+		btn_enable_style = "cbi-button cbi-button-apply important"
+		btn_disable_style = "cbi-button cbi-button-reset -disabled"
+	else
+		btn_enable_style = "cbi-button cbi-button-apply -disabled"
+		btn_disable_style = "cbi-button cbi-button-reset important"
+	end
+-%>
+
+<%+https_dns_proxy/css%>
+<%+https_dns_proxy/js%>
+
+<div class="cbi-value"><label class="cbi-value-title">Service Control</label>
+	<div class="cbi-value-field">
+		<input type="button" class="<%=btn_start_style%>" id="btn_start" name="start" value="<%:Start%>" onclick="button_action(this)" />
+		<span id="btn_start_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_action_style%>" id="btn_action" name="action" value="<%:Reload%>" onclick="button_action(this)" />
+		<span id="btn_action_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_stop_style%>" id="btn_stop" name="stop" value="<%:Stop%>" onclick="button_action(this)"  />
+		<span id="btn_stop_spinner" class="btn_spinner"></span>
+		&nbsp;
+		&nbsp;
+		&nbsp;
+		&nbsp;
+		<input type="button" class="<%=btn_enable_style%>" id="btn_enable" name="enable" value="<%:Enable%>" onclick="button_action(this)"  />
+		<span id="btn_enable_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_disable_style%>" id="btn_disable" name="disable" value="<%:Disable%>" onclick="button_action(this)"  />
+		<span id="btn_disable_spinner" class="btn_spinner"></span>
+	</div>
+</div>

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/css.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/css.htm
@@ -1,0 +1,9 @@
+<style type="text/css">
+	.btn_spinner
+	{
+		display: inline-block;
+		width: 0px;
+		height: 16px;
+		margin: 0 0px;
+	}
+</style>

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/js.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/js.htm
@@ -1,0 +1,60 @@
+
+<script type="text/javascript">
+//<![CDATA[
+ function button_action(action) {
+  var xhr = new XHR(false);
+  var btn_start = document.getElementById("btn_start");
+  var btn_action = document.getElementById("btn_action");
+  var btn_stop = document.getElementById("btn_stop");
+  var btn_enable = document.getElementById("btn_enable");
+  var btn_disable = document.getElementById("btn_disable");
+	var btn_spinner;
+	switch (action.name) {
+		case "start":
+			btn_spinner = document.getElementById("btn_start_spinner");
+			break;
+		case "action":
+			btn_spinner = document.getElementById("btn_action_spinner");
+			break;
+		case "stop":
+			btn_spinner = document.getElementById("btn_stop_spinner");
+			break;
+		case "enable":
+			btn_spinner = document.getElementById("btn_enable_spinner");
+			break;
+		case "disable":
+			btn_spinner = document.getElementById("btn_disable_spinner");
+			break;
+	}
+	btn_start.disabled = true;
+	btn_action.disabled = true;
+	btn_stop.disabled = true;
+	btn_enable.disabled = true;
+	btn_disable.disabled = true;
+  spinner(btn_spinner, 1);
+	xhr.get('<%=luci.dispatcher.build_url("admin", "services", "https_dns_proxy", "action")%>/' + action.name, null,
+		function (x) {
+			if (!x) {
+				return;
+			}
+      btn_start.disabled = false;
+      btn_action.disabled = false;
+      btn_stop.disabled = false;
+      btn_enable.disabled = false;
+      btn_disable.disabled = false;
+			spinner(btn_spinner, 0);
+      location.reload();
+     });
+}
+function spinner(element, state) {
+	if (state === 1) {
+    element.style.width = "16px";
+		element.innerHTML = '<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" width="16" height="16" style="vertical-align:middle" />';
+	}
+	else {
+    element.style.width = "0px";
+		element.innerHTML = '';
+	}
+}
+//]]>
+</script>

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/status-textarea.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/status-textarea.htm
@@ -1,0 +1,13 @@
+<%#
+Copyright 2017-2019 Stan Grishin (stangri@melmac.net)
+This is free software, licensed under the Apache License, Version 2.0
+-%>
+
+<%+cbi/valueheader%>
+
+<textarea rows="<%=select(2, self:cfgvalue(section):gsub('\n', ''))%>"
+  style="border:none;box-shadow:none;background:transparent;font-weight:bold;line-height:20px;width:50em;padding:none;margin:6px;resize:none;overflow:hidden;"
+  disabled="disabled"><%=self:cfgvalue(section)%>
+</textarea>
+
+<%+cbi/valuefooter%>

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/status.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/status.htm
@@ -1,0 +1,10 @@
+<%#
+Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
+This is free software, licensed under the Apache License, Version 2.0
+-%>
+
+<%+cbi/valueheader%>
+
+<input name="status" id="status" type="text" class="cbi-input-text" style="outline:none;border:none;box-shadow:none;background:transparent;font-weight:bold;line-height:30px;height:30px;width:50em;" value="<%=self:cfgvalue(section)%>" disabled="disabled" />
+
+<%+cbi/valuefooter%>


### PR DESCRIPTION
Improvements include:
 - Better integration with DHCP config: create the backup of the originally used servers and restore it on uninstall/service stop.
 - Better service control management in luci app, allowing user to start, reload, stop, enable and disable the service from WebUI.
 - Better service status display in WebUI.

PS. There's quite a bit of duplicate lua code between controller/cbi/view files. If anyone has a suggestion how can I keep it in just one of those files, I'd be much obliged.

Signed-off-by: Stan Grishin <stangri@melmac.net>