### PR TITLE
luci-theme-bootstrap: fix background of large modal overlays.

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2202,7 +2202,6 @@ div.cbi-value var,
 	background: #fff;
 	box-shadow: 0 0 3px #444;
 	padding: 1em 1em .5em 1em;
-	max-height: 2400px;
 	min-width: 270px;
 }
 


### PR DESCRIPTION
See #3382 for reference.