### PR TITLE
luci-app-cifsd: fix defaults (none writeable default shares)

### DIFF
--- a/applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js
+++ b/applications/luci-app-cifsd/htdocs/luci-static/resources/view/cifsd.js
@@ -67,7 +67,8 @@ return L.view.extend({
 		o = s.option(form.Flag, 'read_only', _('Read-only'));
 		o.enabled = 'yes';
 		o.disabled = 'no';
-		o.default = 'no';
+		o.default = 'no'; // smb.conf default is 'yes'
+		o.rmempty = false;
 
 		s.option(form.Flag, 'force_root', _('Force Root'));
 
@@ -77,24 +78,30 @@ return L.view.extend({
 		o = s.option(form.Flag, 'guest_ok', _('Allow guests'));
 		o.enabled = 'yes';
 		o.disabled = 'no';
-		o.default = 'yes';
+		o.default = 'yes'; // smb.conf default is 'no'
+		o.rmempty = false;
 
 		o = s.option(form.Flag, 'inherit_owner', _('Inherit owner'));
 		o.enabled = 'yes';
 		o.disabled = 'no';
 		o.default = 'no';
 
-		s.option(form.Flag, 'hide_dot_files', _('Hide dot files'));
+		o = s.option(form.Flag, 'hide_dot_files', _('Hide dot files'));
+		o.enabled = 'yes';
+		o.disabled = 'no';
+		o.default = 'yes';
 
 		o = s.option(form.Value, 'create_mask', _('Create mask'));
-		o.rmempty = true;
 		o.maxlength = 4;
+		o.default = '0666'; // smb.conf default is '0744'
 		o.placeholder = '0666';
+		o.rmempty = false;
 
 		o = s.option(form.Value, 'dir_mask', _('Directory mask'));
-		o.rmempty = true;
 		o.maxlength = 4;
+		o.default = '0777'; // smb.conf default is '0755'
 		o.placeholder = '0777';
+		o.rmempty = false;
 
 		return m.render();
 	}


### PR DESCRIPTION
* align defaults with upstream
* mark our default UCI changes and enforce updates to config