### PR TITLE
luci-app-advanced-reboot: bugfix: include own copy of applyreboot.htm

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -13,7 +13,7 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=43
+PKG_RELEASE:=44
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
+++ b/applications/luci-app-advanced-reboot/luasrc/controller/advanced_reboot.lua
@@ -169,7 +169,7 @@ function index()
 end
 
 function action_reboot()
-	ltemplate.render("admin_system/applyreboot", {
+	ltemplate.render("advanced_reboot/applyreboot", {
 				title = i18n.translate("Rebooting..."),
 				msg   = i18n.translate("The system is rebooting now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It might be necessary to renew the address of your computer to reach the device again, depending on your settings."),
 				addr  = ip.new(type(ip) == "string" and ip or "192.168.1.1") or "192.168.1.1"
@@ -240,7 +240,7 @@ function action_altreboot()
 			end
 		end
 		if not errorMessage then
-			ltemplate.render("admin_system/applyreboot", {
+			ltemplate.render("advanced_reboot/applyreboot", {
 						title = i18n.translate("Rebooting..."),
 						msg   = i18n.translate("The system is rebooting to an alternative partition now.<br /> DO NOT POWER OFF THE DEVICE!<br /> Wait a few minutes before you try to reconnect. It might be necessary to renew the address of your computer to reach the device again, depending on your settings."),
 						addr  = ip.new(uci:get("network", "lan", "ipaddr")) or "192.168.1.1"
@@ -274,7 +274,7 @@ function action_poweroff()
 			ltemplate.render("advanced_reboot/advanced_reboot",{})
 		end
 	elseif step == 2 then
-		ltemplate.render("admin_system/applyreboot", {
+		ltemplate.render("advanced_reboot/applyreboot", {
 					title = i18n.translate("Shutting down..."),
 					msg   = i18n.translate("The system is shutting down now.<br /> DO NOT POWER OFF THE DEVICE!<br /> It might be necessary to renew the address of your computer to reach the device again, depending on your settings."),
 					addr  = ip.new(uci:get("network", "lan", "ipaddr")) or "192.168.1.1"

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm
@@ -7,8 +7,8 @@
 <html>
 	<head>
 		<title><%=luci.sys.hostname()%> - <%= title or translate("Rebooting...") %></title>
-		<link rel="stylesheet" type="text/css" media="screen" href="<%=media%>/cascade.css" />
-		<script type="text/javascript" src="<%=resource%>/xhr.js"></script>
+		<link rel="stylesheet" type="text/css" media="screen" href="<%=media%>/cascade.css?v=git-19.271.68204-f8775ee" />
+		<script type="text/javascript" src="<%=resource%>/xhr.js?v=git-19.271.68204-f8775ee"></script>
 		<script type="text/javascript">//<![CDATA[
 			var interval = window.setInterval(function() {
 				var img = new Image();


### PR DESCRIPTION
This fixes the luci error when trying to reboot on 19.07 as it no longer has `/usr/lib/lua/luci/view/admin_system/applyreboot.htm`.

Signed-off-by: Stan Grishin <stangri@melmac.net>