### PR TITLE
luci.mk: move indexcache delete into postinst

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -218,6 +218,7 @@ ifneq ($(LUCI_DEFAULTS),)
 define Package/$(PKG_NAME)/postinst
 [ -n "$${IPKG_INSTROOT}" ] || {$(foreach script,$(LUCI_DEFAULTS),
 	(. /etc/uci-defaults/$(script)) && rm -f /etc/uci-defaults/$(script))
+	rm -f /tmp/luci-indexcache
 	exit 0
 }
 endef


### PR DESCRIPTION
Almost every uci-defaults script for ucitrack execute after the uci
commands the following line '/tmp/luci-indexcache'.
So that we don't always write the same thing, we now do this in
postinst. This was the result from discussion in #3388 .
We still need to remove this line from every uci-defualts script.