### PR TITLE
luci-mod-network: dnsmasq: correct sense & usage of dnsseccheckunsigned

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -134,6 +134,7 @@ return L.view.extend({
 			o = s.taboption('advanced', form.Flag, 'dnsseccheckunsigned',
 				_('DNSSEC check unsigned'),
 				_('Requires upstream supports DNSSEC; verify unsigned domain responses really come from unsigned domains'));
+			o.default = o.enabled;
 			o.optional = true;
 		}
 


### PR DESCRIPTION
dnsmasq v2.80 made 'dnssec-check-unsigned' the default, reflect this in
the gui.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>