### PR TITLE
luci-mod-system: add missing speed_mask option in leds.js

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js
@@ -148,6 +148,11 @@ return L.view.extend({
 		o.depends('trigger', 'switch0');
 		o.depends('trigger', 'switch1');
 
+		o = s.option(form.Value, 'speed_mask', _('Switch Speed Mask'));
+		o.modalonly = true;
+		o.depends('trigger', 'switch0');
+		o.depends('trigger', 'switch1');
+
 		return m.render();
 	}
 });


### PR DESCRIPTION
https://github.com/openwrt/openwrt/blob/a8a934060957212eb7b9eb6bd14fc80a3857d9d8/package/base-files/files/etc/init.d/led#L113-L115