### PR TITLE
luci-app-https_dns_proxy: luci-app-https_dns_proxy: remove dnsmasq integration, better service controls, providers as plugins, misc fixes

### DIFF
--- a/applications/luci-app-https_dns_proxy/Makefile
+++ b/applications/luci-app-https_dns_proxy/Makefile
@@ -3,14 +3,14 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
 LUCI_TITLE:=HTTPS DNS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for HTTPS DNS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https_dns_proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=5
+PKG_RELEASE:=9
 
 include ../../luci.mk
 

--- a/applications/luci-app-https_dns_proxy/luasrc/controller/https_dns_proxy.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/controller/https_dns_proxy.lua
@@ -1,7 +1,25 @@
 module("luci.controller.https_dns_proxy", package.seeall)
 function index()
-	if not nixio.fs.access("/etc/config/https_dns_proxy") then
-		return
+	if nixio.fs.access("/etc/config/https_dns_proxy") then
+		entry({"admin", "services", "https_dns_proxy"}, cbi("https_dns_proxy"), _("DNS over HTTPS Proxy"))
+		entry({"admin", "services", "https_dns_proxy", "action"}, call("https_dns_proxy_action"), nil).leaf = true
 	end
-	entry({"admin", "services", "https_dns_proxy"}, cbi("https_dns_proxy"), _("HTTPS DNS Proxy"))
+end
+
+function https_dns_proxy_action(name)
+	local packageName = "https_dns_proxy"
+	if name == "start" then
+		luci.sys.init.start(packageName)
+	elseif name == "action" then
+		luci.util.exec("/etc/init.d/" .. packageName .. " reload >/dev/null 2>&1")
+		luci.util.exec("/etc/init.d/dnsmasq restart >/dev/null 2>&1")
+	elseif name == "stop" then
+		luci.sys.init.stop(packageName)
+	elseif name == "enable" then
+		luci.sys.init.enable(packageName)
+	elseif name == "disable" then
+		luci.sys.init.disable(packageName)
+	end
+	luci.http.prepare_content("text/plain")
+	luci.http.write("0")
 end

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "Digitale-Gesellschaft",
+	label = _("Digitale Gesellschaft"),
+	url_prefix = "https://dns.digitale-gesellschaft.ch/dns-query?",
+	bootstrap_dns = "185.95.218.42,185.95.218.43"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/com.adguard.dns-family.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/com.adguard.dns-family.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "AdGuard-Family",
+	label = _("AdGuard (Family Protection)"),
+	url_prefix = "https://dns-family.adguard.com/dns-query?ct&",
+	bootstrap_dns = "176.103.130.132,176.103.130.134"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/com.adguard.dns.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/com.adguard.dns.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "AdGuard-Standard",
+	label = _("AdGuard (Standard)"),
+	url_prefix = "https://dns.adguard.com/dns-query?ct&",
+	bootstrap_dns = "176.103.130.130,176.103.130.131"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/cz.nic.odvr.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/cz.nic.odvr.lua
@@ -1,0 +1,6 @@
+return {
+	name = "odvr-nic-cz",
+	label = _("ODVR (nic.cz)"),
+	url_prefix = "https://odvr.nic.cz/doh?",
+	bootstrap_dns = "193.17.47.1,185.43.135.1"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/net.quad9.dns.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/net.quad9.dns.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "Quad9-Recommended",
+	label = _("Quad 9 (Recommended)"),
+	url_prefix = "https://dns.quad9.net:5053/dns-query?",
+	bootstrap_dns = "9.9.9.9,149.112.112.112"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/net.quad9.dns10.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/net.quad9.dns10.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "Quad9-Unsecured",
+	label = _("Quad 9 (Unsecured)"),
+	url_prefix = "https://dns10.quad9.net:5053/dns-query?",
+	bootstrap_dns = "9.9.9.10,149.112.112.10"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/net.quad9.dns11.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/net.quad9.dns11.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "Quad9-ECS",
+	label = _("Quad 9 (Secured with ECS Support)"),
+	url_prefix = "https://dns11.quad9.net:5053/dns-query?",
+	bootstrap_dns = "9.9.9.11,149.112.112.11"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/net.quad9.dns9.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/net.quad9.dns9.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "Quad9-Secured",
+	label = _("Quad 9 (Secured)"),
+	url_prefix = "https://dns9.quad9.net:5053/dns-query?",
+	bootstrap_dns = "9.9.9.9,149.112.112.9"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/org.cleanbrowsing.doh-adult.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/org.cleanbrowsing.doh-adult.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "CleanBrowsing-Adult",
+	label = _("CleanBrowsing (Adult Filter)"),
+	url_prefix = "https://doh.cleanbrowsing.org/doh/adult-filter/?ct&",
+	bootstrap_dns = "185.228.168.168"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/org.cleanbrowsing.doh-family.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/org.cleanbrowsing.doh-family.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "CleanBrowsing-Family",
+	label = _("CleanBrowsing (Family Filter)"),
+	url_prefix = "https://doh.cleanbrowsing.org/doh/family-filter/?ct&",
+	bootstrap_dns = "185.228.168.168"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/org.cleanbrowsing.doh-security.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers.disabled/org.cleanbrowsing.doh-security.lua
@@ -1,0 +1,14 @@
+--    .. "</br>"
+--    .. translate("For more information on different options check ")
+--		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
+--    .. "AdGuard.com" .. [[</a>]] .. ", "
+--		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+--    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+--		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+--    .. "Quad9.net" .. [[</a>]] .. "."
+return {
+	name = "CleanBrowsing-Security",
+	label = _("CleanBrowsing (Security Filter)"),
+	url_prefix = "https://doh.cleanbrowsing.org/doh/security-filter/?ct&",
+	bootstrap_dns = "185.228.168.168"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers/com.cloudflare-dns.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers/com.cloudflare-dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "Cloudflare",
+	label = _("Cloudflare"),
+	url_prefix = "https://cloudflare-dns.com/dns-query?ct=application/dns-json&",
+	bootstrap_dns = "1.1.1.1,1.0.0.1"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers/com.google.dns.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers/com.google.dns.lua
@@ -1,0 +1,7 @@
+return {
+	name = "Google",
+	label = _("Google"),
+	url_prefix = "https://dns.google.com/resolve?",
+	bootstrap_dns = "8.8.8.8,8.8.4.4",
+	default = true
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers/sb.dns.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers/sb.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "DNS.SB",
+	label = _("DNS.SB"),
+	url_prefix = "https://doh.dns.sb/dns-query?",
+	bootstrap_dns = "185.222.222.222,185.184.222.222"
+}

--- a/applications/luci-app-https_dns_proxy/luasrc/model/cbi/https_dns_proxy.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/model/cbi/https_dns_proxy.lua
@@ -1,144 +1,118 @@
+local sys = require "luci.sys"
+local util = require "luci.util"
+local fs = require "nixio.fs"
+local dispatcher = require "luci.dispatcher"
+local i18n = require "luci.i18n"
 local uci = require("luci.model.uci").cursor()
-local dispatcher = require("luci.dispatcher")
 
-function uci_del_list(conf, sect, opt, value)
-  local lval = uci:get(conf, sect, opt)
-  if lval == nil or lval == "" then
-    lval = {}
-  elseif type(lval) ~= "table" then
-    lval = { lval }
-  end
+local packageName = "https_dns_proxy"
+local providers_dir = "/usr/lib/lua/luci/" .. packageName .. "/providers/"
 
-  local i
-  local changed = false
-  for i = #lval, 1 do
-    if lval[i] == value then
-      table.remove(lval, i)
-      changed = true
-    end
-  end
-
-  if changed then
-    if #lval > 0 then
-      uci:set(conf, sect, opt, lval)
-    else
-      uci:delete(conf, sect, opt)
-    end
-  end
+function get_provider_name(value)
+	for filename in fs.dir(providers_dir) do
+		local p_func = loadfile(providers_dir .. filename)
+		setfenv(p_func, { _ = i18n.translate })
+		local p = p_func()
+		value = value:gsub('[%p%c%s]', '')
+		p.url_match = p.url_prefix:gsub('[%p%c%s]', '')
+		if value:match(p.url_match) then
+			return p.label
+		end
+	end
+	return translate("Uknown Provider")
 end
 
-function uci_add_list(conf, sect, opt, value)
-  local lval = uci:get(conf, sect, opt)
-  if lval == nil or lval == "" then
-    lval = {}
-  elseif type(lval) ~= "table" then
-    lval = { lval }
-  end
+local tmpfsStatus, tmpfsStatusCode
+local ubusStatus = util.ubus("service", "list", { name = packageName })
+local tmpfsVersion = tostring(util.trim(sys.exec("opkg list-installed " .. packageName .. " | awk '{print $3}'")))
 
-  lval[#lval+1] = value
-  uci:set(conf, sect, opt, lval)
+if not tmpfsVersion or tmpfsVersion == "" then
+	tmpfsStatusCode = -1
+	tmpfsVersion = ""
+	tmpfsStatus = packageName .. " " .. translate("is not installed or not found")
+else  
+	tmpfsVersion = " [" .. packageName .. " " .. tmpfsVersion .. "]"
+	if not ubusStatus or not ubusStatus[packageName] then
+		tmpfsStatusCode = 0
+		tmpfsStatus = translate("Stopped")
+	else
+		tmpfsStatusCode, tmpfsStatus = 1, ""
+		for n = 1,1000 do
+			if ubusStatus and ubusStatus[packageName] and 
+				 ubusStatus[packageName]["instances"] and 
+				 ubusStatus[packageName]["instances"]["instance" .. n] and 
+				 ubusStatus[packageName]["instances"]["instance" .. n]["running"] then
+				local value, k, v, url, url_flag, la, la_flag, lp, lp_flag
+				for k, v in pairs(ubusStatus[packageName]["instances"]["instance" .. n]["command"]) do
+					if la_flag then la, la_flag = v, false end
+					if lp_flag then lp, lp_flag = v, false end
+					if url_flag then url, url_flag = v, false end
+					if v == "-a" then la_flag = true end
+					if v == "-p" then lp_flag = true end
+					if v == "-r" then url_flag = true end
+				end
+				la = la or "127.0.0.1"
+				lp = lp or n + 5053
+				tmpfsStatus = tmpfsStatus .. translate("Running") .. ": " .. get_provider_name(url) .. " " .. translate("DoH") .. " " .. translate("at") .. " " .. la .. ":" .. lp .. "\n"
+			else
+				break
+			end
+		end
+	end
 end
 
-m = Map("https_dns_proxy", translate("HTTPS DNS Proxy Settings"))
-m.template="cbi/map"
+m = Map("https_dns_proxy", translate("DNS over HTTPS Proxy Settings"))
+
+h = m:section(TypedSection, "_dummy", translate("Service Status") .. tmpfsVersion)
+h.template = "cbi/nullsection"
+ss = h:option(DummyValue, "_dummy", translate("Service Status"))
+if tmpfsStatusCode == -1 then
+	ss.template = packageName .. "/status"
+	ss.value = tmpfsStatus
+else
+		if tmpfsStatusCode == 0 then
+			ss.template = packageName .. "/status"
+		else
+			ss.template = packageName .. "/status-textarea"
+		end
+	ss.value = tmpfsStatus
+	buttons = h:option(DummyValue, "_dummy")
+	buttons.template = packageName .. "/buttons"
+end
 
 s3 = m:section(TypedSection, "https_dns_proxy", translate("Instances"), translate("When you add/remove any instances below, they will be used to override the 'DNS forwardings' section of ")
 		.. [[ <a href="]] .. dispatcher.build_url("admin/network/dhcp") .. [[">]]
-    .. translate("DHCP and DNS") .. [[</a>]] .. "."
---    .. "</br>"
---    .. translate("For more information on different options check ")
---		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html#instruction">]]
---    .. "AdGuard.com" .. [[</a>]] .. ", "
---		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
---    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
---		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
---    .. "Quad9.net" .. [[</a>]] .. "."
-    )
+		.. translate("DHCP and DNS") .. [[</a>]] .. ".")
 s3.template = "cbi/tblsection"
 s3.sortable  = false
 s3.anonymous = true
 s3.addremove = true
 
 prov = s3:option(ListValue, "url_prefix", translate("Provider"))
--- prov:value("https://dns.adguard.com/dns-query?", "AdGuard (Standard)")
--- prov:value("https://dns-family.adguard.com/dns-query?", "AdGuard (Family Protection)")
--- prov:value("https://doh.cleanbrowsing.org/doh/security-filter/?ct&", "CleanBrowsing (Security Filter)")
--- prov:value("https://doh.cleanbrowsing.org/doh/family-filter/?ct&", "CleanBrowsing (Family Filter)")
--- prov:value("https://doh.cleanbrowsing.org/doh/adult-filter/?ct&", "CleanBrowsing (Adult Filter)")
-prov:value("https://cloudflare-dns.com/dns-query?ct=application/dns-json&", "Cloudflare")
--- prov:value("https://dns.digitale-gesellschaft.ch/dns-query?", "Digitale Gesellschaft (ch)")
-prov:value("https://doh.dns.sb/dns-query?", "DNS.SB")
-prov:value("https://dns.google.com/resolve?", "Google")
--- prov:value("https://odvr.nic.cz/doh?", "ODVR (nic.cz)")
--- prov:value("https://dns.quad9.net:5053/dns-query?", "Quad9 (Recommended)")
--- prov:value("https://dns9.quad9.net:5053/dns-query?", "Quad9 (Secured)")
--- prov:value("https://dns10.quad9.net:5053/dns-query?", "Quad9 (Unsecured)")
--- prov:value("https://dns11.quad9.net:5053/dns-query?", "Quad9 (Secured with ECS Support)")
-prov.default = "https://dns.google.com/resolve?"
+for filename in fs.dir(providers_dir) do
+	local p_func = loadfile(providers_dir .. filename)
+	setfenv(p_func, { _ = i18n.translate })
+	local p = p_func()
+	prov:value(p.url_prefix, p.label)
+	if p.default then
+		prov.default = p.url_prefix
+	end
+end
 prov.forcewrite = true
 prov.write = function(self, section, value)
-  if not value then return end
-  local n = 0
-  uci:foreach("https_dns_proxy", "https_dns_proxy", function(s)
-      if s[".name"] == section then
-          return false
-      end
-      n = n + 1
-  end)
-  local la_val = la:formvalue(section)
-  local lp_val = lp:formvalue(section)
-  if not la_val or la_val == "" then la_val = "127.0.0.1" end
-  if not lp_val or lp_val == "" then lp_val = n + 5053 end
-  if value:match("dns\.adguard") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "176.103.130.130,176.103.130.131")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://dns.adguard.com/dns-query?ct&")
-  elseif value:match("family\.adguard") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "176.103.130.132,176.103.130.134")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://dns-family.adguard.com/dns-query?ct&")
-  elseif value:match("cleanbrowsing\.org/doh/security") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "185.228.168.168")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://doh.cleanbrowsing.org/doh/security-filter/?ct&")
-  elseif value:match("cleanbrowsing\.org/doh/family") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "185.228.168.168")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://doh.cleanbrowsing.org/doh/family-filter/?ct&")
-  elseif value:match("cleanbrowsing\.org/doh/adult") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "185.228.168.168")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://doh.cleanbrowsing.org/doh/adult-filter/?ct&")
-  elseif value:match("cloudflare") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "1.1.1.1,1.0.0.1")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://cloudflare-dns.com/dns-query?ct=application/dns-json&")
-  elseif value:match("gesellschaft\.ch") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "185.95.218.42,185.95.218.43")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://dns.digitale-gesellschaft.ch/dns-query?")
-  elseif value:match("dns\.sb") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "185.222.222.222,185.184.222.222")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://doh.dns.sb/dns-query?")
-  elseif value:match("google") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "8.8.8.8,8.8.4.4")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://dns.google.com/resolve?")
-  elseif value:match("odvr\.nic\.cz") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "193.17.47.1,185.43.135.1")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://odvr.nic.cz/doh?")
-  elseif value:match("dns\.quad9") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "9.9.9.9,149.112.112.112")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://dns.quad9.net:5053/dns-query?")
-  elseif value:match("dns9\.quad9") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "9.9.9.9,149.112.112.9")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://dns9.quad9.net:5053/dns-query?")
-  elseif value:match("dns10\.quad9") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "9.9.9.10,149.112.112.10")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://dns10.quad9.net:5053/dns-query?")
-  elseif value:match("dns11\.quad9") then
-    uci:set("https_dns_proxy", section, "bootstrap_dns", "9.9.9.11,149.112.112.11")
-    uci:set("https_dns_proxy", section, "url_prefix", "https://dns11.quad9.net:5053/dns-query?")
-  end
-  uci:save("https_dns_proxy")
-  if n == 0 then
-    uci:delete("dhcp", "@dnsmasq[0]", "server")
-  end
-  uci_del_list("dhcp", "@dnsmasq[0]", "server", tostring(la_val) .. "#" .. tostring(lp_val))
-  uci_add_list("dhcp", "@dnsmasq[0]", "server", tostring(la_val) .. "#" .. tostring(lp_val))
-  uci:save("dhcp")
+	if not value then return end
+	for filename in fs.dir(providers_dir) do
+		local p_func = loadfile(providers_dir .. filename)
+		setfenv(p_func, { _ = i18n.translate })
+		local p = p_func()
+		value = value:gsub('[%p%c%s]', '')
+		p.url_match = p.url_prefix:gsub('[%p%c%s]', '')
+		if value:match(p.url_match) then
+			uci:set("https_dns_proxy", section, "bootstrap_dns", p.bootstrap_dns)
+			uci:set("https_dns_proxy", section, "url_prefix", p.url_prefix)
+		end
+	end
+	uci:save("https_dns_proxy")
 end
 
 la = s3:option(Value, "listen_addr", translate("Listen address"))
