### PR TITLE
luci-app-nut: fix typos

### DIFF
--- a/applications/luci-app-nut/luasrc/model/cbi/nut_server.lua
+++ b/applications/luci-app-nut/luasrc/model/cbi/nut_server.lua
@@ -88,7 +88,7 @@ o = s:option(Value, "maxstartdelay", translate("Maximum Start Delay"), translate
 o.optional = true
 o.datatype = "uinteger"
 
-o = s:option(Value, "maxretry", translate("Maxium Retries"), translate("Maximum number of times to try starting a driver."))
+o = s:option(Value, "maxretry", translate("Maximum Retries"), translate("Maximum number of times to try starting a driver."))
 o.optional = true
 o.placeholder = 1
 o.datatype = "uinteger"
@@ -155,7 +155,7 @@ o = s:option(Value, "maxreport", translate("Max USB HID Length Reported"), trans
 o.optional = true
 o.datatype = "uinteger"
 
-o = s:option(Value, "maxstartdelay", translate("Maxium Start Delay"), translate("Time in seconds that upsdrvctl will wait for driver to finish starting"))
+o = s:option(Value, "maxstartdelay", translate("Maximum Start Delay"), translate("Time in seconds that upsdrvctl will wait for driver to finish starting"))
 o.optional = true
 o.datatype = "uinteger"
 o.placeholder = 45

--- a/applications/luci-app-nut/po/bg/nut.po
+++ b/applications/luci-app-nut/po/bg/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/ca/nut.po
+++ b/applications/luci-app-nut/po/ca/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/cs/nut.po
+++ b/applications/luci-app-nut/po/cs/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/de/nut.po
+++ b/applications/luci-app-nut/po/de/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/el/nut.po
+++ b/applications/luci-app-nut/po/el/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/en/nut.po
+++ b/applications/luci-app-nut/po/en/nut.po
@@ -237,8 +237,8 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Maximum time in seconds between refresh of UPS status"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
-msgstr "Maxium Retries"
+msgid "Maximum Retries"
+msgstr "Maximum Retries"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158
 msgid "Maxium Start Delay"

--- a/applications/luci-app-nut/po/es/nut.po
+++ b/applications/luci-app-nut/po/es/nut.po
@@ -245,7 +245,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Tiempo máximo en segundos para la actualización del estado de UPS"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr "Reintentos máximos"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/fr/nut.po
+++ b/applications/luci-app-nut/po/fr/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/he/nut.po
+++ b/applications/luci-app-nut/po/he/nut.po
@@ -236,7 +236,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/hi/nut.po
+++ b/applications/luci-app-nut/po/hi/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/hu/nut.po
+++ b/applications/luci-app-nut/po/hu/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/it/nut.po
+++ b/applications/luci-app-nut/po/it/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/ja/nut.po
+++ b/applications/luci-app-nut/po/ja/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/ko/nut.po
+++ b/applications/luci-app-nut/po/ko/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/mr/nut.po
+++ b/applications/luci-app-nut/po/mr/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/ms/nut.po
+++ b/applications/luci-app-nut/po/ms/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/nb_NO/nut.po
+++ b/applications/luci-app-nut/po/nb_NO/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/pl/nut.po
+++ b/applications/luci-app-nut/po/pl/nut.po
@@ -238,7 +238,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/pt/nut.po
+++ b/applications/luci-app-nut/po/pt/nut.po
@@ -243,7 +243,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Tempo máximo em segundos para atualizar a condição do estado do UPS"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr "Quantidade Máxima de Tentativas"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/pt_BR/nut.po
+++ b/applications/luci-app-nut/po/pt_BR/nut.po
@@ -243,7 +243,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Tempo máximo em segundos para atualizar a condição do estado do Nobreak"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr "Quantidade Máxima de Tentativas"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/ro/nut.po
+++ b/applications/luci-app-nut/po/ro/nut.po
@@ -236,7 +236,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/ru/nut.po
+++ b/applications/luci-app-nut/po/ru/nut.po
@@ -236,7 +236,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/sk/nut.po
+++ b/applications/luci-app-nut/po/sk/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/sv/nut.po
+++ b/applications/luci-app-nut/po/sv/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/templates/nut.pot
+++ b/applications/luci-app-nut/po/templates/nut.pot
@@ -226,7 +226,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/tr/nut.po
+++ b/applications/luci-app-nut/po/tr/nut.po
@@ -235,7 +235,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/uk/nut.po
+++ b/applications/luci-app-nut/po/uk/nut.po
@@ -238,7 +238,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/vi/nut.po
+++ b/applications/luci-app-nut/po/vi/nut.po
@@ -237,7 +237,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/zh-cn/nut.po
+++ b/applications/luci-app-nut/po/zh-cn/nut.po
@@ -240,7 +240,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "刷新 UPS 状态之间的最长时间（秒）"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr "最大重试次数"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158

--- a/applications/luci-app-nut/po/zh-tw/nut.po
+++ b/applications/luci-app-nut/po/zh-tw/nut.po
@@ -241,7 +241,7 @@ msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "重新整理 UPS 狀態之間的最長時間（秒）"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:91
-msgid "Maxium Retries"
+msgid "Maximum Retries"
 msgstr "最大重試次數"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:158


### PR DESCRIPTION
Fixed typos:

- Maxium Retries -> Maximum Retries
- Maxium Start Delay -> Maximum Start Delay

*Maximum Start Delay* is already in the language files, so this is not changed in PO files.