### PR TITLE
[18.06] luci-app-vpnbypass: bugfix: call to action has no parent node

### DIFF
--- a/applications/luci-app-vpnbypass/Makefile
+++ b/applications/luci-app-vpnbypass/Makefile
@@ -3,14 +3,14 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
 LUCI_TITLE:=VPN Bypass Web UI
 LUCI_DESCRIPTION:=Provides Web UI for VPNBypass service.
 LUCI_DEPENDS:=+luci-mod-admin-full +vpnbypass
 LUCI_PKGARCH:=all
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 include ../../luci.mk
 

--- a/applications/luci-app-vpnbypass/luasrc/controller/vpnbypass.lua
+++ b/applications/luci-app-vpnbypass/luasrc/controller/vpnbypass.lua
@@ -1,12 +1,10 @@
 module("luci.controller.vpnbypass", package.seeall)
 function index()
 	if nixio.fs.access("/etc/config/vpnbypass") then
-		if luci.dispatcher.lookup("admin/vpn") then
-			entry({"admin", "vpn", "vpnbypass"}, cbi("vpnbypass"), _("VPN Bypass"))
-		else
-			entry({"admin", "services", "vpnbypass"}, cbi("vpnbypass"), _("VPN Bypass"))
-		end
-	entry({"admin", "services", "vpnbypass", "action"}, call("vpnbypass_action"), nil).leaf = true
+		local node = "services"
+		if luci.dispatcher.lookup("admin/vpn") then node = "vpn" end
+		entry({"admin", node, "vpnbypass"}, cbi("vpnbypass"), _("VPN Bypass"))
+		entry({"admin", node, "vpnbypass", "action"}, call("vpnbypass_action"), nil).leaf = true
 	end
 end
 

--- a/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
+++ b/applications/luci-app-vpnbypass/luasrc/model/cbi/vpnbypass.lua
@@ -4,8 +4,6 @@ local sys = require "luci.sys"
 local util = require "luci.util"
 local packageName = "vpnbypass"
 
-m = Map("vpnbypass", translate("VPN Bypass Settings"))
-
 local tmpfsVersion = tostring(util.trim(sys.exec("opkg list-installed " .. packageName .. " | awk '{print $3}'")))
 if not tmpfsVersion or tmpfsVersion == "" then
   tmpfsStatusCode = -1
@@ -18,6 +16,8 @@ local tmpfsStatus = "Stopped"
 if sys.call("iptables -t mangle -L | grep -q VPNBYPASS") == 0 then
 	tmpfsStatus = "Running"
 end
+
+m = Map("vpnbypass", translate("VPN Bypass Settings"))
 
 h = m:section(NamedSection, "config", packageName, translate("Service Status") .. tmpfsVersion)
 ss = h:option(DummyValue, "_dummy", translate("Service Status"))

--- a/applications/luci-app-vpnbypass/luasrc/view/vpnbypass/js.htm
+++ b/applications/luci-app-vpnbypass/luasrc/view/vpnbypass/js.htm
@@ -1,3 +1,4 @@
+<%- if luci.dispatcher.lookup("admin/vpn") then node = "vpn" else node = "services" end -%>
 
 <script type="text/javascript">
 //<![CDATA[
@@ -32,7 +33,7 @@
 	btn_enable.disabled = true;
 	btn_disable.disabled = true;
   spinner(btn_spinner, 1);
-	xhr.get('<%=luci.dispatcher.build_url("admin", "services", "vpnbypass", "action")%>/' + action.name, null,
+	xhr.get('<%=luci.dispatcher.build_url("admin", node, "vpnbypass", "action")%>/' + action.name, null,
 		function (x) {
 			if (!x) {
 				return;


### PR DESCRIPTION
This fixes: https://github.com/openwrt/luci/issues/3243

Only merge if the luci-app-openvpn which creates its entries under the VPN (and not Services) node will ever be merged to 18.06.

Signed-off-by: Stan Grishin <stangri@melmac.net>
