### PR TITLE
luci-app-samba4: fix defaults (none writeable default shares) [19.07]

### DIFF
--- a/applications/luci-app-samba4/htdocs/luci-static/resources/view/samba4.js
+++ b/applications/luci-app-samba4/htdocs/luci-static/resources/view/samba4.js
@@ -86,7 +86,8 @@ return L.view.extend({
 		o = s.option(form.Flag, 'read_only', _('Read-only'));
 		o.enabled = 'yes';
 		o.disabled = 'no';
-		o.default = 'no';
+		o.default = 'no'; // smb.conf default is 'yes'
+		o.rmempty = false;
 
 		s.option(form.Flag, 'force_root', _('Force Root'));
 
@@ -96,7 +97,8 @@ return L.view.extend({
 		o = s.option(form.Flag, 'guest_ok', _('Allow guests'));
 		o.enabled = 'yes';
 		o.disabled = 'no';
-		o.default = 'Yes';
+		o.default = 'yes'; // smb.conf default is 'no'
+		o.rmempty = false;
 
 		o = s.option(form.Flag, 'guest_only', _('Guests only'));
 		o.enabled = 'yes';
@@ -109,14 +111,16 @@ return L.view.extend({
 		o.default = 'no';
 
 		o = s.option(form.Value, 'create_mask', _('Create mask'));
-		o.rmempty = true;
 		o.maxlength = 4;
+		o.default = '0666'; // smb.conf default is '0744'
 		o.placeholder = '0666';
+		o.rmempty = false;
 
 		o = s.option(form.Value, 'dir_mask', _('Directory mask'));
-		o.rmempty = true;
 		o.maxlength = 4;
+		o.default = '0777'; // smb.conf default is '0755'
 		o.placeholder = '0777';
+		o.rmempty = false;
 		
 		o = s.option(form.Value, 'vfs_objects', _('Vfs objects'));
 		o.rmempty = true;


### PR DESCRIPTION
* align defaults with upstream
* mark our default UCI changes and enforce updates to config
