### PR TITLE
luci-app-noddos: improve table header

### DIFF
--- a/applications/luci-app-noddos/luasrc/view/noddos/clients.htm
+++ b/applications/luci-app-noddos/luasrc/view/noddos/clients.htm
@@ -79,8 +79,8 @@
                     <div class="th cbi-section-table-cell"><%:MAC%></div>
                     <div class="th cbi-section-table-cell"><%:Manufacturer%></div>
                     <div class="th cbi-section-table-cell"><%:Model%></div>
-                    <div class="th cbi-section-table-cell"><%:DhcpVendor%></div>
-                    <div class="th cbi-section-table-cell"><%:DhcpHostname%></div>
+                    <div class="th cbi-section-table-cell"><%:DHCP Vendor%></div>
+                    <div class="th cbi-section-table-cell"><%:DHCP Hostname%></div>
                 </div>
 
                 <%


### PR DESCRIPTION
Changed PascalCase value to human readable words. Can you please cherry-pick this change into branch ``openwrt-19.07``? I did not change this in *.po files now, because this is not just a cosmetic change. Can you please run ``./build/i18n-sync.sh`` after merging?

There is a number (1) after the key name in this line of the file:

```html
<div class="td cbi-value-field"><%=v.DhcpVendor1%></div>
```

Is this OK, or just a typo? The file `applications/luci-app-noddos/htdocs/cgi-bin/clientdetails:77` lists different key (without number):

```lua
for i, key in ipairs{"MacAddress", "Ipv4Address", "Ipv6Address", "DeviceProfileUuid", "DhcpHostname", "DhcpVendor", "SsdpFriendlyName", "SsdpLocation", "SsdpManufacturer", "SsdpModelName", "SsdpModelUrl", "SsdpSerialNumber", "SsdpServer","SsdpUserAgent", "MdnsDeviceUrl", "MdnsHw", "MdnsManufacturer", "MdnsModelName", "MdnsOs", "WsDiscoveryTypes", "WsDiscoveryXaddrs", "DnsQueries"}
```