### PR TITLE
luci-app-fwknopd: fix typos

### DIFF
--- a/applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua
+++ b/applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua
@@ -14,22 +14,22 @@ qr = s:option(DummyValue, "note0", "dummy")
 qr.tmp = tmp
 qr.template = "fwknopd-qr"
 qr:depends("uci_enabled", "1")
-s:option(Value, "SOURCE", "SOURCE", translate("Use ANY for any source ip"))
+s:option(Value, "SOURCE", "SOURCE", translate("Use ANY for any source IP"))
 k1 = s:option(Value, "KEY", "KEY", translate("Define the symmetric key used for decrypting an incoming SPA packet that is encrypted by the fwknop client with Rijndael."))
 k1:depends("keytype", translate("Normal Key"))
 k2 = s:option(Value, "KEY_BASE64", "KEY_BASE64", translate("Define the symmetric key used for decrypting an incoming SPA \
 						packet that is encrypted by the fwknop client with Rijndael."))
-k2:depends("keytype", translate("Base 64 key"))
+k2:depends("keytype", translate("Base64 key"))
 l1 = s:option(ListValue, "keytype", "Key type")
 l1:value("Normal Key", "Normal Key")
-l1:value("Base 64 key", "Base 64 key")
+l1:value("Base64 key", "Base64 key")
 k3 = s:option(Value, "HMAC_KEY", "HMAC_KEY", "The hmac key")
 k3:depends("hkeytype", "Normal Key")
 k4 = s:option(Value, "HMAC_KEY_BASE64", "HMAC_KEY_BASE64", translate("The base64 hmac key"))
-k4:depends("hkeytype", "Base 64 key")
+k4:depends("hkeytype", "Base64 key")
 l2 = s:option(ListValue, "hkeytype", "HMAC Key type")
 l2:value("Normal Key", "Normal Key")
-l2:value("Base 64 key", "Base 64 key")
+l2:value("Base64 key", "Base64 key")
 s:option(Value, "OPEN_PORTS", "OPEN_PORTS", translate("Define a set of ports and protocols (tcp or udp) that will be opened if a valid knock sequence is seen. \
 					If this entry is not set, fwknopd will attempt to honor any proto/port request specified in the SPA data \
 					(unless of it matches any “RESTRICT_PORTS” entries). Multiple entries are comma-separated."))
