### PR TITLE
luci-app-firewall: update form field titles to indicate port ranges are ok

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
@@ -196,7 +196,7 @@ return L.view.extend({
 			));
 		});
 
-		o = s.taboption('advanced', form.Value, 'src_port', _('Source port'),
+		o = s.taboption('advanced', form.Value, 'src_port', _('Source port(s)'),
 			_('Only match incoming traffic originating from the given source port or port range on the client host'));
 		o.modalonly = true;
 		o.rmempty = true;
@@ -220,7 +220,7 @@ return L.view.extend({
 			));
 		});
 
-		o = s.taboption('general', form.Value, 'src_dport', _('External port'),
+		o = s.taboption('general', form.Value, 'src_dport', _('External port(s)'),
 			_('Match incoming traffic directed at the given destination port or port range on this host'));
 		o.modalonly = true;
 		o.rmempty = false;
@@ -248,7 +248,7 @@ return L.view.extend({
 			));
 		});
 
-		o = s.taboption('general', form.Value, 'dest_port', _('Internal port'),
+		o = s.taboption('general', form.Value, 'dest_port', _('Internal port(s)'),
 			_('Redirect matched incoming traffic to the given port on the internal host'));
 		o.modalonly = true;
 		o.rmempty = true;

--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
@@ -196,7 +196,7 @@ return L.view.extend({
 			));
 		});
 
-		o = s.taboption('advanced', form.Value, 'src_port', _('Source port(s)'),
+		o = s.taboption('advanced', form.Value, 'src_port', _('Source ports'),
 			_('Only match incoming traffic originating from the given source port or port range on the client host'));
 		o.modalonly = true;
 		o.rmempty = true;
@@ -220,7 +220,7 @@ return L.view.extend({
 			));
 		});
 
-		o = s.taboption('general', form.Value, 'src_dport', _('External port(s)'),
+		o = s.taboption('general', form.Value, 'src_dport', _('External ports'),
 			_('Match incoming traffic directed at the given destination port or port range on this host'));
 		o.modalonly = true;
 		o.rmempty = false;
@@ -248,7 +248,7 @@ return L.view.extend({
 			));
 		});
 
-		o = s.taboption('general', form.Value, 'dest_port', _('Internal port(s)'),
+		o = s.taboption('general', form.Value, 'dest_port', _('Internal ports'),
 			_('Redirect matched incoming traffic to the given port on the internal host'));
 		o.modalonly = true;
 		o.rmempty = true;


### PR DESCRIPTION
The Source | Internal | External `Port` form's field titles under Luci `Firewall` -> `Port Forwards` do not make it clear (_unlike in their description_) that port ranges (_instead of just a single port_) are accepted.
Closes https://github.com/openwrt/luci/issues/465

Signed-off-by: Avinash Duduskar <strykar@hotmail.com>