### PR TITLE
luci-app-statistics: update misleading load view

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/load.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool/definitions/load.lua
@@ -19,9 +19,24 @@ function rrdargs( graph, plugin, plugin_instance, dtype )
 			},
 
 			options = {
-				load__shortterm = { color = "ff0000", title = "1 minute", noarea = true },
-				load__midterm   = { color = "ff6600", title = "5 minutes", noarea = true },
-				load__longterm  = { color = "ffaa00", title = "15 minutes", noarea = true }
+				load__shortterm = {
+					color = "ff0000",
+					title = "1 minute",
+					noarea = true,
+					weight = 3
+				},
+				load__midterm = {
+					color = "ff6600",
+					title = "5 minutes",
+					overlay = true,
+					weight = 1
+				},
+				load__longterm = {
+					color = "ffaa00",
+					title = "15 minutes",
+					overlay = true,
+					weight = 2
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: #3301

During my tests and developing with the collectd and so
luci-app-statistics I noticed that the values displayed in the Y-axis
are misleading, because probably the individual values are added
together in each case. So the view is not corrected.