### PR TITLE
[RFC] luci-app-opkg: add ipk upload feature

### DIFF
--- a/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
+++ b/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
@@ -781,6 +781,38 @@ function handleOpkg(ev)
 	});
 }
 
+function handleUpload(ev)
+{
+	var path = '/tmp/upload.ipk';
+	return L.ui.showModalUpload(path)
+	.then(L.bind(function(btn, res) {
+		L.showModal(_('Manually install package'), [
+			E('p', {}, _('Installing packages from untrusted sources is a potential security risk! Really attempt to install <em>%h</em>?').format(res.name)),
+			E('ul', {}, [
+				res.size ? E('li', {}, '%s: %1024.2mB'.format(_('Size'), res.size)) : '',
+				res.checksum ? E('li', {}, '%s: %s'.format(_('MD5'), res.checksum)) : '',
+				res.sha256sum ? E('li', {}, '%s: %s'.format(_('SHA256'), res.sha256sum)) : ''
+			]),
+			E('div', { 'class': 'right' }, [
+				E('div', {
+					'click': L.hideModal,
+					'class': 'btn cbi-button-neutral'
+				}, _('Cancel')), ' ',
+				E('div', {
+					'class': 'btn cbi-button-action',
+					'data-command': 'install',
+					'data-package': path,
+					'click': handleOpkg
+				}, _('Install'))
+			])
+		]);
+	}, this, ev.target))
+	.catch(function(e) { L.ui.addNotification(null, E('p', e.message)) })
+	.finally(L.bind(function(btn) {
+		btn.firstChild.data = _('Upload Package…');
+	}, this, ev.target));
+}
+
 function updateLists()
 {
 	cbi_update_table('#packages', [],

--- a/applications/luci-app-opkg/luasrc/view/opkg.htm
+++ b/applications/luci-app-opkg/luasrc/view/opkg.htm
@@ -108,6 +108,8 @@
 		<button class="btn cbi-button-positive" data-command="update" onclick="handleOpkg(event)"><%:Update lists…%></button>
 		&#160;
 		<button class="btn cbi-button-neutral" onclick="handleConfig(event)"><%:Configure opkg…%></button>
+		&#160;
+		<button class="btn cbi-button-positive" onclick="handleUpload(event)"><%:Upload Package…%></button>
 	</div>
 </div>
 

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -1860,6 +1860,7 @@ return L.Class.extend({
 		/* setup old aliases */
 		L.showModal = this.showModal;
 		L.hideModal = this.hideModal;
+		L.showModalUpload = this.showModalUpload;
 		L.showTooltip = this.showTooltip;
 		L.hideTooltip = this.hideTooltip;
 		L.itemlist = this.itemlist;
@@ -1893,6 +1894,92 @@ return L.Class.extend({
 
 	hideModal: function() {
 		document.body.classList.remove('modal-overlay-active');
+	},
+
+	showModalUpload: function(path, node) {
+		return new Promise(function(resolveFn, rejectFn) {
+			L.ui.showModal(_('Uploading file…'), [
+				E('p', _('Please select the file to upload.')),
+				E('div', { 'style': 'display:flex' }, [
+					E('div', { 'class': 'left', 'style': 'flex:1' }, [
+						E('input', {
+							type: 'file',
+							style: 'display:none',
+							change: function(ev) {
+								L.dom.parent(ev.target, '.modal').querySelector('.cbi-button-action.important').disabled = false;
+							}
+						}),
+						E('button', {
+							'class': 'btn',
+							'click': function(ev) {
+								ev.target.previousElementSibling.click();
+							}
+						}, [ _('Browse…') ])
+					]),
+					E('div', { 'class': 'right', 'style': 'flex:1' }, [
+						E('button', {
+							'class': 'btn',
+							'click': function() {
+								L.ui.hideModal();
+								rejectFn(new Error('Upload has been cancelled'));
+							}
+						}, [ _('Cancel') ]),
+						' ',
+						E('button', {
+							'class': 'btn cbi-button-action important',
+							'disabled': true,
+							'click': function(ev) {
+								var input = L.dom.parent(ev.target, '.modal').querySelector('input[type="file"]');
+
+								if (!input.files[0])
+									return;
+
+								var progress = E('div', { 'class': 'cbi-progressbar', 'title': '0%' }, E('div', { 'style': 'width:0' }));
+
+								L.ui.showModal(_('Uploading file…'), [ progress ]);
+
+								var data = new FormData();
+
+								data.append('sessionid', rpc.getSessionID());
+								data.append('filename', path);
+								data.append('filedata', input.files[0]);
+
+								var filename = input.files[0].name;
+
+								L.Request.post('/cgi-bin/cgi-upload', data, {
+									timeout: 0,
+									progress: function(pev) {
+										var percent = (pev.loaded / pev.total) * 100;
+
+										if (node)
+											node.data = '%.2f%%'.format(percent);
+
+										progress.setAttribute('title', '%.2f%%'.format(percent));
+										progress.firstElementChild.style.width = '%.2f%%'.format(percent);
+									}
+								}).then(function(res) {
+									var reply = res.json();
+
+									L.ui.hideModal();
+
+									if (L.isObject(reply) && reply.failure) {
+										L.ui.addNotification(null, E('p', _('Upload request failed: %s').format(reply.message)));
+										rejectFn(new Error(reply.failure));
+									}
+									else {
+										reply.name = filename;
+										resolveFn(reply);
+									}
+								}, function(err) {
+									L.ui.hideModal();
+									rejectFn(err);
+								});
+							}
+						}, [ _('Upload') ])
+					])
+				])
+			]);
+		});
 	},
 
 	/* Tooltip */

--- a/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
+++ b/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
@@ -64,7 +64,8 @@
 				"/sbin/sysupgrade": [ "exec" ],
 				"/bin/tar": [ "exec" ],
 				"/tmp/backup.tar.gz": [ "write" ],
-				"/tmp/firmware.bin": [ "write" ]
+				"/tmp/firmware.bin": [ "write" ],
+				"/tmp/upload.ipk": [ "write" ]
 			},
 			"ubus": {
 				"file": [ "write", "remove", "exec" ],

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
@@ -10,88 +10,6 @@ var callSystemValidateFirmwareImage = rpc.declare({
 	expect: { '': { valid: false, forcable: true } }
 });
 
-function fileUpload(node, path) {
-	return new Promise(function(resolveFn, rejectFn) {
-		L.ui.showModal(_('Uploading file…'), [
-			E('p', _('Please select the file to upload.')),
-			E('div', { 'style': 'display:flex' }, [
-				E('div', { 'class': 'left', 'style': 'flex:1' }, [
-					E('input', {
-						type: 'file',
-						style: 'display:none',
-						change: function(ev) {
-							L.dom.parent(ev.target, '.modal').querySelector('.cbi-button-action.important').disabled = false;
-						}
-					}),
-					E('button', {
-						'class': 'btn',
-						'click': function(ev) {
-							ev.target.previousElementSibling.click();
-						}
-					}, [ _('Browse…') ])
-				]),
-				E('div', { 'class': 'right', 'style': 'flex:1' }, [
-					E('button', {
-						'class': 'btn',
-						'click': function() {
-							L.ui.hideModal();
-							rejectFn(new Error('Upload has been cancelled'));
-						}
-					}, [ _('Cancel') ]),
-					' ',
-					E('button', {
-						'class': 'btn cbi-button-action important',
-						'disabled': true,
-						'click': function(ev) {
-							var input = L.dom.parent(ev.target, '.modal').querySelector('input[type="file"]');
-
-							if (!input.files[0])
-								return;
-
-							var progress = E('div', { 'class': 'cbi-progressbar', 'title': '0%' }, E('div', { 'style': 'width:0' }));
-
-							L.ui.showModal(_('Uploading file…'), [ progress ]);
-
-							var data = new FormData();
-
-							data.append('sessionid', rpc.getSessionID());
-							data.append('filename', path);
-							data.append('filedata', input.files[0]);
-
-							L.Request.post('/cgi-bin/cgi-upload', data, {
-								timeout: 0,
-								progress: function(pev) {
-									var percent = (pev.loaded / pev.total) * 100;
-
-									node.data = '%.2f%%'.format(percent);
-
-									progress.setAttribute('title', '%.2f%%'.format(percent));
-									progress.firstElementChild.style.width = '%.2f%%'.format(percent);
-								}
-							}).then(function(res) {
-								var reply = res.json();
-
-								L.ui.hideModal();
-
-								if (L.isObject(reply) && reply.failure) {
-									L.ui.addNotification(null, E('p', _('Upload request failed: %s').format(reply.message)));
-									rejectFn(new Error(reply.failure));
-								}
-								else {
-									resolveFn(reply);
-								}
-							}, function(err) {
-								L.ui.hideModal();
-								rejectFn(err);
-							});
-						}
-					}, [ _('Upload') ])
-				])
-			])
-		]);
-	});
-}
-
 function findStorageSize(procmtd, procpart) {
 	var kernsize = 0, rootsize = 0, wholesize = 0;
 
@@ -184,7 +102,7 @@ return L.view.extend({
 	},
 
 	handleRestore: function(ev) {
-		return fileUpload(ev.target, '/tmp/backup.tar.gz')
+		return L.ui.showModalUpload('/tmp/backup.tar.gz', ev.target)
 			.then(L.bind(function(btn, res) {
 				btn.firstChild.data = _('Checking archive…');
 				return fs.exec('/bin/tar', [ '-tzf', '/tmp/backup.tar.gz' ]);
@@ -267,7 +185,7 @@ return L.view.extend({
 	},
 
 	handleSysupgrade: function(storage_size, ev) {
-		return fileUpload(ev.target.firstChild, '/tmp/firmware.bin')
+		return L.ui.showModalUpload('/tmp/firmware.bin', ev.target.firstChild)
 			.then(L.bind(function(btn, reply) {
 				btn.firstChild.data = _('Checking image…');
 


### PR DESCRIPTION
Sometime people just want to upload and install a package using luci, however currently it's impossible without other tools (scp, WinSCP).
This pull request add this feature.

There are some minor issues I request for comments:
1. The confirm dialog reuses `handleManualInstall`, and shows `/tmp/upload.ipk` as filename. Should I make it shows it's real name?
![image](https://user-images.githubusercontent.com/12028138/67392917-f3e0a080-f5d3-11e9-8977-7f9e863b4264.png)
2. Should confirm dialog shows checksums and size info?

@jow- 