@@ -43,7 +43,7 @@ s:option(Value, "REQUIRE_SOURCE_ADDRESS", "REQUIRE_SOURCE_ADDRESS", translate("F
 
 s = m:section(TypedSection, "config", translate("fwknopd.conf config options")) 
 s.anonymous=true
-s:option(Value, "MAX_SPA_PACKET_AGE", "MAX_SPA_PACKET_AGE", translate("Maximum age in seconds that an SPA packet will be accepted. defaults to 120 seconds"))
+s:option(Value, "MAX_SPA_PACKET_AGE", "MAX_SPA_PACKET_AGE", translate("Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 seconds."))
 s:option(Value, "PCAP_INTF", "PCAP_INTF", translate("Specify the ethernet interface on which fwknopd will sniff packets."))
 s:option(Value, "ENABLE_IPT_FORWARDING", "ENABLE_IPT_FORWARDING", translate("Allow SPA clients to request access to services through an iptables firewall instead of just to it."))
 s:option(Value, "ENABLE_NAT_DNS", "ENABLE_NAT_DNS", translate("Allow SPA clients to request forwarding destination by DNS name."))

--- a/applications/luci-app-fwknopd/po/bg/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/bg/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/ca/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/ca/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/cs/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/cs/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/de/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/de/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/el/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/el/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/en/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/en/fwknopd.po
@@ -23,8 +23,8 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
-msgstr "Base 64 key"
+msgid "Base64 key"
+msgstr "Base64 key"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
 msgid ""
@@ -91,11 +91,11 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
 msgid "Normal Key"
@@ -110,8 +110,8 @@ msgid "The base64 hmac key"
 msgstr "The base64 hmac key"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
-msgstr "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
+msgstr "Use ANY for any source IP"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8
 msgid ""

--- a/applications/luci-app-fwknopd/po/es/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/es/fwknopd.po
@@ -27,7 +27,7 @@ msgstr ""
 "Permitir que los clientes SPA soliciten el destino de reenvío por nombre DNS."
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr "Llave base 64"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -98,8 +98,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 "Edad máxima en segundos que se aceptará un paquete de SPA. De manera "
 "predeterminada a 120 segundos"
@@ -118,7 +118,7 @@ msgid "The base64 hmac key"
 msgstr "La clave hmac base64"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr "Use CUALQUIERA para cualquier fuente ip"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/fr/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/fr/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/he/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/he/fwknopd.po
@@ -22,7 +22,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -75,8 +75,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -92,7 +92,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/hi/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/hi/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/hu/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/hu/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/it/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/it/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/ja/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/ja/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/ko/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/ko/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/mr/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/mr/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/ms/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/ms/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/nb_NO/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/nb_NO/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/pl/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/pl/fwknopd.po
@@ -24,8 +24,8 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
-msgstr "Klucz Base 64"
+msgid "Base64 key"
+msgstr "Klucz Base64"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
 msgid ""
@@ -77,8 +77,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -94,7 +94,7 @@ msgid "The base64 hmac key"
 msgstr "Klucz HMAC Base64"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/pt-br/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/pt-br/fwknopd.po
@@ -27,7 +27,7 @@ msgstr ""
 "Permitir que clientes SPA requeiram encaminhamento de destinos por nome DNS."
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr "Chave em formato base64"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -96,8 +96,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 "Idade máxima, em segundos, que um pacote SPA será aceito. O padrão é de 120 "
 "segundos"
@@ -116,7 +116,7 @@ msgid "The base64 hmac key"
 msgstr "A chave de autenticação HMAC em formato base64"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr "Use \"ANY\" para qualquer endereço IP de origem"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/pt/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/pt/fwknopd.po
@@ -27,7 +27,7 @@ msgstr ""
 "nome de DNS."
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr "Chave da base 64"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -97,8 +97,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 "Idade máxima em segundos que um pacote SPA será aceite. Predefinido a 120 "
 "segundos"
@@ -116,7 +116,7 @@ msgid "The base64 hmac key"
 msgstr "A chave hmac base64"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr "Use qualquer um (ANY) para qualquer fonte ip"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/ro/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/ro/fwknopd.po
@@ -22,7 +22,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -75,8 +75,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -92,7 +92,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/ru/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/ru/fwknopd.po
@@ -29,7 +29,7 @@ msgstr ""
 "Разрешить SPA клиентам запрашивать направление переадресации по DNS-имени."
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr "64-битный ключ"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -100,8 +100,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 "Максимальное время в секундах, в течение которых будет принят SPA пакет, по "
 "умолчанию 120 секунд."
@@ -119,7 +119,7 @@ msgid "The base64 hmac key"
 msgstr "Ключ Base64 HMAC."
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr "Использовать ЛЮБОЙ, для любого исходящего IP."
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/sk/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/sk/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/sv/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/sv/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/tr/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/tr/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/uk/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/uk/fwknopd.po
@@ -22,7 +22,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -75,8 +75,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -92,7 +92,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/vi/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/vi/fwknopd.po
@@ -21,7 +21,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -74,8 +74,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -91,7 +91,7 @@ msgid "The base64 hmac key"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/zh-cn/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/zh-cn/fwknopd.po
@@ -22,7 +22,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr "允许 SPA 客户端用 DNS 名称请求转发目标。"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr "Base64 密钥"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -84,8 +84,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr "SPA 数据包的最大可接受年龄（秒）。默认为 120 秒"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -101,7 +101,7 @@ msgid "The base64 hmac key"
 msgstr "base64 hmac 密钥"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr "对任何源 IP 使用 ANY"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/po/zh-tw/fwknopd.po
+++ b/applications/luci-app-fwknopd/po/zh-tw/fwknopd.po
@@ -22,7 +22,7 @@ msgid "Allow SPA clients to request forwarding destination by DNS name."
 msgstr "允許 SPA 客戶端用 DNS 名稱請求轉發目標。"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:22
-msgid "Base 64 key"
+msgid "Base64 key"
 msgstr "Base64 金鑰"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:33
@@ -84,8 +84,8 @@ msgstr ""
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:46
 msgid ""
-"Maximum age in seconds that an SPA packet will be accepted. defaults to 120 "
-"seconds"
+"Maximum age in seconds that an SPA packet will be accepted. Defaults to 120 "
+"seconds."
 msgstr "SPA 資料包的最大可接受年齡（秒）。預設為 120 秒"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:19
@@ -101,7 +101,7 @@ msgid "The base64 hmac key"
 msgstr "base64 hmac 金鑰"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:17
-msgid "Use ANY for any source ip"
+msgid "Use ANY for any source IP"
 msgstr "對任何源 IP 使用 ANY"
 
 #: applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua:8

--- a/applications/luci-app-fwknopd/root/etc/uci-defaults/40_luci-fwknopd
+++ b/applications/luci-app-fwknopd/root/etc/uci-defaults/40_luci-fwknopd
@@ -12,8 +12,8 @@ EOF
 
 uci delete fwknopd.@access[0].KEY
 uci delete fwknopd.@access[0].HMAC_KEY
-uci set fwknopd.@access[0].keytype='Base 64 key'
-uci set fwknopd.@access[0].hkeytype='Base 64 key'
+uci set fwknopd.@access[0].keytype='Base64 key'
+uci set fwknopd.@access[0].hkeytype='Base64 key'
 uci set fwknopd.@access[0].KEY_BASE64=`fwknopd --key-gen | awk '/^KEY/ {print $2;}'`
 uci set fwknopd.@access[0].HMAC_KEY_BASE64=`fwknopd --key-gen | awk '/^HMAC/ {print $2;}'`
 uci set fwknopd.@config[0].ENABLE_IPT_FORWARDING='y'

--- a/docs/api/modules/nixio.bin.html
+++ b/docs/api/modules/nixio.bin.html
@@ -262,7 +262,7 @@
 <ul>
 	
 	<li>
-	  buffer: Base 64 Encoded data
+	  buffer: Base64 Encoded data
 	</li>
 	
 </ul>

--- a/libs/luci-lib-nixio/docsrc/nixio.bin.lua
+++ b/libs/luci-lib-nixio/docsrc/nixio.bin.lua
@@ -29,5 +29,5 @@ module "nixio.bin"
 --- Base64 decode a given buffer.
 -- @class function
 -- @name b64decode
--- @param buffer	Base 64 Encoded data
+-- @param buffer	Base64 Encoded data
 -- @return binary data


### PR DESCRIPTION
Fixed typos:

- Base 64 -> Base64
- Use ANY for any source ip -> Use ANY for any source IP
- defaults to 120 seconds -> Defaults to 120 seconds.