### PR TITLE
[18.06] luci-app-https-dns-proxy: package name change, support for RFC8484 binary

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -1,0 +1,17 @@
+# Copyright 2017-2018 Stan Grishin (stangri@melmac.net)
+# This is free software, licensed under the GNU General Public License v3.
+
+include $(TOPDIR)/rules.mk
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
+
+LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
+LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
+LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
+LUCI_PKGARCH:=all
+PKG_RELEASE:=1
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua
@@ -1,0 +1,25 @@
+module("luci.controller.https-dns-proxy", package.seeall)
+function index()
+	if nixio.fs.access("/etc/config/https-dns-proxy") then
+		entry({"admin", "services", "https-dns-proxy"}, cbi("https-dns-proxy"), _("DNS Over HTTPS Proxy"))
+		entry({"admin", "services", "https-dns-proxy", "action"}, call("https_dns_proxy_action"), nil).leaf = true
+	end
+end
+
+function https_dns_proxy_action(name)
+	local packageName = "https-dns-proxy"
+	if name == "start" then
+		luci.sys.init.start(packageName)
+	elseif name == "action" then
+		luci.util.exec("/etc/init.d/" .. packageName .. " reload >/dev/null 2>&1")
+		luci.util.exec("/etc/init.d/dnsmasq restart >/dev/null 2>&1")
+	elseif name == "stop" then
+		luci.sys.init.stop(packageName)
+	elseif name == "enable" then
+		luci.sys.init.enable(packageName)
+	elseif name == "disable" then
+		luci.sys.init.disable(packageName)
+	end
+	luci.http.prepare_content("text/plain")
+	luci.http.write("0")
+end

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "Digitale-Gesellschaft",
+	label = _("Digitale Gesellschaft"),
+	resolver_url = "https://dns.digitale-gesellschaft.ch/dns-query",
+	bootstrap_dns = "185.95.218.42,185.95.218.43"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/cn.rubyfish.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/cn.rubyfish.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "rubyfish.cn",
+	label = _("rubyfish.cn"),
+	resolver_url = "https://dns.rubyfish.cn/dns-query",
+	bootstrap_dns = "118.89.110.78,47.96.179.163"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/sb.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/sb.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "DNS.SB",
+	label = _("DNS.SB"),
+	resolver_url = "https://doh.dns.sb/dns-query",
+	bootstrap_dns = "185.222.222.222,185.184.222.222"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua
@@ -1,0 +1,6 @@
+return {
+	name = "AdGuard-Family",
+	label = _("AdGuard (Family Protection)"),
+	resolver_url = "https://dns-family.adguard.com/dns-query",
+	bootstrap_dns = "176.103.130.132,176.103.130.134"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "AdGuard-Standard",
+	label = _("AdGuard (Standard)"),
+	resolver_url = "https://dns.adguard.com/dns-query",
+	bootstrap_dns = "176.103.130.130,176.103.130.131"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "Cloudflare",
+	label = _("Cloudflare"),
+	resolver_url = "https://cloudflare-dns.com/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua
@@ -1,0 +1,6 @@
+return {
+	name = "odvr-nic-cz",
+	label = _("ODVR (nic.cz)"),
+	resolver_url = "https://odvr.nic.cz/doh",
+	bootstrap_dns = "193.17.47.1,185.43.135.1"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua
@@ -1,0 +1,7 @@
+return {
+	name = "Google",
+	label = _("Google"),
+	resolver_url = "https://dns.google/dns-query",
+	bootstrap_dns = "8.8.8.8,8.8.4.4",
+	default = true
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "Quad9-Recommended",
+	label = _("Quad 9 (Recommended)"),
+	resolver_url = "https://dns.quad9.net/dns-query",
+	bootstrap_dns = "9.9.9.9,149.112.112.112"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua
@@ -1,0 +1,6 @@
+return {
+	name = "Quad9-Unsecured",
+	label = _("Quad 9 (Unsecured)"),
+	resolver_url = "https://dns10.quad9.net/dns-query",
+	bootstrap_dns = "9.9.9.10,149.112.112.10"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua
@@ -1,0 +1,6 @@
+return {
+	name = "Quad9-ECS",
+	label = _("Quad 9 (Secured with ECS Support)"),
+	resolver_url = "https://dns11.quad9.net/dns-query",
+	bootstrap_dns = "9.9.9.11,149.112.112.11"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua
@@ -1,0 +1,6 @@
+return {
+	name = "Quad9-Secured",
+	label = _("Quad 9 (Secured)"),
+	resolver_url = "https://dns9.quad9.net/dns-query",
+	bootstrap_dns = "9.9.9.9,149.112.112.9"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua
@@ -1,0 +1,6 @@
+return {
+	name = "CleanBrowsing-Adult",
+	label = _("CleanBrowsing (Adult Filter)"),
+	resolver_url = "https://doh.cleanbrowsing.org/doh/adult-filter/",
+	bootstrap_dns = "185.228.168.168"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua
@@ -1,0 +1,6 @@
+return {
+	name = "CleanBrowsing-Family",
+	label = _("CleanBrowsing (Family Filter)"),
+	resolver_url = "https://doh.cleanbrowsing.org/doh/family-filter/",
+	bootstrap_dns = "185.228.168.168"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua
@@ -1,0 +1,6 @@
+return {
+	name = "CleanBrowsing-Security",
+	label = _("CleanBrowsing (Security Filter)"),
+	resolver_url = "https://doh.cleanbrowsing.org/doh/security-filter/",
+	bootstrap_dns = "185.228.168.168"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -1,0 +1,149 @@
+local sys = require "luci.sys"
+local util = require "luci.util"
+local fs = require "nixio.fs"
+local dispatcher = require "luci.dispatcher"
+local i18n = require "luci.i18n"
+local uci = require("luci.model.uci").cursor()
+
+local packageName = "https-dns-proxy"
+local providers_dir = "/usr/lib/lua/luci/" .. packageName .. "/providers/"
+
+function get_provider_name(value)
+	for filename in fs.dir(providers_dir) do
+		local p_func = loadfile(providers_dir .. filename)
+		setfenv(p_func, { _ = i18n.translate })
+		local p = p_func()
+		value = value:gsub('[%p%c%s]', '')
+		p.url_match = p.resolver_url:gsub('[%p%c%s]', '')
+		if value:match(p.url_match) then
+			return p.label
+		end
+	end
+	return translate("Uknown Provider")
+end
+
+local tmpfsStatus, tmpfsStatusCode
+local ubusStatus = util.ubus("service", "list", { name = packageName })
+local tmpfsVersion = tostring(util.trim(sys.exec("opkg list-installed " .. packageName .. " | awk '{print $3}'")))
+
+if not tmpfsVersion or tmpfsVersion == "" then
+	tmpfsStatusCode = -1
+	tmpfsVersion = ""
+	tmpfsStatus = packageName .. " " .. translate("is not installed or not found")
+else  
+	tmpfsVersion = " [" .. packageName .. " " .. tmpfsVersion .. "]"
+	if not ubusStatus or not ubusStatus[packageName] then
+		tmpfsStatusCode = 0
+		tmpfsStatus = translate("Stopped")
+	else
+		tmpfsStatusCode, tmpfsStatus = 1, ""
+		for n = 1,1000 do
+			if ubusStatus and ubusStatus[packageName] and 
+				 ubusStatus[packageName]["instances"] and 
+				 ubusStatus[packageName]["instances"]["instance" .. n] and 
+				 ubusStatus[packageName]["instances"]["instance" .. n]["running"] then
+				local value, k, v, url, url_flag, la, la_flag, lp, lp_flag
+				for k, v in pairs(ubusStatus[packageName]["instances"]["instance" .. n]["command"]) do
+					if la_flag then la, la_flag = v, false end
+					if lp_flag then lp, lp_flag = v, false end
+					if url_flag then url, url_flag = v, false end
+					if v == "-a" then la_flag = true end
+					if v == "-p" then lp_flag = true end
+					if v == "-r" then url_flag = true end
+				end
+				la = la or "127.0.0.1"
+				lp = lp or n + 5053
+				tmpfsStatus = tmpfsStatus .. translate("Running") .. ": " .. get_provider_name(url) .. " " .. translate("DoH") .. " " .. translate("at") .. " " .. la .. ":" .. lp .. "\n"
+			else
+				break
+			end
+		end
+	end
+end
+
+m = Map("https-dns-proxy", translate("DNS Over HTTPS Proxy Settings"))
+
+h = m:section(TypedSection, "_dummy", translate("Service Status") .. tmpfsVersion)
+h.template = "cbi/nullsection"
+ss = h:option(DummyValue, "_dummy", translate("Service Status"))
+if tmpfsStatusCode == -1 then
+	ss.template = packageName .. "/status"
+	ss.value = tmpfsStatus
+else
+		if tmpfsStatusCode == 0 then
+			ss.template = packageName .. "/status"
+		else
+			ss.template = packageName .. "/status-textarea"
+		end
+	ss.value = tmpfsStatus
+	buttons = h:option(DummyValue, "_dummy")
+	buttons.template = packageName .. "/buttons"
+end
+
+s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), translate("When you add/remove any instances below, they will be used to override the 'DNS forwardings' section of ")
+		.. [[ <a href="]] .. dispatcher.build_url("admin/network/dhcp") .. [[">]]
+		.. translate("DHCP and DNS") .. [[</a>]] .. "."
+    .. "<br />"
+    .. translate("For more information on different options check ")
+		.. [[ <a href="https://adguard.com/en/adguard-dns/overview.html">]]
+    .. "AdGuard.com" .. [[</a>]] .. ", "
+		.. [[ <a href="https://cleanbrowsing.org/guides/dnsoverhttps">]]
+    .. "CleanBrowsing.org" .. [[</a>]] .. " " .. translate("and") .. " "
+		.. [[ <a href="https://www.quad9.net/doh-quad9-dns-servers/">]]
+    .. "Quad9.net" .. [[</a>]] .. ".")
+s3.template = "cbi/tblsection"
+s3.sortable  = false
+s3.anonymous = true
+s3.addremove = true
+
+prov = s3:option(ListValue, "resolver_url", translate("Resolver"))
+for filename in fs.dir(providers_dir) do
+	local p_func = loadfile(providers_dir .. filename)
+	setfenv(p_func, { _ = i18n.translate })
+	local p = p_func()
+	prov:value(p.resolver_url, p.label)
+	if p.default then
+		prov.default = p.resolver_url
+	end
+end
+prov.forcewrite = true
+prov.write = function(self, section, value)
+	if not value then return end
+	for filename in fs.dir(providers_dir) do
+		local p_func = loadfile(providers_dir .. filename)
+		setfenv(p_func, { _ = i18n.translate })
+		local p = p_func()
+		value = value:gsub('[%p%c%s]', '')
+		p.url_match = p.resolver_url:gsub('[%p%c%s]', '')
+		if value:match(p.url_match) then
+			uci:set(packageName, section, "bootstrap_dns", p.bootstrap_dns)
+			uci:set(packageName, section, "resolver_url", p.resolver_url)
+		end
+	end
+	uci:save(packageName)
+end
+
+la = s3:option(Value, "listen_addr", translate("Listen address"))
+la.datatype    = "host"
+la.placeholder = "127.0.0.1"
+la.rmempty     = true
+
+local n = 0
+uci:foreach(packageName, packageName, function(s)
+		if s[".name"] == section then
+				return false
+		end
+		n = n + 1
+end)
+
+lp = s3:option(Value, "listen_port", translate("Listen port"))
+lp.datatype = "port"
+lp.value    = n + 5053
+
+sa = s3:option(Value, "edns_subnet", translate("EDNS client subnet"))
+sa.rmempty  = true
+
+ps = s3:option(Value, "proxy_server", translate("Proxy server"))
+ps.rmempty  = true
+
+return m

--- a/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm
+++ b/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm
@@ -1,0 +1,56 @@
+<%#
+	Copyright 2019 Stan Grishin <stangri@melmac.net>
+-%>
+
+<%-
+	local packageName = "https-dns-proxy"
+	local enabledFlag = luci.sys.init.enabled(packageName)
+	local ubusStatus = luci.util.ubus("service", "list", { name = packageName })
+
+	if not ubusStatus or not ubusStatus[packageName] then
+		tmpfsStatusCode = 0
+	else
+		tmpfsStatusCode = 1
+	end
+
+	if tmpfsStatusCode == 0 then
+		btn_start_style = "cbi-button cbi-button-apply important"
+		btn_action_style = "cbi-button cbi-button-apply important"
+		btn_stop_style = "cbi-button cbi-button-reset -disabled"
+	else
+		btn_start_style = "cbi-button cbi-button-apply -disabled"
+		btn_action_style = "cbi-button cbi-button-apply important"
+		btn_stop_style = "cbi-button cbi-button-reset important"
+	end
+	if not enabledFlag then
+		btn_start_style = "cbi-button cbi-button-apply -disabled"
+		btn_action_style = "cbi-button cbi-button-apply -disabled"
+		btn_enable_style = "cbi-button cbi-button-apply important"
+		btn_disable_style = "cbi-button cbi-button-reset -disabled"
+	else
+		btn_enable_style = "cbi-button cbi-button-apply -disabled"
+		btn_disable_style = "cbi-button cbi-button-reset important"
+	end
+-%>
+
+<%+https-dns-proxy/css%>
+<%+https-dns-proxy/js%>
+
+<div class="cbi-value"><label class="cbi-value-title">Service Control</label>
+	<div class="cbi-value-field">
+		<input type="button" class="<%=btn_start_style%>" id="btn_start" name="start" value="<%:Start%>" onclick="button_action(this)" />
+		<span id="btn_start_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_action_style%>" id="btn_action" name="action" value="<%:Reload%>" onclick="button_action(this)" />
+		<span id="btn_action_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_stop_style%>" id="btn_stop" name="stop" value="<%:Stop%>" onclick="button_action(this)"  />
+		<span id="btn_stop_spinner" class="btn_spinner"></span>
+		&nbsp;
+		&nbsp;
+		&nbsp;
+		&nbsp;
+		<input type="button" class="<%=btn_enable_style%>" id="btn_enable" name="enable" value="<%:Enable%>" onclick="button_action(this)"  />
+		<span id="btn_enable_spinner" class="btn_spinner"></span>
+		<input type="button" class="<%=btn_disable_style%>" id="btn_disable" name="disable" value="<%:Disable%>" onclick="button_action(this)"  />
+		<span id="btn_disable_spinner" class="btn_spinner"></span>
+	</div>
+</div>

--- a/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/css.htm
+++ b/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/css.htm
@@ -1,0 +1,9 @@
+<style type="text/css">
+	.btn_spinner
+	{
+		display: inline-block;
+		width: 0px;
+		height: 16px;
+		margin: 0 0px;
+	}
+</style>

--- a/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/js.htm
+++ b/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/js.htm
@@ -1,0 +1,60 @@
+
+<script type="text/javascript">
+//<![CDATA[
+ function button_action(action) {
+	var xhr = new XHR(false);
+	var btn_start = document.getElementById("btn_start");
+	var btn_action = document.getElementById("btn_action");
+	var btn_stop = document.getElementById("btn_stop");
+	var btn_enable = document.getElementById("btn_enable");
+	var btn_disable = document.getElementById("btn_disable");
+	var btn_spinner;
+	switch (action.name) {
+		case "start":
+			btn_spinner = document.getElementById("btn_start_spinner");
+			break;
+		case "action":
+			btn_spinner = document.getElementById("btn_action_spinner");
+			break;
+		case "stop":
+			btn_spinner = document.getElementById("btn_stop_spinner");
+			break;
+		case "enable":
+			btn_spinner = document.getElementById("btn_enable_spinner");
+			break;
+		case "disable":
+			btn_spinner = document.getElementById("btn_disable_spinner");
+			break;
+	}
+	btn_start.disabled = true;
+	btn_action.disabled = true;
+	btn_stop.disabled = true;
+	btn_enable.disabled = true;
+	btn_disable.disabled = true;
+	spinner(btn_spinner, 1);
+	xhr.get('<%=luci.dispatcher.build_url("admin", "services", "https-dns-proxy", "action")%>/' + action.name, null,
+		function (x) {
+			if (!x) {
+				return;
+			}
+			btn_start.disabled = false;
+			btn_action.disabled = false;
+			btn_stop.disabled = false;
+			btn_enable.disabled = false;
+			btn_disable.disabled = false;
+			spinner(btn_spinner, 0);
+			location.reload();
+		 });
+}
+function spinner(element, state) {
+	if (state === 1) {
+		element.style.width = "16px";
+		element.innerHTML = '<img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" width="16" height="16" style="vertical-align:middle" />';
+	}
+	else {
+		element.style.width = "0px";
+		element.innerHTML = '';
+	}
+}
+//]]>
+</script>

--- a/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/status-textarea.htm
+++ b/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/status-textarea.htm
@@ -1,0 +1,13 @@
+<%#
+Copyright 2017-2019 Stan Grishin (stangri@melmac.net)
+This is free software, licensed under the Apache License, Version 2.0
+-%>
+
+<%+cbi/valueheader%>
+
+<textarea rows="<%=select(2, self:cfgvalue(section):gsub('\n', ''))%>"
+	style="border:none;box-shadow:none;background:transparent;font-weight:bold;line-height:20px;width:50em;padding:none;margin:6px;resize:none;overflow:hidden;"
+	disabled="disabled"><%=self:cfgvalue(section)%>
+</textarea>
+
+<%+cbi/valuefooter%>

--- a/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/status.htm
+++ b/applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/status.htm
@@ -1,0 +1,10 @@
+<%#
+Copyright 2017-2018 Dirk Brenken (dev@brenken.org)
+This is free software, licensed under the Apache License, Version 2.0
+-%>
+
+<%+cbi/valueheader%>
+
+<input name="status" id="status" type="text" class="cbi-input-text" style="outline:none;border:none;box-shadow:none;background:transparent;font-weight:bold;line-height:30px;height:30px;width:50em;" value="<%=self:cfgvalue(section)%>" disabled="disabled" />
+
+<%+cbi/valuefooter%>

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,0 +1,165 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua:3
+msgid "AdGuard (Family Protection)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua:3
+msgid "AdGuard (Standard)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua:3
+msgid "CleanBrowsing (Adult Filter)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua:3
+msgid "CleanBrowsing (Family Filter)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua:3
+msgid "CleanBrowsing (Security Filter)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.lua:3
+msgid "Cloudflare"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:85
+msgid "DHCP and DNS"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
+msgid "DNS Over HTTPS Proxy"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:64
+msgid "DNS Over HTTPS Proxy Settings"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/sb.dns.lua:3
+msgid "DNS.SB"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua:3
+msgid "Digitale Gesellschaft"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:53
+msgid "Disable"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:56
+msgid "DoH"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:143
+msgid "EDNS client subnet"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:51
+msgid "Enable"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:87
+msgid "For more information on different options check"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua:3
+msgid "Google"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:83
+msgid "Instances"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:126
+msgid "Listen address"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:139
+msgid "Listen port"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/js.htm:52
+msgid "Loading"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua:3
+msgid "ODVR (nic.cz)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:146
+msgid "Proxy server"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua:3
+msgid "Quad 9 (Recommended)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua:3
+msgid "Quad 9 (Secured with ECS Support)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua:3
+msgid "Quad 9 (Secured)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua:3
+msgid "Quad 9 (Unsecured)"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:43
+msgid "Reload"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:99
+msgid "Resolver"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:56
+msgid "Running"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:66
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:68
+msgid "Service Status"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:41
+msgid "Start"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:45
+msgid "Stop"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:37
+msgid "Stopped"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:22
+msgid "Uknown Provider"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:83
+msgid ""
+"When you add/remove any instances below, they will be used to override the "
+"'DNS forwardings' section of"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:91
+msgid "and"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:56
+msgid "at"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:32
+msgid "is not installed or not found"
+msgstr ""
+
+#: luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/cn.rubyfish.dns.lua:3
+msgid "rubyfish.cn"
+msgstr ""

--- a/applications/luci-app-https-dns-proxy/root/etc/uci-defaults/40_luci-https-dns-proxy
+++ b/applications/luci-app-https-dns-proxy/root/etc/uci-defaults/40_luci-https-dns-proxy
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -rf /var/luci-modulecache/; rm -f /var/luci-indexcache;
+exit 0


### PR DESCRIPTION
This luci app supports the new RFC8484-compatible package and more resolvers.

Depends on https://github.com/openwrt/packages/pull/10752.

Signed-off-by: Stan Grishin <stangri@melmac.net>