### PR TITLE
themes: Hide LuCI version if user is not authenticated

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/footer.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/footer.htm
@@ -14,7 +14,11 @@
 	local categories = disp.node_childs(tree)
 %>
    <footer>
+    <%- if disp.context.authsession then %>
     <a href="https://github.com/openwrt/luci">Powered by <%= ver.luciname %> (<%= ver.luciversion %>)</a> / <%= ver.distversion %>
+    <% else %>
+    <a href="https://github.com/openwrt/luci">Powered by LuCI</a>
+    <% end %>
     <% if #categories > 1 then %>
      <ul class="breadcrumb pull-right" id="modemenu">
 	    <% for i, r in ipairs(categories) do %>

--- a/themes/luci-theme-material/luasrc/view/themes/material/footer.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/footer.htm
@@ -28,7 +28,11 @@
 %>
 	</div>
 	<footer class="mobile-hide">
+	<%- if disp.context.authsession then %>
 	<a href="https://github.com/openwrt/luci">Powered by <%= ver.luciname %> (<%= ver.luciversion %>)</a> / <%= ver.distversion %>
+	<% else %>
+	<a href="https://github.com/openwrt/luci">Powered by LuCI</a>
+	<% end %>
 	<% if #categories > 1 then %>
 		<ul class="breadcrumb pull-right" id="modemenu">
 		<% for i, r in ipairs(categories) do %>

--- a/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/footer.htm
+++ b/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/footer.htm
@@ -9,8 +9,13 @@
 </div>
 
 <p class="luci">
-	<% local ver = require "luci.version" -%>
+	<% local ver = require "luci.version"
+	local disp = require "luci.dispatcher" -%>
+	<%- if disp.context.authsession then %>
+	Powered by LuCI
+	<% else %>
 	Powered by <%= ver.luciname %> (<%= ver.luciversion %>)
+	<% end %>
 </p>
 </body>
 </html>

--- a/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
+++ b/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
@@ -198,7 +198,7 @@
 <h2 class="navigation"><a id="navigation" name="navigation"><%:Navigation%></a></h2>
 
 <div class="hostinfo">
-	<%=(boardinfo.hostname or "?")%> | <%=ver.distversion%> |
+	<%=(boardinfo.hostname or "?")%> | <%- if disp.context.authsession then %><%=ver.distversion%><% else %>OpenWrt<% end %> |
 	<%:Load%>: <%="%.2f" % (loadinfo[1] / 65535.0)%> <%="%.2f" % (loadinfo[2] / 65535.0)%> <%="%.2f" % (loadinfo[3] / 65535.0)%>
 	<span id="xhr_poll_status" style="display:none" onclick="XHR.running() ? XHR.halt() : XHR.run()">
 		| <%:Auto Refresh%>:

--- a/themes/luci-theme-rosy/luasrc/view/themes/rosy/footer.htm
+++ b/themes/luci-theme-rosy/luasrc/view/themes/rosy/footer.htm
@@ -29,8 +29,12 @@
 </div>
 </div>
 <footer>
+    <%- if disp.context.authsession then %>
     <a href="https://github.com/openwrt/luci">Powered by<%= ver.luciname %> (<%= ver.luciversion %>)</a> /
     <%= ver.distversion %>
+    <% else %>
+    <a href="https://github.com/openwrt/luci">Powered by LuCI</a>
+    <% end %>
     <% if #categories > 1 then %>
     <ul class="breadcrumb pull-right" id="modemenu">
         <% for i, r in ipairs(categories) do %>


### PR DESCRIPTION
There is no need to adverstise the version number of LuCI on landing page/home page.

May be you will think, it's security through obscuracy, but let's not ease the job of any attacker by displaying the version number on landing page.

It is normally displayed for any authenticated user.