### PR TITLE
luci-app-nextdns: add luci integration for nextdns package

### DIFF
--- a/applications/luci-app-nextdns/Makefile
+++ b/applications/luci-app-nextdns/Makefile
@@ -1,0 +1,12 @@
+# Copyright 2019 Olivier Poitrey (rs@nextdns.io)
+# This is free software, licensed under the Apache License, Version 2.0
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for NextDNS
+LUCI_DEPENDS:=+luci-compat +nextdns
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nextdns/luasrc/controller/nextdns.lua
+++ b/applications/luci-app-nextdns/luasrc/controller/nextdns.lua
@@ -1,0 +1,32 @@
+-- Copyright 2019 Olivier Poitrey (rs@nextdns.io)
+-- This is free software, licensed under the Apache License, Version 2.0
+
+module("luci.controller.nextdns", package.seeall)
+
+local util  = require("luci.util")
+local i18n  = require("luci.i18n")
+local templ = require("luci.template")
+local http  = require("luci.http")
+
+function index()
+	if not nixio.fs.access("/etc/config/nextdns") then
+		return
+	end
+
+	entry({"admin", "services", "nextdns"}, firstchild(), _("NextDNS"), 60).dependent = false
+	entry({"admin", "services", "nextdns", "overview"}, cbi("overview", {hideresetbtn=true, hidesavebtn=true}), _("Overview"), 10).leaf = true
+	entry({"admin", "services", "nextdns", "log"}, template("nextdns/logread"), _("Logs"), 30).leaf = true
+
+	entry({"admin", "services", "nextdns", "logread"}, call("logread"), nil).leaf = true
+
+end
+
+function logread()
+	local content = util.trim(util.exec("logread -e 'nextdns'")) or ""
+
+	if content == "" then
+		content = "No nextdns related logs yet!"
+	end
+	http.write(content)
+end
+

--- a/applications/luci-app-nextdns/luasrc/model/cbi/overview.lua
+++ b/applications/luci-app-nextdns/luasrc/model/cbi/overview.lua
@@ -1,0 +1,41 @@
+local uci = require("luci.model.uci").cursor()
+
+nextdns = Map("nextdns", translate("NextDNS"),
+	translate("NextDNS Configuration.")
+	.. "<br>"
+	.. translatef("For further information, go to "
+	..            "<a href=\"https://nextdns.io\" target=\"_blank\">nextdns.io</a>"))
+
+
+function nextdns.on_after_commit(self)
+	luci.sys.call("env -i /etc/init.d/nextdns restart >/dev/null 2>&1")
+end
+
+s = nextdns:section(TypedSection, "nextdns", translate("General"))
+s.anonymous = true
+
+enabled = s:option(Flag, "enabled", translate("Enabled"),
+	translate("Enable NextDNS."))
+enabled.rmempty = false
+
+conf = s:option(Value, "config", translate("Configuration ID"),
+	translate("The ID of your NextDNS configuration.")
+	.. "<br>"
+	.. translate("Go to nextdns.io to create a configuration."))
+conf.rmempty = false
+
+report_client_info = s:option(Flag, "report_client_info", translate("Report Client Info"),
+	translate("Expose LAN clients information in NextDNS analytics."))
+report_client_info.rmempty = false
+
+hardened_privacy = s:option(Flag, "hardened_privacy", translate("Hardened Privacy"),
+	translate("When enabled, use DNS servers located in jurisdictions with strong privacy laws.")
+	.. "<br>"
+	.. translate("Available locations are: Switzerland, Iceland, Finland, Panama and Hong Kong."))
+hardened_privacy.rmempty = false
+
+log_query = s:option(Flag, "log_query", translate("Log Queries"),
+	translate("Log individual queries to system log."))
+log_query.rmempty = false
+
+return nextdns