@@ -148,10 +122,10 @@ la.rmempty     = true
 
 local n = 0
 uci:foreach("https_dns_proxy", "https_dns_proxy", function(s)
-    if s[".name"] == section then
-        return false
-    end
-    n = n + 1
+		if s[".name"] == section then
+				return false
+		end
+		n = n + 1
 end)
 
 lp = s3:option(Value, "listen_port", translate("Listen port"))

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/buttons.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/buttons.htm
@@ -1,0 +1,56 @@
+<%#
+	Copyright 2019 Stan Grishin <stangri@melmac.net>
+-%>
+
+<%-
+	local packageName = "https_dns_proxy"
+	local enabledFlag = luci.sys.init.enabled(packageName)
+	local ubusStatus = luci.util.ubus("service", "list", { name = packageName })
+
+	if not ubusStatus or not ubusStatus[packageName] then
+		tmpfsStatusCode = 0
+	else
+		tmpfsStatusCode = 1
+	end
+
+	if tmpfsStatusCode == 0 then
+		btn_start_style = "cbi-button cbi-button-apply important"
+		btn_action_style = "cbi-button cbi-button-apply important"
+		btn_stop_style = "cbi-button cbi-button-reset -disabled"
+	else
+		btn_start_style = "cbi-button cbi-button-apply -disabled"
+		btn_action_style = "cbi-button cbi-button-apply important"
+		btn_stop_style = "cbi-button cbi-button-reset important"
+	end
+	if not enabledFlag then
+		btn_start_style = "cbi-button cbi-button-apply -disabled"
+		btn_action_style = "cbi-button cbi-button-apply -disabled"
+		btn_enable_style = "cbi-button cbi-button-apply important"
+		btn_disable_style = "cbi-button cbi-button-reset -disabled"
+	else
+		btn_enable_style = "cbi-button cbi-button-apply -disabled"
+		btn_disable_style = "cbi-button cbi-button-reset important"
+	end
+-%>
+
+<%+https_dns_proxy/css%>
+<%+https_dns_proxy/js%>
+
+<div class="cbi-value"><label class="cbi-value-title">Service Control</label>
+	<div class="cbi-value-field">
+		<input type="button" class="<%=btn_start_style%>" id="btn_start" name="start" value="<%:Start%>" onclick="button_action(this)" />
+		<span id="btn_start_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_action_style%>" id="btn_action" name="action" value="<%:Reload%>" onclick="button_action(this)" />
+		<span id="btn_action_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_stop_style%>" id="btn_stop" name="stop" value="<%:Stop%>" onclick="button_action(this)"  />
+		<span id="btn_stop_spinner" class="btn_spinner"></span>
+		&nbsp;
+		&nbsp;
+		&nbsp;
+		&nbsp;
+		<input type="button" class="<%=btn_enable_style%>" id="btn_enable" name="enable" value="<%:Enable%>" onclick="button_action(this)"  />
+		<span id="btn_enable_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_disable_style%>" id="btn_disable" name="disable" value="<%:Disable%>" onclick="button_action(this)"  />
+		<span id="btn_disable_spinner" class="btn_spinner"></span>
+	</div>
+</div>

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/css.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/css.htm
@@ -1,0 +1,9 @@
+<style type="text/css">
+	.btn_spinner
+	{
+		display: inline-block;
+		width: 0px;
+		height: 16px;
+		margin: 0 0px;
+	}
+</style>

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/js.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/js.htm
@@ -1,0 +1,60 @@
+
+<script type="text/javascript">
+//<![CDATA[
+ function button_action(action) {
+	var xhr = new XHR(false);
+	var btn_start = document.getElementById("btn_start");
+	var btn_action = document.getElementById("btn_action");
+	var btn_stop = document.getElementById("btn_stop");
+	var btn_enable = document.getElementById("btn_enable");
+	var btn_disable = document.getElementById("btn_disable");
+	var btn_spinner;
+	switch (action.name) {
+		case "start":
+			btn_spinner = document.getElementById("btn_start_spinner");
+			break;
+		case "action":
+			btn_spinner = document.getElementById("btn_action_spinner");
+			break;
+		case "stop":
+			btn_spinner = document.getElementById("btn_stop_spinner");
+			break;
+		case "enable":
+			btn_spinner = document.getElementById("btn_enable_spinner");
+			break;
+		case "disable":
+			btn_spinner = document.getElementById("btn_disable_spinner");
+			break;
+	}
+	btn_start.disabled = true;
+	btn_action.disabled = true;
+	btn_stop.disabled = true;
+	btn_enable.disabled = true;
+	btn_disable.disabled = true;
+	spinner(btn_spinner, 1);
+	xhr.get('<%=luci.dispatcher.build_url("admin", "services", "https_dns_proxy", "action")%>/' + action.name, null,
+		function (x) {
+			if (!x) {
+				return;
+			}
+			btn_start.disabled = false;
+			btn_action.disabled = false;
+			btn_stop.disabled = false;
+			btn_enable.disabled = false;
+			btn_disable.disabled = false;
+			spinner(btn_spinner, 0);
+			location.reload();
+		 });
+}
+function spinner(element, state) {
+	if (state === 1) {
+		element.style.width = "16px";
+		element.innerHTML = '<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" width="16" height="16" style="vertical-align:middle" />';
+	}
+	else {
+		element.style.width = "0px";
+		element.innerHTML = '';
+	}
+}
+//]]>
+</script>

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/status-textarea.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/status-textarea.htm
@@ -1,0 +1,13 @@
+<%#
+Copyright 2017-2019 Stan Grishin (stangri@melmac.net)
+This is free software, licensed under the Apache License, Version 2.0
+-%>
+
+<%+cbi/valueheader%>
+
+<textarea rows="<%=select(2, self:cfgvalue(section):gsub('\n', ''))%>"
+	style="border:none;box-shadow:none;background:transparent;font-weight:bold;line-height:20px;width:50em;padding:none;margin:6px;resize:none;overflow:hidden;"
+	disabled="disabled"><%=self:cfgvalue(section)%>
+</textarea>
+
+<%+cbi/valuefooter%>

--- a/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/status.htm
+++ b/applications/luci-app-https_dns_proxy/luasrc/view/https_dns_proxy/status.htm
@@ -1,0 +1,10 @@
+<%#
+Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
+This is free software, licensed under the Apache License, Version 2.0
+-%>
+
+<%+cbi/valueheader%>
+
+<input name="status" id="status" type="text" class="cbi-input-text" style="outline:none;border:none;box-shadow:none;background:transparent;font-weight:bold;line-height:30px;height:30px;width:50em;" value="<%=self:cfgvalue(section)%>" disabled="disabled" />
+
+<%+cbi/valuefooter%>


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.net>

As dnsmasq integration is moved to the principal service in https://github.com/openwrt/packages/pull/10413, luci app no longer needs that functionality.
