### PR TITLE
luci-mod-network: Add description field to VLANs (trivial)

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js
@@ -334,6 +334,8 @@ return L.view.extend({
 				return (value || uci.get('network', section_id, 'vlan'));
 			};
 
+			s.option(form.Value, 'description', _('Description'));
+
 			for (var j = 0; Array.isArray(topology.ports) && j < topology.ports.length; j++) {
 				var portspec = topology.ports[j],
 				    portstate = Array.isArray(topology.portstate) ? topology.portstate[portspec.num] : null;


### PR DESCRIPTION
Having a description attached to a VLAN makes identification a lot easier when
dealing with many VLANs

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>