--- a/applications/luci-app-nextdns/luasrc/view/nextdns/logread.htm
+++ b/applications/luci-app-nextdns/luasrc/view/nextdns/logread.htm
@@ -1,0 +1,46 @@
+<%+header%>
+
+<style type="text/css">
+	select[readonly],
+	textarea[readonly]
+	{
+		width: 100% !important;
+		height: 450px !important;
+		border: 1px solid #cccccc;
+		padding: 5px;
+		font-size: 12px;
+		font-family: monospace;
+		resize: none;
+		pointer-events: auto;
+		cursor: auto;
+	}
+</style>
+
+<script type="text/javascript">
+//<![CDATA[
+	function log_update()
+	{
+		XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "services", "nextdns", "logread")%>', null,
+		function(x)
+		{
+			if (!x)
+			{
+				return;
+			}
+			var view       = document.getElementById("view_id");
+			view.value     = x.responseText;
+			view.scrollTop = view.scrollHeight;
+		});
+	}
+	window.onload = log_update();
+//]]>
+</script>
+
+<div class="cbi-map">
+	<div class="cbi-section">
+		<div class="cbi-section-descr"><%:The syslog output, pre-filtered for nextdns related messages only.%></div>
+		<textarea id="view_id" readonly="readonly" wrap="off" value=""></textarea>
+	</div>
+</div>
+
+<%+footer%>

--- a/applications/luci-app-nextdns/po/templates/nextdns.pot
+++ b/applications/luci-app-nextdns/po/templates/nextdns.pot
@@ -1,0 +1,84 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:34
+msgid ""
+"Available locations are: Switzerland, Iceland, Finland, Panama and Hong Kong."
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:21
+msgid "Configuration ID"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:18
+msgid "Enable NextDNS."
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:17
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:28
+msgid "Expose LAN clients information in NextDNS analytics."
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:6
+msgid ""
+"For further information, go to <a href=\"https://nextdns.io\" target=\"_blank"
+"\">nextdns.io</a>"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:14
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:24
+msgid "Go to nextdns.io to create a configuration."
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:31
+msgid "Hardened Privacy"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:37
+msgid "Log Queries"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:38
+msgid "Log individual queries to system log."
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/controller/nextdns.lua:18
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/controller/nextdns.lua:16
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:3
+msgid "NextDNS"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:4
+msgid "NextDNS Configuration."
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/controller/nextdns.lua:17
+msgid "Overview"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:27
+msgid "Report Client Info"
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:22
+msgid "The ID of your NextDNS configuration."
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/view/nextdns/logread.htm:41
+msgid "The syslog output, pre-filtered for nextdns related messages only."
+msgstr ""
+
+#: applications/luci-app-nextdns/luasrc/model/cbi/overview.lua:32
+msgid ""
+"When enabled, use DNS servers located in jurisdictions with strong privacy "
+"laws."
+msgstr ""

--- a/applications/luci-app-nextdns/root/etc/uci-defaults/60_luci-nextdns
+++ b/applications/luci-app-nextdns/root/etc/uci-defaults/60_luci-nextdns
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+uci -q batch <<-EOF >/dev/null
+	delete ucitrack.@nextdns[-1]
+	add ucitrack nextdns
+	set ucitrack.@nextdns[-1].init=nextdns
+	commit ucitrack
+EOF
+
+rm -f /tmp/luci-indexcache
+exit 0


### PR DESCRIPTION
Signed-off-by: Olivier Poitrey <rs@nextdns.io>

Description:

Adding support for [NextDNS](https://nextdns.io), a DNS over HTTPS service that provides customized block-lists (ad-block, malware protection, kid safety) as well advanced analytics amongst other things.

Depends on: https://github.com/openwrt/packages/pull/10535

<img width="962" alt="Screen Shot 2019-11-12 at 6 29 40 PM" src="https://user-images.githubusercontent.com/68232/68727857-71b41e00-057a-11ea-839a-3dfc351d1d7e.png">
<img width="970" alt="Screen Shot 2019-11-12 at 6 29 49 PM" src="https://user-images.githubusercontent.com/68232/68727859-737de180-057a-11ea-9d5b-8077c350fff3.png">
