### PR TITLE
luci-base: use luasrcdiet from separate package

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -85,7 +85,7 @@ PKG_GITBRANCH?=$(if $(DUMP),x,$(strip $(shell \
 
 PKG_RELEASE?=1
 PKG_INSTALL:=$(if $(realpath src/Makefile),1)
-PKG_BUILD_DEPENDS += lua/host luci-base/host LUCI_CSSTIDY:csstidy/host $(LUCI_BUILD_DEPENDS)
+PKG_BUILD_DEPENDS += lua/host luci-base/host LUCI_CSSTIDY:csstidy/host LUCI_SRCDIET:luasrcdiet/host $(LUCI_BUILD_DEPENDS)
 PKG_CONFIG_DEPENDS += CONFIG_LUCI_SRCDIET CONFIG_LUCI_JSMIN CONFIG_LUCI_CSSTIDY
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -14,13 +14,7 @@ LUCI_BASENAME:=base
 LUCI_TITLE:=LuCI core libraries
 LUCI_DEPENDS:=+lua +luci-lib-nixio +luci-lib-ip +rpcd +libubus-lua +luci-lib-jsonc +liblucihttp-lua +rpcd-mod-file +rpcd-mod-luci +cgi-io
 
-
-PKG_SOURCE:=v1.0.0.tar.gz
-PKG_SOURCE_URL:=https://github.com/jirutka/luasrcdiet/archive/
-PKG_HASH:=48162e63e77d009f5848f18a5cabffbdfc867d0e5e73c6d407f6af5d6880151b
 PKG_LICENSE:=MIT
-
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/luasrcdiet-1.0.0
 
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -41,11 +35,8 @@ endef
 
 define Host/Install
 	$(INSTALL_DIR) $(1)/bin
-	$(INSTALL_DIR) $(1)/lib/lua/5.1
 	$(INSTALL_BIN) src/po2lmo $(1)/bin/po2lmo
 	$(INSTALL_BIN) src/jsmin $(1)/bin/jsmin
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/luasrcdiet $(1)/bin/luasrcdiet
-	$(CP) $(HOST_BUILD_DIR)/luasrcdiet $(1)/lib/lua/5.1/
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
luasrcdiet is being moved to the packages feed as a separate package.
Adjust luci feed accordingly.

See https://github.com/openwrt/packages/pull/10626 for the other half of the move.