### PR TITLE
luci-app-mwan3: minor fixes for httping selection

### DIFF
--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua
@@ -87,8 +87,6 @@ size:value("1016")
 size:value("1472")
 size:value("2040")
 size.datatype = "range(1, 65507)"
-size.rmempty = false
-size.optional = false
 
 max_ttl = mwan_interface:option(Value, "max_ttl", translate("Max TTL"))
 max_ttl.default = "60"

--- a/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua
+++ b/applications/luci-app-mwan3/luasrc/model/cbi/mwan/interfaceconfig.lua
@@ -59,6 +59,7 @@ end
 httping_ssl = mwan_interface:option(Flag, "httping_ssl", translate("Enable ssl tracking"),
 	translate("Enables https tracking on ssl port 443"))
 httping_ssl:depends("track_method", "httping")
+httping_ssl.rmempty = false
 httping_ssl.default = httping_ssl.enabled
 
 reliability = mwan_interface:option(Value, "reliability", translate("Tracking reliability"),


### PR DESCRIPTION
* Always write **httping_ssl** configuration parameter into the config.    

* If **rmempty** and **optional** not removed for the size configuration option, then httping cannot be selected as the tracking method. The field size is a must field for ping but it is not displayed because httping does not need it.