### PR TITLE
luci-app-advanced-reboot: bugfix: luci error on reboot, logger errors

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -13,7 +13,7 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=43
+PKG_RELEASE:=45
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm
@@ -7,8 +7,8 @@
 <html>
 	<head>
 		<title><%=luci.sys.hostname()%> - <%= title or translate("Rebooting...") %></title>
-		<link rel="stylesheet" type="text/css" media="screen" href="<%=media%>/cascade.css" />
-		<script type="text/javascript" src="<%=resource%>/xhr.js"></script>
+		<link rel="stylesheet" type="text/css" media="screen" href="<%=media%>/cascade.css?v=git-19.271.68204-f8775ee" />
+		<script type="text/javascript" src="<%=resource%>/xhr.js?v=git-19.271.68204-f8775ee"></script>
 		<script type="text/javascript">//<![CDATA[
 			var interval = window.setInterval(function() {
 				var img = new Image();


### PR DESCRIPTION
This fixes:
1. Luci error on reboot on 19.07.x and master
2. logger errors for compatible NAND devices (when trying to mount alternative partition in order to obtain OpenWrt version information)

Signed-off-by: Stan Grishin <stangri@melmac.net>