### PR TITLE
luci-app-https_dns_proxy:add rubyfish.cn DOH servise in china

### DIFF
--- a/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers/cn.rubyfish.lua
+++ b/applications/luci-app-https_dns_proxy/luasrc/https_dns_proxy/providers/cn.rubyfish.lua
@@ -1,0 +1,6 @@
+return {
+	name = "rubyfish.cn",
+	label = _("rubyfish.cn"),
+	url_prefix = "https://dns.rubyfish.cn/dns-query?",
+	bootstrap_dns = "118.89.110.78,47.96.179.163"
+}


### PR DESCRIPTION
luci-app-https_dns_proxy:add rubyfish.cn DOH servise in china