### PR TITLE
luci-base: fix typos

### DIFF
--- a/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/dhcp.lua
+++ b/modules/luci-mod-admin-mini/luasrc/model/cbi/mini/dhcp.lua
@@ -71,7 +71,7 @@ if leases then
 	end
 	ip = v:option(DummyValue, 3, translate("<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Address"))
 	mac  = v:option(DummyValue, 2, translate("<abbr title=\"Media Access Control\">MAC</abbr>-Address"))
-	ltime = v:option(DummyValue, 1, translate("Leasetime remaining"))
+	ltime = v:option(DummyValue, 1, translate("Lease time remaining"))
 	function ltime.cfgvalue(self, ...)
 		local value = DummyValue.cfgvalue(self, ...)
 		return wa.date_format(os.difftime(tonumber(value), os.time()))

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -52,7 +52,7 @@ CBILease6Status = form.DummyValue.extend({
 					E('div', { 'class': 'th' }, _('Host')),
 					E('div', { 'class': 'th' }, _('IPv6-Address')),
 					E('div', { 'class': 'th' }, _('DUID')),
-					E('div', { 'class': 'th' }, _('Leasetime remaining'))
+					E('div', { 'class': 'th' }, _('Lease time remaining'))
 				]),
 				E('div', { 'class': 'tr placeholder' }, [
 					E('div', { 'class': 'td' }, E('em', _('Collecting data...')))

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -28,7 +28,7 @@ return L.Class.extend({
 				E('div', { 'class': 'th' }, _('Hostname')),
 				E('div', { 'class': 'th' }, _('IPv4-Address')),
 				E('div', { 'class': 'th' }, _('MAC-Address')),
-				E('div', { 'class': 'th' }, _('Leasetime remaining'))
+				E('div', { 'class': 'th' }, _('Lease time remaining'))
 			])
 		]);
 
@@ -55,7 +55,7 @@ return L.Class.extend({
 				E('div', { 'class': 'th' }, _('Host')),
 				E('div', { 'class': 'th' }, _('IPv6-Address')),
 				E('div', { 'class': 'th' }, _('DUID')),
-				E('div', { 'class': 'th' }, _('Leasetime remaining'))
+				E('div', { 'class': 'th' }, _('Lease time remaining'))
 			])
 		]);
 


### PR DESCRIPTION
There are both *Leasetime remaining* and *Lease time remaining* entries in the language files, so no need to modify the PO files.
