### PR TITLE
luci-app-nft-qos: fix typos

### DIFF
--- a/applications/luci-app-nft-qos/Makefile
+++ b/applications/luci-app-nft-qos/Makefile
@@ -6,7 +6,7 @@
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=Qos over Nftables
+LUCI_TITLE:=QoS over Nftables
 LUCI_DEPENDS:=+luci-compat +nft-qos
 
 include ../../luci.mk

--- a/applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua
+++ b/applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua
@@ -13,7 +13,7 @@ function index()
 	entry({"admin", "status", "realtime", "rate_status"},
 		call("action_rate")).leaf = true
 	entry({"admin", "services", "nft-qos"}, cbi("nft-qos/nft-qos"),
-		_("Qos over Nftables"), 60)
+		_("QoS over Nftables"), 60)
 end
 
 function _action_rate(rv, n)

--- a/applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua
+++ b/applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua
@@ -20,7 +20,7 @@ local enable_priority = uci:get("nft-qos", "default", "priority_enable")
 
 local has_ipv6 = fs.access("/proc/net/ipv6_route")
 
-m = Map("nft-qos", translate("Qos over Nftables"))
+m = Map("nft-qos", translate("QoS over Nftables"))
 
 --
 -- Taboptions
@@ -82,13 +82,13 @@ o.default = def_down or '100'
 o.datatype = "uinteger"
 o:depends("limit_type","dynamic")
 
-o = s:taboption("limit", Value, "dynamic_cidr", translate("Target Network (IPv4/MASK)"), translate("Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"))
+o = s:taboption("limit", Value, "dynamic_cidr", translate("Target Network (IPv4/MASK)"), translate("Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."))
 o.datatype = "cidr4"
 ipc.routes({ family = 4, type = 1 }, function(rt) o.default = rt.dest end)
 o:depends("limit_type","dynamic")
 
 if has_ipv6 then
-	o = s:taboption("limit", Value, "dynamic_cidr6", translate("Target Network6 (IPv6/MASK)"), translate("Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"))
+	o = s:taboption("limit", Value, "dynamic_cidr6", translate("Target Network6 (IPv6/MASK)"), translate("Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."))
 	o.datatype = "cidr6"
 	o:depends("limit_type","dynamic")
 end
