### PR TITLE
[18.06] luci-app-advanced-reboot: bugfix: luci error on reboot, logger errors

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -13,7 +13,7 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full
 LUCI_PKGARCH:=all
-PKG_RELEASE:=43
+PKG_RELEASE:=45
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm
+++ b/applications/luci-app-advanced-reboot/luasrc/view/advanced_reboot/applyreboot.htm
@@ -1,0 +1,53 @@
+<%#
+ Copyright 2008 Steven Barth <steven@midlink.org>
+ Copyright 2008 Jo-Philipp Wich <jow@openwrt.org>
+ Licensed to the public under the Apache License 2.0.
+-%>
+
+<html>
+	<head>
+		<title><%=luci.sys.hostname()%> - <%= title or translate("Rebooting...") %></title>
+		<link rel="stylesheet" type="text/css" media="screen" href="<%=media%>/cascade.css?v=git-19.271.68204-f8775ee" />
+		<script type="text/javascript" src="<%=resource%>/xhr.js?v=git-19.271.68204-f8775ee"></script>
+		<script type="text/javascript">//<![CDATA[
+			var interval = window.setInterval(function() {
+				var img = new Image();
+				var target = ('https:' == document.location.protocol ? 'https://' : 'http://') + <%=addr and "'%s'" % addr or "window.location.host"%>;
+		
+				img.onload = function() {
+					window.clearInterval(interval);
+					window.location.replace(target);
+				};
+				
+				img.src = target + '<%=resource%>/icons/loading.gif?' + Math.random();
+				
+			}, 5000);
+		//]]></script>
+	</head>
+	<body>
+		<header>
+			<div class="fill">
+				<div class="container">
+					<p class="brand"><%=luci.sys.hostname() or "?"%></p>
+				</div>
+			</div>
+		</header>
+		&#160;
+		<div class="main">
+			<div id="maincontainer">
+				<div id="maincontent" class="container">
+					<h2 name="content" id="applyreboot-container" ><%:System%> - <%= title or translate("Rebooting...") %></h2>
+					<div class="cbi-section" id="applyreboot-section">
+						<div>
+							<%= msg or translate("Changes applied.") %>
+						</div>
+						<div>
+							<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle" />
+							<%:Waiting for changes to be applied...%>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
This fixes:
1. Luci error on reboot on 19.07.x and master
2. logger errors for compatible NAND devices (when trying to mount alternative partition in order to obtain OpenWrt version information)

Signed-off-by: Stan Grishin <stangri@melmac.net>