### PR TITLE
luci-app-cifsd: enable cifsd app [19.07]

### DIFF
--- a/applications/luci-app-cifsd/Makefile
+++ b/applications/luci-app-cifsd/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Network Shares - CIFSD CIFS/SMB kernel fileserver
-LUCI_DEPENDS:=+cifsd-tools @BROKEN
+LUCI_DEPENDS:=+cifsd-tools
 
 include ../../luci.mk
 

--- a/applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js
+++ b/applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js
@@ -8,14 +8,19 @@ return L.view.extend({
 		return Promise.all([
 			L.resolveDefault(fs.stat('/sbin/block'), null),
 			L.resolveDefault(fs.stat('/etc/config/fstab'), null),
+			L.resolveDefault(fs.exec("cifsd", ["-h"]), {}).then(function(res) { return L.toArray((res.stderr || '').match(/version : (\S+ \S+)/))[1] }),
 		]);
 	},
 	render: function(stats) {
-		var m, s, o;
+		var m, s, o, v;
+		v = '';
 
 		m = new form.Map('cifsd', _('Network Shares'));
 
-		s = m.section(form.TypedSection, 'globals');
+		if (stats[2]) {
+			v = 'Version ' + stats[2].trim();
+		}
+		s = m.section(form.TypedSection, 'globals', 'Cifsd ' + v);
 		s.anonymous = true;
 
 		s.tab('general',  _('General Settings'));
@@ -72,7 +77,7 @@ return L.view.extend({
 		o = s.option(form.Flag, 'guest_ok', _('Allow guests'));
 		o.enabled = 'yes';
 		o.disabled = 'no';
-		o.default = 'no';
+		o.default = 'yes';
 
 		o = s.option(form.Flag, 'inherit_owner', _('Inherit owner'));
 		o.enabled = 'yes';

--- a/applications/luci-app-cifsd/po/bg/cifsd.po
+++ b/applications/luci-app-cifsd/po/bg/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/ca/cifsd.po
+++ b/applications/luci-app-cifsd/po/ca/cifsd.po
@@ -10,90 +10,90 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "Descripció"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr "Nom"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -101,6 +101,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/cs/cifsd.po
+++ b/applications/luci-app-cifsd/po/cs/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/de/cifsd.po
+++ b/applications/luci-app-cifsd/po/de/cifsd.po
@@ -1,85 +1,90 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2019-10-23 09:54+0000\n"
-"Last-Translator: Paul Spooren <mail@aparcar.org>\n"
+"PO-Revision-Date: 2019-11-07 08:28+0000\n"
+"Last-Translator: Kiste <christian.buschau+weblate@mailbox.org>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationscifsd/de/>\n"
 "Language: de\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.9.1-dev\n"
+"X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr "Gastzugang"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr "Legitimierte Benutzer"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr "Durchsuchbar"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr "Berechtigungs-maske für neue Dateien"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "Beschreibung"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr "Verzeichnis-maske"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr "Template bearbeiten"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
+"Bearbeite die Vorlage, die für die Erstellung der cifsd-Konfiguration "
+"verwendet wird."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
-msgstr ""
+msgstr "Root erzwingen"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
-msgstr ""
+msgstr "Dotfiles ausblenden"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr "Besitzer Erben"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr "Schnittstelle"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#, fuzzy
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
+"Nur an die gegebene Schnittstelle binden, wenn nicht spezifiziert an lan "
+"binden"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr "Name"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr "Netzwerk-freigaben"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr "Pfad"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -87,22 +92,26 @@ msgstr ""
 "Bitte fügen Sie Verzeichnisse hinzu, die Sie freigeben möchten. Jedes "
 "Verzeichnis bezieht sich auf einen Ordner auf einem bereitgestellten Gerät."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr "Nur Lesen"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr "Freigegebene Verzeichnisse"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
 msgstr ""
+"Dies ist der Inhalt der Datei '/etc/cifs/smb.conf.template', aus der die "
+"cifsd-Konfiguration generiert wird. Werte, die durch Pipes ('|') "
+"eingeschlossen sind, sollten nicht verändert werden. Sie erhalten ihre Werte "
+"vom Tab 'Allgemeine Einstellungen'."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr "Arbeitsgruppe"

--- a/applications/luci-app-cifsd/po/el/cifsd.po
+++ b/applications/luci-app-cifsd/po/el/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/en/cifsd.po
+++ b/applications/luci-app-cifsd/po/en/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/es/cifsd.po
+++ b/applications/luci-app-cifsd/po/es/cifsd.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2019-10-16 16:58-0300\n"
-"PO-Revision-Date: 2019-10-31 02:45+0000\n"
+"PO-Revision-Date: 2019-11-13 23:05+0000\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationscifsd/es/>\n"
@@ -13,76 +13,76 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr "Permitir invitados"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr "Usuarios permitidos"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr "Navegable"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr "Crear máscara"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "Descripción"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr "Máscara de directorio"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr "Editar plantilla"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
-msgstr ""
+msgstr "Edite la plantilla que se utiliza para generar la configuración cifsd."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr "Forzar Root"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr "Configuración general"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr "Ocultar archivos pequeños"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr "Heredar propietario"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr "Interfaz"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "Escuche solo en la interfaz dada o, si no se especifica, en lan"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr "Nombre"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr "Samba"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr "Ruta"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -90,23 +90,27 @@ msgstr ""
 "Por favor agregue directorios para compartir. Cada directorio hace "
 "referencia a una carpeta en un dispositivo montado."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr "Solo lectura"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr "Directorios compartidos"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
 msgstr ""
+"Este es el contenido del archivo '/etc/cifs/smb.conf.template' desde el cual "
+"se generará su configuración cifsd. Los valores encerrados por símbolos de "
+"tubería ('|') no deben cambiarse. Obtienen sus valores de la pestaña "
+"'Configuración general'."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr "Grupo de trabajo"
 

--- a/applications/luci-app-cifsd/po/fr/cifsd.po
+++ b/applications/luci-app-cifsd/po/fr/cifsd.po
@@ -10,80 +10,80 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr "Autoriser les invités"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr "Utilisateurs autorisés"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 #, fuzzy
 msgid "Browse-able"
 msgstr "Autorisé à parcourir"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr "Créer un masque"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "Description"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr "Masque de répertoire"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr "Modifier le modèle"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 "Modifier le modèle qui est utilisé pour la génération de a configuration de "
 "cifsd."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr "Forcer le Root"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr "Interface"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 "Écoute uniquement l'interface donnée, ou si non spécifiée, le réseau local"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr "Nom"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr "Partages réseau"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr "Chemin"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -91,15 +91,15 @@ msgstr ""
 "Veuillez ajouter des répertoires à partager. Chaque répertoire fait "
 "référence à un dossier sur un périphérique monté."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr "Lecture seule"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr "Répertoires partagés"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -107,6 +107,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr "Groupe de travail"

--- a/applications/luci-app-cifsd/po/he/cifsd.po
+++ b/applications/luci-app-cifsd/po/he/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/hi/cifsd.po
+++ b/applications/luci-app-cifsd/po/hi/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/hu/cifsd.po
+++ b/applications/luci-app-cifsd/po/hu/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/it/cifsd.po
+++ b/applications/luci-app-cifsd/po/it/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/ja/cifsd.po
+++ b/applications/luci-app-cifsd/po/ja/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/ko/cifsd.po
+++ b/applications/luci-app-cifsd/po/ko/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/ms/cifsd.po
+++ b/applications/luci-app-cifsd/po/ms/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/nb_NO/cifsd.po
+++ b/applications/luci-app-cifsd/po/nb_NO/cifsd.po
@@ -10,90 +10,90 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -101,6 +101,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/pl/cifsd.po
+++ b/applications/luci-app-cifsd/po/pl/cifsd.po
@@ -1,100 +1,113 @@
 msgid ""
 msgstr ""
+"PO-Revision-Date: 2019-11-13 21:11+0000\n"
+"Last-Translator: Michal L <michalrmsmi@wp.pl>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscifsd/pl/>\n"
 "Language: pl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
-msgstr ""
+msgstr "Zezwalaj Gościom"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
-msgstr ""
+msgstr "Użytkownicy z prawem dostępu"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
-msgid "Create mask"
-msgstr ""
-
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
-msgid "Description"
-msgstr ""
-
 #: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+msgid "Create mask"
+msgstr "Utwórz maskę"
+
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+msgid "Description"
+msgstr "Opis"
+
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
-msgstr ""
+msgstr "Maska katalogu"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
-msgstr ""
+msgstr "Edytuj szablon"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
-msgstr ""
+msgstr "Edytuj szablon, który jest używany do generowania konfiguracji cifsd."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
-msgstr ""
+msgstr "Ustawienia główne"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
-msgstr ""
+msgstr "Interfejs"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
-msgstr ""
+msgstr "Słuchaj tylko na podanym interfejsie, lub jeśli nie podano na LANie"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
-msgstr ""
+msgstr "Nazwa"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
-msgstr ""
+msgstr "Udziały sieciowe"
+
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+msgid "Path"
+msgstr "Ścieżka"
 
 #: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
-msgid "Path"
-msgstr ""
-
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
+"Proszę dodać katalogi do udostępnienia. Każdy katalog odnosi się do folderu "
+"w zamontowanym urządzeniu."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
-msgstr ""
+msgstr "Tylko do odczytu"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
-msgstr ""
+msgstr "Udostępniane katalogi"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
 "('|') should not be changed. They get their values from the 'General "
 "Settings' tab."
 msgstr ""
+"To jest zawartość pliku '/etc/cifs/smb.conf.template', na podstawie którego "
+"zostanie wygenerowana konfiguracja cifsd. Wartości otoczone symbolem kreski "
+"pionowej ('|') nie powinny być zmieniane. Wartości ich zostaną pobrane z "
+"zakładki \"Ustawienia ogólne\"."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
-msgstr ""
+msgstr "Grupa robocza"

--- a/applications/luci-app-cifsd/po/pt/cifsd.po
+++ b/applications/luci-app-cifsd/po/pt/cifsd.po
@@ -10,76 +10,76 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr "Permitir Convidados"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr "Utilizadores Permitidos"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr "Navegável"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr "Criar máscara"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr "Máscara do diretório"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr "Editar Modelo"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr "Editar o modelo que é usado para gerar a configuração cifsd."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr "Forçar Root"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr "Ocultar ficheiros de ponto"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr "Herdar proprietário"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr "Interface"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "Ouvir apenas na interface indicada ou, se não especificado, na LAN"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr "Nome"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr "Partilhas da Rede"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr "Caminho"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
@@ -87,15 +87,15 @@ msgstr ""
 "Por favor, adicione diretórios para compartilhar. Cada diretório refere-se a "
 "uma pasta num aparelho montado."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr "Apenas Leitura"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr "Directórios Partilhados"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -107,6 +107,6 @@ msgstr ""
 "tubos ('|') não devem ser alterados. Eles obtêm os seus valores da aba "
 "'Configurações Gerais'."
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr "Grupo de trabalho"

--- a/applications/luci-app-cifsd/po/pt_BR/cifsd.po
+++ b/applications/luci-app-cifsd/po/pt_BR/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/ro/cifsd.po
+++ b/applications/luci-app-cifsd/po/ro/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/ru/cifsd.po
+++ b/applications/luci-app-cifsd/po/ru/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/sk/cifsd.po
+++ b/applications/luci-app-cifsd/po/sk/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/sv/cifsd.po
+++ b/applications/luci-app-cifsd/po/sv/cifsd.po
@@ -10,90 +10,90 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr "Tillåt gäster"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr "Tillåtna användare"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr "Skapa mask"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "Beskrivning"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr "Mask för mapp"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr "Redigera mall"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr "Generella inställningar"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr "Gränssnitt"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr "Namn"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr "Nätverksdelningar"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr "Genväg"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr "Endast läsbar"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr "Delade mappar"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -101,6 +101,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr "Arbetsgrupp"

--- a/applications/luci-app-cifsd/po/templates/cifsd.pot
+++ b/applications/luci-app-cifsd/po/templates/cifsd.pot
@@ -1,90 +1,90 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -92,6 +92,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/tr/cifsd.po
+++ b/applications/luci-app-cifsd/po/tr/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/uk/cifsd.po
+++ b/applications/luci-app-cifsd/po/uk/cifsd.po
@@ -11,90 +11,90 @@ msgstr ""
 "4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "Опис"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr "Загальні параметри"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr "Інтерфейс"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr "Ім'я"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -102,6 +102,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/vi/cifsd.po
+++ b/applications/luci-app-cifsd/po/vi/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/po/zh-cn/cifsd.po
+++ b/applications/luci-app-cifsd/po/zh-cn/cifsd.po
@@ -1,101 +1,102 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
-"Language-Team: \n"
+"PO-Revision-Date: 2019-11-13 23:05+0000\n"
+"Last-Translator: Chen Minqiang <ptpt52@gmail.com>\n"
+"Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationscifsd/zh_Hans/>\n"
+"Language: zh-cn\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.4\n"
-"Last-Translator: Richard Yu <yurichard3839@gmail.com>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"Language: zh_CN\n"
+"X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr "允许匿名用户"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr "允许用户"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr "可浏览"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr "创建权限掩码"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr "描述"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr "目录权限掩码"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr "编辑模板"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr "编辑用来生成 cifsd 设置的模板。"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr "强制 Root"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr "基本设置"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr "继承所有者"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr "接口"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr "仅监听指定的接口，未指定则监听 lan"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
-msgstr "共享名"
+msgstr "名称"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr "网络共享"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr "目录"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr "请添加要共享的目录。每个目录指到已挂载设备上的文件夹。"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr "只读"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr "共享目录"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -105,6 +106,6 @@ msgstr ""
 "这是将从其上生成 cifsd 配置的文件“/etc/cifs/smb.conf.template”的内容。由管道"
 "符（“|”）包围的值不应更改。它们将从“常规设置”标签中获取其值。"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr "工作组"

--- a/applications/luci-app-cifsd/po/zh-tw/cifsd.po
+++ b/applications/luci-app-cifsd/po/zh-tw/cifsd.po
@@ -4,90 +4,90 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
 msgid "Allow guests"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:69
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:74
 msgid "Allowed users"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
 msgid "Browse-able"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:84
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
 msgid "Create mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:89
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:94
 msgid "Directory mask"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:22
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
 msgid "Edit Template"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:34
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:39
 msgid "Edit the template that is used for generating the cifsd configuration."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:72
 msgid "Force Root"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:21
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:26
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:87
 msgid "Hide dot files"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:77
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:82
 msgid "Inherit owner"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:24
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:29
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:25
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:30
 msgid "Listen only on the given interface or, if unspecified, on lan"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:56
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:16
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:18
 #: applications/luci-app-cifsd/luasrc/controller/cifsd.lua:10
 msgid "Network Shares"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:57
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:47
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:52
 msgid ""
 "Please add directories to share. Each directory refers to a folder on a "
 "mounted device."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:62
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:67
 msgid "Read-only"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:46
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:51
 msgid "Shared Directories"
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:35
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:40
 msgid ""
 "This is the content of the file '/etc/cifs/smb.conf.template' from which "
 "your cifsd configuration will be generated. Values enclosed by pipe symbols "
@@ -95,6 +95,6 @@ msgid ""
 "Settings' tab."
 msgstr ""
 
-#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:27
+#: applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js:32
 msgid "Workgroup"
 msgstr ""

--- a/applications/luci-app-cifsd/root/usr/share/rpcd/acl.d/luci-app-cifsd.json
+++ b/applications/luci-app-cifsd/root/usr/share/rpcd/acl.d/luci-app-cifsd.json
@@ -3,7 +3,8 @@
 		"description": "Grant access to LuCI app cifsd",
 		"read": {
 			"file": {
-				"/etc/cifs/smb.conf.template": [ "read" ]
+				"/etc/cifs/smb.conf.template": [ "read" ],
+				"/usr/sbin/cifsd": [ "exec" ]
 			}
 		},
 		"write": {


### PR DESCRIPTION
Tested on mips/lantiq with 19.07-master.
The matching backport PR is here: openwrt/packages#10603

PS: Thanks @ysc3839 for the updated .js code!