@@ -104,7 +104,7 @@ o = s:taboption("priority", Flag, "priority_enable", translate("Enable Traffic P
 o.default = enable_priority or o.enabled
 o.rmempty = false
 
-o = s:taboption("priority", ListValue, "priority_netdev", translate("Default Network Interface"), translate("Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"))
+o = s:taboption("priority", ListValue, "priority_netdev", translate("Default Network Interface"), translate("Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."))
 o:depends("priority_enable", "1")
 wa.cbi_add_networks(o)
 
@@ -123,9 +123,9 @@ o.datatype = "hostname"
 o.default = 'undefined'
 
 if has_ipv6 then
-	o = x:option(Value, "ipaddr", translate("IP Address(V4 / V6)"))
+	o = x:option(Value, "ipaddr", translate("IP Address (v4 / v6)"))
 else
-	o = x:option(Value, "ipaddr", translate("IP Address(V4 Only)"))
+	o = x:option(Value, "ipaddr", translate("IP Address (v4 Only)"))
 end
 o.datatype = "ipaddr"
 if nixio.fs.access("/tmp/dhcp.leases") or nixio.fs.access("/var/dhcp6.leases") then
@@ -160,9 +160,9 @@ o.datatype = "hostname"
 o.default = 'undefined'
 
 if has_ipv6 then
-	o = y:option(Value, "ipaddr", translate("IP Address(V4 / V6)"))
+	o = y:option(Value, "ipaddr", translate("IP Address (v4 / v6)"))
 else
-	o = y:option(Value, "ipaddr", translate("IP Address(V4 Only)"))
+	o = y:option(Value, "ipaddr", translate("IP Address (v4 Only)"))
 end
 o.datatype = "ipaddr"
 if nixio.fs.access("/tmp/dhcp.leases") or nixio.fs.access("/var/dhcp6.leases") then

--- a/applications/luci-app-nft-qos/po/bg/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/bg/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/ca/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/ca/nft-qos.po
@@ -100,12 +100,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/cs/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/cs/nft-qos.po
@@ -100,12 +100,12 @@ msgstr "IP adresa"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr "Protokol"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/de/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/de/nft-qos.po
@@ -100,13 +100,13 @@ msgstr "IP-Adresse"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
-msgstr "IP-Adresse (V4 / V6)"
+msgid "IP Address (v4 / v6)"
+msgstr "IP-Adresse (v4 / v6)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
-msgstr "IP-Adresse (nur V4)"
+msgid "IP Address (v4 Only)"
+msgstr "IP-Adresse (nur v4)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
 msgid "Limit Enable"
@@ -130,16 +130,16 @@ msgid "NFT-QoS Settings"
 msgstr "NFT-QoS-Einstellungen"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 "Netzwerkschnittstelle für Traffic Shaping, z.B. br-lan, eth0.1, eth0, etc."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -161,7 +161,7 @@ msgstr "Protokoll"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/el/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/el/nft-qos.po
@@ -100,12 +100,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/en/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/en/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/es/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/es/nft-qos.po
@@ -103,12 +103,12 @@ msgstr "Dirección IP"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr "Dirección IP (v4/v6)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr "Dirección IP (sólo v4)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -133,18 +133,18 @@ msgid "NFT-QoS Settings"
 msgstr "Configuración de NFT-QoS"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 "Interfaz de red para configuración de tráfico, por ejemplo, br-lan, eth0.1, "
-"eth0, etc"
+"eth0, etc."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
-msgstr "Red a aplicar, por ejemplo. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
+msgstr "Red a aplicar, por ejemplo. 192.168.1.0/24, 10.2.0.0/16, etc."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
-msgstr "Red a aplicar, por ejemplo. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
+msgstr "Red a aplicar, por ejemplo. AAAA::BBBB/64, CCCC::1/128, etc."
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
 msgid "No information available"
@@ -165,7 +165,7 @@ msgstr "Protocolo"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr "Qos sobre Nftables"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/fr/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/fr/nft-qos.po
@@ -100,12 +100,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr "Protocole"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/he/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/he/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/hi/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/hi/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/hu/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/hu/nft-qos.po
@@ -100,12 +100,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr "Protokoll"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/it/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/it/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/ja/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/ja/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/ko/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/ko/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/mr/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/mr/nft-qos.po
@@ -100,12 +100,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/ms/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/ms/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/nb_NO/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/nb_NO/nft-qos.po
@@ -100,12 +100,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/pl/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/pl/nft-qos.po
@@ -101,12 +101,12 @@ msgstr "Adres IP"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
-msgstr "Adres IP (V4 / V6)"
+msgid "IP Address (v4 / v6)"
+msgstr "Adres IP (V4 / v6)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr "Adres IP (tylko v4)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -131,16 +131,16 @@ msgid "NFT-QoS Settings"
 msgstr "Ustawienia NFT-QoS"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 "Interfejs sieciowy dla kształtowania ruchu, np. br-lan, eth0.1, eth0 itp."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr "Sieć do zastosowania, np. 192.168.1.0/24, 10.2.0.0/16, itp."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr "Sieć do zastosowania, np. AAAA::BBBB/64, CCCC::1/128, itp."
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -162,7 +162,7 @@ msgstr "Protokół"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/pt/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/pt/nft-qos.po
@@ -100,13 +100,13 @@ msgstr "Endereço IP"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
-msgstr "Endereço IP (V4 / V6)"
+msgid "IP Address (v4 / v6)"
+msgstr "Endereço IP (v4 / v6)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
-msgstr "Endereço IP (apenas V4)"
+msgid "IP Address (v4 Only)"
+msgstr "Endereço IP (apenas v4)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
 msgid "Limit Enable"
@@ -130,18 +130,18 @@ msgid "NFT-QoS Settings"
 msgstr "Configurações NFT-QoS"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 "Interface de Rede para Traffic Shaping, por exemplo, br-lan, eth0.1, eth0, "
-"etc"
+"etc."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
-msgstr "Rede a aplicar, por exemplo, 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
+msgstr "Rede a aplicar, por exemplo, 192.168.1.0/24, 10.2.0.0/16, etc."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
-msgstr "Rede a aplicar, por exemplo, AAAA::BBBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
+msgstr "Rede a aplicar, por exemplo, AAAA::BBBBB/64, CCCC::1/128, etc."
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
 msgid "No information available"
@@ -162,7 +162,7 @@ msgstr "Protocolo"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr "Qos sobre Nftables"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/pt_BR/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/pt_BR/nft-qos.po
@@ -100,13 +100,13 @@ msgstr "Endereço IP"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
-msgstr "Endereço IP (V4 / V6)"
+msgid "IP Address (v4 / v6)"
+msgstr "Endereço IP (v4 / v6)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
-msgstr "Endereço IP (apenas V4)"
+msgid "IP Address (v4 Only)"
+msgstr "Endereço IP (apenas v4)"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
 msgid "Limit Enable"
@@ -130,18 +130,18 @@ msgid "NFT-QoS Settings"
 msgstr "Configurações NFT-QoS"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 "A Interface de rede para realizar Traffic Shaping, por exemplo, br-lan, "
-"eth0.1, eth0.1, eth0, etc"
+"eth0.1, eth0.1, eth0, etc."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
-msgstr "Rede a ser aplicada, por exemplo, 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
+msgstr "Rede a ser aplicada, por exemplo, 192.168.1.0/24, 10.2.0.0/16, etc."
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
-msgstr "Rede a ser aplicada, por exemplo, AAAA::BBBB/64, CCCC:1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
+msgstr "Rede a ser aplicada, por exemplo, AAAA::BBBB/64, CCCC:1/128, etc."
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
 msgid "No information available"
@@ -162,7 +162,7 @@ msgstr "Protocolo"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr "Qos sobre Nftables"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/ro/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/ro/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/ru/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/ru/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/sk/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/sk/nft-qos.po
@@ -94,12 +94,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -124,15 +124,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -154,7 +154,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/sv/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/sv/nft-qos.po
@@ -100,12 +100,12 @@ msgstr "IP-adress"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr "Protokoll"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/tr/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/tr/nft-qos.po
@@ -100,12 +100,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/uk/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/uk/nft-qos.po
@@ -101,12 +101,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -131,15 +131,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -161,7 +161,7 @@ msgstr "Протокол"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/vi/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/vi/nft-qos.po
@@ -100,12 +100,12 @@ msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
+msgid "IP Address (v4 / v6)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
+msgid "IP Address (v4 Only)"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
@@ -130,15 +130,15 @@ msgid "NFT-QoS Settings"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -160,7 +160,7 @@ msgstr "Giao thức"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr ""
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/zh-cn/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/zh-cn/nft-qos.po
@@ -106,13 +106,13 @@ msgstr "IP 地址"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
-msgstr "IP 地址（V4 / V6）"
+msgid "IP Address (v4 / v6)"
+msgstr "IP 地址（v4 / v6）"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
-msgstr "IP 地址（仅 V4）"
+msgid "IP Address (v4 Only)"
+msgstr "IP 地址（仅 v4）"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
 msgid "Limit Enable"
@@ -136,15 +136,15 @@ msgid "NFT-QoS Settings"
 msgstr "NFT-QoS 设置"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr "流量整形的目标网络接口，例如br-lan、eth0.1、eth0等"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr "将要应用规则的网络，例如192.168.1.0/24、10.2.0.0/16等"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr "将要应用规则的网络，例如AAAA::BBBB/64、CCCC::1/128等"
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -166,7 +166,7 @@ msgstr "协议"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr "QoS Nftables 版"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12

--- a/applications/luci-app-nft-qos/po/zh-tw/nft-qos.po
+++ b/applications/luci-app-nft-qos/po/zh-tw/nft-qos.po
@@ -105,13 +105,13 @@ msgstr "IP 位址"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:126
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:163
-msgid "IP Address(V4 / V6)"
-msgstr "IP 位址（V4 / V6）"
+msgid "IP Address (v4 / v6)"
+msgstr "IP 位址（v4 / v6）"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:128
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:165
-msgid "IP Address(V4 Only)"
-msgstr "IP 位址（僅 V4）"
+msgid "IP Address (v4 Only)"
+msgstr "IP 位址（僅 v4）"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:38
 msgid "Limit Enable"
@@ -135,15 +135,15 @@ msgid "NFT-QoS Settings"
 msgstr "NFT-QoS 設定"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:107
-msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc"
+msgid "Network Interface for Traffic Shaping, e.g. br-lan, eth0.1, eth0, etc."
 msgstr "流量整形的目標網路介面，例如br-lan、eth0.1、eth0等"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:85
-msgid "Network to be apply, e.g. 192.168.1.0/24, 10.2.0.0/16, etc"
+msgid "Network to be applied, e.g. 192.168.1.0/24, 10.2.0.0/16, etc."
 msgstr "將要應用規則的網路，例如192.168.1.0/24、10.2.0.0/16等"
 
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:91
-msgid "Network to be apply, e.g. AAAA::BBBB/64, CCCC::1/128, etc"
+msgid "Network to be applied, e.g. AAAA::BBBB/64, CCCC::1/128, etc."
 msgstr "將要應用規則的網路，例如AAAA::BBBB/64、CCCC::1/128等"
 
 #: applications/luci-app-nft-qos/luasrc/view/nft-qos/rate.htm:65
@@ -165,7 +165,7 @@ msgstr "協議"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:16
 #: applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua:23
-msgid "Qos over Nftables"
+msgid "QoS over Nftables"
 msgstr "QoS Nftables 版"
 
 #: applications/luci-app-nft-qos/luasrc/controller/nft-qos.lua:12


### PR DESCRIPTION
Fixed typos:

- Qos -> QoS
- to be apply -> to be applied
- etc -> etc.
- IP address: V4, V6 -> v4, v6