### PR TITLE
luci-mod-network: add address parameter in DHCP for dnsmasq

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -186,6 +186,13 @@ return L.view.extend({
 		o.placeholder = '/example.org/10.1.2.3';
 
 
+		o = s.taboption('general', form.DynamicList, 'address', _('Addresses'),
+			_('List of domains to force to an IP address.'));
+		
+		o.optional = true;
+		o.placeholder = '/router.local/192.168.0.1';
+
+
 		o = s.taboption('general', form.Flag, 'rebind_protection',
 			_('Rebind protection'),
 			_('Discard upstream RFC1918 responses'));


### PR DESCRIPTION
Address is very useful in dnsmasq. I don't see a reason why we should not have it in the form